### PR TITLE
Fixed javadoc

### DIFF
--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
@@ -314,7 +314,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     }
 
     /**
-     * See {@link AdvancedPackageDownloadOptions#setBlockTimeout(int)}
+     * See {@link AdvancedPackageDownloadOptions#setBlockTimeout(Integer)}}
      *
      * @since 1.1.0
      */
@@ -334,7 +334,7 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     }
 
     /**
-     * See {@link AdvancedPackageDownloadOptions#setNotifyBlockSize(int)}
+     * See {@link AdvancedPackageDownloadOptions#setNotifyBlockSize(Integer)}
      *
      * @since 1.1.0
      */


### PR DESCRIPTION
This PR fixes a javadoc build issue that was occurring in Eclipse Jenkins and not in Travis introduced with PR #2715. 

Jenkins build: https://ci.eclipse.org/kapua/job/develop-build/542

**Related Issue**
This PR fixes an issue introduced with PR #2715

**Description of the solution adopted**
Just fixed javadoc definition.

**Screenshots**
_None_

**Any side note on the changes made**
_None_