### PR TITLE
Fixed typo in PackageAppProperties metrics names

### DIFF
--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
@@ -75,25 +75,25 @@ public enum PackageAppProperties implements KapuaAppProperties {
      *
      * @since 1.1.0
      */
-    APP_PROPERTY_PACKAGE_DOWNLOAD_USERNAME("kapau.package.download.username"),
+    APP_PROPERTY_PACKAGE_DOWNLOAD_USERNAME("kapua.package.download.username"),
     /**
      * URI password
      *
      * @since 1.1.0
      */
-    APP_PROPERTY_PACKAGE_DOWNLOAD_PASSWORD("kapau.package.download.password"),
+    APP_PROPERTY_PACKAGE_DOWNLOAD_PASSWORD("kapua.package.download.password"),
     /**
      * File hash
      *
      * @since 1.1.0
      */
-    APP_PROPERTY_PACKAGE_DOWNLOAD_FILE_HASH("kapau.package.download.file.hash"),
+    APP_PROPERTY_PACKAGE_DOWNLOAD_FILE_HASH("kapua.package.download.file.hash"),
     /**
      * File type
      *
      * @since 1.1.0
      */
-    APP_PROPERTY_PACKAGE_DOWNLOAD_FILE_TYPE("kapau.package.download.file.type"),
+    APP_PROPERTY_PACKAGE_DOWNLOAD_FILE_TYPE("kapua.package.download.file.type"),
     /**
      * Package install
      *


### PR DESCRIPTION
Fixed metric names that contained a typo.

**Related Issue**
_None_

**Description of the solution adopted**
Renamed from `kapau.*` to `kapua.*` some metrics.

**Screenshots**
_None_

**Any side note on the changes made**
_None_