### PR TITLE
Job Targets CSV Export and Jobs Registry readonly REST API

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
@@ -11,11 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.job.client.targets;
 
-import com.extjs.gxt.ui.client.event.ButtonEvent;
-import com.extjs.gxt.ui.client.event.SelectionListener;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.Element;
-import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
@@ -29,6 +24,14 @@ import org.eclipse.kapua.app.console.module.job.shared.model.permission.JobSessi
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobService;
 import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobServiceAsync;
 
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.http.client.URL;
+import com.google.gwt.user.client.Element;
+import com.google.gwt.user.client.Window;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
 public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
 
     private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
@@ -38,6 +41,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
     private GwtJob gwtSelectedJob;
 
     private Button jobStartTargetButton;
+    private Button exportButton;
 
     public JobTabTargetsToolbar(GwtSession currentSession) {
         super(currentSession, true);
@@ -81,9 +85,31 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
         jobStartTargetButton.disable();
         addExtraButton(jobStartTargetButton);
 
+        exportButton = new Button(JOB_MSGS.exportToCSV(), new KapuaIcon(IconSet.FILE_TEXT_O),
+                new SelectionListener<ButtonEvent>() {
+
+                    @Override
+                    public void componentSelected(ButtonEvent be) {
+                        export();
+                    }
+                });
+        exportButton.disable();
+        addExtraButton(exportButton);
         super.onRender(target, index);
 
         checkButtons();
+    }
+
+    private void export() {
+        StringBuilder sbUrl = new StringBuilder("exporter_job_target?format=")
+                .append("csv")
+                .append("&scopeId=")
+                .append(URL.encodeQueryString(currentSession.getSelectedAccountId()));
+
+            sbUrl.append("&jobId=")
+                    .append(gwtSelectedJob.getId());
+
+        Window.open(sbUrl.toString(), "_blank", "location=no");
     }
 
     @Override
@@ -96,10 +122,14 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
                 .setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.delete())
                         && currentSession.hasPermission(JobSessionPermission.write()));
         deleteEntityButton.setText(JOB_MSGS.tabTargetsDeleteButton());
+        exportButton.setEnabled(gwtSelectedJob != null);
     }
 
     private void checkButtons() {
         if (gwtSelectedJob != null) {
+            if (exportButton != null) {
+                exportButton.setEnabled(true);
+            }
             JOB_SERVICE.find(currentSession.getSelectedAccountId(), gwtSelectedJob.getId(), new AsyncCallback<GwtJob>() {
 
                 @Override
@@ -136,6 +166,10 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
             if (jobStartTargetButton != null) {
                 jobStartTargetButton.setEnabled(false);
             }
+            if (exportButton != null) {
+                exportButton.setEnabled(false);
+            }
         }
     }
+
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporter.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.servlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+
+public abstract class JobTargetExporter {
+
+    protected static final String BLANK = "";
+
+    protected static final String[] JOB_TARGET_PROPERTIES = {
+            "Job Target ID",
+            "Job ID",
+            "Device ID",
+            "Step Index",
+            "Status",
+            "Status Message",
+            "Client ID",
+            "Display Name"
+
+    };
+
+    protected HttpServletResponse response;
+
+    protected JobTargetExporter(HttpServletResponse response) {
+        this.response = response;
+    }
+
+    public abstract void init(String account, String jobId)
+            throws ServletException, IOException, KapuaException;
+
+    public abstract void append(KapuaListResult<JobTarget> jobTargets)
+            throws ServletException, IOException, KapuaException;
+
+    public abstract void close()
+            throws ServletException, IOException;
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.servlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+import java.net.URLEncoder;
+import java.nio.charset.Charset;
+import java.text.DateFormat;
+import java.text.SimpleDateFormat;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdFactory;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceAttributes;
+import org.eclipse.kapua.service.device.registry.DeviceFactory;
+import org.eclipse.kapua.service.device.registry.DeviceListResult;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+
+import com.opencsv.CSVWriter;
+
+public class JobTargetExporterCsv extends JobTargetExporter {
+
+    private String scopeId;
+    private String jobId;
+    private DateFormat dateFormat;
+    private CSVWriter writer;
+
+    public JobTargetExporterCsv(HttpServletResponse response) {
+        super(response);
+    }
+
+    @Override
+    public void init(final String scopeId, String jobId)
+            throws ServletException, IOException, KapuaException {
+        this.scopeId = scopeId;
+        this.jobId = jobId;
+        dateFormat = new SimpleDateFormat("MM/dd/yyyy HH:mm:ss.SSS");
+
+        response.setContentType("text/csv");
+        response.setCharacterEncoding("UTF-8");
+        response.setHeader("Content-Disposition", "attachment; filename*=UTF-8''" + URLEncoder.encode(jobId, "UTF-8") + "_job_targets.csv");
+        response.setHeader("Cache-Control", "no-transform, max-age=0");
+
+        OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream(), Charset.forName("UTF-8"));
+        writer = new CSVWriter(osw);
+
+        List<String> cols = new ArrayList<String>();
+        Collections.addAll(cols, JOB_TARGET_PROPERTIES);
+        writer.writeNext(cols.toArray(new String[] {}));
+    }
+
+    @Override
+    public void append(KapuaListResult<JobTarget> jobTargets)
+            throws ServletException, IOException, KapuaException {
+
+        KapuaLocator locator = KapuaLocator.getInstance();
+        final KapuaIdFactory kapuaIdFactory = locator.getFactory(KapuaIdFactory.class);
+        final DeviceRegistryService deviceRegistryService = locator.getService(DeviceRegistryService.class);
+        final DeviceFactory deviceFactory = locator.getFactory(DeviceFactory.class);
+        final DeviceQuery deviceQuery = deviceFactory.newQuery(kapuaIdFactory.newKapuaId(scopeId));
+
+        KapuaId[] targetIds = new KapuaId[jobTargets.getSize()];
+        int i = 0;
+        for (JobTarget jobTarget : jobTargets.getItems()) {
+            targetIds[i] = jobTarget.getJobTargetId();
+            i++;
+        }
+        deviceQuery.setPredicate(deviceQuery.attributePredicate(DeviceAttributes.ENTITY_ID, targetIds));
+        DeviceListResult deviceListResult = deviceRegistryService.query(deviceQuery);
+        Map<String, String> targetClientIdMapping = new HashMap<String, String>();
+        Map<String, String> targetDisplayNameMapping = new HashMap<String, String>();
+        for (Device device : deviceListResult.getItems()) {
+            targetClientIdMapping.put(device.getId().toCompactId(), device.getClientId());
+            targetDisplayNameMapping.put(device.getId().toCompactId(), device.getDisplayName());
+        }
+        for (final JobTarget jobTarget : jobTargets.getItems()) {
+
+            List<String> cols = new ArrayList<String>();
+            String deviceId = jobTarget.getJobTargetId().toCompactId();
+
+            // Job Target ID
+            cols.add(jobTarget.getId().toCompactId());
+
+            // Job ID
+            cols.add(jobId);
+
+            // Device ID
+            cols.add(deviceId);
+
+            // Step Index
+            cols.add(Integer.toString(jobTarget.getStepIndex()));
+
+            // Status
+            cols.add(jobTarget.getStatus().name());
+
+            // Status Message
+            cols.add(jobTarget.getStatusMessage());
+
+            // Client ID
+            String clientId = targetClientIdMapping.get(deviceId);
+            cols.add(clientId != null ? clientId : BLANK);
+
+            // Sent on
+            String displayName = targetDisplayNameMapping.get(deviceId);
+            cols.add(displayName != null ? displayName : BLANK);
+
+            writer.writeNext(cols.toArray(new String[] {}));
+        }
+    }
+
+    @Override
+    public void close()
+            throws ServletException, IOException {
+        writer.flush();
+        writer.close();
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterServlet.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterServlet.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.servlet;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaIllegalAccessException;
+import org.eclipse.kapua.KapuaUnauthenticatedException;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaIdFactory;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
+import org.eclipse.kapua.service.job.targets.JobTargetFactory;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
+import org.eclipse.kapua.service.job.targets.JobTargetService;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class JobTargetExporterServlet extends HttpServlet {
+
+    private static final long serialVersionUID = -2533869595709953567L;
+    private static final Logger logger = LoggerFactory.getLogger(JobTargetExporterServlet.class);
+
+    @Override
+    public void doGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        String reqPathInfo = request.getPathInfo();
+        if (reqPathInfo != null) {
+            response.sendError(404);
+            return;
+        }
+
+        internalDoGet(request, response);
+    }
+
+    private void internalDoGet(HttpServletRequest request, HttpServletResponse response)
+            throws ServletException, IOException {
+        try {
+            // parameter extraction
+            String format = request.getParameter("format");
+            final String scopeId = request.getParameter("scopeId");
+            final String jobId = request.getParameter("jobId");
+
+            // data exporter
+            JobTargetExporter jobTargetExporter;
+            if ("csv".equals(format)) {
+                jobTargetExporter = new JobTargetExporterCsv(response);
+            } else {
+                throw new IllegalArgumentException("format");
+            }
+
+            if (scopeId == null || scopeId.isEmpty()) {
+                throw new IllegalArgumentException("scopeId");
+            }
+
+            if (jobId == null || jobId.isEmpty()) {
+                throw new IllegalArgumentException("jobId");
+            }
+
+            //
+            // get the job and the targets and append them to the exporter
+            KapuaLocator locator = KapuaLocator.getInstance();
+            KapuaIdFactory kapuaIdFactory = locator.getFactory(KapuaIdFactory.class);
+            JobTargetService jobTargetService = locator.getService(JobTargetService.class);
+            JobTargetFactory jobTargetFactory = locator.getFactory(JobTargetFactory.class);
+
+            jobTargetExporter.init(scopeId, jobId);
+
+            int offset = 0;
+
+            JobTargetQuery jobTargetQuery = jobTargetFactory.newQuery(kapuaIdFactory.newKapuaId(scopeId));
+            jobTargetQuery.setPredicate(jobTargetQuery.attributePredicate(JobTargetAttributes.JOB_ID, kapuaIdFactory.newKapuaId(jobId)));
+            // paginate through the matching message
+            jobTargetQuery.setLimit(250);
+
+            KapuaListResult<JobTarget> totalJobTargets = jobTargetFactory.newListResult();
+            KapuaListResult<JobTarget> results;
+            do {
+                jobTargetQuery.setOffset(offset);
+                results = jobTargetService.query(jobTargetQuery);
+                if (results.getSize() > 0) {
+                    totalJobTargets.addItems(results.getItems());
+                }
+                offset += totalJobTargets.getSize();
+            } while (results.getSize() > 0);
+
+            jobTargetExporter.append(totalJobTargets);
+
+            // Close things up
+            jobTargetExporter.close();
+        } catch (IllegalArgumentException iae) {
+            logger.info("Failed to export", iae);
+            response.sendError(400, "Illegal value for query parameter: " + iae.getMessage());
+            return;
+        } catch (KapuaEntityNotFoundException eenfe) {
+            response.sendError(400, eenfe.getMessage());
+            return;
+        } catch (KapuaUnauthenticatedException eiae) {
+            response.sendError(401, eiae.getMessage());
+            return;
+        } catch (KapuaIllegalAccessException eiae) {
+            response.sendError(403, eiae.getMessage());
+            return;
+        } catch (Exception e) {
+            logger.error("Error creating device export", e);
+            throw new ServletException(e);
+        }
+    }
+}

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -115,6 +115,10 @@ dialogDeleteTargetConfirmation=Targets successfully deleted.
 dialogDeleteTargetError=Error removing target: {0}
 
 #
+# Target Export button
+exportToCSV=Export to CSV
+
+#
 # Add steps dialog
 dialogAddStepError=Error while adding step: {0}
 dialogAddStepErrorFetchStepDefinitions=Error while fetching step definitions: {0}

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -58,6 +58,7 @@
         <url-pattern>/exporter_usage/*</url-pattern>
         <url-pattern>/exporter_device/*</url-pattern>
         <url-pattern>/exporter_device_event/*</url-pattern>
+        <url-pattern>/exporter_job_target/*</url-pattern>
         <url-pattern>/settings/*</url-pattern>
         <url-pattern>/role/*</url-pattern>
         <url-pattern>/accessrole/*</url-pattern>
@@ -369,6 +370,15 @@
     <servlet-mapping>
         <servlet-name>jobTargetServlet</servlet-name>
         <url-pattern>/jobTarget</url-pattern>
+    </servlet-mapping>
+
+    <servlet>
+        <servlet-name>jobTargetExporterServlet</servlet-name>
+        <servlet-class>org.eclipse.kapua.app.console.module.job.servlet.JobTargetExporterServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>jobTargetExporterServlet</servlet-name>
+        <url-pattern>/exporter_job_target/*</url-pattern>
     </servlet-mapping>
 
     <servlet>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -55,6 +55,14 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-scheduler-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-stream-api</artifactId>
         </dependency>
         <dependency>

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -1,0 +1,177 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
+import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
+import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
+import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
+import org.eclipse.kapua.service.job.execution.JobExecutionService;
+import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
+import org.eclipse.kapua.service.job.targets.JobTargetFactory;
+import org.eclipse.kapua.service.job.targets.JobTargetListResult;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
+import org.eclipse.kapua.service.job.targets.JobTargetService;
+
+@Path("{scopeId}/jobs/{jobId}/executions")
+public class JobExecutions extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final JobExecutionService jobExecutionService = locator.getService(JobExecutionService.class);
+    private final JobTargetService jobTargetService = locator.getService(JobTargetService.class);
+    private final JobExecutionFactory jobExecutionFactory = locator.getFactory(JobExecutionFactory.class);
+    private final JobTargetFactory jobTargetFactory = locator.getFactory(JobTargetFactory.class);
+
+    /**
+     * Gets the {@link JobExecution} list for a given {@link Job}.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param jobId   The {@link Job} id to filter results
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link JobExecutionListResult} of all the jobs executions associated to the current selected job.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobExecutionListResult simpleQuery(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        JobExecutionQuery query = jobExecutionFactory.newQuery(scopeId);
+
+        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId));
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return query(scopeId, jobId, query);
+    }
+
+    /**
+     * Queries the results with the given {@link JobExecutionQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobExecutionQuery} to use to filter results.
+     * @return The {@link JobExecutionListResult} of all the result matching the given {@link JobExecutionQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_query")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public JobExecutionListResult query(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            JobExecutionQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId));
+        return jobExecutionService.query(query);
+    }
+
+    /**
+     * Counts the results with the given {@link JobExecutionQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobExecutionQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link JobExecutionQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_count")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public CountResult count(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            JobExecutionQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, jobId));
+
+        return new CountResult(jobExecutionService.count(query));
+    }
+
+    /**
+     * Returns the Job specified by the "jobId" path parameter.
+     *
+     * @param scopeId The {@link ScopeId} of the requested {@link Job}.
+     * @param jobId The id of the requested Job.
+     * @param executionId The id of the requested JobExecution.
+     * @return The requested Job object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Path("{executionId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobExecution find(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @PathParam("executionId") EntityId executionId) throws Exception {
+        JobExecutionQuery jobExecutionQuery = jobExecutionFactory.newQuery(scopeId);
+        jobExecutionQuery.setPredicate(jobExecutionQuery.andPredicate(
+                jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobId),
+                jobExecutionQuery.attributePredicate(JobExecutionAttributes.ENTITY_ID, executionId)
+        ));
+        jobExecutionQuery.setOffset(0);
+        jobExecutionQuery.setLimit(1);
+        JobExecutionListResult jobExecutionListResult = jobExecutionService.query(jobExecutionQuery);
+
+        if (jobExecutionListResult.isEmpty()) {
+            throw new KapuaEntityNotFoundException(JobExecution.TYPE, executionId);
+        }
+
+        return jobExecutionListResult.getFirstItem();
+    }
+
+    @GET
+    @Path("{executionId}/targets")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobTargetListResult executionsByTarget(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @PathParam("executionId") EntityId executionId,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        JobExecution jobExecution = jobExecutionService.find(scopeId, executionId);
+        JobTargetQuery jobTargetQuery = jobTargetFactory.newQuery(scopeId);
+        jobTargetQuery.setPredicate(jobTargetQuery.attributePredicate(JobTargetAttributes.ENTITY_ID, jobExecution.getTargetIds().toArray(new KapuaId[0])));
+        jobTargetQuery.setLimit(limit);
+        jobTargetQuery.setOffset(offset);
+
+        return jobTargetService.query(jobTargetQuery);
+    }
+
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
@@ -1,0 +1,178 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
+import org.eclipse.kapua.service.job.execution.JobExecutionFactory;
+import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
+import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
+import org.eclipse.kapua.service.job.execution.JobExecutionService;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
+import org.eclipse.kapua.service.job.targets.JobTargetFactory;
+import org.eclipse.kapua.service.job.targets.JobTargetListResult;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
+import org.eclipse.kapua.service.job.targets.JobTargetService;
+
+@Path("{scopeId}/jobs/{jobId}/targets")
+public class JobTargets extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final JobTargetService jobTargetService = locator.getService(JobTargetService.class);
+    private final JobExecutionService jobExecutionService = locator.getService(JobExecutionService.class);
+    private final JobTargetFactory jobTargetFactory = locator.getFactory(JobTargetFactory.class);
+    private final JobExecutionFactory jobExecutionFactory = locator.getFactory(JobExecutionFactory.class);
+
+    /**
+     * Gets the {@link JobTarget} list for a given {@link Job}.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param jobId   The {@link Job} id to filter results
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link JobTargetListResult} of all the jobs targets associated to the current selected job.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobTargetListResult simpleQuery(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        JobTargetQuery query = jobTargetFactory.newQuery(scopeId);
+
+        query.setPredicate(query.attributePredicate(JobTargetAttributes.JOB_ID, jobId));
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return query(scopeId, jobId, query);
+    }
+
+    /**
+     * Queries the results with the given {@link JobTargetQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobTargetQuery} to use to filter results.
+     * @return The {@link JobTargetListResult} of all the result matching the given {@link JobTargetQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_query")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public JobTargetListResult query(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            JobTargetQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(query.attributePredicate(JobTargetAttributes.JOB_ID, jobId));
+        return jobTargetService.query(query);
+    }
+
+    /**
+     * Counts the results with the given {@link JobTargetQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobTargetQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link JobTargetQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_count")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public CountResult count(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            JobTargetQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(query.attributePredicate(JobTargetAttributes.JOB_ID, jobId));
+
+        return new CountResult(jobTargetService.count(query));
+    }
+
+    /**
+     * Returns the Job specified by the "jobId" path parameter.
+     *
+     * @param scopeId The {@link ScopeId} of the requested {@link Job}.
+     * @param jobId The id of the requested Job.
+     * @param targetId The id of the requested JobTarget.
+     * @return The requested Job object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Path("{targetId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobTarget find(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @PathParam("targetId") EntityId targetId) throws Exception {
+        JobTargetQuery jobTargetQuery = jobTargetFactory.newQuery(scopeId);
+        jobTargetQuery.setPredicate(jobTargetQuery.andPredicate(
+                jobTargetQuery.attributePredicate(JobTargetAttributes.JOB_ID, jobId),
+                jobTargetQuery.attributePredicate(JobTargetAttributes.ENTITY_ID, targetId)
+        ));
+        jobTargetQuery.setOffset(0);
+        jobTargetQuery.setLimit(1);
+        JobTargetListResult jobTargetListResult = jobTargetService.query(jobTargetQuery);
+
+        if (jobTargetListResult.isEmpty()) {
+            throw new KapuaEntityNotFoundException(JobTarget.TYPE, targetId);
+        }
+
+        return jobTargetListResult.getFirstItem();
+    }
+
+    @GET
+    @Path("{targetId}/executions")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobExecutionListResult executionsByTarget(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @PathParam("targetId") EntityId targetId,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        JobExecutionQuery jobExecutionQuery = jobExecutionFactory.newQuery(scopeId);
+        jobExecutionQuery.setPredicate(jobExecutionQuery.attributePredicate(JobExecutionAttributes.TARGET_IDS, new KapuaId[]{ targetId }));
+        JobExecutionListResult jobExecutionListResult = jobExecutionService.query(jobExecutionQuery);
+
+        jobExecutionQuery.setOffset(offset);
+        jobExecutionQuery.setLimit(limit);
+
+        return jobExecutionListResult;
+    }
+
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
@@ -1,0 +1,175 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.scheduler.trigger.Trigger;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerAttributes;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerListResult;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
+
+import com.google.common.base.Strings;
+
+@Path("{scopeId}/jobs/{jobId}/triggers")
+public class JobTriggers extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final TriggerService triggerService = locator.getService(TriggerService.class);
+    private final TriggerFactory triggerFactory = locator.getFactory(TriggerFactory.class);
+
+    /**
+     * Gets the {@link Trigger} list for a given {@link Job}.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param jobId   The {@link Job} id to filter results
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link TriggerListResult} of all the jobs triggers associated to the current selected job.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public TriggerListResult simpleQuery(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @QueryParam("name") String name,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+
+        TriggerQuery query = triggerFactory.newQuery(scopeId);
+
+        AndPredicate andPredicate = query.andPredicate(returnJobIdPredicate(jobId, query));
+
+        if (!Strings.isNullOrEmpty(name)) {
+            andPredicate = andPredicate.and(query.attributePredicate(TriggerAttributes.NAME, name));
+        }
+
+        query.setPredicate(andPredicate);
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return query(scopeId, jobId, query);
+    }
+
+    /**
+     * Queries the results with the given {@link TriggerQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link TriggerQuery} to use to filter results.
+     * @return The {@link TriggerListResult} of all the result matching the given {@link TriggerQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_query")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public TriggerListResult query(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            TriggerQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(returnJobIdPredicate(jobId, query));
+        return triggerService.query(query);
+    }
+
+    /**
+     * Counts the results with the given {@link TriggerQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link TriggerQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link TriggerQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_count")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public CountResult count(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            TriggerQuery query) throws Exception {
+        query.setScopeId(scopeId);
+        query.setPredicate(returnJobIdPredicate(jobId, query));
+
+        return new CountResult(triggerService.count(query));
+    }
+
+    /**
+     * Returns the Job specified by the "jobId" path parameter.
+     *
+     * @param scopeId The {@link ScopeId} of the requested {@link Job}.
+     * @param jobId The id of the requested Job.
+     * @param triggerId The id of the requested Trigger.
+     * @return The requested Job object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Path("{triggerId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Trigger find(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId,
+            @PathParam("triggerId") EntityId triggerId) throws Exception {
+        TriggerQuery triggerQuery = triggerFactory.newQuery(scopeId);
+        triggerQuery.setPredicate(triggerQuery.andPredicate(
+                returnJobIdPredicate(jobId, triggerQuery),
+                triggerQuery.attributePredicate(TriggerAttributes.ENTITY_ID, triggerId)
+        ));
+        triggerQuery.setOffset(0);
+        triggerQuery.setLimit(1);
+        TriggerListResult triggerListResult = triggerService.query(triggerQuery);
+
+        if (triggerListResult.isEmpty()) {
+            throw new KapuaEntityNotFoundException(Trigger.TYPE, triggerId);
+        }
+
+        return triggerListResult.getFirstItem();
+    }
+
+    private AndPredicate returnJobIdPredicate(KapuaId jobId, TriggerQuery query) {
+        AttributePredicate<String> kapuaPropertyNameAttributePredicate = query.attributePredicate(TriggerAttributes.TRIGGER_PROPERTIES_NAME, "jobId");
+        AttributePredicate<String> kapuaPropertyValueAttributePredicate = query.attributePredicate(TriggerAttributes.TRIGGER_PROPERTIES_VALUE, jobId.toCompactId());
+        AttributePredicate<String> kapuaPropertyTypeAttributePredicate = query.attributePredicate(TriggerAttributes.TRIGGER_PROPERTIES_TYPE, KapuaId.class.getName());
+
+        return query.andPredicate(
+                kapuaPropertyNameAttributePredicate,
+                kapuaPropertyValueAttributePredicate,
+                kapuaPropertyTypeAttributePredicate
+        );
+    }
+
+}

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
@@ -1,0 +1,145 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.resources.v1.resources;
+
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.CountResult;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.EntityId;
+import org.eclipse.kapua.app.api.resources.v1.resources.model.ScopeId;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.JobAttributes;
+import org.eclipse.kapua.service.job.JobFactory;
+import org.eclipse.kapua.service.job.JobListResult;
+import org.eclipse.kapua.service.job.JobQuery;
+import org.eclipse.kapua.service.job.JobService;
+
+import com.google.common.base.Strings;
+
+@Path("{scopeId}/jobs")
+public class Jobs extends AbstractKapuaResource {
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final JobService jobService = locator.getService(JobService.class);
+    private final JobFactory jobFactory = locator.getFactory(JobFactory.class);
+
+    /**
+     * Gets the {@link Job} list in the scope.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param name    The {@link Job} name to filter results
+     * @param offset  The result set offset.
+     * @param limit   The result set limit.
+     * @return The {@link JobListResult} of all the jobs associated to the current selected scope.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public JobListResult simpleQuery(
+            @PathParam("scopeId") ScopeId scopeId,
+            @QueryParam("name") String name,
+            @QueryParam("offset") @DefaultValue("0") int offset,
+            @QueryParam("limit") @DefaultValue("50") int limit) throws Exception {
+        JobQuery query = jobFactory.newQuery(scopeId);
+
+        AndPredicate andPredicate = query.andPredicate();
+        if (!Strings.isNullOrEmpty(name)) {
+            andPredicate.and(query.attributePredicate(JobAttributes.NAME, name));
+        }
+        query.setPredicate(andPredicate);
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return query(scopeId, query);
+    }
+
+    /**
+     * Queries the results with the given {@link JobQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobQuery} to use to filter results.
+     * @return The {@link JobListResult} of all the result matching the given {@link JobQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_query")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public JobListResult query(
+            @PathParam("scopeId") ScopeId scopeId,
+            JobQuery query) throws Exception {
+        query.setScopeId(scopeId);
+
+        return jobService.query(query);
+    }
+
+    /**
+     * Counts the results with the given {@link JobQuery} parameter.
+     *
+     * @param scopeId The {@link ScopeId} in which to search results.
+     * @param query   The {@link JobQuery} to use to filter results.
+     * @return The count of all the result matching the given {@link JobQuery} parameter.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @POST
+    @Path("_count")
+    @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
+    public CountResult count(
+            @PathParam("scopeId") ScopeId scopeId,
+            JobQuery query) throws Exception {
+        query.setScopeId(scopeId);
+
+        return new CountResult(jobService.count(query));
+    }
+
+    /**
+     * Returns the Job specified by the "jobId" path parameter.
+     *
+     * @param scopeId The {@link ScopeId} of the requested {@link Job}.
+     * @param jobId The id of the requested Job.
+     * @return The requested Job object.
+     * @throws Exception Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @since 1.0.0
+     */
+    @GET
+    @Path("{jobId}")
+    @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
+    public Job find(
+            @PathParam("scopeId") ScopeId scopeId,
+            @PathParam("jobId") EntityId jobId) throws Exception {
+        Job job = jobService.find(scopeId, jobId);
+
+        if (job == null) {
+            throw new KapuaEntityNotFoundException(Job.TYPE, jobId);
+        }
+
+        return job;
+    }
+
+}

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -79,6 +79,26 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-engine-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-engine-jbatch</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-scheduler-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-scheduler-quartz</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-message-internal</artifactId>
         </dependency>
         <dependency>

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -188,6 +188,23 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointInfoXmlRegistry;
 import org.eclipse.kapua.service.endpoint.EndpointUsage;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.JobListResult;
+import org.eclipse.kapua.service.job.JobQuery;
+import org.eclipse.kapua.service.job.JobXmlRegistry;
+import org.eclipse.kapua.service.job.execution.JobExecution;
+import org.eclipse.kapua.service.job.execution.JobExecutionListResult;
+import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
+import org.eclipse.kapua.service.job.execution.JobExecutionXmlRegistry;
+import org.eclipse.kapua.service.job.step.JobStepListResult;
+import org.eclipse.kapua.service.job.step.JobStepXmlRegistry;
+import org.eclipse.kapua.service.job.targets.JobTarget;
+import org.eclipse.kapua.service.job.targets.JobTargetListResult;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
+import org.eclipse.kapua.service.scheduler.trigger.Trigger;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerListResult;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerXmlRegistry;
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagCreator;
 import org.eclipse.kapua.service.tag.TagListResult;
@@ -495,7 +512,31 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     // Service Config
                     ServiceConfigurationXmlRegistry.class,
                     ServiceConfiguration.class,
-                    ServiceComponentConfiguration.class
+                    ServiceComponentConfiguration.class,
+
+                    // Jobs
+                    Job.class,
+                    JobListResult.class,
+                    JobQuery.class,
+                    JobXmlRegistry.class,
+
+                    JobStepListResult.class,
+                    JobStepXmlRegistry.class,
+
+                    JobExecution.class,
+                    JobExecutionListResult.class,
+                    JobExecutionQuery.class,
+                    JobExecutionXmlRegistry.class,
+
+                    JobTarget.class,
+                    JobTargetListResult.class,
+                    JobTargetQuery.class,
+                    JobExecutionXmlRegistry.class,
+
+                    Trigger.class,
+                    TriggerListResult.class,
+                    TriggerQuery.class,
+                    TriggerXmlRegistry.class
             }, properties);
         } catch (Exception e) {
             throw new RuntimeException(e);

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -98,6 +98,31 @@
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
 
+        <api>org.eclipse.kapua.service.job.JobService</api>
+        <api>org.eclipse.kapua.service.job.JobFactory</api>
+
+        <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>
+        <api>org.eclipse.kapua.service.job.execution.JobExecutionFactory</api>
+
+        <api>org.eclipse.kapua.service.job.step.JobStepService</api>
+        <api>org.eclipse.kapua.service.job.step.JobStepFactory</api>
+
+        <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService</api>
+        <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory</api>
+
+        <api>org.eclipse.kapua.service.job.targets.JobTargetService</api>
+        <api>org.eclipse.kapua.service.job.targets.JobTargetFactory</api>
+
+        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
+        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
+        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
+
+        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
+        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
+
+
         <api>org.eclipse.kapua.service.tag.TagFactory</api>
         <api>org.eclipse.kapua.service.tag.TagService</api>
 
@@ -120,6 +145,7 @@
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.job.engine.jbatch</package>
         <package>org.eclipse.kapua.message</package>
         <package>org.eclipse.kapua.service</package>
         <package>org.eclipse.kapua.transport</package>

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -104,6 +104,11 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 /v1/*/endpointInfos.xml         = kapuaAuthcAccessToken
 /v1/*/endpointInfos/**          = kapuaAuthcAccessToken
 
+# Endpoint
+/v1/*/jobs.json                 = kapuaAuthcAccessToken
+/v1/*/jobs.xml                  = kapuaAuthcAccessToken
+/v1/*/jobs/**                   = kapuaAuthcAccessToken
+
 # Service Configurations
 /v1/*/serviceConfigurations     = kapuaAuthcAccessToken
 /v1/*/serviceConfigurations/**  = kapuaAuthcAccessToken

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
@@ -13,12 +13,14 @@ package org.eclipse.kapua.service.job.targets;
 
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
 /**
  * {@link JobTarget} definition.
@@ -43,6 +45,7 @@ public interface JobTarget extends KapuaUpdatableEntity {
      * @return The {@link org.eclipse.kapua.service.job.Job} {@link KapuaId}.
      * @since 1.0.0
      */
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getJobId();
 
     /**
@@ -59,6 +62,7 @@ public interface JobTarget extends KapuaUpdatableEntity {
      * @return The {@link org.eclipse.kapua.model.KapuaEntity} {@link KapuaId}.
      * @since 1.0.0
      */
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getJobTargetId();
 
     /**

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
@@ -13,12 +13,14 @@ package org.eclipse.kapua.service.scheduler.trigger;
 
 import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.util.Date;
 import java.util.List;
 
@@ -129,6 +131,7 @@ public interface Trigger extends KapuaNamedEntity {
      * @return The {@link org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition} {@link KapuaId} which this {@link Trigger} refers to.
      * @since 1.1.0
      */
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     KapuaId getTriggerDefinitionId();
 
     /**


### PR DESCRIPTION
This PR introduces two features:

- A console user can now export Targets for a given Job to a CSV file
- Readonly REST APIs are now available to query all Jobs related informations. The following endpoints are now available:
  - Jobs:
    - `GET {scopeId}/jobs`
    - `GET {scopeId}/jobs/{jobId}`
    - `POST {scopeId}/jobs/{jobId}/_query`
    - `POST {scopeId}/jobs/{jobId}/_count`
  - Targets:
    - `GET {scopeId}/jobs/{jobId}/targets`
    - `GET {scopeId}/jobs/{jobId}/targets/{targetId}`
    - `GET {scopeId}/jobs/{jobId}/targets/{targetId}/executions`
    - `POST {scopeId}/jobs/{jobId}/targets/_query`
    - `POST {scopeId}/jobs/{jobId}/targets/_count`
  - Executions:
    - `GET {scopeId}/jobs/{jobId}/executions`
    - `GET {scopeId}/jobs/{jobId}/executions/{executionId}`
    - `GET {scopeId}/jobs/{jobId}/executions/{executionId}/targets`
    - `POST {scopeId}/jobs/{jobId}/executions/_query`
    - `POST {scopeId}/jobs/{jobId}/executions/_count`
  - Triggers:
    - `GET {scopeId}/jobs/{jobId}/triggers`
    - `GET {scopeId}/jobs/{jobId}/triggers/{triggerId}`
    - `POST {scopeId}/jobs/{jobId}/triggers/_query`
    - `POST {scopeId}/jobs/{jobId}/triggers/_count`

**Related Issue**
No related issues
