### PR TITLE
Fix NPE on RolesPermissions REST API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
@@ -117,8 +117,9 @@ public class RolesPermissions extends AbstractKapuaResource {
 
         AndPredicate andPredicate = query.andPredicate();
         andPredicate.and(query.attributePredicate(RolePermissionAttributes.ROLE_ID, roleId));
-        andPredicate.and(query.getPredicate());
-
+        if (query.getPredicate() != null) {
+            andPredicate.and(query.getPredicate());
+        }
         query.setPredicate(andPredicate);
 
         return rolePermissionService.query(query);


### PR DESCRIPTION
Quick fix to avoid a `NullPointerException` when calling the REST API `POST /{scopeId}/roles/{roleId}/permissions`

**Related Issue**
No related issues


