### PR TITLE
Added integration tests for the Execute-On-Reconnect feature 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -75,6 +75,10 @@ jobs:
     - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
+    - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @triggerService" verify
+    - bash <(curl -s https://codecov.io/bash)
+  - stage: test
+    script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @account" verify
     - bash <(curl -s https://codecov.io/bash)
   - stage: test

--- a/.travis.yml
+++ b/.travis.yml
@@ -40,23 +40,18 @@ jobs:
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @brokerAcl" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @tag" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @broker" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @device" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @connection" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @datastore" verify
@@ -64,51 +59,39 @@ jobs:
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @user" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @security" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobs" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @triggerService" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @account" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineStartOfflineDevice" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineStartOnlineDevice" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOfflineDevice" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOnlineDevice" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineRestartOnlineDeviceSecondPart" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @jobEngineServiceStop" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - $M2_HOME/bin/mvn -B -DskipTests install javadoc:jar
@@ -122,3 +105,6 @@ addons:
   apt:
     packages:
     - openjdk-8-jdk
+
+after_script:
+  - bash <(curl -s https://codecov.io/bash)

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -57,3 +57,7 @@ DELETE FROM job_job_step_definition_properties WHERE step_definition_id NOT IN (
 DELETE FROM job_job_step_properties;
 
 DELETE FROM job_job_target;
+
+DELETE FROM schdl_trigger;
+
+DELETE FROM schdl_trigger_properties;

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunExecuteOnDeviceConnectI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunExecuteOnDeviceConnectI9nTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.jobScheduling;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = {
+                "classpath:features/jobScheduling/ExecuteOnDeviceConnectI9n.feature",
+        },
+        glue = { "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+                "org.eclipse.kapua.service.scheduler.steps"
+        },
+        plugin = { "pretty",
+                "html:target/cucumber",
+                "json:target/cucumber.json" },
+        strict = true,
+        monochrome = true)
+public class RunExecuteOnDeviceConnectI9nTest {
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunTriggerServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunTriggerServiceI9nTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.jobScheduling;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = {
+                "classpath:features/jobScheduling/TriggerServiceI9n.feature",
+        },
+        glue = { "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+                "org.eclipse.kapua.service.scheduler.steps"
+        },
+        plugin = { "pretty",
+                "html:target/cucumber",
+                "json:target/cucumber.json" },
+        strict = true,
+        monochrome = true)
+public class RunTriggerServiceI9nTest {
+}

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -1,0 +1,335 @@
+###############################################################################
+# Copyright (c) 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@jobs
+@triggerService
+@integration
+
+Feature: JobEngineService execute job on device connect
+
+  Scenario: Start event broker for all scenarios
+    Given Start Event Broker
+
+  Scenario: Start broker for all scenarios
+    Given Start Broker
+
+  Scenario: Executing Job When Device Connected After The Specified Start Date And Time
+    Login as the kapua-sys user and create a new job with a Command Execution job step.
+    Define a new "Device Connect" schedule and add it to the created job.
+    The schedule should have a start date in the past and no defined end date.
+    Add a previously disconnected KuraMock device as the job target.
+    After the restart of the KuraMock device the job should be started.
+    The execution of the job should be confirmed, the job targets step index should be
+    0 and status PROCESS_OK.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When KuraMock is disconnected
+    And I wait 1 second
+    Then Device status is "DISCONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "DEATH"
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "TestSchedule1"
+    And The trigger is set to start today at 00:00.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And I restart the Kura Mock
+    And I wait 2 seconds
+    When Device is connected
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "COMMAND"
+    And I logout
+
+  Scenario: Executing Job When Device Connected Before The Specified Start Date And Time
+    Login as the kapua-sys user and create a new job with a Command Execution job step.
+    Define a new "Device Connect" schedule and add it to the created job.
+    The schedule should have a start date in the future and no defined end date.
+    Add a previously disconnected KuraMock device as the job target.
+    After the restart of the KuraMock device the job should not be started.
+    No executions of the job should be found, the job targets step index should be
+    0 and status PROCESS_AWAITING.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When KuraMock is disconnected
+    And I wait 1 second
+    Then Device status is "DISCONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "DEATH"
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "TestSchedule2"
+    And The trigger is set to start tomorrow at 06:00.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And I restart the Kura Mock
+    And I wait 2 seconds
+    When Device is connected
+    And I wait 10 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 0
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BIRTH"
+    And I logout
+
+  Scenario: Executing Job When Device Connected Before End Date And Time
+    Login as the kapua-sys user and create a new job with a Command Execution job step.
+    Define a new "Device Connect" schedule and add it to the created job.
+    The schedule should have start and end dates in the future.
+    Add a previously disconnected KuraMock device as the job target.
+    After the restart of the KuraMock device the job should be started.
+    The execution of the job should be confirmed, the job targets step index should be
+    0 and status PROCESS_OK.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When KuraMock is disconnected
+    And I wait 1 second
+    Then Device status is "DISCONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "DEATH"
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "TestSchedule3"
+    And The trigger is set to start today at 00:00.
+    And The trigger is set to end tomorrow at 20:00.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And I restart the Kura Mock
+    And I wait 2 seconds
+    When Device is connected
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "COMMAND"
+    And I logout
+
+    Scenario: Executing Job When Device Connected After End Date And Time
+      Login as the kapua-sys user and create a new job with a Command Execution job step.
+      Define a new "Device Connect" schedule and add it to the created job.
+      The schedule should have start and end dates in the past.
+      Add a previously disconnected KuraMock device as the job target.
+      After the KuraMock is reconnected the job should not be started.
+      No executions of the job should be found, the job targets step index should be
+      0 and status PROCESS_AWAITING.
+
+      Given I start the Kura Mock
+      When Device is connected
+      And I wait 1 second
+      Then Device status is "CONNECTED"
+      When KuraMock is disconnected
+      And I wait 1 second
+      Then Device status is "DISCONNECTED"
+      When I login as user with name "kapua-sys" and password "kapua-password"
+      And I select account "kapua-sys"
+      And I get the KuraMock device
+      When I search for events from device "rpione3" in account "kapua-sys"
+      Then I find 2 device event
+      And The type of the last event is "DEATH"
+      Given I create a job with the name "TestJob"
+      And A new job target item
+      And Search for step definition with the name "Command Execution"
+      And A regular step creator with the name "TestStep" and the following properties
+        | name         | type                                                                    | value                                                                                                                                         |
+        | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+        | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+      When I create a new step entity from the existing creator
+      Then No exception was thrown
+      And I found trigger properties with name "Device Connect"
+      And A regular trigger creator with the name "TestSchedule4"
+      And The trigger is set to start on 10-10-2018 at 6:00.
+      And The trigger is set to end on 15-10-2018 at 6:00.
+      Then I create a new trigger from the existing creator with previously defined date properties
+      And I restart the Kura Mock
+      And I wait 2 seconds
+      When Device is connected
+      And I wait 10 seconds
+      Given I query for the job with the name "TestJob"
+      When I query for the execution items for the current job
+      Then I count 0
+      And I search for the last job target in the database
+      And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+      When I search for events from device "rpione3" in account "kapua-sys"
+      Then I find 3 device events
+      And The type of the last event is "BIRTH"
+      And I logout
+
+  Scenario: Executing Job And Then Restarting Device
+    Login as the kapua-sys user and create a new job with a Command Execution job step.
+    Define a new "Device Connect" schedule and add it to the created job.
+    The schedule should have a start date in the past and no defined end date.
+    Add a previously disconnected KuraMock device as the job target.
+    After the KuraMock is reconnected the job should be started.
+    Another restart of the KuraMock the should not trigger another job execution.
+    The previous execution of the job should be confirmed, and the job targets step
+    index should be 0 and status PROCESS_OK.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When KuraMock is disconnected
+    And I wait 1 second
+    Then Device status is "DISCONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "DEATH"
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    And Search for step definition with the name "Command Execution"
+    And A regular step creator with the name "TestStep" and the following properties
+      | name         | type                                                                    | value                                                                                                                                         |
+      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput  | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
+      | timeout      | java.lang.Long                                                          | 10000                                                                                                                                         |
+    When I create a new step entity from the existing creator
+    Then No exception was thrown
+    And I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "TestSchedule1"
+    And The trigger is set to start today at 00:00.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And I restart the Kura Mock
+    When Device is connected
+    And I wait 2 seconds
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 4 device events
+    And The type of the last event is "COMMAND"
+    Then KuraMock is disconnected
+    And I wait 2 seconds
+    When I restart the Kura Mock
+    Then Device is connected
+    And I wait 15 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 1
+    And I confirm the executed job is finished
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_OK"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 6 device events
+    And The type of the last event is "BIRTH"
+    And I logout
+
+  Scenario: Executing Job Without Steps
+    Login as the kapua-sys user and create a new job without any steps defined.
+    Create a new "Device Connect" schedule and add it to the created job.
+    The schedule should have a start date in the past and no defined end date.
+    Add a previously disconnected KuraMock device as the job target.
+    After the KuraMock is restarted there should be no job executions found as
+    there are no job steps defined.
+    The job targets step index should be 0 and the status PROCESS_AWAITING.
+
+    Given I start the Kura Mock
+    When Device is connected
+    And I wait 1 second
+    Then Device status is "CONNECTED"
+    When KuraMock is disconnected
+    And I wait 1 second
+    Then Device status is "DISCONNECTED"
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I get the KuraMock device
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 2 device event
+    And The type of the last event is "DEATH"
+    Given I create a job with the name "TestJob"
+    And A new job target item
+    Then I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "TestSchedule1"
+    And The trigger is set to start today at 00:00.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And I restart the Kura Mock
+    When Device is connected
+    And I wait 2 seconds
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 3 device events
+    And The type of the last event is "BIRTH"
+    Then KuraMock is disconnected
+    And I wait 2 seconds
+    When I restart the Kura Mock
+    Then Device is connected
+    And I wait 10 seconds
+    Given I query for the job with the name "TestJob"
+    When I query for the execution items for the current job
+    Then I count 0
+    And I search for the last job target in the database
+    And I confirm the step index is 0 and status is "PROCESS_AWAITING"
+    When I search for events from device "rpione3" in account "kapua-sys"
+    Then I find 5 device events
+    And The type of the last event is "BIRTH"
+    And I logout
+
+  Scenario: Stop broker after all scenarios
+    Given Stop Broker
+
+  Scenario: Stop event broker for all scenarios
+    Given Stop Event Broker

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -1,0 +1,235 @@
+###############################################################################
+# Copyright (c) 2019 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@jobs
+@triggerService
+@integration
+
+Feature: Trigger service tests
+
+  Scenario: Adding "Device Connect" Schedule With All Valid Parameters
+    Login as kapua-sys user and create a job with name job0.
+    Add schedule0 with a valid start date to the created job.
+    No errors should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    And The trigger is set to start today at 10:00.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And I logout
+
+    # ***********************
+    # * Schedule Name Tests *
+    # ***********************
+
+  Scenario: Adding "Device Connect" Schedule Without Name
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule with a valid start date but
+    without defining its name. A KapuaIllegalNullArgumentException
+    should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name ""
+    And The trigger is set to start today at 10:00.
+    When I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    And I create a new trigger from the existing creator with previously defined date properties
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Name Only
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule0, without defining any other property
+    except the schedule name. A KapuaIllegalNullArgumentException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    When I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    And I create a new trigger from the existing creator with previously defined date properties
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Non-Unique Name
+    Login as kapua-sys user and create a job with name job0.
+    Add schedule1 to the created job. After the schedule1 is added
+    successfully try to add a new schedule with the same name.
+    A KapuaDuplicateNameException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule1"
+    And The trigger is set to start today at 10:00.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And A regular trigger creator with the name "schedule1"
+    And The trigger is set to start today at 12:00.
+    When I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same value for field already exists"
+    And I create a new trigger from the existing creator with previously defined date properties
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Max Length Name
+    Login as kapua-sys user and create a job with name job0.
+    Add a new schedule with 255 character long name.
+    As this is the defined limit for the max number of characters
+    for the schedule name, no errors should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww"
+    And The trigger is set to start today at 10:00.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Min Length Name
+    Login as kapua-sys user and create a job with name job0.
+    Add a new schedule with one character long name.
+    As this is the defined limit for the min number of characters
+    for the schedule name, no errors should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "w"
+    And The trigger is set to start today at 10:00.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And I logout
+
+    # *****************************
+    # * Schedule Start Date Tests *
+    # *****************************
+
+  Scenario: Adding "Device Connect" Schedule Without The Start Date Parameter
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule0 without passing the value for start date property.
+    A KapuaIllegalNullArgumentException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create a new trigger from the existing creator with previously defined date properties
+    And An exception was thrown
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Non-Unique Start Date Parameter
+    Login as kapua-sys user and create a job with name job0.
+    Create a new schedule0 with a specific start date parameter.
+    Try to create a new schedule1 with the same start date parameter.
+    No errors should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    And The trigger is set to start on 12-12-2020 at 10:10.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And A regular trigger creator with the name "schedule1"
+    And The trigger is set to start on 12-12-2020 at 10:10.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With Start Date Only
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule with a defined start date but
+    without setting the name parameter.
+    A KapuaIllegalNullArgumentException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A trigger creator without a name
+    And The trigger is set to start on 12-12-2020 at 10:10.
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create a new trigger from the existing creator with previously defined date properties
+    And An exception was thrown
+    And I logout
+
+    # ***************************
+    # * Schedule End Date Tests *
+    # ***************************
+
+  Scenario: Adding "Device Connect" Schedule With Non-Unique End Date Parameter
+    Login as kapua-sys user and create a job with name job0.
+    Create a new schedule0 with specific start and end date parameters.
+    Try to create a new schedule1 with the same end date parameter.
+    No errors should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    Then A regular trigger creator with the name "schedule0"
+    And The trigger is set to start on 12-01-2020 at 10:10.
+    And The trigger is set to end on 15-12-2020 at 10:10.
+    Then I create a new trigger from the existing creator with previously defined date properties
+    And A regular trigger creator with the name "schedule1"
+    And The trigger is set to start on 12-12-2020 at 10:10.
+    And The trigger is set to end on 15-12-2020 at 10:10.
+    And I create a new trigger from the existing creator with previously defined date properties
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With End Date Only
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a schedule without defining any other property except the end date.
+    A KapuaIllegalNullArgumentException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A trigger creator without a name
+    And The trigger is set to end on 12-12-2020 at 10:10.
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided"
+    When I create a new trigger from the existing creator with previously defined date properties
+    And An exception was thrown
+    And I logout
+
+    # *************************************************
+    # * Schedule Start And Stop Date Comparison Tests *
+    # *************************************************
+
+  Scenario: Adding "Device Connect" Schedule With End Time before Start time
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule0 with start date later than the end date.
+    A KapuaEndBeforeStartTimeException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    And The trigger is set to start on 12-12-2020 at 10:00.
+    And The trigger is set to end on 10-12-2020 at 10:00.
+    When I expect the exception "KapuaEndBeforeStartTimeException" with the text "The start time cannot be later than the end time."
+    And I create a new trigger from the existing creator with previously defined date properties
+    And An exception was thrown
+    And I logout
+
+  Scenario: Adding "Device Connect" Schedule With the same Start and End time
+    Login as kapua-sys user and create a job with name job0.
+    Try to create a new schedule0 with start date the same as the end date.
+    A KapuaException should be thrown.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a job with the name "job0"
+    When I found trigger properties with name "Device Connect"
+    And A regular trigger creator with the name "schedule0"
+    And The trigger is set to start on 12-12-2020 at 10:00.
+    And The trigger is set to end on 12-12-2020 at 10:00.
+    When I expect the exception "KapuaException" with the text "Start and end time cannot be at the same point in time"
+    And I create a new trigger from the existing creator with previously defined date properties
+    And  An exception was thrown
+    And I logout

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
@@ -201,6 +201,21 @@ public class BrokerSteps extends TestBase {
         stepData.put("KuraDevices", kuraDevices);
     }
 
+    @When("^I restart the Kura Mock$")
+    public void restartKuraMock() throws Exception {
+        ArrayList<KuraDevice> kuraDevices = (ArrayList<KuraDevice>) stepData.get("KuraDevices");
+        List<KuraDevice> restartedKuraDevices = new ArrayList<>();
+        if (!kuraDevices.isEmpty()) {
+            for (KuraDevice kuraDevice : kuraDevices) {
+                kuraDevice.mqttClientSetup();
+                kuraDevice.mqttClientConnect();
+                restartedKuraDevices.add(kuraDevice);
+            }
+        }
+        stepData.put("KuraDevices", restartedKuraDevices);
+    }
+
+
     @When("I get the KuraMock device(?:|s)$")
     public void getKuraMockDevice() throws Exception {
         ArrayList<Device> deviceList = new ArrayList<>();

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
@@ -187,7 +187,7 @@ public class KuraDevice implements MqttCallback {
     /**
      * Prepare client and server part of mocked mqtt.
      */
-    private void mqttClientSetup() {
+    public void mqttClientSetup() {
         /*
          * mqttClient is meant to simulate Kura device for sending messages,
          * while subscribedClient is meant to receive messages from Kura device side.

--- a/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
+++ b/service/scheduler/test-steps/src/main/java/org/eclipse/kapua/service/scheduler/steps/JobScheduleServiceSteps.java
@@ -43,8 +43,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Date;
 import java.util.List;
 
@@ -66,6 +68,7 @@ public class JobScheduleServiceSteps extends TestBase {
 // ****************************************************************************************
 
     private static final Logger LOGGER = LoggerFactory.getLogger(JobScheduleServiceSteps.class);
+    private static final String KAPUA_ID_CLASS_NAME = "org.eclipse.kapua.model.id.KapuaId";
 
     // Default constructor
     @Inject
@@ -171,6 +174,31 @@ public class JobScheduleServiceSteps extends TestBase {
         }
     }
 
+    @And("^A regular trigger creator with the name \"([^\"]*)\"$")
+    public void aRegularTriggerCreatorWithTheName(String triggerName) {
+        TriggerCreator triggerCreator = triggerFactory.newCreator(getCurrentScopeId());
+        KapuaId currentTriggerDefId = (KapuaId) stepData.get("TriggerDefinitionId");
+        KapuaId jobId = (KapuaId) stepData.get("CurrentJobId");
+
+        triggerCreator.setName(triggerName);
+        triggerCreator.setTriggerDefinitionId(currentTriggerDefId);
+        triggerCreator.getTriggerProperties().add(triggerDefinitionFactory.newTriggerProperty("jobId", KAPUA_ID_CLASS_NAME, jobId.toCompactId()));
+        triggerCreator.getTriggerProperties().add(triggerDefinitionFactory.newTriggerProperty("scopeId", KAPUA_ID_CLASS_NAME, getCurrentScopeId().toCompactId()));
+        stepData.remove("TriggerCreator");
+        stepData.put("TriggerCreator", triggerCreator);
+    }
+
+    @And("^A trigger creator without a name")
+    public void aTriggerCreatorWithoutAName() {
+        TriggerCreator triggerCreator = triggerFactory.newCreator(getCurrentScopeId());
+        KapuaId currentTriggerDefId = (KapuaId) stepData.get("TriggerDefinitionId");
+
+        triggerCreator.setTriggerDefinitionId(currentTriggerDefId);
+        triggerCreator.setName(null);
+
+        stepData.put("TriggerCreator", triggerCreator);
+    }
+
     @And("^A regular trigger creator with the name \"([^\"]*)\" and following properties$")
     public void aRegularTriggerCreatorWithTheNameAndFollowingProperties(String triggerName, List<CucTriggerProperty> list) {
         TriggerCreator triggerCreator = triggerFactory.newCreator(getCurrentScopeId());
@@ -228,6 +256,117 @@ public class JobScheduleServiceSteps extends TestBase {
         } catch (Exception ex) {
             verifyException(ex);
         }
+    }
+
+    @And("^I create a new trigger from the existing creator with previously defined date properties$")
+    public void createTriggerWithDateProperties() throws Exception {
+        TriggerCreator triggerCreator = (TriggerCreator) stepData.get("TriggerCreator");
+        Date startDate = (Date) stepData.get("TriggerStartDate");
+        Date endDate = (Date) stepData.get("TriggerEndDate");
+        triggerCreator.setScopeId(getCurrentScopeId());
+        triggerCreator.setStartsOn(startDate);
+        triggerCreator.setEndsOn(endDate);
+        primeException();
+        try {
+            stepData.remove("Trigger");
+            stepData.remove("CurrentTriggerId");
+            Trigger trigger = triggerService.create(triggerCreator);
+            trigger.getTriggerProperties();
+            stepData.put("Trigger", trigger);
+            stepData.put("CurrentTriggerId", trigger.getId());
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+    @And("^The trigger is set to start on (.*) at (.*).")
+    public void setTriggerStartDate(String startDateStr, String startTimeStr) throws Exception {
+        try {
+            primeException();
+            Date startDate = setDateAndTimeValue(startDateStr, startTimeStr);
+            stepData.put("TriggerStartDate", startDate);
+        } catch (ParseException ex) {
+           verifyException(ex);
+        }
+    }
+
+    @And("^The trigger is set to start today at (.*).")
+    public void setTodayAsTriggerStartDate(String startTimeStr) throws Exception {
+        try {
+            primeException();
+            Date startDate = setTodayAsDateValue(startTimeStr);
+            stepData.put("TriggerStartDate", startDate);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+    @And("^The trigger is set to start tomorrow at (.*).")
+    public void setTomorrowAsTriggerStartDate(String startTimeStr) throws Exception {
+        try {
+            primeException();
+            Date startDate = setTomorrowAsDateValue(startTimeStr);
+            stepData.put("TriggerStartDate", startDate);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+    @And("^The trigger is set to end tomorrow at (.*).")
+    public void setTomorrowAsTriggerEndDate(String startTimeStr) throws Exception {
+        try {
+            primeException();
+            Date endDate = setTomorrowAsDateValue(startTimeStr);
+            stepData.put("TriggerEndDate", endDate);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+    @And("^The trigger is set to end on (.*) at (.*).")
+    public void setTriggerEndDate(String endDateStr, String endTimeStr) throws Exception {
+        try {
+            primeException();
+            Date endDate = setDateAndTimeValue(endDateStr, endTimeStr);
+            stepData.put("TriggerEndDate", endDate);
+        } catch (ParseException ex) {
+            verifyException(ex);
+        }
+    }
+
+    private Date setDateAndTimeValue(String dateStr, String timeStr) throws ParseException {
+        Date date = new SimpleDateFormat("dd-MM-yyyy").parse(dateStr);
+        String [] timeComponents = timeStr.split(":");
+        int hour = Integer.parseInt(timeComponents[0]);
+        int minutes = Integer.parseInt(timeComponents[1]);
+        date.setHours(hour);
+        date.setMinutes(minutes);
+        return date;
+    }
+
+    private Date setTomorrowAsDateValue(String timeStr) {
+        Date date = new Date();
+        Calendar calendar = Calendar.getInstance();
+        calendar.setTime(date);
+        calendar.add(Calendar.DATE, 1);
+        date = calendar.getTime();
+
+        String [] timeComponents = timeStr.split(":");
+        int hour = Integer.parseInt(timeComponents[0]);
+        int minutes = Integer.parseInt(timeComponents[1]);
+        date.setHours(hour);
+        date.setMinutes(minutes);
+        return date;
+    }
+
+    private Date setTodayAsDateValue(String timeString) {
+        Date date = new Date();
+        String [] timeComponents = timeString.split(":");
+        int hour = Integer.parseInt(timeComponents[0]);
+        int minutes = Integer.parseInt(timeComponents[1]);
+        date.setHours(hour);
+        date.setMinutes(minutes);
+        return date;
     }
 }
 


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Added integration tests for the Execute-On-Reconnect feature.

**Related Issue**
This PR fixes/closes part of #2757

**Description of the solution adopted**
The added integration tests are divided into two groups/ feature files.
The first and main group of tests checks the execution of the created job with added `Device Connect` schedule, restarted `KuraMock` device as the job target and a `Command Execution` step . 
List of added tests - _ExecuteOnDeviceConnectI9n.feature_:

1. Executing Job When Device Connected After The Specified Start Date And Time
2. Executing Job When Device Connected Before The Specified Start Date And Time
3. Executing Job When Device Connected Before End Date And Time
4. Executing Job When Device Connected After End Date And Time
5. Executing Job And Then Restarting Device
6. Executing Job Without Steps

The second group/feature file contains the missing tests for the `TriggerService`, for checking the process of creating a `Device Connect` schedule with different valid as well as invalid input parameters. List of added tests - _TriggerServiceI9n.feature_:

1. Adding "Device Connect" Schedule With All Valid Parameters
2. Adding "Device Connect" Schedule Without Name
3. Adding "Device Connect" Schedule With Name Only
4. Adding "Device Connect" Schedule With Non-Unique Name
5. Adding "Device Connect" Schedule With Max Length Name
6. Adding "Device Connect" Schedule With Min Length Name
7. Adding "Device Connect" Schedule Without The Start Date Parameter
8. Adding "Device Connect" Schedule With Non-Unique Start Date Parameter
9. Adding "Device Connect" Schedule With Start Date Only
10. Adding "Device Connect" Schedule With Non-Unique End Date Parameter
11. Adding "Device Connect" Schedule With End Date Only
12. Adding "Device Connect" Schedule With End Time before Start time
13. Adding "Device Connect" Schedule With the same Start and End time

Updated `.travis.yml` file for running the new group of tests with `@triggerService` tag. 
Updated the `all_delete.sql` file in the qa package to correctly clear trigger data from the test database.
Added new step for restarting the KuraMock to the BrokerSteps class. 
Added the needed methods to the JobScheduleServiceSteps class.

**Screenshots**
_None_

**Any side note on the changes made**
_None_