### PR TITLE
Fixed Broker configuration on Vagrant machine

### DIFF
--- a/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
+++ b/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
@@ -15,6 +15,8 @@ BROKER_ASSEMBLY_DIR="/kapua/assembly/broker";
 BROKER_CORE_DEPENDENCY_DIR="/kapua/broker-core/target/dependency";
 BROKER_INSTALLATION_DIR="/usr/local/activemq";
 
+VAGRANT_DEPENDENCY_DIR="/kapua/dev-tools/vagrant/target/dependency";
+
 echo "Cleanup the symbolic links to Kapua jars..."
 for name in $(find lib/extra -type l);
     do
@@ -32,6 +34,14 @@ for name in $(ls  ${BROKER_CORE_DEPENDENCY_DIR} | grep -Ev 'qa|jaxb-|activemq-|k
         ln -s  ${BROKER_CORE_DEPENDENCY_DIR}/${name} ./lib/extra/${name};
     done;
 echo "    Copy dependencies for broker-core... DONE!"
+
+echo "    Copy additional dependencies for broker-core..."
+for name in $(ls  ${VAGRANT_DEPENDENCY_DIR});
+    do
+        echo "        Create symbolic link from ./lib/extra/${name}  ${VAGRANT_DEPENDENCY_DIR}/${name}";
+        ln -s  ${VAGRANT_DEPENDENCY_DIR}/${name} ./lib/extra/${name};
+    done;
+echo "    Copy additional dependencies for broker-core... DONE!"
 
 echo '    Copy Kapua modules...'
 for name in $(find /kapua -name 'kapua-*.jar' | grep target | grep -Ev 'qa|bin|test|console|WEB-INF|dependency|mysql|assembly|dev-tools');

--- a/dev-tools/vagrant/pom.xml
+++ b/dev-tools/vagrant/pom.xml
@@ -23,5 +23,30 @@
     <packaging>pom</packaging>
     <artifactId>kapua-dev-tools-vagrant</artifactId>
 
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <id>Copy provided dependencies</id>
+                        <goals>
+                            <goal>copy-dependencies</goal>
+                        </goals>
+                        <configuration>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+    <dependencies>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+    </dependencies>
 
 </project>


### PR DESCRIPTION
This PR fixes the setup of the Vagrant development machine.

**Related Issue**
_None_

**Description of the solution adopted**
After merge of #2737 vagrant machine configuration was broker since the broker lost tracking of H2 dependency that contained also the JDBC driver.

**Screenshots**
_None_

**Any side note on the changes made**
_None_