### PR TITLE
fix username validation after reset

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -164,10 +164,10 @@ public class LoginDialog extends Dialog {
         reset = new Button(CORE_MSGS.loginReset());
         reset.addListener(Events.OnFocus, new Listener<BaseEvent>() {
 
-    @Override
-    public void handleEvent(BaseEvent be) {
-        username.clearInvalid();
-        password.clearInvalid();
+            @Override
+            public void handleEvent(BaseEvent be) {
+                username.clearInvalid();
+                password.clearInvalid();
             }
         });
 


### PR DESCRIPTION
Brief description of the PR.
When User press reset button, no more red color on username and  password fields

**Related Issue**
This PR fixes issue #1931 

**Description of the solution adopted**
Added onFocus event listener on reset button in Login dialog

**Screenshots**
If applicable, add screenshots to help explain your solution

**Any side note on the changes made**
Description of any other change that has been made, which is not directly linked to the issue resolution
[e.g. Code clean up/Sonar issue resolution]
