### PR TITLE
Fix metric valueType on JsonKapuaPayload

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonDatastoreMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonDatastoreMessage.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources.model.data;
 
-import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.Storable;
 import org.eclipse.kapua.service.datastore.model.StorableId;
@@ -52,7 +51,7 @@ public class JsonDatastoreMessage extends JsonKapuaDataMessage implements Storab
         setCapturedOn(datastoreMessage.getCapturedOn());
 
         setPosition(datastoreMessage.getPosition());
-        setChannel((KapuaDataChannel) datastoreMessage.getChannel());
+        setChannel(datastoreMessage.getChannel());
         setPayload(datastoreMessage.getPayload());
     }
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
@@ -48,7 +48,7 @@ public class JsonKapuaPayload {
             XmlAdaptedMetric jsonMetric = new XmlAdaptedMetric();
 
             jsonMetric.setName(metricName);
-            jsonMetric.setValueType(metricName.getClass());
+            jsonMetric.setValueType(metricValue.getClass());
             jsonMetric.setValue(ObjectValueConverter.toString(metricValue));
 
             getMetrics().add(jsonMetric);


### PR DESCRIPTION
Metrics in `JsonKapuaPayload` always have a `string` value type, no matter the real type of the metric. This PR fixes this.

**Related Issue**
Fixes #2744 