### PR TITLE
Added tests for Group service

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/authorization/RunAuthorizationServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/authorization/RunAuthorizationServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -29,7 +29,8 @@ import cucumber.api.CucumberOptions;
         glue = { "org.eclipse.kapua.qa.common",
                  "org.eclipse.kapua.service.authorization.steps",
                  "org.eclipse.kapua.service.account.steps",
-                 "org.eclipse.kapua.service.user.steps"
+                 "org.eclipse.kapua.service.user.steps",
+                 "org.eclipse.kapua.service.device.registry.steps"
                },
         plugin = {"pretty", 
                   "html:target/cucumber/AuthorizationServiceI9n",

--- a/qa/integration/src/test/resources/features/authorization/GroupService.feature
+++ b/qa/integration/src/test/resources/features/authorization/GroupService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -159,8 +159,8 @@ Feature: Group Service tests
       | integer | maxNumberChildEntities | 5     | 0       | 1        |
     Given I create the groups
       | scope | name        |
-      | 0     | test_name_6 |
-      | 0     | test_name_7 |
+      | 1     | test_name_6 |
+      | 1     | test_name_7 |
     And I search for the group with name "test_name_7"
     Then The group was found
     When I delete the group with name "test_name_7"
@@ -255,4 +255,793 @@ Feature: Group Service tests
     And The group name is "test_name_18"
     When I query for the group "test_name_25" in scope 1
     Then I count 0
+    And I logout
+
+  Scenario: Creating Unique Group Without Description
+  Login as kapua-sys, go to groups, try to create a group with valid name without description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "ValidGroup"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Non-unique Group Without Description
+  Login as kapua-sys, go to groups, try to create a group with valid name without description. After that create another group with the same name.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "ValidGroup"
+    Then No exception was thrown
+    Given I expect the exception "Exception" with the text "*"
+    When I create a group with name "ValidGroup"
+    Then I logout
+
+  Scenario: Creating Group With Short Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with short name (3 characters).
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "abc"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Too Short Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with too short name (1 character).
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "Exception" with the text "*"
+    When I create a group with name "a"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Long Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with long name (255 characters).
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "y6Nzz2qKaF8nbRxaRo8o9mRvH8CEvldYg0kCVq7EPfutbHvaQZf7m8eHcTBiXexxYl8zZI9taDwWGnnyMbnuOmpQp4tdmXeA9tnLx6dtuhu8vIfNU9YKyROkHW6f1RnMV8NhVChvE2eeTYdtczRzmJ5Zqx2MlHWJ68vbRqZ7Jw7BttDxB0bCveEYjg0JVJGsigZBRTifJhcQnXndfMcQ7WKAxXwJplvRx6sasjLKP2ZefVTqbxZQr1tVAuvLJvX"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Too Long Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with too long name (256 characters).
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I create a group with name "aaay6Nzz2qKaF8nbRxaRo8o9mRvH8CEvldYg0kCVq7EPfutbHvaQZf7m8eHcTBiXexxYl8zZI9taDwWGnnyMbnuOmpQp4tdmXeA9tnLx6dtuhu8vIfNU9YKyROkHW6f1RnMV8NhVChvE2eeTYdtczRzmJ5Zqx2MlHWJ68vbRqZ7Jw7BttDxB0bCveEYjg0JVJGsigZBRTifJhcQnXndfMcQ7WKAxXwJplvRx6sasjLKP2ZefVTqbxZQr1tVAuvLJvX"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Permitted Symbols And Numbers In Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with name that contains permitted symbols.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "Valid-group-name_1_2_3"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group Invalid Symbols In Name Without Description
+  Login as kapua-sys, go to groups, try to create a group with name that contains invalid symbols.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I try to create groups with invalid characters in name
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group Without a Name And Without Description
+  Login as kapua-sys, go to groups, try to create a group with without a name.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "Exception" with the text "*"
+    When I create a group with name ""
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Unique Group With Unique Description
+  Login as kapua-sys, go to groups, try to create a group with a valid description with all possible symbols.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I create the group with name "Group1" and description "Valid_description-123 !#$%&'()=»Ç>:;<-.,⁄@‹›€*ı–°·‚_±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«◊Ñˆ¯Èˇ¿"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Unique Group With Non-unique Description
+  Login as kapua-sys, go to groups, try to create a group with a non-unique description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I create the group with name "Group1" and description "Non-unique description"
+    And I create the group with name "Group2" and description "Non-unique description"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Non-Unique Group With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with a non-unique description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I create the group with name "Group1" and description "Non-unique description"
+    Given I expect the exception "Exception" with the text "*"
+    When I create the group with name "Group1" and description "Non-unique description"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Short Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with short (3 characters) name and valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "abc" and description "Valid description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Too Short Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with too short (1 character) name and valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I create the group with name "a" and description "Valid description 123"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Long Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with long (255 characters) name and valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF" and description "Valid description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Too Long Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with too long (256) name and valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I create the group with name "aPxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF" and description "Valid description 123"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Permitted Symbols In Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with permitted symbols in name and valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group-1_2_3" and description "Valid description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Invalid Symbols In Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with invalid symbols in name and valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I create the group with name "Group@123" and description "Valid description 123"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group Without a Name And With Valid Description
+  Login as kapua-sys, go to groups, try to create a group without a name and valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
+    When I create the group with name "" and description "Valid description 123"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Creating Group With Numbers In Name With Valid Description
+  Login as kapua-sys, go to groups, try to create a group with name that contains numbers and valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1234567890" and description "Valid description 123"
+    Then No exception was thrown
+    When I create the group with name "1234567890" and description "Valid description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Unique Group With Short Description
+  Login as kapua-sys, go to groups, try to create a group with short description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "a"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Creating Unique Group With Long Description
+  Login as kapua-sys, go to groups, try to create a group with long (255 characters) description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To Unique One
+  Login as kapua-sys, go to groups, try to edit group's name to a unique one, leave description as it is.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    And I change the group name from "Group1" to "Group2"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Changing Group's Name To Non-Unique One
+  Login as kapua-sys, go to groups, try to edit group's name to a non-unique one, leave description as it is.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    And I create the group with name "Group2" and description "Description2"
+    Given I expect the exception "KapuaDuplicateNameException" with the text "*"
+    When I change the group name from "Group2" to "Group1"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To Short One Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to a short one, leave description as it is.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    When I change the group name from "Group1" to "abc"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To a Too Short One Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to a too short one, leave description as it is.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I change the group name from "Group1" to "a"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To a Long One Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to a long one, leave description as it is.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    When I change the group name from "Group1" to "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To a Too Long One Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to a long one, leave description as it is.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I change the group name from "Group1" to "aPxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To Contain Permitted Symbols In Name Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to contain permitted symbols, leave description as it is.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    When I change the group name from "Group1" to "Group_1-2-3"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Name To Contain Invalid Symbols In Name Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to contain invalid symbols, leave description as it is.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I change the group name from "Group1" to "Group@123"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Deleting Group's Name And Leaving It Empty Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to empty string, leave description as it is.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description"
+    Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
+    When I change the group name from "Group1" to ""
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Editing Group's Name To Contain Numbers Without Changing Description
+  Login as kapua-sys, go to groups, try to edit group's name to one that contains numbers, leave description as it is.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group" and description "Description"
+    When I change the group name from "Group" to "1234567890"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Description To Uniqe One
+  Login as kapua-sys, go to groups, try to edit group's description, name should remain unchanged.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group" and description "Description"
+    And I change the description of group with name "Group" to "Description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Group's Description To Non-Uniqe One
+  Login as kapua-sys, go to groups, try to edit group's description to a non-unique one, name should remain unchanged.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group1" and description "Description1"
+    And I create the group with name "Group2" and description "Description2"
+    And I change the description of group with name "Group2" to "Description1"
+    Then I logout
+
+  Scenario: Changing Description On Group With Short Name
+  Login as kapua-sys, go to groups, try to edit description on a group that has short name.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "abc" and description "Description1"
+    When I change the description of group with name "abc" to "Description 2"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Description On Group With Long Name
+  Login as kapua-sys, go to groups, try to edit description on a group that has long name.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF" and description "Description1"
+    When I change the description of group with name "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF" to "Description 123"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Description On Group With Permitted Symbols
+  Login as kapua-sys, go to groups, try to edit description on a group that has name with permited symbols.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group-1_2_3" and description "Description1"
+    When I change the description of group with name "Group-1_2_3" to "Description2"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Description On Group With Numbers In Name
+  Login as kapua-sys, go to groups, try to edit description on a group that has numbers in name.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group123" and description "Description1"
+    When I change the description of group with name "Group123" to "Description2"
+    Then No exception was thrown
+    When I create the group with name "1234567890" and description "Description1"
+    When I change the description of group with name "1234567890" to "Description2"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Description On Group With Short Description
+  Login as kapua-sys, go to groups, try to edit description on a group that has short description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group-1_2_3" and description "a"
+    When I change the description of group with name "Group-1_2_3" to "b"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Changing Description On Group With Long Description
+  Login as kapua-sys, go to groups, try to edit description on a group that to long description (255 characters).
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create the group with name "Group-1_2_3" and description "Valid description"
+    When I change the description of group with name "Group-1_2_3" to "PxYHG9FEvy3d4CKlLwoA7b5FTk7XptHr1TZoKVft4Qhxe4BwjQE5zGFn5Jh0AGSQjbAv0ooPPBCRasXk0lnjeeHiU5mWM2KxG98ziV5WIxnUaZhIpGVfV8bqhQobJtx4QrIPizEPpG0p6DCcS72ulKqnoVsusqEkDsBBadZjhZzy4NbauKnlZnAoXerKBg23ku0CDDaB1boKqrlZ4yGmoLjgSWz4GMg6SCfjYabOCkt73HOs0SlZowCCmtzb7kF"
+    Then No exception was thrown
+    Then I logout
+
+  Scenario: Deleting Existing Group
+  Login as kapua-sys, go to groups, create a group, and delete it.
+  Check if group has been deleted.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "Group1"
+    And I delete the group with name "Group1"
+    And I search for a group named "Group1"
+    Then No group was found
+    And I logout
+
+  Scenario: Deleting Unexisitng Group
+  Login as kapua-sys, go to groups, create a group, and delete it and then try to delete it once again.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "Group1"
+    And I delete the group with name "Group1"
+    And I search for a group named "Group1"
+    Then No group was found
+    Given I expect the exception "NullPointerException" with the text "*"
+    When I delete the group with name "Group1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Deleting Existing Group And Creating It Again With Same Name
+  Login as kapua-sys, go to groups, create a group, delete it and then create it again with the same name.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    When I create a group with name "Group1"
+    And I delete the group with name "Group1"
+    And I search for a group named "Group1"
+    Then No group was found
+    When I create a group with name "Group1"
+    And I search for a group named "Group1"
+    Then The group was found
+    And No exception was thrown
+    And I logout
+
+  Scenario: Adding Regular Group Without Description to Device
+  Login as kapua-sys, go to groups, create a group.
+  Go to devices, create a device and add created group to it.
+  Check if created device is in Asigned Devices of the group.
+  Kapua should not throw any errors
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create a group with name "Group1"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Adding Same Regular Group Without Description to Device
+  Login as kapua-sys, go to groups, create a group.
+  Go to devices, create a device ("Device1") and add created group to it.
+  Check if created device is in Asigned Devices of the group.
+  Create another group and add it to "Device1"
+  Check both groups Assigned Devices ("Device1" should only be in second group)
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create a group with name "Group1"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    When I create a group with name "Group2"
+    And I add device "Device1" to group "Group2"
+    Then Device "Device1" is in Assigned Devices of group "Group2"
+    Then Device "Device1" is not in Assigned Devices of group "Group1"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Adding Regular Device to a Group Without a Description
+  Login as kapua-sys, go to groups, create a group.
+  Go to devices, create a device and add it to newly created group.
+  Check if created device is in Assigned Devices of the group.
+  Remove group from the selected group.
+  Check group's Assigned Devices - "device1" should be part of this group.
+  Kapua should not throw any errors
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create a group with name "Group1"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    When I remove device "Device1" from all groups
+    Then Device "Device1" is not in Assigned Devices of group "Group1"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Have Two Devices in The Same Group Without Description
+  Login as kapua-sys, go to groups, create a group.
+  Go to devices, create two devices and add them to created group.
+  Check if created device is in Assigned Devices of the group.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create a group with name "Group1"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    And I create a device with name "Device2"
+    And I add device "Device2" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    Then Device "Device2" is in Assigned Devices of group "Group1"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Assign 100 Devices to One Group
+  Login as kapua-sys, go to groups, create a group "Group1".
+  Go to devices, create 100 devices and add them to created group.
+  Check if created devices are in Assigned Devices of the group.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create a group with name "Group1"
+    And I create 100 devices and add them to group "Group1"
+    Then Device "Device00" is in Assigned Devices of group "Group1"
+    Then Device "Device55" is in Assigned Devices of group "Group1"
+    Then Device "Device99" is in Assigned Devices of group "Group1"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Adding Regular Device to a Group With Description
+  Login as kapua-sys, go to groups, create a group with description.
+  Go to devices, create a device and add it to newly created group.
+  Check if created device is in Assigned Devices of the group.
+  Kapua should not throw any errors
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create the group with name "Group1" and description "Description 1234"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    And No exception was thrown
+    And I logout
+
+  Scenario: Moving Device From One Group With Description to Another
+  Login as kapua-sys, go to groups, create a group.
+  Go to devices, create a device ("Device1") and add it to the created group.
+  Check if created device is in Assigned Devices of the group.
+  Create another group and add "Device1" to it.
+  Check both groups Assigned Devices ("Device1" should only be in second group)
+  Kapua should throw Exception when checking for device in "Group1"
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the group service
+      | type    | name                   | value | scopeId | parentId |
+      | boolean | infiniteChildEntities  | true  | 0       | 1        |
+      | integer | maxNumberChildEntities | 5     | 0       | 1        |
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 10    |
+    When I create the group with name "Group1" and description "Description 123"
+    And I create a device with name "Device1"
+    And I add device "Device1" to group "Group1"
+    Then Device "Device1" is in Assigned Devices of group "Group1"
+    When I create the group with name "Group2" and description "Description 123"
+    And I add device "Device1" to group "Group2"
+    Then Device "Device1" is in Assigned Devices of group "Group2"
+    Then Device "Device1" is not in Assigned Devices of group "Group1"
+    And No exception was thrown
     And I logout

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -1442,7 +1442,7 @@ Feature: User Permission tests
     And A device named "test_device"
     And I create a job with the name "test_job"
     And I create tag with name "test_tag" without description
-    And I create the group with name "test_group"
+    And I create a group with name "test_group"
     And I create the following role
       | scopeId | name      |
       | 1       | test_role |

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -230,9 +230,8 @@ Feature: User role service integration tests
     And I add access role "test_role" to user "user1"
     And I logout
     Then I login as user with name "user1" and password "User@10031995"
-    And I create the group with name "group1"
-    And I find the group with name "group1"
-    And I update the group name to "group2"
+    And I create a group with name "group1"
+    And I change the group name from "group1" to "group2"
     And I delete the group with name "group2"
     Then No exception was thrown
     And I logout
@@ -808,7 +807,7 @@ Feature: User role service integration tests
     And I find a role with name "test_role"
     And I update the last created role name to "role1"
     And I delete the role with name "test_role"
-    And I create the group with name "TestGroup"
+    And I create a group with name "TestGroup"
     And I find the group with name "TestGroup"
     And I update the group name to "TestGroup1"
     And I delete the group with name "TestGroup1"
@@ -1314,7 +1313,7 @@ Feature: User role service integration tests
     And I add access role "Role1" to user "SubUser" in account "SubAccount"
     And I logout
     And I login as user with name "SubUser" and password "User@10031995"
-    And I create the group with name "TestGroup"
+    And I create a group with name "TestGroup"
     And I find the group with name "TestGroup"
     And I update the group name to "TestGroup1"
     When I delete the group with name "TestGroup1"

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -23,7 +23,6 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 import org.apache.shiro.SecurityUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
@@ -45,6 +44,7 @@ import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingPayload;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.qa.common.DBHelper;
 import org.eclipse.kapua.qa.common.StepData;
@@ -63,6 +63,11 @@ import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authorization.access.AccessInfoService;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupAttributes;
+import org.eclipse.kapua.service.authorization.group.GroupFactory;
+import org.eclipse.kapua.service.authorization.group.GroupQuery;
+import org.eclipse.kapua.service.authorization.group.GroupService;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
@@ -171,6 +176,8 @@ public class DeviceRegistrySteps extends TestBase {
     private TagFactory tagFactory;
     private KapuaMessageFactory messageFactory;
     private KapuaLifecycleMessageFactory lifecycleMessageFactory;
+    private GroupService groupService;
+    private GroupFactory groupFactory;
 
     private AclCreator aclCreator;
 
@@ -223,6 +230,8 @@ public class DeviceRegistrySteps extends TestBase {
         accessInfoService = locator.getService(AccessInfoService.class);
         tagService = locator.getService(TagService.class);
         tagFactory = locator.getFactory(TagFactory.class);
+        groupService = locator.getService(GroupService.class);
+        groupFactory = locator.getFactory(GroupFactory.class);
 
         aclCreator = new AclCreator();
 
@@ -2666,12 +2675,31 @@ public class DeviceRegistrySteps extends TestBase {
             device.setTagIds(tags);
             Device newDevice = deviceRegistryService.update(device);
             stepData.put("tags", tags);
-            stepData.put("Device", newDevice);
         } catch (Exception e) {
             verifyException(e);
         }
     }
 
+    @And("^I add device \"([^\"]*)\" to group \"([^\"]*)\"$")
+    public void iAddDeviceToGroup(String deviceName, String groupName) throws Exception {
+
+        try {
+            GroupQuery query = groupFactory.newQuery(getCurrentScopeId());
+            query.setPredicate(query.attributePredicate(GroupAttributes.NAME, groupName, AttributePredicate.Operator.EQUAL));
+            Group foundGroup = groupService.query(query).getFirstItem();
+
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            Device device = deviceRegistryService.query(tmpQuery).getFirstItem();
+
+            KapuaId groupId = foundGroup.getId();
+            device.setGroupId(groupId);
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
 
     @When("^I try to edit devices display name to \"([^\"]*)\"$")
     public void iTryToEditDevicesDisplayNameTo(String displayName) throws Exception {
@@ -2706,6 +2734,22 @@ public class DeviceRegistrySteps extends TestBase {
         }
     }
 
+    @When("^I remove device \"([^\"]*)\" from all groups$")
+    public void iChangeDevicesGroupToNoGroup(String deviceName) throws Exception{
+
+        try {
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            Device device = deviceRegistryService.query(tmpQuery).getFirstItem();
+
+            device.setGroupId(null);
+            device = deviceRegistryService.update(device);
+            stepData.put("Device", device);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
     @Given("^I unassign tag from device$")
     public void iUnassignTagFromDevice() throws Exception {
         Tag tag = (Tag) stepData.get("tag");
@@ -2716,6 +2760,21 @@ public class DeviceRegistrySteps extends TestBase {
             device.setTagIds(tagIds);
             Device newDevice = deviceRegistryService.update(device);
             stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @And("^I create (\\d+) devices and add them to group \"([^\"]*)\"$")
+    public void iCreateDevicesAndAddThemToGroup(int numberOfDevices, String groupName) throws Exception {
+        Group group = (Group) stepData.get("Group");
+        assertEquals(group.getName(), groupName);
+
+        try {
+            for(int i = 0; i < numberOfDevices; i++) {
+                iCreateADeviceWithName(String.format("Device%02d", i));
+                iAddDeviceToGroup(String.format("Device%02d", i), group.getName());
+            }
         } catch (Exception e) {
             verifyException(e);
         }
@@ -2739,6 +2798,25 @@ public class DeviceRegistrySteps extends TestBase {
             device.setTagIds(tagIds);
             Device newDevice = deviceRegistryService.update(device);
             stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Then("^Device \"([^\"]*)\" is in Assigned Devices of group \"([^\"]*)\"$")
+    public void deviceIsInGroupsAssignedDevices(String deviceName, String groupName) throws Exception {
+
+        try {
+            GroupQuery query = groupFactory.newQuery(getCurrentScopeId());
+            query.setPredicate(query.attributePredicate(GroupAttributes.NAME, groupName, AttributePredicate.Operator.EQUAL));
+            Group foundGroup = groupService.query(query).getFirstItem();
+
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            Device device = deviceRegistryService.query(tmpQuery).getFirstItem();
+
+            KapuaId expectedGroupId = foundGroup.getId();
+            assertEquals(device.getGroupId(), expectedGroupId);
         } catch (Exception e) {
             verifyException(e);
         }
@@ -2782,6 +2860,25 @@ public class DeviceRegistrySteps extends TestBase {
 
             Set<KapuaId> tagIds = device.getTagIds();
             assertFalse(tagIds.contains(tag.getId()));
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Then("^Device \"([^\"]*)\" is not in Assigned Devices of group \"([^\"]*)\"$")
+    public void deviceIsNotInGroupsAssignedDevices(String deviceName, String groupName) throws Exception {
+
+        try {
+            GroupQuery query = groupFactory.newQuery(getCurrentScopeId());
+            query.setPredicate(query.attributePredicate(GroupAttributes.NAME, groupName, AttributePredicate.Operator.EQUAL));
+            Group foundGroup = groupService.query(query).getFirstItem();
+
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            Device device = deviceRegistryService.query(tmpQuery).getFirstItem();
+
+            KapuaId expectedGroupId = foundGroup.getId();
+            assertNotEquals(device.getGroupId(), expectedGroupId);
         } catch (Exception e) {
             verifyException(e);
         }


### PR DESCRIPTION
Added tests for adding, deleting and editing groups, and adding devices to groups.

Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

Test scenarios for Groups are added in this PR.

**Related Issue**
_None_

**Description of the solution adopted**
Test scenarios that are added in this PR are checking functionalities regarding Groups. All scenarios are added to `GroupService.feature`. Scenarios are testing if Groups are correctly created, edited or deleted and if Devices can be added to Groups.

**Screenshots**
/
