### PR TITLE
Added new user account permission integration tests

### DIFF
--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -875,6 +875,601 @@ Feature: User Permission tests
     Then No exception was thrown
     And I logout
 
+  Scenario: Adding Account:Read permission to user in same scope
+  Login as kapua-sys user on the kapua-sys account and add a new user0 user with
+  the Account:Read permission to the kapua-sys account. Create a child account subAccount0.
+  Login as user0 and perform actions on the subAccount0. Verify that only allowed actions
+  are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    Then I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I search for the account with the remembered account Id
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "subAccount0"
+    Then An exception was thrown
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "subAccount0"
+    Then An exception was thrown
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "kapua-sys"
+    Then An exception was thrown
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I delete account "kapua-sys"
+    Then An exception was thrown
+    And I logout
+
+    Scenario: Adding Account:Write permission to user in same scope
+    Login as kapua-sys user on the kapua-sys account and add a new user0 user with
+    the Account:Write permission to the kapua-sys account. Create a child account subAccount0.
+    Login as user0 and perform actions on the subAccount0. Verify that only allowed actions are
+    performed and the exception is thrown where needed.
+
+      Given I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And A generic user
+        | name  | displayName  | email           | phoneNumber     | status  | userType |
+        | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+      And Credentials
+        | name  | password          | enabled |
+        | user0 | ToManySecrets123# | true    |
+      And Add permissions to the last created user
+        | domain  | action |
+        | account | write  |
+      And Account
+        | name        | scopeId |
+        | subAccount0 | 1       |
+    And I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I search for the account with the remembered account Id
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "subAccount0"
+    And An exception was thrown
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "kapua-sys"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "kapua-sys"
+    And An exception was thrown
+    And I logout
+
+  Scenario: Adding Account:Delete permission to user in same scope
+  Login as kapua-sys user on the kapua-sys account and add a new user0 user with
+  the Account:Delete permission to the kapua-sys account. Create a child account subAccount0.
+  Login as user0 and perform actions on the subAccount0. Verify that only allowed actions are
+  performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | delete |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I search for the account with the remembered account Id
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "subAccount0"
+    And An exception was thrown
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "kapua-sys"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "kapua-sys"
+    And An exception was thrown
+    And I logout
+
+  Scenario: Adding Account:Read and Account:Write permissions to user in same scope
+  Login as kapua-sys user on the kapua-sys account and add a new user0 user with the Account:Read
+  and Account:Write permissions to the kapua-sys account. Create a child account subAccount0.
+  Login as user0 and perform actions on the subAccount0. Verify that only allowed actions are
+  performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+      | account | write  |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    Then I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I search for the account with the remembered account Id
+    When I modify the account "subAccount0"
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "subAccount0"
+    Then An exception was thrown
+    When I modify the account "kapua-sys"
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I delete account "kapua-sys"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Adding Account:Read and Account:Delete permissions to user in same scope
+  Login as kapua-sys user on the kapua-sys account and add a new user0 user with the Account:Read
+  and Account:Delete permissions to the kapua-sys account. Create a child account subAccount0.
+  Login as user0 and perform actions on the subAccount0. Verify that only allowed actions
+  are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+      | account | delete |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    Then I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I search for the account with the remembered account Id
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "subAccount0"
+    Then An exception was thrown
+    When I delete account "subAccount0"
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "kapua-sys"
+    Then An exception was thrown
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I delete account "kapua-sys"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Adding Account:Write and Account:Delete permission to user in same scope
+  Login as kapua-sys user on the kapua-sys account and add a new user0 user with the Account:Write
+  and Account:Delete permission to the kapua-sys account. Create a child account subAccount0.
+  Login as user0 and perform actions on the subAccount0. Verify that only allowed actions are
+  performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | write  |
+      | account | delete |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I search for the account with the remembered account Id
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "subAccount0"
+    And An exception was thrown
+    When I delete account "subAccount0"
+    And I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I modify the account "kapua-sys"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "kapua-sys"
+    And An exception was thrown
+    And I logout
+
+    Scenario: Adding all Account permissions to user in same scope
+    Login as kapua-sys user on the kapua-sys account and add a new user0 user with all account
+    domain permissions to the kapua-sys account. Create a child account subAccount0.
+    Login as user0 and perform actions on the subAccount0. Verify that only allowed actions are
+    performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user0 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+      | account | write  |
+      | account | delete |
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I logout
+    When I login as user with name "user0" and password "ToManySecrets123#"
+    Then I search for the account with the remembered account Id
+    And I modify the account "subAccount0"
+    And I delete account "subAccount0"
+    And I modify the account "kapua-sys"
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I delete account "kapua-sys"
+    And An exception was thrown
+    And I logout
+
+   Scenario: Adding Account:Read permission to user in sub-account scope
+   Login as kapua-sys user on the kapua-sys account and create a new subaccount0 account.
+   Create another subAccount1 and add a user1 user with the Account:Read permission to it.
+   Login as user1 and perform actions on the subAccount0, subAccount1 and the kapua-sys accounts.
+   Verify that only allowed actions are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+     And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+    And I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then I search for the account with the remembered account Id
+    And Account "subAccount1" has 0 children
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "kapua-sys"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    When I delete account "kapua-sys"
+    And An exception was thrown
+    Then Account
+       | name         |
+       | subAccount01 |
+     And Account "subAccount1" has 1 children
+     And I logout
+
+  Scenario: Adding Account:Write permission to user in sub-account scope
+  Login as kapua-sys user on the kapua-sys account and create a new subaccount0 account.
+  Create another subAccount1 and add a user1 user with the Account:Write permission to it.
+  Login as user0 and perform actions on the subAccount0 and subAccount1 accounts.
+  Verify that only allowed actions are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | write  |
+    And I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And Account "subAccount1" has 0 children
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount1"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount1"
+    And An exception was thrown
+    Then Account
+     | name         |
+     | subAccount01 |
+    And Account "subAccount1" has 1 children
+    And I set the expiration date to 2030-05-05
+    And I logout
+
+  Scenario: Adding Account:Delete permission to user in sub-account scope
+  Login as kapua-sys user on the kapua-sys account and create a new subaccount0 account.
+  Create another subAccount1 and add a user1 user with the Account:Delete permission to it.
+  Login as user1 and perform actions on the subAccount0 and subAccount1 accounts.
+  Verify that only allowed actions are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | delete |
+    Then Account
+      | name         |
+      | subAccount10 |
+    And I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And Account "subAccount1" has 1 children
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount1"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount1"
+    And An exception was thrown
+    And I delete account "subAccount10"
+    And I logout
+
+  Scenario: Adding all Account permissions to user in sub-account scope
+  Login as kapua-sys user on the kapua-sys account and create a new subaccount1 account.
+  Create another subAccount01 and add a user1 user with all account domain permissions to it.
+  Login as user1 and perform actions on the subAccount1 and subAccount01 accounts.
+  Verify that only allowed actions are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+    And Account
+      | name         | scopeId |
+      | subAccount01 | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+      | account | write  |
+      | account | delete |
+    And I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    And Account "subAccount01" has 0 children
+    And I modify the account "subAccount01"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount01"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount1"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount1"
+    And An exception was thrown
+    And I logout
+
+  Scenario: Modifying Sub-account of a different parent account
+  Login as kapua-sys user on the kapua-sys account and create a new subaccount0 account
+  and add user0 to it. Create another subAccount1 and a subAccount01, with user1 on it. User1 has only
+  the Account:Read permision. Login as user1 and perform actions on the user0 and subAccount0. Verify
+  that only allowed actions are performed and the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And Account
+      | name        | scopeId |
+      | subAccount0 | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user0 | Kapua User 0 | user0@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+    And Account
+      | name         | scopeId |
+      | subAccount01 | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+    And I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I search for user with name "user0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I modify the account "subAccount0"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I delete account "subAccount0"
+    And An exception was thrown
+    And I logout
+
+  Scenario: Querying Other Items With All Account Permissions
+  Login as kapua-sys user on the kapua-sys account and create a new account1 account and add user1 to it.
+  User1 should have all the permissions from the account domain. Create a new device, job, tag, group and role.
+  Login as user1 and perform actions on the added entities. Verify that only allowed actions are performed and
+  the exception is thrown where needed.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And Account
+      | name        | scopeId |
+      | subAccount1 | 1       |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10   |
+    And I configure the tag service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I configure the job service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure the role service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And A generic user
+      | name  | displayName  | email           | phoneNumber     | status  | userType |
+      | user1 | Kapua User 1 | user1@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
+    And Credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain  | action |
+      | account | read   |
+      | account | write  |
+      | account | delete |
+    And A device named "test_device"
+    And I create a job with the name "test_job"
+    And Tag with name "test_tag"
+    And I create the group with name "test_group"
+    And I create the following role
+      | scopeId | name      |
+      | 1       | test_role |
+    Then I logout
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I search for user with name "user1"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I query for devices with Client Id "test_device"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I find a job with name "test_job"
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And Tag with name "test_tag" is searched
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I search for the last created group
+    And An exception was thrown
+    Then I expect the exception "SubjectUnauthorizedException" with the text "User does not have permission"
+    And I find role with name "test_role"
+    And An exception was thrown
+    And I logout
+
   Scenario: Stop broker after all scenarios
     Given Stop Broker
 

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -667,13 +667,18 @@ public class AccountServiceSteps extends TestBase {
 
     @Then("^Account \"(.*)\" has (\\d+) children$")
     public void checkNumberOfChildrenForNamedAccount(String name, int num)
-            throws KapuaException {
+            throws Exception {
 
-        Account tmpAcc = accountService.findByName(name);
-        KapuaQuery<Account> query = accountFactory.newQuery(tmpAcc.getId());
-        long accountCnt = accountService.count(query);
+        try {
+            primeException();
+            Account tmpAcc = accountService.findByName(name);
+            KapuaQuery<Account> query = accountFactory.newQuery(tmpAcc.getId());
+            long accountCnt = accountService.count(query);
 
-        assertEquals(num, accountCnt);
+            assertEquals(num, accountCnt);
+        } catch (KapuaException ke) {
+            verifyException(ke);
+        }
     }
 
     @Then("^The account does not exist$")

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationServiceSteps.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authorization/steps/AuthorizationServiceSteps.java
@@ -2104,10 +2104,16 @@ public class AuthorizationServiceSteps extends TestBase {
 
     @And("^I find role with name \"([^\"]*)\"$")
     public void iFindRoleWithName(String roleName) throws Exception {
-        RoleQuery roleQuery = roleFactory.newQuery(getCurrentScopeId());
-        roleQuery.setPredicate(roleQuery.attributePredicate(RoleAttributes.NAME, roleName, AttributePredicate.Operator.EQUAL));
-        RoleListResult roleListResult = roleService.query(roleQuery);
-        assertTrue(roleListResult.getSize() > 0);
+        try {
+            primeException();
+            RoleQuery roleQuery = roleFactory.newQuery(getCurrentScopeId());
+            roleQuery.setPredicate(roleQuery.attributePredicate(RoleAttributes.NAME, roleName, AttributePredicate.Operator.EQUAL));
+            RoleListResult roleListResult = roleService.query(roleQuery);
+            assertTrue(roleListResult.getSize() > 0);
+        } catch (KapuaException ke) {
+            verifyException(ke);
+        }
+
     }
 
     @And("^I create the group with name \"([^\"]*)\"$")

--- a/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -153,13 +153,18 @@ public class TagServiceSteps extends TestBase {
 
     @When("^Tag with name \"([^\"]*)\" is searched$")
     public void tagWithNameIfSearched(String tagName) throws Throwable {
+        try {
+            primeException();
+            TagQuery query = tagFactory.newQuery(SYS_SCOPE_ID);
+            query.setPredicate(query.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
+            TagListResult queryResult = tagService.query(query);
+            Tag foundTag = queryResult.getFirstItem();
+            stepData.put("tag", foundTag);
+            stepData.put("queryResult", queryResult);
+        } catch (KapuaException ke) {
+            verifyException(ke);
+        }
 
-        TagQuery query = tagFactory.newQuery(SYS_SCOPE_ID);
-        query.setPredicate(query.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
-        TagListResult queryResult = tagService.query(query);
-        Tag foundTag = queryResult.getFirstItem();
-        stepData.put("tag", foundTag);
-        stepData.put("queryResult", queryResult);
     }
 
     @Then("^Tag with name \"([^\"]*)\" is found$")


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added new user account permission integration tests

**Related Issue**
This PR fixes/closes part of #126

**Description of the solution adopted**
Added new test scenarios to the `UserPermissionI9n.feature`:
1.  Adding Account:Read permission to user in same scope
2. Adding Account:Write permission to user in same scope
3. Adding Account:Delete permission to user in same scope
4. Adding Account:Read and Account:Write permissions to user in same scope
5. Adding Account:Read and Account:Delete permissions to user in same scope
6. Adding Account:Write and Account:Delete permission to user in same scope
7. Adding all Account permissions to user in same scope
8. Adding Account:Read permission to user in sub-account scope
9. Adding Account:Write permission to user in sub-account scope
10. Adding Account:Delete permission to user in sub-account scope
11. Adding all Account permissions to user in sub-account scope
12. Modifying Sub-account of a different parent account
13. Querying Other Items With All Account Permissions

**Screenshots**
_None_

**Any side note on the changes made**
Updated some of the existing test steps for better error handling. 

