### PR TITLE
Feature predicates in rest api

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AttributePredicateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AttributePredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -57,13 +57,28 @@ public class AttributePredicateImpl<T> implements AttributePredicate<T> {
     }
 
     @Override
+    public void setAttributeName(String attributeName) {
+        this.attributeName = attributeName;
+    }
+
+    @Override
     public T getAttributeValue() {
         return attributeValue;
     }
 
     @Override
+    public void setAttributeValue(T attributeValue) {
+        this.attributeValue = attributeValue;
+    }
+
+    @Override
     public Operator getOperator() {
         return operator;
+    }
+
+    @Override
+    public void setOperator(Operator operator) {
+        this.operator = operator;
     }
 
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/PredicateFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/PredicateFactoryImpl.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.model.query.predicate;
+
+import org.eclipse.kapua.commons.model.query.FieldSortCriteriaImpl;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.query.FieldSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
+import org.eclipse.kapua.model.query.predicate.OrPredicate;
+import org.eclipse.kapua.model.query.predicate.PredicateFactory;
+import org.eclipse.kapua.model.query.predicate.QueryPredicate;
+
+@KapuaProvider
+public class PredicateFactoryImpl implements PredicateFactory {
+
+
+    @Override
+    public <T> AttributePredicate<T> attributePredicate(String attributeName, T attributeValue) {
+        return new AttributePredicateImpl<>(attributeName, attributeValue);
+    }
+
+    @Override
+    public <T> AttributePredicate<T> attributePredicate(String attributeName, T attributeValue, Operator operator) {
+        return new AttributePredicateImpl<>(attributeName, attributeValue, operator);
+    }
+
+    @Override
+    public AndPredicate andPredicate() {
+        return new AndPredicateImpl();
+    }
+
+    @Override
+    public AndPredicate andPredicate(QueryPredicate... queryPredicates) {
+        return new AndPredicateImpl(queryPredicates);
+    }
+
+    @Override
+    public OrPredicate orPredicate() {
+        return new OrPredicateImpl();
+    }
+
+    @Override
+    public OrPredicate orPredicate(QueryPredicate... queryPredicates) {
+        return new OrPredicateImpl(queryPredicates);
+    }
+
+    @Override
+    public FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder) {
+        return new FieldSortCriteriaImpl(attributeName, sortOrder);
+    }
+
+}

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -438,9 +438,91 @@ components:
           description: An Offset on the result size. Used to skip the first `n` items of a result set, with `n` equal to the value of `offset`
           type: integer
           default: 0
+        predicate:
+          $ref: '#/components/schemas/predicate'
       example:
         offset: 0
         limit: 50
+    ### Predicates ###
+    andPredicate:
+      description: A Predicate that puts in logical AND condition other Predicates
+      properties:
+        predicates:
+          type: array
+          items:
+            - $ref: '#/components/schemas/predicate'
+    orPredicate:
+      description: A Predicate that puts in logical OR condition other Predicates
+      properties:
+        predicates:
+          type: array
+          items:
+            - $ref: '#/components/schemas/predicate'
+    attributePredicate:
+      description: A Predicate that filters entities according to an Attribute and its value
+      properties:
+        attributeName:
+          description: The Name of the Attribute to use as a filter
+          type: string
+        attributeValue:
+          description: The Value of the Attribute to use as a filter
+          type: object
+          properties:
+            valueType:
+              description: The type of `value` if present, or the type of the items inside `arrayValue` otherwise
+              type: string
+            value:
+              description: the value that must match the `attributeName` for the Predicate to be true. Mutually exclusive with `arrayValue`
+              type: string
+            arrayValue:
+              description: |
+                an array of strings if `operator` is EQUAL (or not present, since EQUAL is the default value in that case).
+                EQUAL operator will act as an `IN` SQL clause. Mutually exclusive with `value`
+              type: array
+              items:
+                type: string
+        operator:
+          description: The Operator to use as a filter
+          type: string
+          enum:
+            - EQUAL
+            - NOT_EQUAL
+            - IS_NULL
+            - NOT_NULL
+            - STARTS_WITH
+            - LIKE
+            - GREATER_THAN
+            - GREATER_THAN_OR_EQUAL
+            - LESS_THAN
+            - LESS_THAN_OR_EQUAL
+          default: EQUAL
+    predicate:
+      description: |
+        A Predicate object containing the predicate to be used in the query. It can be one of `andPredicate`, `orPredicate` or `attributePredicate`
+        `andPredicate`s and `orPredicates` can contain additional Predicates (of every type) to implement complex logical operations.
+        An `attributePredicate` will contain an `attributeName`, an `attributeValue` and an optional `operator`.
+      type: object
+      # TODO this oneOf is commented because SwaggerUI reports dozens of errors if file is built with --dereference, and
+      # building without --dereference is not possible because of the circular reference between predicate, andPredicate
+      # and orPredicate. Once SwaggerUI fixes this, or circular references are better handled in swagger-cli, this oneOf
+      # can be brought in again.
+#      oneOf:
+#          - $ref: '#/components/schemas/andPredicate'
+#          - $ref: '#/components/schemas/orPredicate'
+#          - $ref: '#/components/schemas/attributePredicate'
+      properties:
+        type:
+          type: string
+          enum:
+            - andPredicate
+            - orPredicate
+            - attributePredicate
+      discriminator:
+        propertyName: type
+        mapping:
+          andPredicate: '#/components/schemas/andPredicate'
+          orPredicate: '#/components/schemas/orPredicate'
+          attributePredicate: '#/components/schemas/attributePredicate'
     ### Creators ###
     kapuaEntityCreator:
       description: An object that contains the informations needed to create an Entity
@@ -496,6 +578,43 @@ components:
         application/json:
           schema:
             $ref: '#/components/schemas/kapuaQuery'
+          examples:
+            simple_query:
+              summary: Simple query
+              description: |
+                A simple query with no filtering predicates. Only `offset` and `limit` are present, to limit the result
+                set
+              value:
+                offset: 0
+                limit: 50
+            complex_query:
+              summary: Complex query with Predicates
+              description: |
+                A complex query for a `kapuaNamedEntity` (an entity with a `name` field). The main Predicate is an
+                `andPredicate`, with two sub-predicates: an `attributePredicate` to match on a set of `id`s (AQ or Ag),
+                and another one to match all entities with a `displayName` that contains the "Broker" string. So, in
+                pseudo-SQL code, this clause would translate as `WHERE id IN ['AQ', 'Ag'] AND name LIKE '%broker%'`.
+
+                **The `value` and `arrayValue` properties are mutually exclusive within the same predicate**.
+              value:
+                offset: 0
+                limit: 50
+                predicate:
+                  type: andPredicate
+                  predicates:
+                    - type: attributePredicate
+                      attributeName: id
+                      attributeValue:
+                        arrayValue:
+                          - AQ
+                          - Ag
+                        valueType: org.eclipse.kapua.model.id.KapuaId
+                    - type: attributePredicate
+                      attributeName: name
+                      attributeValue:
+                        value: broker
+                        valueType: string
+                      operator: LIKE
       required: true
   responses:
     countResult:

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -38,6 +38,12 @@ import org.eclipse.kapua.model.config.metatype.KapuaTicon;
 import org.eclipse.kapua.model.config.metatype.KapuaTmetadata;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.config.metatype.KapuaToption;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate;
+import org.eclipse.kapua.model.query.predicate.OrPredicate;
+import org.eclipse.kapua.model.query.predicate.PredicateValueXmlAdapter;
+import org.eclipse.kapua.model.query.predicate.PredicateXmlRegistry;
+import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountCreator;
 import org.eclipse.kapua.service.account.AccountListResult;
@@ -268,6 +274,14 @@ public class JaxbContextResolver implements ContextResolver<JAXBContext> {
                     KapuaTicon.class,
                     KapuaTmetadata.class,
                     KapuaToption.class,
+
+                    // Predicates
+                    QueryPredicate.class,
+                    AndPredicate.class,
+                    OrPredicate.class,
+                    AttributePredicate.class,
+                    PredicateValueXmlAdapter.class,
+                    PredicateXmlRegistry.class,
 
                     // Account
                     Account.class,

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -142,6 +142,8 @@
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
+
+        <api>org.eclipse.kapua.model.query.predicate.PredicateFactory</api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -84,7 +84,7 @@ public interface KapuaQuery<E extends KapuaEntity> {
      * @return The {@link KapuaQuery} {@link QueryPredicate}s.
      * @since 1.0.0
      */
-    @XmlTransient
+    @XmlElement(name = "predicate")
     QueryPredicate getPredicate();
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,11 @@
 package org.eclipse.kapua.model.query.predicate;
 
 import javax.validation.constraints.NotNull;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlElementWrapper;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
@@ -21,6 +26,8 @@ import java.util.List;
  *
  * @since 1.0.0
  */
+@XmlRootElement(name = "andPredicate")
+@XmlType(factoryClass = PredicateXmlRegistry.class, factoryMethod = "newAndPredicate")
 public interface AndPredicate extends QueryPredicate {
 
     /**
@@ -31,6 +38,7 @@ public interface AndPredicate extends QueryPredicate {
      * @throws NullPointerException if the given parameter is {@code null}.
      * @since 1.0.0
      */
+    @XmlTransient
     AndPredicate and(@NotNull QueryPredicate predicate);
 
     /**
@@ -39,6 +47,8 @@ public interface AndPredicate extends QueryPredicate {
      * @return The {@link List} of {@link QueryPredicate}s
      * @since 1.0.0
      */
+    @XmlElementWrapper(name = "predicates")
+    @XmlElement(name = "predicate")
     List<QueryPredicate> getPredicates();
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AttributePredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AttributePredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,12 +11,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query.predicate;
 
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
 /**
  * {@link AttributePredicate} definition.
  *
  * @param <T> Attribute value type.
  * @since 1.0.0
  */
+@XmlRootElement(name = "attributePredicate")
+@XmlType(factoryClass = PredicateXmlRegistry.class, factoryMethod = "newAttributePredicate")
 public interface AttributePredicate<T> extends QueryPredicate {
 
     /**
@@ -129,13 +136,19 @@ public interface AttributePredicate<T> extends QueryPredicate {
      */
     String getAttributeName();
 
+    void setAttributeName(String attributeName);
+
     /**
      * Gets the value to compare the results.
      *
      * @return The value to compare the results.
      * @since 1.0.0
      */
+    @XmlAnyElement
+    @XmlJavaTypeAdapter(PredicateValueXmlAdapter.class)
     T getAttributeValue();
+
+    void setAttributeValue(T value);
 
     /**
      * Get the {@link Operator} used to compare results.
@@ -144,4 +157,6 @@ public interface AttributePredicate<T> extends QueryPredicate {
      * @since 1.0.0
      */
     Operator getOperator();
+
+    void setOperator(Operator operator);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateFactory.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.query.predicate;
+
+import org.eclipse.kapua.model.KapuaObjectFactory;
+import org.eclipse.kapua.model.query.FieldSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+
+public interface PredicateFactory extends KapuaObjectFactory {
+
+    <T> AttributePredicate<T> attributePredicate(String attributeName, T attributeValue);
+
+    <T> AttributePredicate<T> attributePredicate(String attributeName, T attributeValue, AttributePredicate.Operator operator);
+
+    AndPredicate andPredicate();
+
+    AndPredicate andPredicate(QueryPredicate... queryPredicates);
+
+    OrPredicate orPredicate();
+
+    OrPredicate orPredicate(QueryPredicate... queryPredicates);
+
+    FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder);
+
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateValueXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateValueXmlAdapter.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.query.predicate;
+
+import javax.xml.bind.annotation.adapters.XmlAdapter;
+
+import java.util.Arrays;
+
+import org.eclipse.kapua.model.type.ObjectValueConverter;
+
+public class PredicateValueXmlAdapter extends XmlAdapter<XmlAdaptedPredicateValue, Object> {
+
+    @Override
+    public Object unmarshal(XmlAdaptedPredicateValue xmlAdaptedPredicateValue) throws Exception {
+        if (xmlAdaptedPredicateValue.getArrayValue() != null) {
+            return Arrays.stream(xmlAdaptedPredicateValue.getArrayValue()).map(value -> ObjectValueConverter.fromString(value, xmlAdaptedPredicateValue.getValueType())).toArray();
+        } else {
+            return ObjectValueConverter.fromString(xmlAdaptedPredicateValue.getValue(), xmlAdaptedPredicateValue.getValueType());
+        }
+    }
+
+    @Override
+    public XmlAdaptedPredicateValue marshal(Object value) throws Exception {
+        XmlAdaptedPredicateValue xmlAdaptedPredicateValue = new XmlAdaptedPredicateValue();
+        if (value.getClass().isArray()) {
+            Object[] objects = (Object[]) value;
+            xmlAdaptedPredicateValue.setArrayValue(Arrays.stream(objects).map(ObjectValueConverter::toString).toArray(String[]::new));
+            if (objects.length > 0) {
+                xmlAdaptedPredicateValue.setValueType(objects[0].getClass());
+            }
+        } else {
+            xmlAdaptedPredicateValue.setValueType(value.getClass());
+            xmlAdaptedPredicateValue.setValue(ObjectValueConverter.toString(value));
+        }
+        return xmlAdaptedPredicateValue;
+    }
+
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/PredicateXmlRegistry.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.query.predicate;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+@XmlRegistry
+public class PredicateXmlRegistry {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final PredicateFactory PREDICATE_FACTORY = LOCATOR.getFactory(PredicateFactory.class);
+
+    public AttributePredicate newAttributePredicate() {
+        return PREDICATE_FACTORY.attributePredicate(null, null);
+    }
+
+    public AndPredicate newAndPredicate() {
+        return PREDICATE_FACTORY.andPredicate();
+    }
+
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/XmlAdaptedPredicateValue.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/XmlAdaptedPredicateValue.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.model.query.predicate;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+import org.eclipse.kapua.model.xml.ObjectTypeXmlAdapter;
+
+@XmlAccessorType(XmlAccessType.FIELD)
+public class XmlAdaptedPredicateValue {
+
+    @XmlJavaTypeAdapter(ObjectTypeXmlAdapter.class)
+    @XmlElement(name = "valueType")
+    private Class<?> valueType;
+
+    @XmlElement(name = "value")
+    private String value;
+
+    @XmlElement(name = "arrayValue")
+    private String[] arrayValue;
+
+    public XmlAdaptedPredicateValue() {
+    }
+
+    public Class<?> getValueType() {
+        return valueType;
+    }
+
+    public void setValueType(Class<?> type) {
+        this.valueType = type;
+    }
+
+    public String getValue() {
+        return value;
+    }
+
+    public void setValue(String value) {
+        if (getArrayValue() != null) {
+            throw new IllegalStateException("\"value\" and \"arrayValue\" properties are mutually exclusive");
+        }
+        this.value = value;
+    }
+
+    public String[] getArrayValue() {
+        return arrayValue;
+    }
+
+    public void setArrayValue(String[] arrayValue) {
+        if (getValue() != null) {
+            throw new IllegalStateException("\"value\" and \"arrayValue\" properties are mutually exclusive");
+        }
+        this.arrayValue = arrayValue;
+    }
+
+}

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,12 +11,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.type;
 
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdFactory;
+
 /**
  * Utilities to convert the value of objects to serialize them.
  *
  * @since 1.0.0
  */
 public class ObjectValueConverter {
+
+    private static final KapuaIdFactory KAPUA_ID_FACTORY = KapuaLocator.getInstance().getFactory(KapuaIdFactory.class);
 
     private ObjectValueConverter() {
     }
@@ -80,6 +86,8 @@ public class ObjectValueConverter {
                 value = Boolean.parseBoolean(stringValue);
             } else if (type == byte[].class || type == Byte[].class) {
                 value = ByteArrayConverter.fromString(stringValue);
+            } else if (type == KapuaId.class) {
+                value = KAPUA_ID_FACTORY.newKapuaId(stringValue);
             } else {
                 value = stringValue;
             }
@@ -87,4 +95,5 @@ public class ObjectValueConverter {
 
         return value;
     }
+
 }


### PR DESCRIPTION
With this PR is now possible to provide a `predicate` object in REST APIs to perform complex queries.

**Related Issue**
No related issues

**Description of the solution adopted**
Three different kinds of Predicates are available:

- `andPredicate`: an object with the following schema:
```
{
    "type": "andPredicate",
    "predicates": [{
...
    }] 
}
```
Used to create logical AND operations from multiple predicates

- `orPredicate`: an object with the following schema:
```
{
    "type": "orPredicate",
    "predicates": [{
...
    }] 
}
```
Used to create logical OR operations from multiple predicates

- `attributePredicate`: an  object with the following schema:
```
{
    "type": "attributePredicate",
    "attributeName": "displayName",
    "attributeValue": {
        "value": "Broker",
        "valueType": "string"
    },
    "operator": "LIKE"
}
```
Properties:
- `attributeName`: the name of the Attribute in which to filter on
- `attributeValue` an object containing the value to filter on. It contains:
  - `value`: the value that must match the `attributeName` for the Predicate to be true. Mutually exclusive with `arrayValue`
  - `arrayValue`: an array of strings if `operator` is `EQUAL` (or not present, since `EQUAL` is the default value in that case). `EQUAL` operator will act as an `IN` SQL clause. Mutually exclusive with `value`
  - `valueType`: the type of `value` if present, or the type of items inside `arrayValue` if present
- `operator`: the operator to use. MUST be one of the following:
  - EQUAL
  - NOT_EQUAL
  - IS_NULL
  - NOT_NULL
  - STARTS_WITH
  - LIKE
  - GREATER_THAN
  - GREATER_THAN_OR_EQUAL
  - LESS_THAN
  - LESS_THAN_OR_EQUAL
