### PR TITLE
Removed unneeded codecov.io bash command

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -55,7 +55,6 @@ jobs:
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @datastore" verify
-    - bash <(curl -s https://codecov.io/bash)
   - stage: test
     script:
     - ./travis.sh $M2_HOME/bin/mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @user" verify


### PR DESCRIPTION
Signed-off-by: ct-ajovanovic <aleksandra.jovanovic@comtrade.com>

Brief description of the PR.
Removed unneeded `codecov.io` `bash` command

**Related Issue**
This PR fixes/closes #2802 

**Description of the solution adopted**
Removed the unneeded bash command from one of the test stages, as the `travis.yml` file already contains the `after_script` where this command is called. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_
