### PR TITLE
Set module version to 1.2.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ The team maintains some docker images in a Docker Hub repository at [Kapua Repos
 **Note:** the Docker Hub repository mentioned above is not the official project repository from Eclipse Foundation.
 ***
 
-Suppose the target is the current snapshot 1.1.0-SNAPSHOT.
+Suppose the target is the current snapshot 1.2.0-SNAPSHOT.
 
 * Clone Eclipse Kapua into a local directory
 * Open an OS shell and move to Kapua project root directory

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-assembly</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/broker-core/pom.xml
+++ b/broker-core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-broker-core</artifactId>

--- a/broker/api/pom.xml
+++ b/broker/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>kapua-broker</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -23,7 +23,7 @@
 
     <groupId>org.eclipse.kapua.build</groupId>
     <artifactId>kapua-build-tools</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/client/gateway/api/pom.xml
+++ b/client/gateway/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/features/karaf/pom.xml
+++ b/client/gateway/features/karaf/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-features</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/features/pom.xml
+++ b/client/gateway/features/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client-gateway-features</artifactId>

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client-gateway</artifactId>

--- a/client/gateway/profile/kura/pom.xml
+++ b/client/gateway/profile/kura/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/mqtt/pom.xml
+++ b/client/gateway/provider/mqtt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/pom.xml
+++ b/client/gateway/provider/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/spi/pom.xml
+++ b/client/gateway/spi/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-commons</artifactId>

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-core</artifactId>

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-about</artifactId>

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-account</artifactId>

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-api</artifactId>

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-authentication</artifactId>

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-authorization</artifactId>

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-data</artifactId>

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-device</artifactId>

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-endpoint</artifactId>

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-job</artifactId>

--- a/console/module/pom.xml
+++ b/console/module/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>kapua-console</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module</artifactId>

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-tag</artifactId>

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-user</artifactId>

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-welcome</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console</artifactId>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-console</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-web</artifactId>

--- a/deployment/docker/pom.xml
+++ b/deployment/docker/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/deployment/minishift/pom.xml
+++ b/deployment/minishift/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/deployment/openshift/pom.xml
+++ b/deployment/openshift/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-dev-tools</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-cucumber-reports</artifactId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-dev-tools</artifactId>

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -20,7 +20,7 @@ env_vars = {
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',
   'JETTY_VERSION'         => '9.4.12.v20180830',
-  'KAPUA_VERSION'         => '1.1.0-SNAPSHOT'
+  'KAPUA_VERSION'         => '1.2.0-SNAPSHOT'
 }
 
 # Vagrant 1.9.6 or major is required

--- a/dev-tools/vagrant/pom.xml
+++ b/dev-tools/vagrant/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-dev-tools</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/docs/developer-guide/en/running.md
+++ b/docs/developer-guide/en/running.md
@@ -157,7 +157,7 @@ For example, if your Openshift deployment is running at the address `192.168.64.
 Not all MQTT clients have WebSocket support, so we need to enable direct MQTT over TCP access to the broker as well. By default, Kapua comes with the NodePort service that routes all traffic from port `31883` to the broker.
 So you can connect your MQTT clients directly to this service. For the simulator example similar to the above, that would look something like
 
-    java -jar target/kapua-simulator-kura-1.1.0-SNAPSHOT-app.jar --broker tcp://kapua-broker:kapua-password@192.168.64.2:31883
+    java -jar target/kapua-simulator-kura-1.2.0-SNAPSHOT-app.jar --broker tcp://kapua-broker:kapua-password@192.168.64.2:31883
 
 This is suitable only for the local deployments. In the cloud or production environments, you should deploy a proper LoadBalancer Openshift service to enable external traffic flow to the broker.
 

--- a/extras/foreignkeys/pom.xml
+++ b/extras/foreignkeys/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-extras</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-foreignkeys</artifactId>        

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-extras</artifactId>

--- a/job-engine/api/pom.xml
+++ b/job-engine/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-api</artifactId>

--- a/job-engine/commons/pom.xml
+++ b/job-engine/commons/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-commons</artifactId>

--- a/job-engine/extra/pom.xml
+++ b/job-engine/extra/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-job-engine</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/job-engine/extra/remote/pom.xml
+++ b/job-engine/extra/remote/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-job-engine-extra</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-remote</artifactId>

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-jbatch</artifactId>

--- a/job-engine/pom.xml
+++ b/job-engine/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-locator</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-guice</artifactId>

--- a/locator/pom.xml
+++ b/locator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/message/api/pom.xml
+++ b/message/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-message</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-message-api</artifactId>

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-message</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-message-internal</artifactId>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
 
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
     <name>kapua</name>
 
     <packaging>pom</packaging>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-common</artifactId>

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-integration-steps</artifactId>

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -273,7 +273,7 @@ public class DockerSteps {
      * @param debugPort                debug port on docker
      * @param debugHostPort            debug port on docker host
      * @param brokerInternalDebugPort
-     * @param dockerImage              full name of image (e.g. "kapua/kapua-broker:1.1.0-SNAPSHOT")
+     * @param dockerImage              full name of image (e.g. "kapua/kapua-broker:1.2.0-SNAPSHOT")
      * @return Container configuration for specific boroker instance
      */
     private ContainerConfig getBrokerContainerConfig(String brokerAddr, String brokerIp,
@@ -355,7 +355,7 @@ public class DockerSteps {
                         "DB_PASSWORD=kapua",
                         "DB_PORT_3306_TCP_PORT=3306"
                 )
-                .image("kapua/kapua-sql:1.1.0-SNAPSHOT")
+                .image("kapua/kapua-sql:1.2.0-SNAPSHOT")
                 .build();
     }
 
@@ -400,7 +400,7 @@ public class DockerSteps {
         return ContainerConfig.builder()
                 .hostConfig(hostConfig)
                 .exposedPorts(String.valueOf(brokerPort))
-                .image("kapua/kapua-events-broker:1.1.0-SNAPSHOT")
+                .image("kapua/kapua-events-broker:1.2.0-SNAPSHOT")
                 .build();
     }
 

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-integration</artifactId>

--- a/qa/integration/src/test/resources/features/docker/broker.feature
+++ b/qa/integration/src/test/resources/features/docker/broker.feature
@@ -16,8 +16,8 @@ Feature: Testing docker steps
   Scenario: Execute possible docker steps to show its usage
     For now it only lists docker images
 
-    Given List images by name "kapua/kapua-broker:1.1.0-SNAPSHOT"
-    #And Pull image "kapua/kapua-sql:1.1.0-SNAPSHOT"
+    Given List images by name "kapua/kapua-broker:1.2.0-SNAPSHOT"
+    #And Pull image "kapua/kapua-sql:1.2.0-SNAPSHOT"
     And Pull image "elasticsearch:5.4.0"
     Then Create network
     And Start DB container with name "db"
@@ -26,10 +26,10 @@ Feature: Testing docker steps
     Then I wait 15 seconds
     And Start Message Broker container
       | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
-      | broker-1 | broker1         | 0.0.0.0  | test-cluster | 1883     | 1883         | 8883      | 8883          | 8161    | 8161        | 9999      | 9999          | 9991                   | kapua/kapua-broker:1.1.0-SNAPSHOT |
+      | broker-1 | broker1         | 0.0.0.0  | test-cluster | 1883     | 1883         | 8883      | 8883          | 8161    | 8161        | 9999      | 9999          | 9991                   | kapua/kapua-broker:1.2.0-SNAPSHOT |
     And Start Message Broker container
       | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
-      | broker-2 | broker2        | 0.0.0.0  | test-cluster | 1883     | 1884         | 8883      | 8884          | 8161    | 8162        | 9999      | 9998          | 9991                   | kapua/kapua-broker:1.1.0-SNAPSHOT |
+      | broker-2 | broker2        | 0.0.0.0  | test-cluster | 1883     | 1884         | 8883      | 8884          | 8161    | 8162        | 9999      | 9998          | 9991                   | kapua/kapua-broker:1.2.0-SNAPSHOT |
     Then I wait 30 seconds
     And Create mqtt "client-1" client for broker "0.0.0.0" on port 1883 with user "kapua-sys" and pass "kapua-password"
     And Connect to mqtt client "client-1"

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-markers</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>
@@ -80,7 +80,7 @@
                             <images>
                                 <image>
                                     <alias>db</alias>
-                                    <name>kapua/kapua-sql:1.1.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-sql:1.2.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8181:8181</port>
@@ -115,7 +115,7 @@
                                 </image>
                                 <image>
                                     <alias>events-broker</alias>
-                                    <name>kapua/kapua-events-broker:1.1.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-events-broker:1.2.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>5672:5672</port>
@@ -128,7 +128,7 @@
                                 </image>
                                 <image>
                                     <alias>broker</alias>
-                                    <name>kapua/kapua-broker:1.1.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-broker:1.2.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>1883:1883</port>
@@ -153,7 +153,7 @@
                                 </image>
                                 <image>
                                     <alias>kapua-console</alias>
-                                    <name>kapua/kapua-console:1.1.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-console:1.2.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8080:8080</port>
@@ -179,7 +179,7 @@
                                 </image>
                                 <image>
                                     <alias>kapua-api</alias>
-                                    <name>kapua/kapua-api:1.1.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-api:1.2.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8081:8080</port>

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-core</artifactId>

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api</artifactId>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-resources</artifactId>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-web</artifactId>

--- a/service/account/api/pom.xml
+++ b/service/account/api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-api</artifactId>

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-internal</artifactId>

--- a/service/account/pom.xml
+++ b/service/account/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/account/test-steps/pom.xml
+++ b/service/account/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-test-steps</artifactId>

--- a/service/account/test/pom.xml
+++ b/service/account/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-test</artifactId>

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-api</artifactId>

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-api</artifactId>

--- a/service/datastore/client-api/pom.xml
+++ b/service/datastore/client-api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>kapua-datastore-client-api</artifactId>
 

--- a/service/datastore/client-embedded/pom.xml
+++ b/service/datastore/client-embedded/pom.xml
@@ -15,7 +15,7 @@
   <parent>
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua-datastore</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>kapua-datastore-client-embedded</artifactId>
   <description>Embedded Elasticsearch node provider. To be used for test purpose</description>

--- a/service/datastore/client-rest/pom.xml
+++ b/service/datastore/client-rest/pom.xml
@@ -16,7 +16,7 @@
   <parent>
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua-datastore</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   <artifactId>kapua-datastore-client-rest</artifactId>
   

--- a/service/datastore/client-transport/pom.xml
+++ b/service/datastore/client-transport/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <artifactId>kapua-datastore-client-transport</artifactId>
 

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-internal</artifactId>

--- a/service/datastore/pom.xml
+++ b/service/datastore/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-test-steps</artifactId>

--- a/service/datastore/test/pom.xml
+++ b/service/datastore/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-test</artifactId>

--- a/service/device/api/pom.xml
+++ b/service/device/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-api</artifactId>

--- a/service/device/call/api/pom.xml
+++ b/service/device/call/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-call</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-call-api</artifactId>

--- a/service/device/call/kura/pom.xml
+++ b/service/device/call/kura/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-call</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-call-kura</artifactId>

--- a/service/device/call/pom.xml
+++ b/service/device/call/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-commons</artifactId>

--- a/service/device/management/all/api/pom.xml
+++ b/service/device/management/all/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-api</artifactId>

--- a/service/device/management/all/internal/pom.xml
+++ b/service/device/management/all/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-internal</artifactId>

--- a/service/device/management/all/job/pom.xml
+++ b/service/device/management/all/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-job</artifactId>

--- a/service/device/management/all/pom.xml
+++ b/service/device/management/all/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/api/pom.xml
+++ b/service/device/management/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-api</artifactId>

--- a/service/device/management/asset/api/pom.xml
+++ b/service/device/management/asset/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-api</artifactId>

--- a/service/device/management/asset/internal/pom.xml
+++ b/service/device/management/asset/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-internal</artifactId>

--- a/service/device/management/asset/job/pom.xml
+++ b/service/device/management/asset/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-job</artifactId>

--- a/service/device/management/asset/pom.xml
+++ b/service/device/management/asset/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/bundle/api/pom.xml
+++ b/service/device/management/bundle/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-api</artifactId>

--- a/service/device/management/bundle/internal/pom.xml
+++ b/service/device/management/bundle/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-internal</artifactId>

--- a/service/device/management/bundle/job/pom.xml
+++ b/service/device/management/bundle/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-job</artifactId>

--- a/service/device/management/bundle/pom.xml
+++ b/service/device/management/bundle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/command/api/pom.xml
+++ b/service/device/management/command/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-api</artifactId>

--- a/service/device/management/command/internal/pom.xml
+++ b/service/device/management/command/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-internal</artifactId>

--- a/service/device/management/command/job/pom.xml
+++ b/service/device/management/command/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-job</artifactId>

--- a/service/device/management/command/pom.xml
+++ b/service/device/management/command/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/management/configuration/api/pom.xml
+++ b/service/device/management/configuration/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-api</artifactId>

--- a/service/device/management/configuration/internal/pom.xml
+++ b/service/device/management/configuration/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-internal</artifactId>

--- a/service/device/management/configuration/job/pom.xml
+++ b/service/device/management/configuration/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-job</artifactId>

--- a/service/device/management/configuration/pom.xml
+++ b/service/device/management/configuration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/job/api/pom.xml
+++ b/service/device/management/job/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-job-api</artifactId>

--- a/service/device/management/job/internal/pom.xml
+++ b/service/device/management/job/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-job-internal</artifactId>

--- a/service/device/management/job/pom.xml
+++ b/service/device/management/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/packages/api/pom.xml
+++ b/service/device/management/packages/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-api</artifactId>

--- a/service/device/management/packages/internal/pom.xml
+++ b/service/device/management/packages/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-internal</artifactId>

--- a/service/device/management/packages/job/pom.xml
+++ b/service/device/management/packages/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-job</artifactId>

--- a/service/device/management/packages/pom.xml
+++ b/service/device/management/packages/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/pom.xml
+++ b/service/device/management/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/registry/api/pom.xml
+++ b/service/device/management/registry/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-registry</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-registry-api</artifactId>

--- a/service/device/management/registry/internal/pom.xml
+++ b/service/device/management/registry/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-registry</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-registry-internal</artifactId>

--- a/service/device/management/registry/pom.xml
+++ b/service/device/management/registry/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/request/api/pom.xml
+++ b/service/device/management/request/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-device-management-request</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-request-api</artifactId>

--- a/service/device/management/request/internal/pom.xml
+++ b/service/device/management/request/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-request</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-request-internal</artifactId>

--- a/service/device/management/request/pom.xml
+++ b/service/device/management/request/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/pom.xml
+++ b/service/device/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/registry/api/pom.xml
+++ b/service/device/registry/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-api</artifactId>

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-internal</artifactId>

--- a/service/device/registry/pom.xml
+++ b/service/device/registry/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/registry/test-steps/pom.xml
+++ b/service/device/registry/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-test-steps</artifactId>

--- a/service/device/registry/test/pom.xml
+++ b/service/device/registry/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-test</artifactId>

--- a/service/endpoint/api/pom.xml
+++ b/service/endpoint/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <artifactId>kapua-endpoint</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-endpoint</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-endpoint-internal</artifactId>

--- a/service/endpoint/pom.xml
+++ b/service/endpoint/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/endpoint/test-steps/pom.xml
+++ b/service/endpoint/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-endpoint</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-endpoint-test-steps</artifactId>

--- a/service/job/api/pom.xml
+++ b/service/job/api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-api</artifactId>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-internal</artifactId>

--- a/service/job/pom.xml
+++ b/service/job/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-test-steps</artifactId>

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-test</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/scheduler/api/pom.xml
+++ b/service/scheduler/api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-api</artifactId>

--- a/service/scheduler/pom.xml
+++ b/service/scheduler/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-quartz</artifactId>

--- a/service/scheduler/test-steps/pom.xml
+++ b/service/scheduler/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-test-steps</artifactId>

--- a/service/security/authentication/api/pom.xml
+++ b/service/security/authentication/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authentication</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-authentication-api</artifactId>

--- a/service/security/authentication/pom.xml
+++ b/service/security/authentication/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/security/authorization/api/pom.xml
+++ b/service/security/authorization/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authorization</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-authorization-api</artifactId>

--- a/service/security/authorization/pom.xml
+++ b/service/security/authorization/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/certificate/internal/pom.xml
+++ b/service/security/certificate/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/certificate/pom.xml
+++ b/service/security/certificate/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-security</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/pom.xml
+++ b/service/security/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/security/registration/api/pom.xml
+++ b/service/security/registration/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-registration</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration-api</artifactId>

--- a/service/security/registration/pom.xml
+++ b/service/security/registration/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration</artifactId>

--- a/service/security/registration/simple/pom.xml
+++ b/service/security/registration/simple/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-registration</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration-simple</artifactId>

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-shiro</artifactId>

--- a/service/security/test-steps/pom.xml
+++ b/service/security/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-test-steps</artifactId>

--- a/service/stream/api/pom.xml
+++ b/service/stream/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-stream</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-stream-api</artifactId>

--- a/service/stream/internal/pom.xml
+++ b/service/stream/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-stream</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-stream-internal</artifactId>

--- a/service/stream/pom.xml
+++ b/service/stream/pom.xml
@@ -14,7 +14,7 @@
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/tag/api/pom.xml
+++ b/service/tag/api/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-api</artifactId>

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-internal</artifactId>

--- a/service/tag/pom.xml
+++ b/service/tag/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/tag/test-steps/pom.xml
+++ b/service/tag/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-test-steps</artifactId>

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-test</artifactId>

--- a/service/user/api/pom.xml
+++ b/service/user/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-api</artifactId>

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-internal</artifactId>

--- a/service/user/pom.xml
+++ b/service/user/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/user/test-steps/pom.xml
+++ b/service/user/test-steps/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-test-steps</artifactId>

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-test</artifactId>

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/sso/api/pom.xml
+++ b/sso/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-sso-api</artifactId>

--- a/sso/jwt/pom.xml
+++ b/sso/jwt/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-sso-jwt</artifactId>

--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/sso/provider-generic/pom.xml
+++ b/sso/provider-generic/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-sso-provider-generic</artifactId>

--- a/sso/provider-keycloak/pom.xml
+++ b/sso/provider-keycloak/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-sso-provider-keycloak</artifactId>

--- a/sso/provider/pom.xml
+++ b/sso/provider/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-sso-provider</artifactId>

--- a/translator/api/pom.xml
+++ b/translator/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-api</artifactId>

--- a/translator/kapua/kura/pom.xml
+++ b/translator/kapua/kura/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator-kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kapua-kura</artifactId>

--- a/translator/kapua/pom.xml
+++ b/translator/kapua/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/translator/kura/jms/pom.xml
+++ b/translator/kura/jms/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator-kura</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kura-jms</artifactId>

--- a/translator/kura/mqtt/pom.xml
+++ b/translator/kura/mqtt/pom.xml
@@ -18,7 +18,7 @@
   <parent>
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua-translator-kura</artifactId>
-    <version>1.1.0-SNAPSHOT</version>
+    <version>1.2.0-SNAPSHOT</version>
   </parent>
   
   <artifactId>kapua-translator-kura-mqtt</artifactId>

--- a/translator/kura/pom.xml
+++ b/translator/kura/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/translator/pom.xml
+++ b/translator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/transport/api/pom.xml
+++ b/transport/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-api</artifactId>

--- a/transport/jms/pom.xml
+++ b/transport/jms/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-jms</artifactId>

--- a/transport/mqtt/pom.xml
+++ b/transport/mqtt/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-mqtt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.1.0-SNAPSHOT</version>
+        <version>1.2.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
After release [1.1.0](https://github.com/eclipse/kapua/releases/tag/1.1.0) we need to bump the artifact version to 1.2.0-SNAPSHOT for the next release iteration.

**Related Issue**
_None_

**Description of the solution adopted**
Bumped artifact version to `1.2.0-SNAPSHOT` of all modules.

**Screenshots**
_None_

**Any side note on the changes made**
On test side there will be likely failures. Due to the fact that those failures come from `develop` we will merge this anyway since it does not affects code, unless build errors occurs.
