### PR TITLE
Fallback to byte array for non-Kura body payload

### DIFF
--- a/translator/kura/jms/src/main/java/org/eclipse/kapua/translator/jms/kura/TranslatorDataJmsKura.java
+++ b/translator/kura/jms/src/main/java/org/eclipse/kapua/translator/jms/kura/TranslatorDataJmsKura.java
@@ -16,6 +16,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.message.internal.MessageException;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
@@ -26,7 +27,7 @@ import org.eclipse.kapua.transport.message.jms.JmsTopic;
 
 /**
  * Messages translator implementation from {@link org.eclipse.kapua.transport.message.jms.JmsMessage} to {@link org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage}
- * 
+ *
  * @since 1.0
  */
 public class TranslatorDataJmsKura extends Translator<JmsMessage, KuraDataMessage> {
@@ -61,7 +62,11 @@ public class TranslatorDataJmsKura extends Translator<JmsMessage, KuraDataMessag
         KuraDataPayload kuraPayload = null;
         if (jmsPayload.getBody() != null) {
             kuraPayload = new KuraDataPayload();
-            kuraPayload.readFromByteArray(jmsPayload.getBody());
+            try {
+                kuraPayload.readFromByteArray(jmsPayload.getBody());
+            } catch (MessageException ex) {
+                kuraPayload.setBody(jmsPayload.getBody());
+            }
         }
         return kuraPayload;
     }

--- a/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/mqtt/kura/TranslatorDataMqttKura.java
+++ b/translator/kura/mqtt/src/main/java/org/eclipse/kapua/translator/mqtt/kura/TranslatorDataMqttKura.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.translator.mqtt.kura;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.message.internal.MessageException;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataChannel;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataMessage;
 import org.eclipse.kapua.service.device.call.message.kura.data.KuraDataPayload;
@@ -56,10 +57,14 @@ public class TranslatorDataMqttKura extends Translator<MqttMessage, KuraDataMess
 
     private KuraDataPayload translate(MqttPayload mqttPayload)
             throws KapuaException {
-        byte[] jmsBody = mqttPayload.getBody();
+        byte[] mqttBody = mqttPayload.getBody();
 
         KuraDataPayload kuraPayload = new KuraDataPayload();
-        kuraPayload.readFromByteArray(jmsBody);
+        try {
+            kuraPayload.readFromByteArray(mqttBody);
+        } catch (MessageException ex) {
+            kuraPayload.setBody(mqttBody);
+        }
 
         //
         // Return Kura Payload


### PR DESCRIPTION
Currently, if a message is sent to the broker that does not conform to the Kura Protobuf specification, that message is discarded. With this PR it will be stored anyway instead, with the raw payload in the body.

**Related Issue**
No related issue
