### PR TITLE
Package Install integration tests with multiple online targets

### DIFF
--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -628,7 +628,7 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout  | java.lang.Long   | 10000 |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 30 seconds
+    And I wait 45 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1 or more
@@ -722,7 +722,7 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout  | java.lang.Long   | 10000 |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 30 seconds
+    And I wait 45 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1 or more
@@ -735,7 +735,7 @@ Feature: JobEngineService restart job tests with online device - second part
     When Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     Then I restart a job
-    And I wait 30 seconds
+    And I wait 45 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 2 or more
@@ -984,6 +984,170 @@ Feature: JobEngineService restart job tests with online device - second part
     And KuraMock is disconnected
     And I logout
 
+  Scenario: Restarting a job with valid Package Install Step, Multiple Devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new valid Package Install
+  step to the created job. Restart the job. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_OK.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    And Packages are requested
+    And Number of received packages is 1
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    And Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                            |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I restart a job
+    And I wait 45 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Package Install Step, Multiple Devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new invalid Package Install
+  step to the created job. Restart the job. After the executed job is finished, the executed target's step
+  index should be 0 and the status PROCESS_FAILED.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    And Packages are requested
+    And Number of received packages is 1
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    And Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                               |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with valid Package Install Step, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock device as the job target. Add a new valid Package Install
+  step to the created job. Restart the job two times. After the executed job is finished, the executed
+  target's step index should be 0 and the status PROCESS_OK.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    And Packages are requested
+    And Number of received packages is 1
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    And Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                            |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
+    When I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 45 seconds
+    Then I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    When I restart a job
+    And I wait 45 seconds
+    Then I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Package Install Step, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new invalid Package Install
+  step to the created job. Restart the job two times. After the executed job is finished, the executed target's
+  step index should be 0 and the status PROCESS_FAILED.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    And Packages are requested
+    And Number of received packages is 1
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                               |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
+    When I create a new step entity from the existing creator
+    And I restart a job
+    And I wait 15 seconds
+    Then I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    When I restart a job
+    And I wait 15 seconds
+    Then I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    And KuraMock is disconnected
+    And I logout
+
     # *************************************************************
     # * Restarting a job with multiple Targets and multiple Steps *
     # *************************************************************
@@ -1202,6 +1366,212 @@ Feature: JobEngineService restart job tests with online device - second part
     Then Bundles are requested
     And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
     When KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with valid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new valid Package Install
+  and Bundle Start steps to the created job. Restart the job. After the executed job is finished,
+  the executed target's step index should be 1 and the status PROCESS_OK.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    Then Packages are requested
+    And Number of received packages is 1
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    Then Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                            |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 60 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new invalid Package Install
+  and Bundle Start steps to the created job. Restart the job. After the executed job is finished,
+  the executed target's step index should be 0 and the status PROCESS_FAILED.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    Then Packages are requested
+    And Number of received packages is 1
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    Then Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                               |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with valid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new valid Package Install
+  and Bundle Start steps to the created job. Restart the job two times. After the executed job is finished,
+  the executed target's step index should be 1 and the status PROCESS_OK.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    Then Packages are requested
+    And Number of received packages is 1
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    Then Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                            |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | 34    |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 45 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    Then I restart a job
+    And I wait 45 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2 or more
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 1 and status is "PROCESS_OK"
+    When Packages are requested
+    Then Number of received packages is 2
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
+    And KuraMock is disconnected
+    And I logout
+
+  Scenario: Restarting a job with invalid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
+  Create a new job and set a connected KuraMock devices as the job targets. Add a new invalid Package Install
+  and Bundle Start steps to the created job. Restart the job two times. After the executed job is finished,
+  the executed target's step index should be 0 and the status PROCESS_FAILED.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    When I add 2 devices to Kura Mock
+    And Devices "are" connected
+    And I wait 1 second
+    And I get the KuraMock devices
+    Then Packages are requested
+    And Number of received packages is 1
+    Then Bundles are requested
+    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Given I create a job with the name "TestJob"
+    And I add targets to job
+    Then Search for step definition with the name "Package Download / Install"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name                     | type                                                                                             | value                                                                                                                                                                                                                                                            |
+      | packageDownloadRequest   | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
+      | timeout                  | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
+    When I create a new step entity from the existing creator
+    Then Search for step definition with the name "Bundle Start"
+    And A regular step creator with the name "TestStep1" and the following properties
+      | name     | type             | value |
+      | bundleId | java.lang.String | #34   |
+      | timeout  | java.lang.Long   | 10000 |
+    And I create a new step entity from the existing creator
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    Then I restart a job
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 2
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I wait 1 seconds
+    And I confirm the step index is 0 and status is "PROCESS_FAILED"
+    When Packages are requested
+    Then Number of received packages is 1
+    When Bundles are requested
+    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
+    And KuraMock is disconnected
     And I logout
 
   Scenario: Stop broker after all scenarios


### PR DESCRIPTION
Brief description of the PR.
Added second part of Package Install integration tests.

**Related Issue**
This PR fixes/closes part of #2662

**Description of the solution adopted**
This PR continues the work from PR #2733, and the mentioned PR should be merged first.
After that a rebase will be performed and the number of added lines decreased.

**Added tests:**
**_//job start tests with multiple online targets:_**

1. Starting a job with valid Package Install step and multiple devices
2. Starting a job with invalid Package Install step and multiple devices
3. Starting a job with valid Package Install and Bundle Start steps and multiple devices
4. Starting a job with invalid Package Install and Bundle Start steps and multiple devices

**_//job restart tests with multiple online targets_**

5. Restarting a job with valid Package Install Step, Multiple Devices And Step Index=0 For The First Time
6. Restarting a job with invalid Package Install Step, Multiple Devices And Step Index=0 For The First Time
7. Restarting a job with valid Package Install Step, Multiple Devices And Step Index=0 For The Second Time
8. Restarting a job with invalid Package Install Step, Multiple Devices And Step Index=0 For The Second Time
9. Restarting a job with valid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
10. Restarting a job with invalid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The First Time
11. Restarting a job with valid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time
12. Restarting a job with invalid Package Install and Bundle Start Steps, Multiple Devices And Step Index=0 For The Second Time

**Screenshots**
_None_

**Any side note on the changes made**
_None_