### PR TITLE
Added Tests For Scheduler And Endpoint Permissions

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucPermission.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucPermission.java
@@ -13,7 +13,6 @@ package org.eclipse.kapua.qa.common.cucumber;
 
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.model.domain.Actions;
-
 import java.math.BigInteger;
 
 /**
@@ -25,6 +24,7 @@ public class CucPermission {
 
     private Actions action;
 
+    private Integer targetScope;
     private KapuaEid targetScopeId;
 
     public String getDomain() {
@@ -44,6 +44,9 @@ public class CucPermission {
     }
 
     public KapuaEid getTargetScopeId() {
+        if (targetScope != null) {
+            return targetScopeId = new KapuaEid(BigInteger.valueOf(targetScope));
+        }
         return targetScopeId;
     }
 

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserPermissionI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserPermissionI9nTest.java
@@ -27,7 +27,9 @@ import cucumber.api.CucumberOptions;
                 "org.eclipse.kapua.service.device.registry.steps",
                 "org.eclipse.kapua.service.tag.steps",
                 "org.eclipse.kapua.service.job.steps",
-                "org.eclipse.kapua.service.datastore.steps"
+                "org.eclipse.kapua.service.datastore.steps",
+                "org.eclipse.kapua.service.scheduler.steps",
+                "org.eclipse.kapua.service.endpoint.steps"
         },
         plugin = {"pretty",
                 "html:target/cucumber/UserServiceI9n",

--- a/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
+++ b/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
@@ -16,6 +16,7 @@ import cucumber.api.java.After;
 import cucumber.api.java.Before;
 import cucumber.api.java.en.And;
 import cucumber.api.java.en.Then;
+import cucumber.api.java.en.When;
 import cucumber.runtime.java.guice.ScenarioScoped;
 import org.apache.shiro.SecurityUtils;
 import org.eclipse.kapua.KapuaException;
@@ -137,7 +138,6 @@ public class EndpointServiceSteps extends TestBase {
         }
     }
 
-
     @And("^I try to find endpoint with schema \"([^\"]*)\"$")
     public void iFoundEndpointWithSchema(String schema) throws Exception {
         primeException();
@@ -149,7 +149,7 @@ public class EndpointServiceSteps extends TestBase {
 
             stepData.put("EndpointInfo", endpointInfo);
             stepData.put("EndpointInfoId", endpointInfo.getId());
-        } catch (KapuaException ex) {
+        } catch (Exception ex) {
             verifyException(ex);
         }
     }
@@ -163,11 +163,25 @@ public class EndpointServiceSteps extends TestBase {
 
     @And("^I delete the last created endpoint$")
     public void iDeleteTheLastCreatedEndpoint() throws Exception {
-        EndpointInfo endpointInfo = (EndpointInfo) stepData.get("EndpointInfo");
 
         try {
-            primeException();
-            endpointInfoService.delete(getCurrentScopeId(), endpointInfo.getId());
+            EndpointInfo endpointInfo = (EndpointInfo) stepData.get("EndpointInfo");
+            endpointInfoService.delete(SYS_SCOPE_ID, endpointInfo.getId());
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @When("^I delete endpoint with schema \"([^\"]*)\"$")
+    public void iDeleteEndpointWithSchema(String schema) throws Throwable {
+        primeException();
+
+        try {
+            EndpointInfoQuery endpointInfoQuery = endpointInfoFactory.newQuery(getCurrentScopeId());
+            endpointInfoQuery.setPredicate(endpointInfoQuery.attributePredicate(EndpointInfoAttributes.SCHEMA, schema, AttributePredicate.Operator.EQUAL));
+            EndpointInfo endpointInfo = endpointInfoService.query(endpointInfoQuery).getFirstItem();
+
+            endpointInfoService.delete(SYS_SCOPE_ID, endpointInfo.getId());
         } catch (KapuaException ex) {
             verifyException(ex);
         }

--- a/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
+++ b/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
@@ -201,32 +201,31 @@ public class JobScheduleServiceSteps extends TestBase {
             Trigger trigger = triggerService.create(triggerCreator);
             stepData.put("Trigger", trigger);
             stepData.put("CurrentTriggerId", trigger.getId());
-        } catch (KapuaException ex) {
+        } catch (Exception ex) {
             verifyException(ex);
         }
     }
 
     @And("^I try to edit trigger name \"([^\"]*)\"$")
     public void iTryToEditTriggerName(String newTriggerName) throws Exception {
-        Trigger trigger = (Trigger) stepData.get("Trigger");
-        trigger.setName(newTriggerName);
         try {
+            Trigger trigger = (Trigger) stepData.get("Trigger");
+            trigger.setName(newTriggerName);
             primeException();
             Trigger newTrigger = triggerService.update(trigger);
             stepData.put("Trigger", newTrigger);
-        } catch (KapuaException ex) {
+        } catch (Exception ex) {
             verifyException(ex);
         }
     }
 
     @And("^I try to delete last created trigger$")
     public void iTryToDeleteTrigger() throws Exception {
-        Trigger trigger = (Trigger) stepData.get("Trigger");
-
         try {
+            Trigger trigger = (Trigger) stepData.get("Trigger");
             primeException();
             triggerService.delete(getCurrentScopeId(), trigger.getId());
-        } catch (KapuaException ex) {
+        } catch (Exception ex) {
             verifyException(ex);
         }
     }


### PR DESCRIPTION
Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

Added 3 tests for user permissions managing with Endpoints and Scheduler.

**Related Issue**
This PR fixes/closes part of issue #126 

**Description of the solution adopted**
In this pull request I added 3 test scenarios for user permissions. The scenarios were added to `UserPermissionI9n.feature` file. The scenarios are:

1. Add Scheduler Permissions Without Job Permissions
2. Add Scheduler Permissions With Job Permissions
3. Add Endpoint Permission To The User

I also modified `CucPermission.java` class so you can add targetScopeId to cucumber scenario directly as an integer.

**Screenshots**
/

**Any side note on the changes made**
/
