### PR TITLE
Fix lifecycle messages processing dev

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
@@ -50,6 +50,9 @@ public class KapuaConnectionContext {
     private String brokerIpOrHostName;
     private Certificate[] clientCertificates;
 
+    //flag to help the correct lifecycle handling
+    private boolean missing;
+
     // use to track the allowed destinations for debug purpose
     private List<String> authDestinations;
 
@@ -71,11 +74,12 @@ public class KapuaConnectionContext {
         }
     }
 
-    public KapuaConnectionContext(String brokerId, String brokerIpOrHostName, KapuaPrincipal kapuaPrincipal, String accountName, ConnectionInfo info, String fullClientIdPattern) {
+    public KapuaConnectionContext(String brokerId, String brokerIpOrHostName, KapuaPrincipal kapuaPrincipal, String accountName, ConnectionInfo info, String fullClientIdPattern, boolean missing) {
         authDestinations = new ArrayList<>();
         this.brokerId = brokerId;
         this.brokerIpOrHostName = brokerIpOrHostName;
         this.accountName = accountName;
+        this.missing = missing;
         userName = info.getUserName();
         clientId = kapuaPrincipal.getClientId();
         scopeId = kapuaPrincipal.getAccountId();
@@ -186,6 +190,10 @@ public class KapuaConnectionContext {
 
     public String getBrokerIpOrHostName() {
         return brokerIpOrHostName;
+    }
+
+    public boolean isMissing() {
+        return missing;
     }
 
     public void addAuthDestinationToLog(String message) {

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
@@ -41,6 +41,9 @@ public class KapuaSecurityContext extends SecurityContext {
     private boolean hasDeviceView;
     private boolean hasDeviceManage;
 
+    //flag to help the correct lifecycle handling
+    private boolean missing;
+
     public KapuaSecurityContext(KapuaConnectionContext kcc,
             AuthorizationMap authMap) {
         super(kcc.getPrincipal().getName());
@@ -98,5 +101,13 @@ public class KapuaSecurityContext extends SecurityContext {
 
     public KapuaSession getKapuaSession() {
         return kapuaSession;
+    }
+
+    public void setMissing() {
+        missing = true;
+    }
+
+    public boolean isMissing() {
+        return missing;
     }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.device.registry.event;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
-import org.eclipse.kapua.service.device.registry.Device;
 
 /**
  * {@link DeviceEventService} definition.
@@ -22,19 +21,6 @@ import org.eclipse.kapua.service.device.registry.Device;
  * @since 1.0.0
  */
 public interface DeviceEventService extends KapuaEntityService<DeviceEvent, DeviceEventCreator> {
-
-    /**
-     * Creates the {@link DeviceEvent}.
-     * This method allows to specify if the related {@link Device#getLastEventId()} must be updated after the {@link DeviceEvent} creation.<br>
-     * Use this methods only on particular cases that does not require update of the {@link Device#getLastEventId()}.
-     *
-     * @param creator                 The {@link DeviceEventCreator} from which create the {@link DeviceEvent}.
-     * @param updateDeviceLastEventId Whether or not update the {@link Device#getLastEventId()}.
-     * @return The created {@link DeviceEvent}
-     * @throws KapuaException
-     * @since 1.0.0
-     */
-    DeviceEvent create(DeviceEventCreator creator, boolean updateDeviceLastEventId) throws KapuaException;
 
     /**
      * Returns the {@link DeviceEventListResult} with elements matching the provided query.


### PR DESCRIPTION
Brief description of the PR.
Fixing the missing device detection. If the device disconnect in a not clean way, the ActiveMQ broker doesn't fill the throwable filed on the disconnection method inside the broker plugin.

**Related Issue**
#2714 

**Description of the solution adopted**
To correctly detect the not clear disconnection a different approach must be implemented. So, thanks to the LWT message, a different detection way can be implemented.

**Screenshots**
none

**Any side note on the changes made**
none
