### PR TITLE
Separated tests for job engine service - restart job 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -95,6 +95,10 @@ jobs:
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOnlineDeviceSecondPart" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOfflineDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOfflineDeviceI9nTest.java
@@ -19,8 +19,6 @@ import org.junit.runner.RunWith;
 @CucumberOptions(
         features = {
                 "classpath:features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature",
-                "classpath:features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature",
-                "classpath:features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature",
                 "classpath:features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature"
         },
         glue = { "org.eclipse.kapua.service.job.steps",
@@ -34,5 +32,5 @@ import org.junit.runner.RunWith;
                 "json:target/cucumber.json" },
         strict = true,
         monochrome = true)
-public class RunJobEngineServiceI9nTest {
+public class RunJobEngineServiceOfflineDeviceI9nTest {
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOnlineDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOnlineDeviceI9nTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.jobEngine;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = {
+                "classpath:features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature",
+                "classpath:features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature",
+                "classpath:features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature"
+        },
+        glue = { "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+        },
+        plugin = { "pretty",
+                "html:target/cucumber",
+                "json:target/cucumber.json" },
+        strict = true,
+        monochrome = true)
+public class RunJobEngineServiceOnlineDeviceI9nTest {
+}

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -649,7 +649,7 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -755,7 +755,7 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -763,7 +763,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -877,7 +877,7 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -984,7 +984,7 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -998,7 +998,7 @@ Feature: JobEngineService restart job tests with online device
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -1115,7 +1115,7 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1223,7 +1223,7 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1237,7 +1237,7 @@ Feature: JobEngineService restart job tests with online device
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -1320,402 +1320,6 @@ Feature: JobEngineService restart job tests with online device
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and RESOLVED
     And KuraMock is disconnected
     And I wait 1 second
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting A Job with valid Configuration Put Step And Step Index=0 For The First Time
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new valid Configuration Put step to the created job. Restart the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    When Device "is" connected
-    And I wait 1 seconds
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    Then I create a new step entity from the existing creator
-    And I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting A Job with invalid Configuration Put Step And Step Index=0 For The First Time
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device "is" connected
-    And I wait 1 seconds
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                               |
-    Then I create a new step entity from the existing creator
-    And I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting A Job with valid Configuration Put Step And Step Index=0 For The Second Time
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new valid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    When Device "is" connected
-    And I wait 1 seconds
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    Then I create a new step entity from the existing creator
-    And I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting A Job with invalid Configuration Put Step And Step Index=0 For The Second Time
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device "is" connected
-    And I wait 1 seconds
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                               |
-    Then I create a new step entity from the existing creator
-    And I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then I restart a job
-    And I wait 15 seconds
-    When I query for the job with the name "TestJob"
-    And I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    Then I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-    # *******************************************************
-    # * Restarting a job with one Target and multiple Steps *
-    # *******************************************************
-
-  Scenario: Restarting Job With Valid Configuration Put And Bundle Start Steps And Step Index=0 For The First Time
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job.
-  After the executed job is finished, the step index of executed targets should
-  be 1 and the status PROCESS_OK
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    When I start the Kura Mock
-    And Device "is" connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | 34    |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    When KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting Job With Invalid Configuration Put And Bundle Start Steps And Step Index=0 For The First Time
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    When I start the Kura Mock
-    And Device "is" connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting Job With Valid Configuration Put And Bundle Start Steps And Step Index=0 For The Second Time
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 1 and the status PROCESS_OK
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    When I start the Kura Mock
-    And Device "is" connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | 34    |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    When KuraMock is disconnected
-    And I wait 1 seconds
-    And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting Job With Invalid Configuration Put And Bundle Start Steps And Step Index=0 For The Second Time
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    When I start the Kura Mock
-    And Device "is" connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When KuraMock is disconnected
-    And I wait 1 seconds
     And Device status is "DISCONNECTED"
     And I logout
 
@@ -1831,7 +1435,7 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1839,7 +1443,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -2020,7 +1624,7 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -2033,7 +1637,7 @@ Feature: JobEngineService restart job tests with online device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -2221,7 +1825,7 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -2234,7 +1838,7 @@ Feature: JobEngineService restart job tests with online device
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -2307,176 +1911,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I wait 1 seconds
     And Device status is "DISCONNECTED"
-    And I logout
-
-  Scenario: Restarting A Job With Valid Configuration Put Step, Multiple Devices and Step Index=0 For The First Time
-  Create a new job and set a connected KuraMock devices as the job target.
-  Add a new valid Configuration Put step to the created job. Restart the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting a job with invalid Configuration Put Step, Multiple Devices And Step Index=0 For The First Time
-  Create a new job and set a connected KuraMock devices as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And I wait 1 seconds
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting A Job With Valid Configuration Put Step, Multiple Devices And Step Index=0 For The Second Time
-  Create a new job and set a connected KuraMock devices as the job target.
-  Add a new valid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting a job with invalid Configuration Put, Multiple Devices And Step Index=0 For The Second Time
-  Create a new job and set a connected KuraMock devices as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And I wait 1 seconds
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And KuraMock is disconnected
     And I logout
 
     # *************************************************************
@@ -2626,7 +2060,7 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -2634,7 +2068,7 @@ Feature: JobEngineService restart job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 1 and status is "PROCESS_OK"
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -2750,7 +2184,7 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -3096,7 +2530,7 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -3110,7 +2544,7 @@ Feature: JobEngineService restart job tests with online device
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
     And A bundle named com.google.guava with id 95 and version 19.0.0 is present and ACTIVE
     Then I restart a job
-    And I wait 15 seconds
+    And I wait 30 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2
@@ -3196,223 +2630,7 @@ Feature: JobEngineService restart job tests with online device
     And Device status is "DISCONNECTED"
     And I logout
 
-  Scenario: Restarting job with valid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
-  Create a new job. Set a connected Kura Mock devices as a job target.
-  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job.
-  After the executed job is finished, the step index of executed targets should
-  be 1 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | 34    |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
-  Create a new job. Set connected Kura Mock devices as a job target.
-  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with valid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
-  Create a new job. Set a connected Kura Mock devices as a job target.
-  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 1 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | 34    |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 1 and status is "PROCESS_OK"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
-  Create a new job. Set connected Kura Mock devices as a job target.
-  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices "are" connected
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope
-    Then I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
-      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    Then I restart a job
-    And I wait 15 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm the step index is 0 and status is "PROCESS_FAILED"
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    Then Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Stop broker after all scenarios
+   Scenario: Stop broker after all scenarios
     Given Stop Broker
 
   Scenario: Stop event broker for all scenarios

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -1,0 +1,825 @@
+###############################################################################
+# Copyright (c) 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@jobEngineRestartOnlineDeviceSecondPart
+@integration
+
+Feature: JobEngineService restart job tests with online device - second part
+
+  Scenario: Set environment variables
+    Given System property "broker.ip" with value "localhost"
+    And System property "commons.db.connection.host" with value "localhost"
+
+  Scenario: Start event broker for all scenarios
+    Given Start Event Broker
+
+  Scenario: Start broker for all scenarios
+    Given Start Broker
+
+    # *************************************************
+    # * Restarting a job with one Target and one Step *
+    # *************************************************
+
+  Scenario: Restarting A Job with valid Configuration Put Step And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add a new valid Configuration Put step to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+    Then I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting A Job with invalid Configuration Put Step And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add a new invalid Configuration Put step to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                               |
+    Then I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting A Job with valid Configuration Put Step And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add a new valid Configuration Put step to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+    Then I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting A Job with invalid Configuration Put Step And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target.
+  Add a new invalid Configuration Put step to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    When Device "is" connected
+    And I wait 1 seconds
+    Then Device status is "CONNECTED"
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                               |
+    Then I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then I restart a job
+    And I wait 15 seconds
+    When I query for the job with the name "TestJob"
+    And I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    Then I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    And KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+     # *******************************************************
+    # * Restarting a job with one Target and multiple Steps *
+    # *******************************************************
+
+  Scenario: Restarting Job With Valid Configuration Put And Bundle Start Steps And Step Index=0 For The First Time
+  Create a new job. Set a connected Kura Mock device as a job target.
+  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the step index of executed targets should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid Configuration Put And Bundle Start Steps And Step Index=0 For The First Time
+  Create a new job. Set a connected Kura Mock device as a job target.
+  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Valid Configuration Put And Bundle Start Steps And Step Index=0 For The Second Time
+  Create a new job. Set a connected Kura Mock device as a job target.
+  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the step index of executed targets should
+  be 1 and the status PROCESS_OK
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 30 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then I restart a job
+    And I wait 30 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+  Scenario: Restarting Job With Invalid Configuration Put And Bundle Start Steps And Step Index=0 For The Second Time
+  Create a new job. Set a connected Kura Mock device as a job target.
+  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I start the Kura Mock
+    And Device "is" connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    And I get the KuraMock device
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When KuraMock is disconnected
+    And I wait 1 seconds
+    And Device status is "DISCONNECTED"
+    And I logout
+
+    # *******************************************************
+    # * Restarting a job with multiple Targets and one Step *
+    # *******************************************************
+
+  Scenario: Restarting A Job With Valid Configuration Put Step, Multiple Devices and Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job target.
+  Add a new valid Configuration Put step to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+    When I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Configuration Put Step, Multiple Devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job target.
+  Add a new invalid Configuration Put step to the created job. Restart the job.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And I wait 1 seconds
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting A Job With Valid Configuration Put Step, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job target.
+  Add a new valid Configuration Put step to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
+    When I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Configuration Put, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job target.
+  Add a new invalid Configuration Put step to the created job. Restart the job two times.
+  After the executed job is finished, the executed target's step index should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And I wait 1 seconds
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    And KuraMock is disconnected
+    And I logout
+
+    # *************************************************************
+    # * Restarting a job with multiple Targets and multiple Steps *
+    # *************************************************************
+
+  Scenario: Restarting job with valid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
+  Create a new job. Set a connected Kura Mock devices as a job target.
+  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the step index of executed targets should
+  be 1 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 30 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    When KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting job with invalid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
+  Create a new job. Set connected Kura Mock devices as a job target.
+  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting job with valid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job. Set a connected Kura Mock devices as a job target.
+  Add a new valid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the step index of executed targets should
+  be 1 and the status PROCESS_OK
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 30 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then I restart a job
+    And I wait 30 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    When KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting job with invalid Configuration Put and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job. Set connected Kura Mock devices as a job target.
+  Add a new invalid Configuration Put and Bundle Start steps to the created job. Restart the job two times.
+  After the executed job is finished, the step index of executed targets should
+  be 0 and the status PROCESS_FAILED
+
+    Given I start the Kura Mock
+    Then I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock devices
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    When I count the targets in the current scope
+    Then I count 2
+    And Search for step definition with the name "Configuration Put"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name          | type                                                                           | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration  | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag>|
+      | timeout       | java.lang.Long                                                                 | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep2" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    When I create a new step entity from the existing creator
+    And I search the database for created job steps and I find 2
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    Then Configuration is requested
+    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    When KuraMock is disconnected
+    And I logout
+
+  Scenario: Stop broker after all scenarios
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+    Given Stop Event Broker

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -300,7 +300,6 @@
       Then I count 1
       And I confirm the executed job is finished
       And I search for the last job target in the database
-      And I wait 3 seconds
       And I confirm the step index is 0 and status is "PROCESS_FAILED"
       When I start the Kura Mock
       And Device "is" connected


### PR DESCRIPTION
Signed-off-by: Ana Albic <ana.albic@comtrade.com>

Brief description of the PR.
Separated tests for restarting job in job engine service.

**Related Issue**
This PR fixes/closes _{issue number}_

**Description of the solution adopted**
In this PR, test scenarios for restarting job with online device/devices are separated in two `.feature` files. Also, in job restart steps with wait are changed and in some scenarios wait is increased to 30 seconds instead of 15 seconds. 

**Screenshots**
/

**Any side note on the changes made**
/
