### PR TITLE
fix broker metrics names

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -48,7 +48,8 @@ public abstract class AbstractKapuaConverter {
     public static final Logger logger = LoggerFactory.getLogger(AbstractKapuaConverter.class);
 
     // metrics
-    protected static final String METRIC_COMPONENT_NAME = "converter";
+    protected static final String METRIC_MODULE_NAME = "converter";
+    protected static final String METRIC_COMPONENT_NAME = "kapua";
     protected static final MetricsService METRICS_SERVICE = MetricServiceFactory.getInstance();
 
     private final Counter metricConverterJmsMessage;
@@ -59,9 +60,9 @@ public abstract class AbstractKapuaConverter {
      * Constructor
      */
     protected AbstractKapuaConverter() {
-        metricConverterJmsMessage = METRICS_SERVICE.getCounter(METRIC_COMPONENT_NAME, "kapua", "jms", "messages", "count");
-        metricConverterJmsErrorMessage = METRICS_SERVICE.getCounter(METRIC_COMPONENT_NAME, "kapua", "jms", "messages", "error", "count");
-        metricConverterErrorMessage = METRICS_SERVICE.getCounter(METRIC_COMPONENT_NAME, "kapua", "kapua_message", "messages", "error", "count");
+        metricConverterJmsMessage = METRICS_SERVICE.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "jms", "message", "count");
+        metricConverterJmsErrorMessage = METRICS_SERVICE.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "jms", "message", "error", "count");
+        metricConverterErrorMessage = METRICS_SERVICE.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "kapua_message", "message", "error", "count");
     }
 
     /**

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
@@ -41,7 +41,9 @@ public class DeviceManagementNotificationMessageProcessor extends AbstractProces
     private static final DeviceManagementRegistryManagerService DEVICE_MANAGEMENT_REGISTRY_MANAGER_SERVICE = KapuaLocator.getInstance().getService(DeviceManagementRegistryManagerService.class);
     private static final JobDeviceManagementOperationManagerService JOB_DEVICE_MANAGEMENT_OPERATION_MANAGER_SERVICE = KapuaLocator.getInstance().getService(JobDeviceManagementOperationManagerService.class);
 
-    private static final String METRIC_COMPONENT_NAME = "deviceManagementRegistry";
+    private static final String METRIC_MODULE_NAME = "device_management_registry";
+    private static final String METRIC_COMPONENT_NAME = "notification";
+    private static final String METRIC_PROCESS_QUEUE = "process_queue";
 
     // queues counters
     private final Counter metricQueueCommunicationErrorCount;
@@ -52,9 +54,9 @@ public class DeviceManagementNotificationMessageProcessor extends AbstractProces
         super("Device Management Notify Processor");
         MetricsService metricService = MetricServiceFactory.getInstance();
 
-        metricQueueCommunicationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "deviceManagementNotification", "process", "queue", "communication", "error", "count");
-        metricQueueConfigurationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "deviceManagementNotification", "process", "queue", "configuration", "error", "count");
-        metricQueueGenericErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "deviceManagementNotification", "process", "queue", "generic", "error", "count");
+        metricQueueCommunicationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, METRIC_PROCESS_QUEUE, "communication", "error", "count");
+        metricQueueConfigurationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, METRIC_PROCESS_QUEUE, "configuration", "error", "count");
+        metricQueueGenericErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, METRIC_PROCESS_QUEUE, "generic", "error", "count");
     }
 
     /**

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
@@ -77,19 +77,19 @@ public class UserAuthenticationLogic extends AuthenticationLogic {
 
         kcc.updatePermissions(hasPermissions);
 
-        Context loginFindClientIdTimeContext = loginMetric.getFindClientIdTime().time();
+        Context loginFindDeviceConnectionTimeContext = loginMetric.getFindDeviceConnectionTime().time();
         DeviceConnection deviceConnection = KapuaSecurityUtils.doPrivileged(() -> deviceConnectionService.findByClientId(kcc.getScopeId(), kcc.getClientId()));
-        loginFindClientIdTimeContext.stop();
+        loginFindDeviceConnectionTimeContext.stop();
 
         // enforce the user-device bound
         enforceDeviceConnectionUserBound(KapuaSecurityUtils.doPrivileged(() -> deviceConnectionService.getConfigValues(kcc.getScopeId())), deviceConnection, kcc.getScopeId(), kcc.getUserId());
 
-        Context loginFindDevTimeContext = loginMetric.getFindDevTime().time();
+        Context loginUpdateDeviceConnectionTimeContext = loginMetric.getUpdateDeviceConnectionTime().time();
         {
             deviceConnection = upsertDeviceConnection(kcc, deviceConnection);
             kcc.updateKapuaConnectionId(deviceConnection);
         }
-        loginFindDevTimeContext.stop();
+        loginUpdateDeviceConnectionTimeContext.stop();
 
         List<AuthorizationEntry> authorizationEntries = buildAuthorizationMap(kcc);
         loginNormalUserTimeContext.stop();

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
@@ -34,8 +34,8 @@ public class LoginMetric {
     private Timer normalUserTime;
     private Timer shiroLoginTime;
     private Timer checkAccessTime;
-    private Timer findClientIdTime;
-    private Timer findDevTime;
+    private Timer findDeviceConnectionTime;
+    private Timer updateDeviceConnectionTime;
     private Timer shiroLogoutTime;
     private Timer sendLoginUpdateMsgTime;
     private Timer removeConnectionTime;
@@ -62,8 +62,8 @@ public class LoginMetric {
         normalUserTime = metricsService.getTimer("security", "login", "user", "time", "s");
         shiroLoginTime = metricsService.getTimer("security", "login", "shiro", "login", "time", "s");
         checkAccessTime = metricsService.getTimer("security", "login", "check_access", "time", "s");
-        findClientIdTime = metricsService.getTimer("security", "login", "find_client_id", "time", "s");
-        findDevTime = metricsService.getTimer("security", "login", "find_device", "time", "s");
+        findDeviceConnectionTime = metricsService.getTimer("security", "login", "find_device_connection", "time", "s");
+        updateDeviceConnectionTime = metricsService.getTimer("security", "login", "update_device_connection", "time", "s");
         shiroLogoutTime = metricsService.getTimer("security", "login", "shiro", "logout", "time", "s");
         sendLoginUpdateMsgTime = metricsService.getTimer("security", "login", "send_login_update", "time", "s");
         removeConnectionTime = metricsService.getTimer("security", "login", "remove_connection", "time", "s");
@@ -129,12 +129,12 @@ public class LoginMetric {
         return checkAccessTime;
     }
 
-    public Timer getFindClientIdTime() {
-        return findClientIdTime;
+    public Timer getFindDeviceConnectionTime() {
+        return findDeviceConnectionTime;
     }
 
-    public Timer getFindDevTime() {
-        return findDevTime;
+    public Timer getUpdateDeviceConnectionTime() {
+        return updateDeviceConnectionTime;
     }
 
     public Timer getShiroLogoutTime() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
@@ -54,18 +54,18 @@ public class RaiseServiceEventInterceptor implements MethodInterceptor {
     private static final Logger LOG = LoggerFactory.getLogger(RaiseServiceEventInterceptor.class);
 
     private static final String MODULE = "commons";
-    private static final String COMPONENT = "serviceEvent";
+    private static final String COMPONENT = "service_event";
     private static final String ACTION = "event_data_filler";
     private static final String COUNT = "count";
 
 
     private static final MetricsService METRIC_SERVICE = MetricServiceFactory.getInstance();
 
-    private Counter wrongIds;
+    private Counter wrongId;
     private Counter wrongEntity;
 
     public RaiseServiceEventInterceptor() {
-        wrongIds = METRIC_SERVICE.getCounter(MODULE, COMPONENT, ACTION, "wrong_ids", COUNT);
+        wrongId = METRIC_SERVICE.getCounter(MODULE, COMPONENT, ACTION, "wrong_id", COUNT);
         wrongEntity = METRIC_SERVICE.getCounter(MODULE, COMPONENT, ACTION, "wrong_entity", COUNT);
     }
 
@@ -183,7 +183,7 @@ public class RaiseServiceEventInterceptor implements MethodInterceptor {
     private void useKapuaIdsToFillEvent(ServiceEvent serviceEvent, List<KapuaId> ids, Class<?>[] implementedClass) {
         if (ids.size()>2) {
             LOG.warn("Found more than two KapuaId in the parameters! Assuming to use the first two!");
-            wrongIds.inc();
+            wrongId.inc();
         }
         if (ids.size() >= 2) {
             serviceEvent.setEntityScopeId(ids.get(0));

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -87,8 +87,6 @@ public final class MessageStoreFacade {
 
     private final Counter metricMessagesAlreadyInTheDatastoreCount;
 
-    private static final String METRIC_COMPONENT_NAME = "datastore";
-
     private final MessageStoreMediator mediator;
     private final ConfigurationProvider configProvider;
     private DatastoreClient client;
@@ -106,7 +104,7 @@ public final class MessageStoreFacade {
         this.mediator = mediator;
         client = DatastoreClientFactory.getInstance();
         MetricsService metricService = MetricServiceFactory.getInstance();
-        metricMessagesAlreadyInTheDatastoreCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "already_in_the_datastore", "count");
+        metricMessagesAlreadyInTheDatastoreCount = metricService.getCounter(MessageStoreServiceImpl.METRIC_MODULE_NAME, MessageStoreServiceImpl.METRIC_COMPONENT_NAME, "store", "messages", "already_in_the_datastore", "count");
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -56,7 +56,8 @@ import java.util.UUID;
 @KapuaProvider
 public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService implements MessageStoreService {
 
-    protected static final String METRIC_COMPONENT_NAME = "datastore";
+    public static final String METRIC_MODULE_NAME = "datastore";
+    public static final String METRIC_COMPONENT_NAME = "driver";
 
     protected static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     // metrics
@@ -91,17 +92,17 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         DatastoreMediator.getInstance().setMessageStoreFacade(messageStoreFacade);
         // data message
         MetricsService metricService = MetricServiceFactory.getInstance();
-        metricMessageCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "count");
-        metricCommunicationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "communication", "error", "count");
-        metricConfigurationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "configuration", "error", "count");
-        metricGenericErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "generic", "error", "count");
-        metricValidationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "validation", "error", "count");
+        metricMessageCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "count");
+        metricCommunicationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "communication", "error", "count");
+        metricConfigurationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "configuration", "error", "count");
+        metricGenericErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "generic", "error", "count");
+        metricValidationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "validation", "error", "count");
         // error messages queues size
-        metricQueueCommunicationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "communication", "error", "count");
-        metricQueueConfigurationErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "configuration", "error", "count");
-        metricQueueGenericErrorCount = metricService.getCounter(METRIC_COMPONENT_NAME, "datastore", "store", "queue", "generic", "error", "count");
+        metricQueueCommunicationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "queue", "communication", "error", "count");
+        metricQueueConfigurationErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "queue", "configuration", "error", "count");
+        metricQueueGenericErrorCount = metricService.getCounter(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "queue", "generic", "error", "count");
         // store timers
-        metricDataSaveTime = metricService.getTimer(METRIC_COMPONENT_NAME, "datastore", "store", "messages", "time", "s");
+        metricDataSaveTime = metricService.getTimer(METRIC_MODULE_NAME, METRIC_COMPONENT_NAME, "store", "messages", "time", "s");
     }
 
     @Override


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>

Fix some metrics names since they had a wrong name (not meaningful or completely wrong) 

e.g.
security_login_find_client_id_time_s ---> security_login_find_device_connection_time_s
security_login_find_device_time_s ---> security_login_update_device_connection_time_s








