### PR TITLE
Added tests for restarting job with one online target and multiple steps

### DIFF
--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -612,6 +612,719 @@ Feature: JobEngineService restart job tests with online device
     And I logout
 
     # *******************************************************
+    # * Restarting a job with one Target and multiple Steps *
+    # *******************************************************
+
+  Scenario: Restarting Job With Valid "Command Execution" and "Bundle Start" steps And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new valid Command Execution and valid Bundle Start steps to the created job.
+  Restart the job one time. After the executed job is finished, the executed target's
+  step index should be 1 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And Command pwd is executed
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "COMMAND"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Command Execution" and "Bundle Start" And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new invalid Command Execution, and invalid Bundle Start steps to the created job.
+  Restart the job one time. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And Command invalidCommand is executed
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "COMMAND"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                                                        |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><commandInvalidTag>invalidCommand</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                                                        |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "COMMAND"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Valid "Command Execution" and "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new valid Command Execution and valid Bundle Start steps to the created job.
+  Restart the job two times. After the executed job is finished, the executed target's
+  step index should be 1 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Command pwd is executed
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 7 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Command Execution" and "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new invalid Command Execution and invalid Bundle Start steps to the created job.
+  Restart the job two times. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Command invalidCommand is executed
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandInvalidTag>pwd</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    And I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Two Valid "Bundle Start" steps And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add two new valid Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then No exception was thrown
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Invalid "Bundle Start" And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add two new invalid Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34  |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Valid "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add two new Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 7 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With two Invalid "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add two new invalid Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Valid "Bundle Stop" and "Bundle Start" And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new valid Bundle Stop and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then Device status is "CONNECTED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 77    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Bundle Stop" and "Bundle Start" And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new invalid Bundle Stop and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #77   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Valid "Bundle Stop" and "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add new valid Bundle Stop step to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then Device status is "CONNECTED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 77    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 95    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 7 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid "Bundle Stop" and "Bundle Start" And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets.
+  Add new invalid Bundle Stop and Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    And Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then Device status is "CONNECTED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    And I get the KuraMock device
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Bundle Stop"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #77   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #95   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I search the database for created job steps and I find 2
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BUNDLE"
+    Then Bundles are requested
+    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
+    And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
+    And KuraMock is disconnected
+    And I wait 1 second
+    And Device status is "DISCONNECTED"
+    And I logout
+
+    # *******************************************************
     # * Restarting a job with multiple Targets and one Step *
     # *******************************************************
 


### PR DESCRIPTION
Signed-off-by: ct-anaalbic <Ana.Albic@comtrade.com>

Brief description of the PR.
Added tests for restarting job with one online target.

**Related Issue**
This PR fixes/closes part of issue #2662 

**Description of the solution adopted**
This PR represents part of test scenarios for job restart with one online devices as job targets and multiple steps.

**Screenshots**
/

**Any side note on the changes made**
/
