### PR TITLE
Upgraded Jose4j version from 0.5.2 to 0.7.0 - CWE-200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,7 +65,7 @@
         <javax-validation-api.version>1.1.0.Final</javax-validation-api.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
-        <jose4j.version>0.5.2</jose4j.version>
+        <jose4j.version>0.7.0</jose4j.version>
         <junit.version>4.11</junit.version>
         <liquibase.version>3.0.5</liquibase.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
This PR bumps the version of Jose4J Library to 0.70
The only transitive dependecy is `slf4j-api` but we already have a later version.

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
CQ filed: [21503](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21503)

**Screenshots**
_None_

**Any side note on the changes made**
_None_