### PR TITLE
Modified column definition of DeviceEvent.Position.Altitudite

### DIFF
--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device_event-modify_gps_column.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device_event-modify_gps_column.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -15,10 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device-1.1.0.xml">
+        logicalFilePath="KapuaDB/device_event-modify_gps_column.xml">
 
-    <include relativeToChangelogFile="true" file="./device-add-model-name.xml"/>
-    <include relativeToChangelogFile="true" file="./device-remove-modem-constraint.xml"/>
-    <include relativeToChangelogFile="true" file="./device_event-modify_gps_column.xml"/>
+    <changeSet id="device_event-modify_gps_column" author="eurotech">
+        <modifyDataType tableName="dvc_device_event" columnName="pos_altitude" newDataType="decimal(13,8)"/>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
Changed the column definition which was limiting the max value of altitude to 999.99999999.

**Related Issue**
This PR fixes #2702 

**Description of the solution adopted**
Changed column definition from `DECIMAL(11,8)` to `DECIMAL(13,8)`.

**Screenshots**
_None_

**Any side note on the changes made**
_None_