### PR TITLE
Upgraded commons-beanutils version from 1.9.3 to 1.9.4 - CVE-2019-10086 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,7 +33,7 @@
         <artemis.version>2.2.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>
         <camel.version>2.16.3</camel.version>
-        <commons-beanutils.version>1.9.3</commons-beanutils.version>
+        <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.9</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>


### PR DESCRIPTION
Brief description of the PR.
This PR bumps the version of `commons-beanutils` dependency to 1.9.4

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available.
CQ submitted: [CQ 21417](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21417)

**Screenshots**
_None_

**Any side note on the changes made**
Full list of fixes: https://issues.apache.org/jira/browse/BEANUTILS-496?jql=project%20%3D%20BEANUTILS%20AND%20fixVersion%20%3D%201.9.4

We are not using this dependency directly but is a transient dependency of:
- shiro-core - 1.3.2: https://mvnrepository.com/artifact/org.apache.shiro/shiro-core/1.3.2
- artemis-jms-server - 2.2.0: https://mvnrepository.com/artifact/org.apache.activemq/artemis-jms-server/2.2.0
- apache-activemq - 5.14.5: https://mvnrepository.com/artifact/org.apache.activemq/activemq-broker/5.15.5