### PR TITLE
Add Windows profile in Maven to use specific swagger-cli executable

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -26,6 +26,7 @@
 
     <properties>
         <nodejs.version>10.16.3</nodejs.version>
+        <swagger-cli.executable>${project.build.directory}/bin/swagger-cli</swagger-cli.executable>
     </properties>
 
     <dependencies>
@@ -307,7 +308,7 @@
                     </execution>
                 </executions>
                 <configuration>
-                    <executable>${project.build.directory}/bin/swagger-cli</executable>
+                    <executable>${swagger-cli.executable}</executable>
                     <environmentVariables>
                         <PATH>$PATH:${project.build.directory}/node</PATH>
                     </environmentVariables>
@@ -380,6 +381,17 @@
                     </plugin>
                 </plugins>
             </build>
+        </profile>
+        <profile>
+            <id>swagger-cli-windows</id>
+            <activation>
+                <os>
+                    <family>Windows</family>
+                </os>
+            </activation>
+            <properties>
+                <swagger-cli.executable>${project.build.directory}/node/swagger-cli.cmd</swagger-cli.executable>
+            </properties>
         </profile>
     </profiles>
 


### PR DESCRIPTION
After merging #2795, [swagger-cli](https://www.npmjs.com/package/swagger-cli) is used to bundle all the OpenAPI files in a single file to be served from SwaggerUI. Apparently, when building under Windows, swagger-cli is installed in a different location than when building under macOS and Linux, so a new Maven profile, automatically activated when building in Windows, has been created to customize the swagger-cli executable path.

**Related Issue**
Fixes #2826
