### PR TITLE
Fixed device clientId validation

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -59,7 +59,7 @@ public class TextFieldValidator implements Validator {
     public enum FieldType {
 
         SIMPLE_NAME("simple_name", "^[a-zA-Z0-9\\-]{3,}$"),
-        DEVICE_CLIENT_ID("device_client_id", "^[a-zA-Z0-9\\:\\_\\-]{1,}$"),
+        DEVICE_CLIENT_ID("device_client_id", "^((?!#|\\+|\\*|&|,|\\?|>|\\/|\\:\\:).)*$"),
         SNAPSHOT_FILE("snapshot_file", "^([a-zA-Z0-9\\:\\_\\-\\\\]){1,255}(\\.xml)"),
         NAME("name", "^[a-zA-Z0-9\\_\\-]{3,}$"),
         NAME_SPACE("name_space", "^[a-zA-Z0-9\\ \\_\\-]{3,}$"),

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -95,16 +95,6 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         NO_GROUP.setId(null);
     }
 
-    // protected TextField<String> username;
-    // protected TextField<String> password;
-    // protected TextField<String> confirmPassword;
-    // protected TextField<String> displayName;
-    // protected TextField<String> email;
-    // protected TextField<String> phoneNumber;
-    // protected SimpleComboBox<GwtUser.GwtUserStatus> userStatus;
-    // protected DateField expirationDate;
-    // protected NumberField optlock;
-
     public DeviceAddDialog(GwtSession currentSession) {
         super(currentSession);
 
@@ -128,10 +118,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         formPanel.setFrame(false);
         formPanel.setBodyBorder(false);
         formPanel.setHeaderVisible(false);
-        // formPanel.setWidth(310);
         formPanel.setScrollMode(Scroll.AUTOY);
-        // formPanel.setStyleAttribute("padding-bottom", "0px");
-        // formPanel.setLayout(new FlowLayout());
 
         Listener<BaseEvent> comboBoxListener = new Listener<BaseEvent>() {
 
@@ -188,6 +175,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         statusCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelStatusEmptyText());
         statusCombo.add(GwtDeviceQueryPredicates.GwtDeviceStatus.ENABLED);
         statusCombo.add(GwtDeviceQueryPredicates.GwtDeviceStatus.DISABLED);
+        statusCombo.setSimpleValue(GwtDeviceStatus.ENABLED);
 
         fieldSet.add(statusCombo, formData);
 
@@ -204,6 +192,7 @@ public class DeviceAddDialog extends EntityAddEditDialog {
         groupCombo.setTemplate("<tpl for=\".\"><div role=\"listitem\" class=\"x-combo-list-item\" title={groupName}>{groupName}</div></tpl>");
         groupCombo.setValueField("id");
         groupCombo.setEmptyText(DEVICE_MSGS.deviceFilteringPanelGroupEmptyText());
+
         if (currentSession.hasPermission(GroupSessionPermission.read())) {
             groupCombo.addListener(Events.Select, comboBoxListener);
 
@@ -230,7 +219,9 @@ public class DeviceAddDialog extends EntityAddEditDialog {
                             return group1.getGroupName().compareTo(group2.getGroupName());
                         }
                     });
+
                     groupCombo.getStore().add(result);
+                    groupCombo.setValue(NO_GROUP);
                 }
             });
             fieldSet.add(groupCombo, formData);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
@@ -103,6 +103,8 @@ public final class DeviceValidation {
         ArgumentValidator.notNull(deviceCreator, "deviceCreator");
         ArgumentValidator.notNull(deviceCreator.getScopeId(), "deviceCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(deviceCreator.getClientId(), "deviceCreator.clientId");
+        ArgumentValidator.lengthRange(deviceCreator.getClientId(), 1, 255, "deviceCreator.clientId");
+        ArgumentValidator.match(deviceCreator.getClientId(), DeviceValidationRegex.CLIENT_ID, "deviceCreator.clientId");
 
         if (deviceCreator.getGroupId() != null) {
             ArgumentValidator.notNull(groupService.find(deviceCreator.getScopeId(), deviceCreator.getGroupId()), "deviceCreator.groupId");

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationRegex.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationRegex.java
@@ -13,12 +13,27 @@ package org.eclipse.kapua.service.device.registry.common;
 
 import org.eclipse.kapua.commons.util.ValidationRegex;
 import org.eclipse.kapua.service.device.registry.DeviceAttributes;
+import org.eclipse.kapua.service.device.registry.DeviceCreator;
+import org.eclipse.kapua.service.device.registry.DeviceQuery;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
 
 import java.util.regex.Pattern;
 
 public enum DeviceValidationRegex implements ValidationRegex {
 
-    QUERY_FETCH_ATTRIBUTES("(" + DeviceAttributes.CONNECTION + "|" + DeviceAttributes.LAST_EVENT + ")");
+    /**
+     * Validates value of {@link DeviceQuery#getFetchAttributes()}.
+     *
+     * @since 1.0.0
+     */
+    QUERY_FETCH_ATTRIBUTES("(" + DeviceAttributes.CONNECTION + "|" + DeviceAttributes.LAST_EVENT + ")"),
+
+    /**
+     * Validates value of {@link DeviceConnectionCreator#getClientId()} and {@link DeviceCreator#getClientId()}
+     *
+     * @since 1.2.0
+     */
+    CLIENT_ID("^((?!#|\\+|\\*|&|,|\\?|>|\\/|\\:\\:).)*$");
 
     private Pattern pattern;
 


### PR DESCRIPTION
This PR fixes and improves the validation of the `clientId` of the `Device` and the `DeviceConnection`.

**Related Issue**
This PR fixes #2713 

**Description of the solution adopted**
With @riccardomodanese  we determined the set of invalid chars in the `clientId` fields:

`#` `+` `*` `&` `,` `?` `>` `/` `::`

This Regex has been added to the validation of the `deviceCreator.clientId` and `deviceConnectionCreator.clientId` alongside other validation on the min/max length of the String:

`^((?!#|\+|\*|&|,|\?|>|\/|\:\:).)*$`

Test regex match: [regex101](https://regex101.com/r/jC8nB0/837)

**Screenshots**
_None_

**Any side note on the changes made**
Added check for the duplicate `clientId` when creating a Device or a DeviceConnection.
Fixed managing of the Group and Status Comboboxes on the DeviceAddDialog