### PR TITLE
Unnecessarily space is removed in travis.yml file

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,11 +75,11 @@ jobs:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobs" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
-      script:
-    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @account"  verify
+    script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @account" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
-      script:
+    script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineService" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test


### PR DESCRIPTION
Signed-off-by: ct-anaalbic <Ana.Albic@comtrade.com>

Brief description of the PR.
Unnecessarily space is removed in travis.yml file

**Related Issue**
This PR is part of PR #2697 

**Description of the solution adopted**
After merging PR #2697, travis not work properly. Actually, build is stopped. The problem is parsing of `travis.yml` file. So in this PR, syntax error is removed from `travis.yml` file.

**Screenshots**
/

**Any side note on the changes made**
/
