### PR TITLE
Added Dialog to show Job Execution Log in Console

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogButton.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogButton.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client.execution;
+
+import com.extjs.gxt.ui.client.event.ButtonEvent;
+import com.extjs.gxt.ui.client.event.SelectionListener;
+import com.google.gwt.core.client.GWT;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+
+public class JobExecutionLogButton extends Button {
+
+    private static final ConsoleJobMessages MSGS_JOB = GWT.create(ConsoleJobMessages.class);
+
+    public JobExecutionLogButton(SelectionListener<ButtonEvent> listener) {
+        super(MSGS_JOB.jobExecutionLogButton(),
+                new KapuaIcon(IconSet.STICKY_NOTE_O),
+                listener);
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogDialog.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client.execution;
+
+import com.google.gwt.core.client.GWT;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityLogDialog;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobExecution;
+
+public class JobExecutionLogDialog extends EntityLogDialog {
+
+    private static final ConsoleJobMessages MSG_JOB = GWT.create(ConsoleJobMessages.class);
+
+    public JobExecutionLogDialog(GwtJobExecution jobExecution) {
+        super(MSG_JOB.jobExecutionLogDialogHeader(), jobExecution.getUnescapedLog());
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
@@ -30,6 +30,7 @@ public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtJobExecution> 
     private String jobId;
 
     private Button stopJobButton;
+    private Button logExecutionButton;
 
     public JobTabExecutionsToolbar(GwtSession currentSession) {
         super(currentSession, true);
@@ -58,6 +59,15 @@ public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtJobExecution> 
         stopJobButton.disable();
         addExtraButton(stopJobButton);
 
+        logExecutionButton = new JobExecutionLogButton(new SelectionListener<ButtonEvent>() {
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                JobExecutionLogDialog logDialog = new JobExecutionLogDialog(gridSelectionModel.getSelectedItem());
+                logDialog.show();
+            }
+        });
+        addExtraButton(logExecutionButton);
+
         super.onRender(target, index);
 
         checkButtons();
@@ -77,6 +87,10 @@ public class JobTabExecutionsToolbar extends EntityCRUDToolbar<GwtJobExecution> 
 
         if (stopJobButton != null) {
             stopJobButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && gridSelectionModel.getSelectedItem().getEndedOn() == null);
+        }
+
+        if (logExecutionButton != null) {
+            logExecutionButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null);
         }
     }
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
@@ -60,4 +60,16 @@ public class GwtJobExecution extends GwtUpdatableEntityModel {
     public void setEndedOn(Date endedOn) {
         set("endedOn", endedOn);
     }
+
+    public String getLog() {
+        return get("log");
+    }
+
+    public String getUnescapedLog() {
+        return getUnescaped("log");
+    }
+
+    public void setLog(String log) {
+        set("log", log);
+    }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -170,6 +170,7 @@ public class KapuaGwtJobModelConverter {
         gwtJobExecution.setJobId(KapuaGwtCommonsModelConverter.convertKapuaId(jobExecution.getJobId()));
         gwtJobExecution.setStartedOn(jobExecution.getStartedOn());
         gwtJobExecution.setEndedOn(jobExecution.getEndedOn());
+        gwtJobExecution.setLog(jobExecution.getLog());
 
         return gwtJobExecution;
     }

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -216,6 +216,11 @@ jobExecutionStopStoppedMessage=Job execution successfully stopped.
 jobExecutionStopErrorMessage=Selected job execution could not be stopped. Either job execution has not been started or it could not be stopped. Please check console log for errors.
 
 #
+# Stop Job Execution dialog
+jobExecutionLogButton=Log
+jobExecutionLogDialogHeader=Job Execution Log
+
+#
 # Job Filter
 filterHeader=Job Filter
 filterFieldJobNameLabel=Name


### PR DESCRIPTION
This PR adds a Dialog that shows the Job Execution Log in console.

**Related Issue**
_None_

**Description of the solution adopted**
Added new button that displays a Dialog with the log of the selected Job Execution.
 
**Screenshots**
_None_

**Any side note on the changes made**
_None_