### PR TITLE
Added test scenarios for restarting job with multiple online devices - second part

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ before_script:
   - export PATH=${M2_HOME}/bin:${PATH}
   - export BUILD_OPTS=""
   - export CONFIG_OVERRIDES="-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true  -Dbroker.host=localhost"
-  - export MAVEN_OPTS="-Xmx1024m"
+  - export MAVEN_OPTS="-Xmx4096m"
   - hash -r
 
 jobs:
@@ -80,7 +80,11 @@ jobs:
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
-    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineService" verify
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineServiceStart" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineServiceRestart" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -9,7 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-@jobEngineService
+@jobEngineServiceRestart
 @jobEngineRestartOfflineDevice
 @integration
 
@@ -40,7 +40,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I login as user with name "kapua-sys" and password "kapua-password"
     And I get the KuraMock device
@@ -54,7 +54,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -74,7 +74,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I login as user with name "kapua-sys" and password "kapua-password"
     And I get the KuraMock device
@@ -88,7 +88,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -108,7 +108,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I login as user with name "kapua-sys" and password "kapua-password"
     And I get the KuraMock device
@@ -122,7 +122,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -145,7 +145,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -158,7 +158,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -181,7 +181,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Bundles are requested
     Then A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -194,7 +194,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -217,7 +217,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Packages are requested
     Then Number of received packages is 1
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -230,7 +230,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -253,7 +253,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Packages are requested
     Then Number of received packages is 1
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -266,7 +266,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -294,7 +294,7 @@ Feature: JobEngineService tests for restarting job with offline device
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -314,7 +314,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -338,7 +338,7 @@ Feature: JobEngineService tests for restarting job with offline device
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -358,7 +358,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 1 second
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -383,7 +383,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -402,7 +402,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -427,7 +427,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     And I create a job with the name "TestJob"
@@ -446,7 +446,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     When I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     And I query for the job with the name "TestJob"
     And I query for the execution items for the current job
     Then I count 1
@@ -469,7 +469,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     Given I create a job with the name "TestJob"
@@ -488,7 +488,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -511,7 +511,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     Given I create a job with the name "TestJob"
@@ -530,7 +530,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -553,7 +553,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock device
     Given I create a job with the name "TestJob"
@@ -572,7 +572,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -599,7 +599,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -614,13 +614,12 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -638,7 +637,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -653,13 +652,12 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 3 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -677,7 +675,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Packages are requested
     And Number of received packages is 1
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -692,7 +690,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -715,7 +713,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Packages are requested
     And Number of received packages is 1
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -730,13 +728,12 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -752,7 +749,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -767,7 +764,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -789,7 +786,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -804,13 +801,12 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -826,7 +822,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I wait 1 second
     Then Device status is "CONNECTED"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -841,13 +837,12 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -870,7 +865,7 @@ Feature: JobEngineService tests for restarting job with offline device
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -892,13 +887,12 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -917,7 +911,7 @@ Feature: JobEngineService tests for restarting job with offline device
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -939,13 +933,12 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -965,7 +958,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -987,7 +980,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1012,7 +1005,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -1034,13 +1027,12 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
     And I confirm the executed job is finished
     And I search for the last job target in the database
-    And I wait 5 seconds
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
@@ -1058,7 +1050,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -1080,7 +1072,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1103,7 +1095,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -1125,7 +1117,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1148,7 +1140,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "DISCONNECTED"
     And I get the KuraMock devices
     Given I create a job with the name "TestJob"
@@ -1170,7 +1162,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 5 seconds
+    And I wait 2 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -9,7 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-@jobEngineService
+@jobEngineServiceRestart
 @jobEngineRestartOnlineDevice
 @integration
 
@@ -36,8 +36,8 @@ Feature: JobEngineService restart job tests with online device
   be 0 and the status PROCESS_OK
 
     Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 seconds
+    When Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -45,18 +45,6 @@ Feature: JobEngineService restart job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -74,10 +62,10 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -88,8 +76,8 @@ Feature: JobEngineService restart job tests with online device
   be 0 and the status PROCESS_FAILED
 
     Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 seconds
+    When Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -97,18 +85,6 @@ Feature: JobEngineService restart job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -129,7 +105,7 @@ Feature: JobEngineService restart job tests with online device
     Then I find 1 device event
     And The type of the last event is "BIRTH"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -140,8 +116,8 @@ Feature: JobEngineService restart job tests with online device
   be 0 and the status PROCESS_OK
 
     Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 seconds
+    When Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -149,18 +125,6 @@ Feature: JobEngineService restart job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -186,10 +150,10 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -200,8 +164,8 @@ Feature: JobEngineService restart job tests with online device
   be 0 and the status PROCESS_FAILED
 
     Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 seconds
+    When Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -209,18 +173,6 @@ Feature: JobEngineService restart job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -249,7 +201,7 @@ Feature: JobEngineService restart job tests with online device
     Then I find 1 device event
     And The type of the last event is "BIRTH"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -262,27 +214,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -301,12 +241,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -319,27 +259,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -358,12 +286,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -376,26 +304,14 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -414,7 +330,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
@@ -427,12 +343,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device event
+    Then I find 5 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -445,26 +361,14 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 2 device event
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -492,12 +396,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -510,27 +414,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -549,12 +441,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -567,27 +459,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -606,12 +486,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -624,27 +504,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -663,7 +531,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
@@ -676,12 +544,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device event
+    Then I find 5 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -694,27 +562,15 @@ Feature: JobEngineService restart job tests with online device
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     When I start the Kura Mock
-    And Device is connected
-    And I wait 1 seconds
+    And Device "is" connected
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -733,7 +589,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
@@ -746,12 +602,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -767,27 +623,15 @@ Feature: JobEngineService restart job tests with online device
 
     Given I add 2 devices to Kura Mock
     When Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     And I get the KuraMock devices
     And Command pwd is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -808,7 +652,7 @@ Feature: JobEngineService restart job tests with online device
     Then I find 2 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -820,27 +664,15 @@ Feature: JobEngineService restart job tests with online device
 
     Given I add 2 devices to Kura Mock
     When Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     And I get the KuraMock devices
     And Command invalidCommand is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -858,10 +690,10 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -873,27 +705,15 @@ Feature: JobEngineService restart job tests with online device
 
     Given I add 2 devices to Kura Mock
     When Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     And I get the KuraMock devices
     And Command pwd is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -919,10 +739,10 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -934,27 +754,15 @@ Feature: JobEngineService restart job tests with online device
 
     Given I add 2 devices to Kura Mock
     When Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
     And I get the KuraMock devices
     And Command invalidCommand is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -980,10 +788,10 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -997,26 +805,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1035,12 +831,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1054,26 +850,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Devices status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1092,12 +876,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1111,25 +895,13 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1148,7 +920,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
@@ -1161,12 +933,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1180,25 +952,13 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1226,7 +986,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
@@ -1245,26 +1005,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1283,12 +1031,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1302,26 +1050,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1340,12 +1076,12 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1359,26 +1095,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1397,7 +1121,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
@@ -1410,7 +1134,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
@@ -1429,26 +1153,14 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1467,7 +1179,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
@@ -1480,12 +1192,485 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
     And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+    # *************************************************************
+    # * Restarting a job with multiple Targets and multiple Steps *
+    # *************************************************************
+
+  Scenario: Restarting Job With Valid "Command Execution" and "Bundle Start" steps, multiple devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new valid Command Execution and valid Bundle Start steps to the created job.
+  Restart the job one time. After the executed job is finished, the executed target's
+  step index should be 1 and the status PROCESS_OK
+
+    Given I add 2 devices to Kura Mock
+    When Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And Command pwd is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "COMMAND"
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Command Execution" and "Bundle Start", multiple devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new invalid Command Execution, and invalid Bundle Start steps to the created job.
+  Restart the job one time. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_FAILED
+
+    Given I add 2 devices to Kura Mock
+    When Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And Command invalidCommand is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "COMMAND"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                                                        |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><commandInvalidTag>invalidCommand</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                                                        |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And Command pwd is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "COMMAND"
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Valid "Command Execution" and "Bundle Start", multiple devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new valid Command Execution and valid Bundle Start steps to the created job.
+  Restart the job two times. After the executed job is finished, the executed target's
+  step index should be 1 and the status PROCESS_OK
+
+    Given I add 2 devices to Kura Mock
+    When Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Command pwd is executed
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And Command pwd is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "COMMAND"
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Command Execution" and "Bundle Start", multiple devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a new invalid Command Execution and invalid Bundle Start steps to the created job.
+  Restart the job two times. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_FAILED
+
+    Given I add 2 devices to Kura Mock
+    When Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Command invalidCommand is executed
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandInvalidTag>pwd</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And Command invalidCommand is executed
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "COMMAND"
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Two Valid "Bundle Start" steps, multiple devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a two new valid Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 128   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Invalid "Bundle Start", multiple devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a two new invalid Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    Then Devices status is "CONNECTED"
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #128  |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    And Bundles are requested
+    Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Valid "Bundle Start", multiple devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a two new Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Invalid "Bundle Start", multiple devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add a two new invalid Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock devices
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "device0" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -9,7 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-@jobEngineService
+@jobEngineServiceStart
 @jobEngineStartOfflineDevice
 @integration
 
@@ -37,26 +37,14 @@
 
       Given I start the Kura Mock
       When Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       When I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock device
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Command Execution"
@@ -67,7 +55,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -84,26 +72,14 @@
 
       Given I start the Kura Mock
       When Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       When I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock device
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Asset Write"
@@ -114,7 +90,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -133,26 +109,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Bundle Start"
@@ -163,7 +127,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -175,7 +139,7 @@
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -189,26 +153,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       And I get the KuraMock device
       And Bundles are requested
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Bundle Stop"
@@ -219,7 +171,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -231,7 +183,7 @@
       And Bundles are requested
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -246,23 +198,11 @@
       And I wait 1 seconds
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock device
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Configuration Put"
@@ -273,7 +213,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -292,26 +232,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Packages are requested
       And Number of received packages is 1
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Package Download / Install"
@@ -322,7 +250,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -334,7 +262,7 @@
       And Packages are requested
       Then Number of received packages is 1
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -348,27 +276,15 @@
       And I select account "kapua-sys"
       Then I start the Kura Mock
       When Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Packages are requested
       And Number of received packages is 1
       And Package named org.eclipse.kura.example.ble.tisensortag with version 1.0.0 is received
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Package Uninstall"
@@ -379,7 +295,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -392,7 +308,7 @@
       And Packages are requested
       Then Number of received packages is 1
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -410,26 +326,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device is connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Command Execution"
@@ -446,7 +350,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -458,7 +362,7 @@
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -472,26 +376,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device is connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Asset Write"
@@ -508,7 +400,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -519,7 +411,7 @@
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -533,27 +425,15 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Bundles are requested
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Bundle Start"
@@ -570,7 +450,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -583,7 +463,7 @@
       Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -597,26 +477,14 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       And I get the KuraMock device
       And Bundles are requested
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Bundle Stop"
@@ -633,7 +501,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -646,7 +514,7 @@
       And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -660,25 +528,13 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device is connected
-      And I wait 1 seconds
+      And I wait 1 second
       And I get the KuraMock device
       And Bundles are requested
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Configuration Put"
@@ -695,7 +551,7 @@
       And I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -707,7 +563,7 @@
       And Bundles are requested
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -721,7 +577,7 @@
       And I select account "kapua-sys"
       When I start the Kura Mock
       And Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Packages are requested
@@ -729,20 +585,8 @@
       And Bundles are requested
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Package Download / Install"
@@ -759,7 +603,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -773,7 +617,7 @@
       And Bundles are requested
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       And Device status is "DISCONNECTED"
       And I logout
 
@@ -787,7 +631,7 @@
       And I select account "kapua-sys"
       Then I start the Kura Mock
       When Device "is" connected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock device
       And Packages are requested
@@ -796,20 +640,8 @@
       And Bundles are requested
       And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
       When KuraMock is disconnected
-      And I wait 1 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-      And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
       Given I create a job with the name "TestJob"
       And A new job target item
       And Search for step definition with the name "Package Uninstall"
@@ -826,7 +658,7 @@
       When I create a new step entity from the existing creator
       And I search the database for created job steps and I find 2
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -852,25 +684,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -883,13 +704,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -901,25 +721,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -932,13 +741,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -952,26 +760,14 @@
       And I select account "kapua-sys"
       And I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock devices
       And Packages are requested
       And Number of received packages is 1
       When KuraMock is disconnected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -984,7 +780,7 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -1006,25 +802,13 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1037,13 +821,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 15 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 15 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1055,25 +838,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1086,13 +858,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1104,25 +875,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1135,13 +895,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1153,25 +912,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1184,13 +932,12 @@
       When I create a new step entity from the existing creator
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1206,25 +953,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1244,13 +980,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1262,25 +997,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
+      And I wait 1 second
       When KuraMock is disconnected
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1300,13 +1024,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1320,26 +1043,14 @@
       And I select account "kapua-sys"
       And I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       And I get the KuraMock devices
       And Packages are requested
       And Number of received packages is 1
       When KuraMock is disconnected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1359,7 +1070,7 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 5 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
@@ -1381,25 +1092,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1419,13 +1119,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 15 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 15 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1437,25 +1136,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1475,13 +1163,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1493,25 +1180,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1531,13 +1207,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 
@@ -1549,25 +1224,14 @@
 
       Given I add 2 devices to Kura Mock
       When Devices "are" connected
-      And I wait 5 seconds
+      And I wait 1 second
       Then Device status is "CONNECTED"
       When KuraMock is disconnected
+      And I wait 1 second
       Then Device status is "DISCONNECTED"
       And I login as user with name "kapua-sys" and password "kapua-password"
       And I select account "kapua-sys"
       And I get the KuraMock devices
-      And I configure the job service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job target service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
-      And I configure the job step service
-        | type    | name                   | value |
-        | boolean | infiniteChildEntities  | true  |
-        | integer | maxNumberChildEntities | 5     |
       Given I create a job with the name "TestJob"
       And I add targets to job
       When I count the targets in the current scope
@@ -1587,13 +1251,12 @@
       And I search the database for created job steps and I find 2
       Then No exception was thrown
       And I start a job
-      And I wait 3 seconds
+      And I wait 2 seconds
       Given I query for the job with the name "TestJob"
       When I query for the execution items for the current job
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -9,7 +9,7 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-@jobEngineService
+@jobEngineServiceStart
 @jobEngineStartOnlineDevice
 @integration
 
@@ -37,7 +37,7 @@ Feature: JobEngineService start job tests with online device
 
     Given I start the Kura Mock
     When Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -45,18 +45,6 @@ Feature: JobEngineService start job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -75,10 +63,10 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -90,7 +78,7 @@ Feature: JobEngineService start job tests with online device
 
     Given I start the Kura Mock
     When Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -98,18 +86,6 @@ Feature: JobEngineService start job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 1 device event
     And The type of the last event is "BIRTH"
-    And I configure the job service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-      | type    | name                       | value |
-      | boolean | infiniteChildEntities      | true  |
-      | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -131,7 +107,7 @@ Feature: JobEngineService start job tests with online device
     Then I find 1 device event
     And The type of the last event is "BIRTH"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -145,26 +121,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -183,12 +147,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -202,26 +166,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -240,12 +192,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -259,26 +211,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -297,12 +237,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -317,26 +257,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -355,15 +283,15 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
-#
+
     # *****************************************************
     # * Starting a job with one Target and multiple Steps *
     # *****************************************************
@@ -386,19 +314,7 @@ Feature: JobEngineService start job tests with online device
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When I search for events from device "rpione3" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 3 device event
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
+    Then I find 3 device events
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -425,12 +341,12 @@ Feature: JobEngineService start job tests with online device
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 5 device event
+    Then I find 5 device events
     When Command pwd is executed
     And Bundles are requested
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -452,19 +368,7 @@ Feature: JobEngineService start job tests with online device
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When I search for events from device "rpione3" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 3 device event
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
+    Then I find 3 device events
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -496,7 +400,7 @@ Feature: JobEngineService start job tests with online device
     And Bundles are requested
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -510,27 +414,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -547,7 +439,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 30 seconds
+    And I wait 15 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -555,13 +447,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device event
+    Then I find 4 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -575,27 +467,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -612,7 +492,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 30 seconds
+    And I wait 15 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -620,13 +500,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -640,27 +520,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -677,7 +545,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 30 seconds
+    And I wait 15 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -685,13 +553,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device event
+    Then I find 4 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -705,27 +573,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I start the Kura Mock
     And Device is connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock device
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     Then Device status is "CONNECTED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -742,7 +598,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 30 seconds
+    And I wait 15 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -750,20 +606,20 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
-    # *****************************************************
-    # * Starting a job with multiple Targets and one Step *
-    # *****************************************************
-
+#    # *****************************************************
+#    # * Starting a job with multiple Targets and one Step *
+#    # *****************************************************
+#
   Scenario: Starting job with valid Command Execution step and multiple devices
   Create a new job. Set a disconnected Kura Mock devices as a job targets.
   Add a new valid Command Execution step to the created job. Start the job.
@@ -774,25 +630,13 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Command "pwd" is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -812,10 +656,10 @@ Feature: JobEngineService start job tests with online device
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When Command pwd is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "COMMAND"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -829,25 +673,13 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Command "pwd" is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "COMMAND"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -867,10 +699,10 @@ Feature: JobEngineService start job tests with online device
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When Command pwd is executed
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "COMMAND"
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -884,27 +716,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Device "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then Bundles are received
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -923,12 +743,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -942,32 +762,20 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Device "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
     And A regular step creator with the name "TestStep" and the following properties
       | name     | type             | value |
-      | bundleId | java.lang.String | *34   |
+      | bundleId | java.lang.String | #34   |
       | timeout  | java.lang.Long   | 10000 |
     When I create a new step entity from the existing creator
     Then No exception was thrown
@@ -980,12 +788,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -999,26 +807,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1039,13 +835,12 @@ Feature: JobEngineService start job tests with online device
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     Then KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
-
 
   Scenario: Starting a job with invalid Bundle Stop step and multiple devices
   Create a new job and set a connected KuraMock devices as the job targets.
@@ -1057,26 +852,14 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1095,12 +878,12 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1118,7 +901,7 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Command "pwd" is executed
@@ -1126,19 +909,7 @@ Feature: JobEngineService start job tests with online device
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When I search for events from device "device0" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 3 device event
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
+    Then I find 3 device events
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -1165,12 +936,12 @@ Feature: JobEngineService start job tests with online device
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 3 device event
+    Then I find 3 device events
     When Command pwd is executed
     And Bundles are requested
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1184,7 +955,7 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Command "pwd" is executed
@@ -1192,19 +963,7 @@ Feature: JobEngineService start job tests with online device
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When I search for events from device "device0" in account "kapua-sys"
     And The type of the last event is "BUNDLE"
-    Then I find 3 device event
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
+    Then I find 3 device events
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
@@ -1230,13 +989,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device event
+    Then I find 3 device events
     And The type of the last event is "BUNDLE"
     When Command pwd is executed
     And Bundles are requested
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     When KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1250,27 +1009,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1295,13 +1042,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1315,27 +1062,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When  I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     Then Device status is "CONNECTED"
     And I get the KuraMock devices
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
@@ -1360,13 +1095,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1380,27 +1115,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1425,13 +1148,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1445,27 +1168,15 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     When I add 2 devices to Kura Mock
     And Devices "are" connected
-    And I wait 1 seconds
+    And I wait 1 second
     And I get the KuraMock devices
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     Then A bundle named org.eclipse.kura.wire.component.conditional.provider with id 128 and version 1.0.0 is present and ACTIVE
     Then Device status is "CONNECTED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
-    And I configure the job service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job target service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
-    And I configure the job step service
-      | type    | name                   | value |
-      | boolean | infiniteChildEntities  | true  |
-      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
@@ -1490,13 +1201,13 @@ Feature: JobEngineService start job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device event
+    Then I find 2 device events
     And The type of the last event is "BUNDLE"
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     And KuraMock is disconnected
-    And I wait 1 seconds
+    And I wait 1 second
     And Device status is "DISCONNECTED"
     And I logout
 


### PR DESCRIPTION
Signed-off-by: ct-anaalbic <Ana.Albic@comtrade.com>

Brief description of the PR.
Added second part of scenarios for restarting job with multiple online devices.

**Related Issue**
This PR fixes/closes part of issue #2662

**Description of the solution adopted**
This PR represents second part of JobEngineService integration tests for restarting job with multiple online devices. In feature file JobEngineServiceRestartOnlineDeviceI9n.feature the scenarios for restarting job with multiple targets and one or more steps are added. Also, in this scenarios, job is restarted with valid and invalid proper parameters. 

**Screenshots**
/

**Any side note on the changes made**
/
