### PR TITLE
Fixed closing of the Device Management Operation

### DIFF
--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -233,7 +233,13 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         //
         // Do exec
         DeviceCallExecutor<?, ?, ?, PackageResponseMessage> deviceApplicationCall = new DeviceCallExecutor<>(packageRequestMessage, packageDownloadOptions.getTimeout());
-        PackageResponseMessage responseMessage = deviceApplicationCall.send();
+        PackageResponseMessage responseMessage;
+        try {
+            responseMessage = deviceApplicationCall.send();
+        } catch (Exception e) {
+            closeManagementOperation(scopeId, deviceId, operationId);
+            throw e;
+        }
 
         //
         // Create event
@@ -410,7 +416,13 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         //
         // Do get
         DeviceCallExecutor<?, ?, ?, PackageResponseMessage> deviceApplicationCall = new DeviceCallExecutor<>(packageRequestMessage, packageInstallOptions.getTimeout());
-        PackageResponseMessage responseMessage = deviceApplicationCall.send();
+        PackageResponseMessage responseMessage;
+        try {
+            responseMessage = deviceApplicationCall.send();
+        } catch (Exception e) {
+            closeManagementOperation(scopeId, deviceId, operationId);
+            throw e;
+        }
 
         //
         // Create event
@@ -556,7 +568,13 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         //
         // Do get
         DeviceCallExecutor<?, ?, ?, PackageResponseMessage> deviceApplicationCall = new DeviceCallExecutor<>(packageRequestMessage, packageUninstallOptions.getTimeout());
-        PackageResponseMessage responseMessage = deviceApplicationCall.send();
+        PackageResponseMessage responseMessage;
+        try {
+            responseMessage = deviceApplicationCall.send();
+        } catch (Exception e) {
+            closeManagementOperation(scopeId, deviceId, operationId);
+            throw e;
+        }
 
         //
         // Create event


### PR DESCRIPTION
This PR fixes a bug for which any exception occurring while performing an async Device Management Operation (i.e. Timeout, Device not connected) was not closing the Device Management Operation log.

**Related Issue**
_None_

**Description of the solution adopted**
Added `catch` exception and invoked the utility method that closes the Device Management Operation

**Screenshots**
_None_

**Any side note on the changes made**
_None_