### PR TITLE
Fix device management lifecycle APPS message processing

### DIFF
--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,33 +12,37 @@
 package org.eclipse.kapua.service.device.registry.lifecycle.internal;
 
 import com.google.common.base.Strings;
-
+import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaOptimisticLockingException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
-import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthPayload;
 import org.eclipse.kapua.message.device.lifecycle.KapuaDisconnectMessage;
+import org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
+import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceCreator;
 import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
-import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventServiceImpl;
 import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+
+import javax.validation.constraints.NotNull;
 
 /**
  * {@link DeviceLifeCycleService} implementation.
@@ -48,29 +52,35 @@ import org.slf4j.LoggerFactory;
 @KapuaProvider
 public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
 
-    private static final Logger logger = LoggerFactory.getLogger(DeviceEventServiceImpl.class);
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceLifeCycleServiceImpl.class);
 
-    private static final int MAX_ITERATION = 3;
+    private static final int MAX_RETRY = 3;
     private static final double MAX_WAIT = 500d;
 
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final DeviceEventService DEVICE_EVENT_SERVICE = LOCATOR.getService(DeviceEventService.class);
+    private static final DeviceEventFactory DEVICE_EVENT_FACTORY = LOCATOR.getFactory(DeviceEventFactory.class);
+
+    private static final DeviceRegistryService DEVICE_REGISTRY_SERVICE = LOCATOR.getService(DeviceRegistryService.class);
+    private static final DeviceFactory DEVICE_FACTORY = LOCATOR.getFactory(DeviceFactory.class);
+
     @Override
-    public void birth(KapuaId connectionId, KapuaBirthMessage message)
-            throws KapuaException {
-        KapuaBirthPayload payload = message.getPayload();
-        KapuaBirthChannel channel = message.getChannel();
+    public void birth(KapuaId connectionId, KapuaBirthMessage message) throws KapuaException {
+
         KapuaId scopeId = message.getScopeId();
         KapuaId deviceId = message.getDeviceId();
 
+        KapuaBirthPayload payload = message.getPayload();
+        KapuaBirthChannel channel = message.getChannel();
+
         //
         // Device update
-        KapuaLocator locator = KapuaLocator.getInstance();
-        DeviceRegistryService deviceRegistryService = locator.getService(DeviceRegistryService.class);
-        Device device = null;
+        Device device;
         if (deviceId == null) {
             String clientId = channel.getClientId();
 
-            DeviceFactory deviceFactory = locator.getFactory(DeviceFactory.class);
-            DeviceCreator deviceCreator = deviceFactory.newCreator(scopeId, clientId);
+            DeviceCreator deviceCreator = DEVICE_FACTORY.newCreator(scopeId, clientId);
 
             deviceCreator.setDisplayName(payload.getDisplayName());
             deviceCreator.setSerialNumber(payload.getSerialNumber());
@@ -93,166 +103,165 @@ public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
             // issue #57
             deviceCreator.setConnectionId(connectionId);
 
-            device = deviceRegistryService.create(deviceCreator);
+            device = DEVICE_REGISTRY_SERVICE.create(deviceCreator);
         } else {
-            int iteration = 0;
-            do {
-                try {
-                    device = deviceRegistryService.find(scopeId, deviceId);
+            device = updateDeviceInfoFromMessage(scopeId, deviceId, message.getPayload(), connectionId);
+        }
 
-                    // If the BirthMessage does not contain a 'Display Name' keep the one registered on the DeviceRegistryService.
-                    if (!Strings.isNullOrEmpty(payload.getDisplayName())) {
-                        device.setDisplayName(payload.getDisplayName());
-                    }
+        //
+        // Event create
+        createLifecycleEvent(device, "BIRTH", message);
+    }
 
-                    device.setSerialNumber(payload.getSerialNumber());
-                    device.setModelId(payload.getModelId());
-                    device.setModelName(payload.getModelName());
-                    device.setImei(payload.getModemImei());
-                    device.setImsi(payload.getModemImsi());
-                    device.setIccid(payload.getModemIccid());
-                    device.setBiosVersion(payload.getBiosVersion());
-                    device.setFirmwareVersion(payload.getFirmwareVersion());
-                    device.setOsVersion(payload.getOsVersion());
-                    device.setJvmVersion(payload.getJvmVersion());
-                    device.setOsgiFrameworkVersion(payload.getContainerFrameworkVersion());
-                    device.setApplicationFrameworkVersion(payload.getApplicationFrameworkVersion());
-                    device.setConnectionInterface(payload.getConnectionInterface());
-                    device.setConnectionIp(payload.getConnectionIp());
-                    device.setApplicationIdentifiers(payload.getApplicationIdentifiers());
-                    device.setAcceptEncoding(payload.getAcceptEncoding());
+    @Override
+    public void applications(KapuaId connectionId, KapuaAppsMessage message) throws KapuaException {
 
-                    // issue #57
-                    device.setConnectionId(connectionId);
+        Device device = updateDeviceInfoFromMessage(message.getScopeId(), message.getDeviceId(), message.getPayload(), connectionId);
 
-                    device = deviceRegistryService.update(device);
-                    break;
+        //
+        // Event create
+        createLifecycleEvent(device, "APPLICATION", message);
+    }
+
+    @Override
+    public void missing(KapuaId connectionId, KapuaMissingMessage message) throws KapuaException {
+        KapuaId scopeId = message.getScopeId();
+        KapuaId deviceId = message.getDeviceId();
+
+        //
+        // Event create
+        createLifecycleEvent(scopeId, deviceId, "MISSING", message);
+    }
+
+    @Override
+    public void death(KapuaId connectionId, KapuaDisconnectMessage message) throws KapuaException {
+        KapuaId scopeId = message.getScopeId();
+        KapuaId deviceId = message.getDeviceId();
+
+        //
+        // Event create
+        createLifecycleEvent(scopeId, deviceId, "DEATH", message);
+    }
+
+    /**
+     * Updates the {@link Device} infos from the {@link KapuaBirthPayload} (or {@link org.eclipse.kapua.message.device.lifecycle.KapuaAppsPayload}.
+     * <p>
+     * Tries to update the {@link Device} a number of times to allow close device updates to be stored properly.
+     *
+     * @param scopeId      The {@link Device#getScopeId()} to update.
+     * @param deviceId     The {@link Device#getId()} to update.
+     * @param payload      The {@link KapuaBirthPayload} from which extract data.
+     * @param connectionId The {@link DeviceConnection#getId()}
+     * @return The updated {@link Device}.
+     * @throws KapuaException If {@link Device} does not exists or {@link DeviceRegistryService#update(KapuaEntity)} causes an error.
+     * @since 1.2.0
+     */
+    private Device updateDeviceInfoFromMessage(KapuaId scopeId, KapuaId deviceId, KapuaBirthPayload payload, KapuaId connectionId) throws KapuaException {
+
+        Device device = null;
+
+        int retry = 0;
+        do {
+            retry++;
+
+            try {
+                device = DEVICE_REGISTRY_SERVICE.find(scopeId, deviceId);
+
+                if (device == null) {
+                    throw new KapuaEntityNotFoundException(Device.TYPE, deviceId);
                 }
-                catch (KapuaOptimisticLockingException e) {
-                    logger.warn("Concurrent update for device {}... try again (if maximum attempts is not reach)", device.getClientId());
-                    if (iteration++ >= MAX_ITERATION) {
-                        throw e;
-                    }
+
+                // If the BirthMessage does not contain a 'Display Name' keep the one registered on the DeviceRegistryService.
+                if (!Strings.isNullOrEmpty(payload.getDisplayName())) {
+                    device.setDisplayName(payload.getDisplayName());
+                }
+
+                device.setSerialNumber(payload.getSerialNumber());
+                device.setModelId(payload.getModelId());
+                device.setModelName(payload.getModelName());
+                device.setImei(payload.getModemImei());
+                device.setImsi(payload.getModemImsi());
+                device.setIccid(payload.getModemIccid());
+                device.setBiosVersion(payload.getBiosVersion());
+                device.setFirmwareVersion(payload.getFirmwareVersion());
+                device.setOsVersion(payload.getOsVersion());
+                device.setJvmVersion(payload.getJvmVersion());
+                device.setOsgiFrameworkVersion(payload.getContainerFrameworkVersion());
+                device.setApplicationFrameworkVersion(payload.getApplicationFrameworkVersion());
+                device.setConnectionInterface(payload.getConnectionInterface());
+                device.setConnectionIp(payload.getConnectionIp());
+                device.setApplicationIdentifiers(payload.getApplicationIdentifiers());
+                device.setAcceptEncoding(payload.getAcceptEncoding());
+
+                // issue #57
+                device.setConnectionId(connectionId);
+
+                device = DEVICE_REGISTRY_SERVICE.update(device);
+                break;
+            } catch (KapuaOptimisticLockingException e) {
+                LOG.warn("Concurrent update for device: {}... Attempt: {}/{}. {}", device.getClientId(), retry, MAX_RETRY, retry < MAX_RETRY ? "Retrying..." : "Raising exception!");
+
+                if (retry < MAX_RETRY) {
                     try {
-                        Thread.sleep((long)(Math.random() * MAX_WAIT));
+                        Thread.sleep((long) (Math.random() * MAX_WAIT));
                     } catch (InterruptedException e1) {
-                        logger.warn("Error while waiting {}", e.getMessage(), e);
+                        LOG.warn("Error while waiting retry: {}", e.getMessage());
                     }
+                } else {
+                    throw e;
                 }
             }
-            while(iteration < MAX_ITERATION);
         }
+        while (retry < MAX_RETRY);
 
-        //
-        // Event create
-        DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
-        DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, device.getId(), message.getReceivedOn(), "BIRTH");
+        return device;
+    }
 
-        deviceEventCreator.setEventMessage(payload.toDisplayString());
-        // TODO check this change
+
+    /**
+     * Creates a {@link DeviceEvent} from the {@link KapuaLifecycleMessage}.
+     * <p>
+     * Internally invokes {@link DeviceRegistryService#find(KapuaId, KapuaId)} with the given parameters and
+     * then uses {@link #createLifecycleEvent(Device, String, KapuaLifecycleMessage)}
+     *
+     * @param scopeId  The {@link Device#getScopeId()} of the {@link Device} that generated the {@link KapuaLifecycleMessage}.
+     * @param deviceId The {@link Device#getId()} of the {@link Device} that generated the {@link KapuaLifecycleMessage}.
+     * @param resource The resource used to publish the {@link KapuaLifecycleMessage}
+     * @param message  The {@link KapuaLifecycleMessage} from which to extranct data.
+     * @throws KapuaException if storing the {@link DeviceEvent} throws a {@link KapuaException}
+     * @since 1.2.0
+     */
+    private DeviceEvent createLifecycleEvent(@NotNull KapuaId scopeId, KapuaId deviceId, @NotNull String resource, @NotNull KapuaLifecycleMessage<?, ?> message) throws KapuaException {
+
+        Device device = DEVICE_REGISTRY_SERVICE.find(scopeId, deviceId);
+
+        return createLifecycleEvent(device, resource, message);
+    }
+
+    /**
+     * Creates a {@link DeviceEvent} from the {@link KapuaLifecycleMessage}.
+     *
+     * @param device   The {@link Device} that generated the {@link KapuaLifecycleMessage}.
+     * @param resource The resource used to publish the {@link KapuaLifecycleMessage}
+     * @param message  The {@link KapuaLifecycleMessage} from which to extranct data.
+     * @throws KapuaException if storing the {@link DeviceEvent} throws a {@link KapuaException}
+     * @since 1.2.0
+     */
+    private DeviceEvent createLifecycleEvent(@NotNull Device device, @NotNull String resource, @NotNull KapuaLifecycleMessage<?, ?> message) throws KapuaException {
+
+        DeviceEventCreator deviceEventCreator = DEVICE_EVENT_FACTORY.newCreator(device.getScopeId(), device.getId(), message.getReceivedOn(), resource);
         deviceEventCreator.setResponseCode(KapuaResponseCode.ACCEPTED);
         deviceEventCreator.setSentOn(message.getSentOn());
 
-        KapuaPosition position = message.getPosition();
-        if (position != null) {
-            deviceEventCreator.setPosition(position);
+        if (message.getPayload() != null) {
+            deviceEventCreator.setEventMessage(message.getPayload().toDisplayString());
         }
-
-        KapuaSecurityUtils.doPrivileged(() -> deviceEventService.create(deviceEventCreator));
-    }
-
-    @Override
-    public void death(KapuaId connectionId, KapuaDisconnectMessage message)
-            throws KapuaException {
-        KapuaId scopeId = message.getScopeId();
-        KapuaId deviceId = message.getDeviceId();
-
-        //
-        // Device update
-        KapuaLocator locator = KapuaLocator.getInstance();
-
-        //
-        // Event create
-        DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
-        DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, deviceId, message.getReceivedOn(), "DEATH");
-
-        deviceEventCreator.setReceivedOn(message.getReceivedOn());
-        // TODO check this change
-        deviceEventCreator.setResponseCode(KapuaResponseCode.ACCEPTED);
-        deviceEventCreator.setSentOn(message.getSentOn());
 
         KapuaPosition position = message.getPosition();
         if (position != null) {
             deviceEventCreator.setPosition(position);
         }
 
-        KapuaSecurityUtils.doPrivileged(() -> deviceEventService.create(deviceEventCreator));
-    }
-
-    @Override
-    public void missing(KapuaId connectionId, KapuaMissingMessage message)
-            throws KapuaException {
-        KapuaPayload payload = message.getPayload();
-        KapuaId scopeId = message.getScopeId();
-        KapuaId deviceId = message.getDeviceId();
-
-        //
-        // Device update
-        KapuaLocator locator = KapuaLocator.getInstance();
-        DeviceRegistryService deviceRegistryService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceRegistryService.find(scopeId, deviceId);
-
-        //
-        // Event create
-        DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
-        DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, device.getId(), message.getReceivedOn(), "MISSING");
-
-        deviceEventCreator.setEventMessage(payload.toDisplayString());
-        // TODO check this change
-        deviceEventCreator.setResponseCode(KapuaResponseCode.ACCEPTED);
-        deviceEventCreator.setSentOn(message.getReceivedOn());
-
-        KapuaPosition position = message.getPosition();
-        if (position != null) {
-            deviceEventCreator.setPosition(position);
-        }
-
-        KapuaSecurityUtils.doPrivileged(() -> deviceEventService.create(deviceEventCreator));
-
-    }
-
-    @Override
-    public void applications(KapuaId connectionId, KapuaAppsMessage message)
-            throws KapuaException {
-        KapuaPayload payload = message.getPayload();
-        KapuaId scopeId = message.getScopeId();
-        KapuaId deviceId = message.getDeviceId();
-
-        //
-        // Device update
-        KapuaLocator locator = KapuaLocator.getInstance();
-        DeviceRegistryService deviceRegistryService = locator.getService(DeviceRegistryService.class);
-        Device device = deviceRegistryService.find(scopeId, deviceId);
-
-        //
-        // Event create
-        DeviceEventService deviceEventService = locator.getService(DeviceEventService.class);
-        DeviceEventFactory deviceEventFactory = locator.getFactory(DeviceEventFactory.class);
-        DeviceEventCreator deviceEventCreator = deviceEventFactory.newCreator(scopeId, device.getId(), message.getReceivedOn(), "APPLICATION");
-
-        deviceEventCreator.setEventMessage(payload.toDisplayString());
-        // TODO check this change
-        deviceEventCreator.setResponseCode(KapuaResponseCode.ACCEPTED);
-        deviceEventCreator.setSentOn(message.getReceivedOn());
-
-        KapuaPosition position = message.getPosition();
-        if (position != null) {
-            deviceEventCreator.setPosition(position);
-        }
-
-        KapuaSecurityUtils.doPrivileged(() -> deviceEventService.create(deviceEventCreator));
+        return KapuaSecurityUtils.doPrivileged(() -> DEVICE_EVENT_SERVICE.create(deviceEventCreator));
     }
 }


### PR DESCRIPTION
Fixed the processing of the APP message from the DeviceLifecycleService.

**Related Issue**
_None_

**Description of the solution adopted**
On the processing of the APPS message from the service, the Device info update was missing and only the lastEvent was updated.

Now the service stores correctly updated device infos from the APPS message. 

**Screenshots**
_None_

**Any side note on the changes made**
I've also performed a small improvement of the code