### PR TITLE
Adding User Credentials bug fix

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -11,6 +11,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.authentication.client.tabs.credentials;
 
+import com.extjs.gxt.ui.client.event.BaseEvent;
+import com.extjs.gxt.ui.client.event.Events;
+import com.extjs.gxt.ui.client.event.Listener;
 import com.extjs.gxt.ui.client.event.SelectionChangedEvent;
 import com.extjs.gxt.ui.client.event.SelectionChangedListener;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
@@ -101,6 +104,11 @@ public class CredentialAddDialog extends EntityAddEditDialog {
                 confirmPassword.setAllowBlank(selectionChangedEvent.getSelectedItem().getValue() != GwtCredentialType.PASSWORD);
                 password.clearInvalid();
                 confirmPassword.clearInvalid();
+                if (selectionChangedEvent.getSelectedItem().getValue() != GwtCredentialType.PASSWORD) {
+                    password.clear();
+                    confirmPassword.clear();
+                    confirmPassword.disable();
+                }
             }
         });
         credentialFormPanel.add(credentialType);
@@ -121,7 +129,21 @@ public class CredentialAddDialog extends EntityAddEditDialog {
         confirmPassword.setValidator(new ConfirmPasswordFieldValidator(confirmPassword, password));
         confirmPassword.setPassword(true);
         confirmPassword.setVisible(false);
+        confirmPassword.disable();
         credentialFormPanel.add(confirmPassword);
+
+        password.addListener(Events.KeyUp, new Listener<BaseEvent>() {
+
+            @Override
+            public void handleEvent(BaseEvent be) {
+                if (password.getValue() != null) {
+                    confirmPassword.enable();
+                } else {
+                    confirmPassword.disable();
+                    confirmPassword.clear();
+                }
+            }
+        });
 
         expirationDate = new KapuaDateField();
         expirationDate.setEmptyText(MSGS.dialogAddNoExpiration());


### PR DESCRIPTION
Brief description of the PR.
Adding User Credentials bug fix

**Related Issue**
This PR fixes/closes #1858 

**Description of the solution adopted**
The problem was that values in password and/or confirmPassword field, entered previously were not cleared when the user changed credentialType to API_KEY and tried to submit.
In credentialType's  SelectionChangedListener new if check is added, so that if a credentialType other than PASSWORD is chosen, password and confirmPassword fields are cleared and confirmPassword field is then disabled. A new listener is added to the password field, that controls when the confirmPassword field is enabled/disabled and cleared depending on the value of the password.

**Screenshots**
None

**Any side note on the changes made**
None

Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>