### PR TITLE
Fix KapuaNamedEntity name validation

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -13,6 +13,8 @@ package org.eclipse.kapua.commons.util;
 
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 
 import javax.annotation.Nullable;
 import javax.validation.constraints.NotNull;
@@ -214,7 +216,7 @@ public class ArgumentValidator {
      * @param argumentName The argument name with will be used in the exception
      * @throws KapuaIllegalArgumentException If the given {@link String} excedees the given length limits.
      */
-    public static void lengthRange(@NotNull String value, @Nullable Long minLength, @Nullable Long maxLength, @NotNull String argumentName) throws KapuaIllegalArgumentException {
+    public static void lengthRange(@NotNull String value, @Nullable Integer minLength, @Nullable Integer maxLength, @NotNull String argumentName) throws KapuaIllegalArgumentException {
 
         if (minLength != null && value.length() < minLength) {
             throw new KapuaIllegalArgumentException(argumentName, "Value less than allowed min length. Min length is " + minLength);
@@ -223,5 +225,50 @@ public class ArgumentValidator {
         if (maxLength != null && value.length() > maxLength) {
             throw new KapuaIllegalArgumentException(argumentName, "Value over than allowed max length. Max length is " + maxLength);
         }
+    }
+
+    /**
+     * Comprehensive validation method for the {@link KapuaNamedEntity#getName()} or {@link KapuaNamedEntityCreator#getName()} fields.
+     * <p>
+     * Same as {@link #validateEntityName(String, Integer, Integer, String)} but assumes default minimum length of 3 chars and maximum length of 255 chars.
+     *
+     * @param name         The value to validate. Usually would be the {@link KapuaNamedEntity#getName()} or {@link KapuaNamedEntityCreator#getName()}, but other values could be provided
+     * @param argumentName The name of the argumento to bundle with the {@link KapuaIllegalArgumentException}
+     * @throws KapuaIllegalNullArgumentException If the given value to validate is {@code null}.
+     * @throws KapuaIllegalArgumentException     If other validations fails.
+     * @see ArgumentValidator#notEmptyOrNull(String, String)
+     * @see ArgumentValidator#lengthRange(String, Integer, Integer, String)
+     * @see ArgumentValidator#match(String, ValidationRegex, String)
+     * @since 1.2.0
+     */
+    public static void validateEntityName(@Nullable String name, @NotNull String argumentName) throws KapuaIllegalNullArgumentException, KapuaIllegalArgumentException {
+        validateEntityName(name, 3, 255, argumentName);
+    }
+
+    /**
+     * Comprehensive validation method for the {@link KapuaNamedEntity#getName()} or {@link KapuaNamedEntityCreator#getName()} fields.
+     * <p>
+     * It invokes in sequence the three {@link ArgumentValidator} validation methods, using the provided parameters.
+     * <ul>
+     *     <li>{@link #notEmptyOrNull(String, String)}</li>
+     *     <li>{@link #lengthRange(String, Integer, Integer, String)}</li>
+     *     <li>{@link #match(String, ValidationRegex, String)} with {@link CommonsValidationRegex#NAME_SPACE_REGEXP} </li>
+     * </ul>
+     *
+     * @param name         The value to validate. Usually would be the {@link KapuaNamedEntity#getName()} or {@link KapuaNamedEntityCreator#getName()}, but other values could be provided
+     * @param minLength    The minimum length of the field. If {@code null} the minLength validation is skipped
+     * @param maxLength    The maximum length of the field. If {@code null} the maxLength validation is skipped
+     * @param argumentName The name of the argumento to bundle with the {@link KapuaIllegalArgumentException}
+     * @throws KapuaIllegalNullArgumentException If the given value to validate is {@code null}.
+     * @throws KapuaIllegalArgumentException     If other validations fails.
+     * @see ArgumentValidator#notEmptyOrNull(String, String)
+     * @see ArgumentValidator#lengthRange(String, Integer, Integer, String)
+     * @see ArgumentValidator#match(String, ValidationRegex, String)
+     * @since 1.2.0
+     */
+    public static void validateEntityName(@Nullable String name, @Nullable Integer minLength, @Nullable Integer maxLength, @NotNull String argumentName) throws KapuaIllegalNullArgumentException, KapuaIllegalArgumentException {
+        notEmptyOrNull(name, argumentName);
+        lengthRange(name, minLength, maxLength, argumentName);
+        match(name, CommonsValidationRegex.NAME_SPACE_REGEXP, argumentName);
     }
 }

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -52,9 +52,10 @@ public class GroupAddDialog extends EntityAddEditDialog {
         FormPanel groupFormPanel = new FormPanel(FORM_LABEL_WIDTH);
         groupNameField = new KapuaTextField<String>();
         groupNameField.setAllowBlank(false);
+        groupNameField.setMinLength(3);
         groupNameField.setMaxLength(255);
         groupNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        groupNameField.setValidator(new TextFieldValidator(groupNameField, FieldType.NAME));
+        groupNameField.setValidator(new TextFieldValidator(groupNameField, FieldType.NAME_SPACE));
         groupNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         groupFormPanel.add(groupNameField);
 
@@ -71,7 +72,7 @@ public class GroupAddDialog extends EntityAddEditDialog {
     public void validateGroups() {
         if (groupNameField.getValue() == null) {
             ConsoleInfo.display("Error", CONSOLE_MSGS.allFieldsRequired());
-        } 
+        }
     }
 
     @Override

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -50,7 +50,7 @@ public class RoleAddDialog extends EntityAddEditDialog {
     public void validateRoles() {
         if (roleNameField.getValue() == null) {
             ConsoleInfo.display("Error", CONSOLE_MSGS.allFieldsRequired());
-        } 
+        }
     }
 
     @Override
@@ -117,9 +117,10 @@ public class RoleAddDialog extends EntityAddEditDialog {
         // Name
         roleNameField = new KapuaTextField<String>();
         roleNameField.setAllowBlank(false);
+        roleNameField.setMinLength(3);
         roleNameField.setMaxLength(255);
         roleNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        roleNameField.setValidator(new TextFieldValidator(roleNameField, FieldType.NAME));
+        roleNameField.setValidator(new TextFieldValidator(roleNameField, FieldType.NAME_SPACE));
         roleNameField.setToolTip(MSGS.dialogAddFieldNameTooltip());
         roleFormPanel.add(roleNameField);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
@@ -53,10 +53,11 @@ public class JobAddDialog extends EntityAddEditDialog {
 
         name = new KapuaTextField<String>();
         name.setAllowBlank(false);
+        name.setMinLength(3);
         name.setMaxLength(255);
         name.setName("name");
         name.setFieldLabel("* " + JOB_MSGS.dialogAddFieldName());
-        name.setValidator(new TextFieldValidator(name, FieldType.NAME));
+        name.setValidator(new TextFieldValidator(name, FieldType.NAME_SPACE));
         name.setToolTip(JOB_MSGS.dialogAddFieldNameTooltip());
         jobFormPanel.add(name);
 
@@ -74,7 +75,7 @@ public class JobAddDialog extends EntityAddEditDialog {
     public void validateJob() {
         if (name.getValue() == null) {
             ConsoleInfo.display("Error", CONSOLE_MSGS.allFieldsRequired());
-        } 
+        }
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -44,6 +44,7 @@ import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.AfterDateValidator;
 import org.eclipse.kapua.app.console.module.api.client.util.validator.BeforeDateValidator;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTrigger;
@@ -138,7 +139,9 @@ public class JobScheduleAddDialog extends EntityAddEditDialog {
         };
 
         triggerName.setAllowBlank(false);
+        triggerName.setMinLength(3);
         triggerName.setMaxLength(255);
+        triggerName.setValidator(new TextFieldValidator(triggerName, TextFieldValidator.FieldType.NAME_SPACE));
         triggerName.setFieldLabel("* " + JOB_MSGS.dialogAddScheduleScheduleNameLabel());
         triggerName.setToolTip(JOB_MSGS.dialogAddScheduleNameTooltip());
         mainPanel.add(triggerName);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -45,6 +45,7 @@ import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaSafeHtmlUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.validator.TextFieldValidator;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
 import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobStep;
@@ -98,7 +99,10 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         this.jobId = jobId;
 
         jobStepName = new KapuaTextField<String>();
+        jobStepName.setMinLength(3);
         jobStepName.setMaxLength(255);
+        jobStepName.setValidator(new TextFieldValidator(jobStepName, TextFieldValidator.FieldType.NAME_SPACE));
+
         jobStepDescription = new KapuaTextField<String>();
         jobStepDefinitionCombo = new ComboBox<GwtJobStepDefinition>();
         jobStepPropertiesFieldSet = new FieldSet();

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -53,7 +53,8 @@ public class TagAddDialog extends EntityAddEditDialog {
         tagNameField = new KapuaTextField<String>();
         tagNameField.setAllowBlank(false);
         tagNameField.setFieldLabel("* " + MSGS.dialogAddFieldName());
-        tagNameField.setValidator(new TextFieldValidator(tagNameField, FieldType.NAME));
+        tagNameField.setValidator(new TextFieldValidator(tagNameField, FieldType.NAME_SPACE));
+        tagNameField.setMinLength(3);
         tagNameField.setMaxLength(255);
         tagFormPanel.add(tagNameField);
 
@@ -70,7 +71,7 @@ public class TagAddDialog extends EntityAddEditDialog {
     public void validateTags() {
         if (tagNameField.getValue() == null) {
             ConsoleInfo.display("Error", CONSOLE_MSGS.allFieldsRequired());
-        } 
+        }
     }
 
     @Override

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -66,10 +66,9 @@ Feature: Job service CRUD tests
       | boolean | infiniteChildEntities      | true  |
       | integer | maxNumberChildEntities     | 5     |
     Given A job creator with an empty name
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "name"
     When I create a new job entity from the existing creator
-    Then No exception was thrown
-    When I search for the job in the database
-    Then The job entity matches the creator
+    Then An exception was thrown
     Then I logout
 
   Scenario: Job with a duplicate name

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -97,14 +97,14 @@ Feature: Trigger service tests
 
   Scenario: Adding "Device Connect" Schedule With Min Length Name
     Login as kapua-sys user and create a job with name job0.
-    Add a new schedule with one character long name.
+    Add a new schedule with three character long name.
     As this is the defined limit for the min number of characters
     for the schedule name, no errors should be thrown.
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I create a job with the name "job0"
     When I found trigger properties with name "Device Connect"
-    And A regular trigger creator with the name "w"
+    And A regular trigger creator with the name "www"
     And The trigger is set to start today at 10:00.
     And I create a new trigger from the existing creator with previously defined date properties
     And I logout

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -75,11 +75,11 @@ public class EndpointInfoServiceImpl
 
         ArgumentValidator.notEmptyOrNull(endpointInfoCreator.getSchema(), "endpointInfoCreator.schema");
         ArgumentValidator.match(endpointInfoCreator.getSchema(), CommonsValidationRegex.URI_SCHEME, "endpointInfoCreator.schema");
-        ArgumentValidator.lengthRange(endpointInfoCreator.getSchema(), 1L, 64L, "endpointInfoCreator.schema");
+        ArgumentValidator.lengthRange(endpointInfoCreator.getSchema(), 1, 64, "endpointInfoCreator.schema");
 
         ArgumentValidator.notEmptyOrNull(endpointInfoCreator.getDns(), "endpointInfoCreator.dns");
         ArgumentValidator.match(endpointInfoCreator.getDns(), CommonsValidationRegex.URI_DNS, "endpointInfoCreator.dns");
-        ArgumentValidator.lengthRange(endpointInfoCreator.getDns(), 1L, 1024L, "endpointInfoCreator.dns");
+        ArgumentValidator.lengthRange(endpointInfoCreator.getDns(), 1, 1024, "endpointInfoCreator.dns");
 
         ArgumentValidator.notNegative(endpointInfoCreator.getPort(), "endpointInfoCreator.port");
         ArgumentValidator.numRange(endpointInfoCreator.getPort(), 1, 65535, "endpointInfoCreator.port");
@@ -109,11 +109,11 @@ public class EndpointInfoServiceImpl
 
         ArgumentValidator.notEmptyOrNull(endpointInfo.getSchema(), "endpointInfo.schema");
         ArgumentValidator.match(endpointInfo.getSchema(), CommonsValidationRegex.URI_SCHEME, "endpointInfo.schema");
-        ArgumentValidator.lengthRange(endpointInfo.getSchema(), 1L, 64L, "endpointInfo.schema");
+        ArgumentValidator.lengthRange(endpointInfo.getSchema(), 1, 64, "endpointInfo.schema");
 
         ArgumentValidator.notEmptyOrNull(endpointInfo.getDns(), "endpointInfo.dns");
         ArgumentValidator.match(endpointInfo.getDns(), CommonsValidationRegex.URI_DNS, "endpointInfo.dns");
-        ArgumentValidator.lengthRange(endpointInfo.getDns(), 1L, 1024L, "endpointInfo.dns");
+        ArgumentValidator.lengthRange(endpointInfo.getDns(), 1, 1024, "endpointInfo.dns");
 
         ArgumentValidator.notNegative(endpointInfo.getPort(), "endpointInfo.port");
         ArgumentValidator.numRange(endpointInfo.getPort(), 1, 65535, "endpointInfo.port");

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobServiceImpl.java
@@ -75,7 +75,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         // Argument validation
         ArgumentValidator.notNull(creator, "jobCreator");
         ArgumentValidator.notNull(creator.getScopeId(), "jobCreator.scopeId");
-        ArgumentValidator.notNull(creator.getName(), "jobCreator.name");
+        ArgumentValidator.validateEntityName(creator.getName(), "jobCreator.name");
 
         //
         // Check access
@@ -106,7 +106,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         // Argument Validation
         ArgumentValidator.notNull(job, "job");
         ArgumentValidator.notNull(job.getScopeId(), "job.scopeId");
-        ArgumentValidator.notNull(job.getName(), "job.name");
+        ArgumentValidator.validateEntityName(job.getName(), "job.name");
 
         //
         // Check access
@@ -195,7 +195,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
     //
     // Private methods
-        //
+    //
 
     /**
      * Deletes the {@link Job} like {@link #delete(KapuaId, KapuaId)}.
@@ -249,7 +249,7 @@ public class JobServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         //
         // Do delete
         try {
-        KapuaSecurityUtils.doPrivileged(() -> jobEngineService.cleanJobData(scopeId, jobId));
+            KapuaSecurityUtils.doPrivileged(() -> jobEngineService.cleanJobData(scopeId, jobId));
         } catch (Exception e) {
             if (forced) {
                 LOG.warn("Error while cleaning Job data. Ignoring exception since delete is forced! Error: {}", e.getMessage());

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
@@ -61,7 +61,7 @@ public class JobStepDefinitionServiceImpl
         ArgumentValidator.notNull(creator, "stepDefinitionCreator");
         ArgumentValidator.notNull(creator.getScopeId(), "stepDefinitionCreator.scopeId");
         ArgumentValidator.notNull(creator.getStepType(), "stepDefinitionCreator.stepType");
-        ArgumentValidator.notEmptyOrNull(creator.getName(), "stepDefinitionCreator.name");
+        ArgumentValidator.validateEntityName(creator.getName(), "stepDefinitionCreator.name");
         ArgumentValidator.notEmptyOrNull(creator.getProcessorName(), "stepDefinitionCreator.processorName");
 
         //
@@ -80,7 +80,7 @@ public class JobStepDefinitionServiceImpl
         ArgumentValidator.notNull(jobStepDefinition, "stepDefinition");
         ArgumentValidator.notNull(jobStepDefinition.getScopeId(), "stepDefinition.scopeId");
         ArgumentValidator.notNull(jobStepDefinition.getStepType(), "jobStepDefinition.stepType");
-        ArgumentValidator.notEmptyOrNull(jobStepDefinition.getName(), "jobStepDefinition.name");
+        ArgumentValidator.validateEntityName(jobStepDefinition.getName(), "jobStepDefinition.name");
         ArgumentValidator.notEmptyOrNull(jobStepDefinition.getProcessorName(), "jobStepDefinition.processorName");
 
         //

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -16,13 +16,13 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
-import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -71,8 +71,7 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(jobStepCreator, "jobStepCreator");
         ArgumentValidator.notNull(jobStepCreator.getScopeId(), "jobStepCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(jobStepCreator.getName(), "jobStepCreator.name");
-        ArgumentValidator.numRange(jobStepCreator.getName().length(), 1, 255, "jobStepCreator.name");
+        ArgumentValidator.validateEntityName(jobStepCreator.getName(), "jobStepCreator.name");
         ArgumentValidator.notNull(jobStepCreator.getJobStepDefinitionId(), "jobStepCreator.stepDefinitionId");
 
         if (jobStepCreator.getDescription() != null) {
@@ -152,7 +151,7 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(jobStep, "jobStep");
         ArgumentValidator.notNull(jobStep.getScopeId(), "jobStep.scopeId");
-        ArgumentValidator.notNull(jobStep.getName(), "jobStep.name");
+        ArgumentValidator.validateEntityName(jobStep.getName(), "jobStep.name");
         ArgumentValidator.notNull(jobStep.getJobStepDefinitionId(), "jobStep.stepDefinitionId");
         if (jobStep.getDescription() != null) {
             ArgumentValidator.numRange(jobStep.getDescription().length(), 0, 8192, "jobStep.description");

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
@@ -54,7 +54,7 @@ public class TriggerDefinitionServiceImpl extends AbstractKapuaService implement
         ArgumentValidator.notNull(creator, "stepDefinitionCreator");
         ArgumentValidator.notNull(creator.getScopeId(), "stepDefinitionCreator.scopeId");
         ArgumentValidator.notNull(creator.getTriggerType(), "stepDefinitionCreator.stepType");
-        ArgumentValidator.notEmptyOrNull(creator.getName(), "stepDefinitionCreator.name");
+        ArgumentValidator.validateEntityName(creator.getName(), "stepDefinitionCreator.name");
         ArgumentValidator.notEmptyOrNull(creator.getProcessorName(), "stepDefinitionCreator.processorName");
 
         //
@@ -73,7 +73,7 @@ public class TriggerDefinitionServiceImpl extends AbstractKapuaService implement
         ArgumentValidator.notNull(triggerDefinition, "stepDefinition");
         ArgumentValidator.notNull(triggerDefinition.getScopeId(), "stepDefinition.scopeId");
         ArgumentValidator.notNull(triggerDefinition.getTriggerType(), "triggerDefinition.stepType");
-        ArgumentValidator.notEmptyOrNull(triggerDefinition.getName(), "triggerDefinition.name");
+        ArgumentValidator.validateEntityName(triggerDefinition.getName(), "triggerDefinition.name");
         ArgumentValidator.notEmptyOrNull(triggerDefinition.getProcessorName(), "triggerDefinition.processorName");
 
         //

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -133,7 +133,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(triggerCreator, "triggerCreator");
         ArgumentValidator.notNull(triggerCreator.getScopeId(), "triggerCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(triggerCreator.getName(), "triggerCreator.name");
+        ArgumentValidator.validateEntityName(triggerCreator.getName(), "triggerCreator.name");
         ArgumentValidator.notNull(triggerCreator.getStartsOn(), "triggerCreator.startsOn");
 
         //
@@ -209,7 +209,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(trigger.getScopeId(), "trigger.scopeId");
         ArgumentValidator.notNull(trigger.getId(), "trigger.id");
-        ArgumentValidator.notEmptyOrNull(trigger.getName(), "trigger.name");
+        ArgumentValidator.validateEntityName(trigger.getName(), "trigger.name");
 
         //
         // Check Access

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -63,7 +63,7 @@ public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedSe
         // Argument validation
         ArgumentValidator.notNull(groupCreator, "groupCreator");
         ArgumentValidator.notNull(groupCreator.getScopeId(), "roleCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(groupCreator.getName(), "groupCreator.name");
+        ArgumentValidator.validateEntityName(groupCreator.getName(), "groupCreator.name");
 
         //
         // Check Access
@@ -94,9 +94,9 @@ public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedSe
         //
         // Argument validator
         ArgumentValidator.notNull(group, "group");
-        ArgumentValidator.notNull(group.getScopeId(), "group.scopeId");
         ArgumentValidator.notNull(group.getId(), "group.id");
-        ArgumentValidator.notEmptyOrNull(group.getName(), "group.name");
+        ArgumentValidator.notNull(group.getScopeId(), "group.scopeId");
+        ArgumentValidator.validateEntityName(group.getName(), "group.name");
 
         //
         // Check Access

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -69,7 +69,7 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         // Argument validation
         ArgumentValidator.notNull(roleCreator, "roleCreator");
         ArgumentValidator.notNull(roleCreator.getScopeId(), "roleCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(roleCreator.getName(), "roleCreator.name");
+        ArgumentValidator.validateEntityName(roleCreator.getName(), "roleCreator.name");
         ArgumentValidator.notNull(roleCreator.getPermissions(), "roleCreator.permissions");
         //
         // Check Access
@@ -130,9 +130,9 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         //
         // Argument validation
         ArgumentValidator.notNull(role, "role");
-        ArgumentValidator.notNull(role.getScopeId(), "role.scopeId");
         ArgumentValidator.notNull(role.getId(), "role.id");
-        ArgumentValidator.notEmptyOrNull(role.getName(), "role.name");
+        ArgumentValidator.notNull(role.getScopeId(), "role.scopeId");
+        ArgumentValidator.validateEntityName(role.getName(), "role.name");
 
         //
         // Check Access
@@ -179,7 +179,7 @@ public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         if (find(scopeId, roleId) == null) {
             throw new KapuaEntityNotFoundException(Role.TYPE, roleId);
         }
-        if(roleId.equals(KapuaId.ONE)) {
+        if (roleId.equals(KapuaId.ONE)) {
             throw new KapuaException(KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR);
         }
 

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaMaxNumberOfItemsReachedException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-//import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -36,6 +35,8 @@ import org.eclipse.kapua.service.tag.TagService;
 
 import javax.inject.Inject;
 
+//import org.eclipse.kapua.locator.KapuaLocator;
+
 /**
  * {@link TagService} implementation.
  *
@@ -43,11 +44,6 @@ import javax.inject.Inject;
  */
 @KapuaProvider
 public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Tag, TagCreator, TagService, TagListResult, TagQuery, TagFactory> implements TagService {
-
-//    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-//
-//    private static final AuthorizationService AUTHORIZATION_SERVICE = LOCATOR.getService(AuthorizationService.class);
-//    private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     @Inject
     private AuthorizationService authorizationService;
@@ -65,11 +61,10 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         // Argument validation
         ArgumentValidator.notNull(tagCreator, "tagCreator");
         ArgumentValidator.notNull(tagCreator.getScopeId(), "tagCreator.scopeId");
-        ArgumentValidator.notEmptyOrNull(tagCreator.getName(), "tagCreator.name");
+        ArgumentValidator.validateEntityName(tagCreator.getName(), "tagCreator.name");
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.write, tagCreator.getScopeId()));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.write, tagCreator.getScopeId()));
 
         //
@@ -97,13 +92,12 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
         //
         // Argument validation
         ArgumentValidator.notNull(tag, "tag");
-        ArgumentValidator.notNull(tag.getScopeId(), "tag.scopeId");
         ArgumentValidator.notNull(tag.getId(), "tag.id");
-        ArgumentValidator.notEmptyOrNull(tag.getName(), "tag.name");
+        ArgumentValidator.notNull(tag.getScopeId(), "tag.scopeId");
+        ArgumentValidator.validateEntityName(tag.getName(), "tag.name");
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.write, tag.getScopeId()));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.write, tag.getScopeId()));
 
         //
@@ -140,7 +134,6 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.delete, scopeId));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.delete, scopeId));
 
         //
@@ -163,7 +156,6 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.read, scopeId));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.read, scopeId));
 
         //
@@ -179,7 +171,6 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.read, query.getScopeId()));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.read, query.getScopeId()));
 
         //
@@ -195,7 +186,6 @@ public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedServ
 
         //
         // Check Access
-//        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(TagDomains.TAG_DOMAIN, Actions.read, query.getScopeId()));
         authorizationService.checkPermission(permissionFactory.newPermission(TagDomains.TAG_DOMAIN, Actions.read, query.getScopeId()));
 
         //


### PR DESCRIPTION
This PR fixes the validation on `KapuaNamedEntity`es.

The validation of the `name` field for some entities had thw wrong check on the UI and the wrong/none validation on the backend.

**Related Issue**
This PR also fixes #2709 , #2710 

**Description of the solution adopted**
Created a new utility method in `ArgumentValidator` class that validates the value provided supposing it is a `KapuaNamedEntity` name.

Checks for:

- not null
- min length and max langth (provided)
- That contains only alphanumerics, dash, underscore and whitespaces

**Screenshots**
_None_

**Any side note on the changes made**
Removed some unused code.
Refactored `ArgumentValidator. lengthRange(...)` with was requiring `Long` type for max and min length that made no sense.