### PR TITLE
Upgraded Jackson dependencies version from 2.9.9.1 to 2.10.1 - CWE-502

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -88,8 +88,7 @@
         <elasticsearch-client-rest.version>5.3.0</elasticsearch-client-rest.version>
         <elasticsearch-netty-3.version>3.10.6.Final</elasticsearch-netty-3.version>
         <elasticsearch-netty-4.version>4.1.15.Final</elasticsearch-netty-4.version>
-        <jackson.version>2.9.9</jackson.version> <!-- Elastic Search uses 2.8.6 -->
-        <jackson-databind.version>2.9.9.1</jackson-databind.version> <!-- Elastic Search uses 2.8.6 -->
+        <jackson.version>2.10.1</jackson.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
@@ -1469,7 +1468,7 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson-databind.version}</version>
+                <version>${jackson.version}</version>
             </dependency>
 
             <dependency>


### PR DESCRIPTION
This PR bumps the version of Jackson Databind Library to 2.10.1
Transitive dependencies:

- Jackson Core: from 2.9.9 to 2.10.1
- Jackson Annotations: from 2.9.9 to 2.10.1

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs.

Jackson Databind: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21421
Jackson Core: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21422
Jackson Annotations: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21423

**Screenshots**
_None_

**Any side note on the changes made**
_None_