### PR TITLE
Fix REST-API device/{deviceId}/request API

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
@@ -12,7 +12,7 @@
 package org.eclipse.kapua.app.api.core.exception;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.exception.model.KapuaExceptionInfo;
+import org.eclipse.kapua.app.api.core.exception.model.ExceptionInfo;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,7 +31,7 @@ public class KapuaExceptionMapper implements ExceptionMapper<KapuaException> {
         LOG.error("Generic Kapua exception!", kapuaException);
         return Response
                 .serverError()
-                .entity(new KapuaExceptionInfo(Status.INTERNAL_SERVER_ERROR, kapuaException.getCode(), kapuaException))
+                .entity(new ExceptionInfo(Status.INTERNAL_SERVER_ERROR, kapuaException.getCode(), kapuaException))
                 .build();
     }
 

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
@@ -11,6 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.exception.model;
 
+import io.swagger.annotations.ApiModelProperty;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
@@ -18,14 +23,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import io.swagger.annotations.ApiModelProperty;
-import org.eclipse.kapua.KapuaEntityNotFoundException;
-import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.model.id.KapuaIdAdapter;
-
 @XmlRootElement(name = "entityNotFoundExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class EntityNotFoundExceptionInfo extends KapuaExceptionInfo {
+public class EntityNotFoundExceptionInfo extends ExceptionInfo {
 
     @XmlElement(name = "entityType")
     private String entityType;

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
@@ -11,21 +11,26 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.exception.model;
 
-import javax.ws.rs.core.Response.Status;
-import javax.xml.bind.annotation.XmlElement;
-
 import org.eclipse.kapua.KapuaErrorCode;
 import org.eclipse.kapua.KapuaException;
 
-public class KapuaExceptionInfo extends ThrowableInfo {
+import javax.ws.rs.core.Response.Status;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement(name = "exceptionInfo")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class ExceptionInfo extends ThrowableInfo {
 
     @XmlElement(name = "kapuaErrorCode")
     private String kapuaErrorCode;
 
-    public KapuaExceptionInfo() {
+    public ExceptionInfo() {
     }
 
-    public KapuaExceptionInfo(Status httpStatus, KapuaErrorCode kapuaErrorCode, KapuaException exception) {
+    public ExceptionInfo(Status httpStatus, KapuaErrorCode kapuaErrorCode, KapuaException exception) {
         super(httpStatus, exception);
         setKapuaErrorCode(kapuaErrorCode);
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
@@ -11,17 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.exception.model;
 
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.eclipse.kapua.KapuaIllegalArgumentException;
-
 @XmlRootElement(name = "illegalArgumentExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class IllegalArgumentExceptionInfo extends KapuaExceptionInfo {
+public class IllegalArgumentExceptionInfo extends ExceptionInfo {
 
     @XmlElement(name = "argumentName")
     private String argumentName;

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
@@ -11,17 +11,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.exception.model;
 
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-import org.eclipse.kapua.KapuaIllegalNullArgumentException;
-
 @XmlRootElement(name = "illegalNullArgumentExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class IllegalNullArgumentExceptionInfo extends KapuaExceptionInfo {
+public class IllegalNullArgumentExceptionInfo extends ExceptionInfo {
 
     @XmlElement(name = "argumentName")
     private String argumentName;

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "subjectUnauthorizedExceptionInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-public class SubjectUnauthorizedExceptionInfo extends KapuaExceptionInfo {
+public class SubjectUnauthorizedExceptionInfo extends ExceptionInfo {
 
     @XmlElement(name = "permission")
     private Permission permission;

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources.model.message;
 
+import io.swagger.annotations.ApiModelProperty;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.xml.XmlAdaptedMetric;
 import org.eclipse.kapua.model.type.ObjectValueConverter;
@@ -24,8 +25,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.ArrayList;
 import java.util.List;
-
-import io.swagger.annotations.ApiModelProperty;
 
 @XmlRootElement(name = "payload")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -44,12 +43,12 @@ public class JsonKapuaPayload {
 
         setBody(payload.getBody());
 
-        payload.getMetrics().forEach((metricName, metricValue) -> {
-            XmlAdaptedMetric jsonMetric = new XmlAdaptedMetric();
+        payload.getMetrics().entrySet().stream().filter((metric) -> metric.getValue() != null).forEach((metric) -> {
 
-            jsonMetric.setName(metricName);
-            jsonMetric.setValueType(metricValue.getClass());
-            jsonMetric.setValue(ObjectValueConverter.toString(metricValue));
+            XmlAdaptedMetric jsonMetric = new XmlAdaptedMetric();
+            jsonMetric.setName(metric.getKey());
+            jsonMetric.setValueType(metric.getValue().getClass());
+            jsonMetric.setValue(ObjectValueConverter.toString(metric.getValue()));
 
             getMetrics().add(jsonMetric);
         });

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.app.api.web;
 
 import org.eclipse.kapua.app.api.core.exception.model.EntityNotFoundExceptionInfo;
+import org.eclipse.kapua.app.api.core.exception.model.ExceptionInfo;
 import org.eclipse.kapua.app.api.core.exception.model.IllegalArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.core.exception.model.IllegalNullArgumentExceptionInfo;
 import org.eclipse.kapua.app.api.core.exception.model.SubjectUnauthorizedExceptionInfo;
@@ -131,11 +132,11 @@ import org.eclipse.kapua.service.device.management.command.DeviceCommandXmlRegis
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationXmlRegistry;
-import org.eclipse.kapua.service.device.management.message.request.xml.RequestMessageXmlRegistry;
 import org.eclipse.kapua.service.device.management.message.notification.OperationStatus;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestChannel;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestPayload;
+import org.eclipse.kapua.service.device.management.message.request.xml.RequestMessageXmlRegistry;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackage;
@@ -233,6 +234,7 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
 
                     // REST API exception models
                     ThrowableInfo.class,
+                    ExceptionInfo.class,
 
                     SubjectUnauthorizedExceptionInfo.class,
 


### PR DESCRIPTION
This PR fixes the REST API resource: `device/{deviceId}/request`

**Related Issue**
_None_

**Description of the solution adopted**
Found the problem where when one of metric value on the answer payload was `null`.
Now those metrics will be not serialized. 

**Screenshots**
_None_

**Any side note on the changes made**
I've also found a problem on the mapping of the `KapuaExceptionInfo` on XML format. I've performed a refactoring fixing also that. 