### PR TITLE
Fix H2 URI in Dockerfile

### DIFF
--- a/assembly/sql/docker/Dockerfile
+++ b/assembly/sql/docker/Dockerfile
@@ -21,7 +21,7 @@ RUN useradd -u 1001 -g 0 -d '/var/opt/h2' -s '/sbin/nologin' h2 && \
     mkdir -p /var/opt/h2/data && chmod -R a+rw /var/opt/h2 && \
     mkdir -p /opt/h2 && chmod a+r /opt/h2 && \
     cd /opt/h2 && \
-    curl -s http://repo2.maven.org/maven2/com/h2database/h2/1.4.193/h2-1.4.193.jar -o h2.jar
+    curl -s https://repo1.maven.org/maven2/com/h2database/h2/1.4.193/h2-1.4.193.jar -o h2.jar
 
 VOLUME /var/opt/h2/data
 

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -155,7 +155,7 @@ Vagrant.configure(2) do |config|
     #############################
     sudo mkdir -p /usr/local/h2-${H2DB_VERSION}
     cd /usr/local/h2-${H2DB_VERSION}
-    sudo curl -O http://repo2.maven.org/maven2/com/h2database/h2/${H2DB_VERSION}/h2-${H2DB_VERSION}.jar
+    sudo curl -O https://repo1.maven.org/maven2/com/h2database/h2/${H2DB_VERSION}/h2-${H2DB_VERSION}.jar
     cd ../
     ln -s h2-${H2DB_VERSION} h2
 


### PR DESCRIPTION
Since January 15, 2020, [The Maven Central Repository access requires https](https://links.sonatype.com/central/501-https-required) to download artifacts. This PR fixes the URI for H2 Jar that would fail otherwise.

**Related Issue**
No related issues
