### PR TITLE
Total Count in Queries

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
@@ -47,6 +47,7 @@ public abstract class AbstractKapuaQuery<E extends KapuaEntity> implements Kapua
 
     private Integer offset;
     private Integer limit;
+    private Boolean askTotalCount;
 
     /**
      * Constructor.
@@ -191,4 +192,14 @@ public abstract class AbstractKapuaQuery<E extends KapuaEntity> implements Kapua
     public FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder) {
         return new FieldSortCriteriaImpl(attributeName, sortOrder);
     }
+
+    @Override
+    public Boolean getAskTotalCount() {
+        return askTotalCount;
+    }
+
+    public void setAskTotalCount(Boolean askTotalCount) {
+        this.askTotalCount = askTotalCount;
+    }
+
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
@@ -31,6 +31,7 @@ public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResu
 
     private ArrayList<E> items;
     private boolean limitExceeded;
+    private Long totalCount;
 
     /**
      * Constructor.
@@ -99,4 +100,15 @@ public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResu
     public void sort(Comparator<E> comparator) {
         getItems().sort(comparator);
     }
+
+    @Override
+    public Long getTotalCount() {
+        return totalCount;
+    }
+
+    @Override
+    public void setTotalCount(Long totalCount) {
+        this.totalCount = totalCount;
+    }
+
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -416,6 +416,10 @@ public class ServiceDAO {
             resultContainer.setLimitExceeded(true);
         }
 
+        if (Boolean.TRUE.equals(kapuaQuery.getAskTotalCount())) {
+            resultContainer.setTotalCount(count(em, interfaceClass, implementingClass, kapuaQuery));
+        }
+
         // Set results
         resultContainer.addItems(result);
         return resultContainer;

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -680,7 +680,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
             AccountQuery query = GwtKapuaAccountModelConverter.convertAccountQuery(loadConfig, gwtAccountQuery);
 
             KapuaListResult<Account> accounts = ACCOUNT_SERVICE.query(query);
-            totalLength = (int) ACCOUNT_SERVICE.count(query);
+            totalLength = accounts.getTotalCount().intValue();
 
             if (!accounts.isEmpty()) {
                 UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/GwtKapuaAccountModelConverter.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/GwtKapuaAccountModelConverter.java
@@ -98,7 +98,7 @@ public class GwtKapuaAccountModelConverter {
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
         query.setPredicate(predicate);
-
+        query.setAskTotalCount(gwtAccountQuery.getAskTotalCount());
         return query;
     }
 }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/query/GwtQuery.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/query/GwtQuery.java
@@ -18,6 +18,7 @@ public class GwtQuery implements Serializable {
     private static final long serialVersionUID = 3080860571269787362L;
 
     private String scopeId;
+    private boolean askTotalCount = true;
 
     public GwtQuery() {
         super();
@@ -30,4 +31,13 @@ public class GwtQuery implements Serializable {
     public void setScopeId(String scopeId) {
         this.scopeId = scopeId;
     }
+
+    public boolean getAskTotalCount() {
+        return askTotalCount;
+    }
+
+    public void setAskTotalCount(boolean askTotalCount) {
+        this.askTotalCount = askTotalCount;
+    }
+
 }

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -84,7 +84,7 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
             // query
             CredentialListResult credentials = CREDENTIAL_SERVICE.query(credentialQuery);
             credentials.sort(credentialComparator);
-            totalLength = (int) CREDENTIAL_SERVICE.count(credentialQuery);
+            totalLength = credentials.getTotalCount().intValue();
 
             // If there are results
             if (!credentials.isEmpty()) {

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
@@ -83,6 +83,7 @@ public class GwtKapuaAuthenticationModelConverter {
         query.setPredicate(andPredicate);
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
+        query.setAskTotalCount(gwtCredentialQuery.getAskTotalCount());
 
         //
         // Return converted

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessPermissionServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessPermissionServiceImpl.java
@@ -148,7 +148,7 @@ public class GwtAccessPermissionServiceImpl extends KapuaRemoteServiceServlet im
                     query.setSortCriteria(sortCriteria);
 
                     AccessPermissionListResult accessPermissionList = ACCESS_PERMISSION_SERVICE.query(query);
-                    totalLength = (int) ACCESS_PERMISSION_SERVICE.count(query);
+                    totalLength = accessPermissionList.getTotalCount().intValue();
 
                     if (!accessPermissionList.isEmpty()) {
                         for (final AccessPermission accessPermission : accessPermissionList.getItems()) {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
@@ -144,7 +144,7 @@ public class GwtAccessRoleServiceImpl extends KapuaRemoteServiceServlet implemen
                     query.setSortCriteria(sortCriteria);
                     AccessRoleListResult accessRoleList = accessRoleService.query(query);
 
-                    totalLegnth = (int) accessRoleService.count(query);
+                    totalLegnth = accessRoleList.getTotalCount().intValue();
                     if (!accessRoleList.isEmpty()) {
                         for (final AccessRole accessRole : accessRoleList.getItems()) {
                             User createdByUser = KapuaSecurityUtils.doPrivileged(new Callable<User>() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -126,7 +126,7 @@ public class GwtGroupServiceImpl extends KapuaRemoteServiceServlet implements Gw
         try {
             GroupQuery groupQuery = GwtKapuaAuthorizationModelConverter.convertGroupQuery(loadConfig, gwtGroupQuery);
             GroupListResult groups = GROUP_SERVICE.query(groupQuery);
-            totalLength = (int) GROUP_SERVICE.count(groupQuery);
+            totalLength = groups.getTotalCount().intValue();
 
             if (!groups.isEmpty()) {
                 UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -181,7 +181,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // query
             RoleListResult roles = ROLE_SERVICE.query(roleQuery);
-            totalLength = Long.valueOf(ROLE_SERVICE.count(roleQuery)).intValue();
+            totalLength = roles.getTotalCount().intValue();
 
             if (!roles.isEmpty()) {
                 UserListResult usernames = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {
@@ -282,7 +282,7 @@ public class GwtRoleServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             query.setSortCriteria(sortCriteria);
 
             RolePermissionListResult list = ROLE_PERMISSION_SERVICE.query(query);
-            totalLength = (int) ROLE_PERMISSION_SERVICE.count(query);
+            totalLength = list.getTotalCount().intValue();
 
             if (list != null) {
                 for (final RolePermission rolePermission : list.getItems()) {

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
@@ -107,6 +107,7 @@ public class GwtKapuaAuthorizationModelConverter {
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
         query.setPredicate(predicate);
+        query.setAskTotalCount(true);
 
         return query;
     }
@@ -147,7 +148,7 @@ public class GwtKapuaAuthorizationModelConverter {
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
         query.setPredicate(predicate);
-
+        query.setAskTotalCount(gwtRoleQuery.getAskTotalCount());
         //
         // Return converted
         return query;
@@ -163,7 +164,7 @@ public class GwtKapuaAuthorizationModelConverter {
         query.setPredicate(query.attributePredicate(AccessRoleAttributes.ROLE_ID, KapuaEid.parseCompactId(gwtRoleQuery.getRoleId())));
         query.setOffset(pagingLoadConfig.getOffset());
         query.setLimit(pagingLoadConfig.getLimit());
-
+        query.setAskTotalCount(gwtRoleQuery.getAskTotalCount());
         return query;
 
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
@@ -76,7 +76,7 @@ public class GwtDeviceConnectionServiceImpl extends KapuaRemoteServiceServlet im
             DeviceConnectionQuery query = GwtKapuaDeviceModelConverter.convertConnectionQuery(loadConfig, gwtDeviceConnectionQuery);
 
             KapuaListResult<DeviceConnection> deviceConnections = DEVICE_CONNECTION_SERVICE.query(query);
-            totalLength = (int) DEVICE_CONNECTION_SERVICE.count(query);
+            totalLength = deviceConnections.getTotalCount().intValue();
 
             if (!deviceConnections.isEmpty()) {
                 Map<String, String> users = new HashMap<String, String>();

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementOperationServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementOperationServiceImpl.java
@@ -15,7 +15,6 @@ import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.common.base.Strings;
-import com.google.common.primitives.Ints;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
 import org.eclipse.kapua.app.console.module.api.server.util.KapuaExceptionHandler;
@@ -61,7 +60,7 @@ public class GwtDeviceManagementOperationServiceImpl extends KapuaRemoteServiceS
             DeviceManagementOperationQuery query = GwtKapuaDeviceModelConverter.convertDeviceManagementOperationQuery(loadConfig, gwtQuery);
 
             DeviceManagementOperationListResult managementOperations = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.query(query);
-            totalLength = Ints.checkedCast(DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.count(query));
+            totalLength = managementOperations.getTotalCount().intValue();
 
             for (DeviceManagementOperation dmo : managementOperations.getItems()) {
                 GwtDeviceManagementOperation gwtDmo = KapuaGwtDeviceModelConverter.convertManagementOperation(dmo);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
@@ -302,7 +302,7 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
             deviceQuery.addFetchAttributes(DeviceAttributes.LAST_EVENT);
 
             KapuaListResult<Device> devices = deviceRegistryService.query(deviceQuery);
-            totalResult = (int) deviceRegistryService.count(deviceQuery);
+            totalResult = devices.getTotalCount().intValue();
             for (Device d : devices.getItems()) {
                 GwtDevice gwtDevice = KapuaGwtDeviceModelConverter.convertDevice(d);
 
@@ -546,7 +546,7 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
             query.setSortCriteria(query.fieldSortCriteria(DeviceEventAttributes.RECEIVED_ON, SortOrder.DESCENDING));
             query.setOffset(bplc.getOffset());
             query.setLimit(bplc.getLimit());
-
+            query.setAskTotalCount(true);
             // query execute
             KapuaListResult<DeviceEvent> deviceEvents = des.query(query);
 
@@ -556,7 +556,7 @@ public class GwtDeviceServiceImpl extends KapuaRemoteServiceServlet implements G
             }
             gwtResults = new BasePagingLoadResult<GwtDeviceEvent>(gwtDeviceEvents);
             gwtResults.setOffset(loadConfig.getOffset());
-            gwtResults.setTotalLength((int) des.count(query));
+            gwtResults.setTotalLength(deviceEvents.getTotalCount().intValue());
 
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -112,7 +112,7 @@ public class GwtKapuaDeviceModelConverter {
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
         query.setPredicate(predicate);
-
+        query.setAskTotalCount(gwtDeviceConnectionQuery.getAskTotalCount());
         return query;
     }
 
@@ -235,7 +235,7 @@ public class GwtKapuaDeviceModelConverter {
         }
 
         query.setPredicate(andPred);
-
+        query.setAskTotalCount(gwtDeviceQuery.getAskTotalCount());
         return query;
     }
 
@@ -276,7 +276,7 @@ public class GwtKapuaDeviceModelConverter {
             query.setLimit(loadConfig.getLimit());
             query.setOffset(loadConfig.getOffset());
         }
-
+        query.setAskTotalCount(gwtQuery.getAskTotalCount());
         return query;
     }
 }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -134,7 +134,7 @@ public class GwtEndpointServiceImpl extends KapuaRemoteServiceServlet implements
             EndpointInfoQuery endpointQuery = GwtKapuaEndpointModelConverter.convertEndpointQuery(loadConfig, gwtEndpointQuery);
 
             EndpointInfoListResult endpoints = ENDPOINT_INFO_SERVICE.query(endpointQuery);
-            totalLength = (int) ENDPOINT_INFO_SERVICE.count(endpointQuery);
+            totalLength = endpoints.getTotalCount().intValue();
 
             if (!endpoints.isEmpty()) {
                 UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/GwtKapuaEndpointModelConverter.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/GwtKapuaEndpointModelConverter.java
@@ -82,7 +82,7 @@ public class GwtKapuaEndpointModelConverter {
         query.setSortCriteria(sortCriteria);
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
-
+        query.setAskTotalCount(gwtEndpointQuery.getAskTotalCount());
         return query;
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
@@ -47,7 +47,7 @@ public class GwtJobExecutionServiceImpl extends KapuaRemoteServiceServlet implem
 
             JobExecutionQuery executionQuery = GwtKapuaJobModelConverter.convertJobExecutionQuery(loadConfig, gwtJobExecutionQuery);
             JobExecutionListResult jobExecutionList = EXECUTION_SERVICE.query(executionQuery);
-            totalLength = (int) EXECUTION_SERVICE.count(executionQuery);
+            totalLength = jobExecutionList.getTotalCount().intValue();
 
             // Converto to GWT entity
             for (JobExecution jobExecution : jobExecutionList.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -72,7 +72,7 @@ public class GwtJobServiceImpl extends KapuaRemoteServiceServlet implements GwtJ
 
             // query
             JobListResult jobs = JOB_SERVICE.query(jobQuery);
-            totalLength = (int) JOB_SERVICE.count(jobQuery);
+            totalLength = jobs.getTotalCount().intValue();
 
             // If there are results
             if (!jobs.isEmpty()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -59,7 +59,7 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
 
             // query
             JobStepListResult jobStepList = JOB_STEP_SERVICE.query(jobStepQuery);
-            totalLength = (int) JOB_STEP_SERVICE.count(jobStepQuery);
+            totalLength = jobStepList.getTotalCount().intValue();
 
             // Converto to GWT entity
             for (JobStep js : jobStepList.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
@@ -72,7 +72,7 @@ public class GwtJobTargetServiceImpl extends KapuaRemoteServiceServlet implement
 
             // query
             JobTargetListResult jobTargetList = JOB_TARGET_SERVICE.query(jobTargetQuery);
-            totalLength = (int) JOB_TARGET_SERVICE.count(jobTargetQuery);
+            totalLength = jobTargetList.getTotalCount().intValue();
 
             List<KapuaId> deviceIds = new ArrayList<KapuaId>();
             // Convert to GWT entity

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
@@ -119,7 +119,7 @@ public class GwtTriggerServiceImpl extends KapuaRemoteServiceServlet implements 
 
             // query
             TriggerListResult triggerListResult = TRIGGER_SERVICE.query(triggerQuery);
-            totalLength = (int) TRIGGER_SERVICE.count(triggerQuery);
+            totalLength = triggerListResult.getTotalCount().intValue();
 
             // Converto to GWT entity
             for (Trigger t : triggerListResult.getItems()) {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -150,7 +150,7 @@ public class GwtKapuaJobModelConverter {
         FieldSortCriteria sortCriteria = query.fieldSortCriteria(sortField, sortOrder);
         query.setSortCriteria(sortCriteria);
         query.setPredicate(predicate);
-
+        query.setAskTotalCount(gwtJobQuery.getAskTotalCount());
         return query;
     }
 
@@ -173,7 +173,7 @@ public class GwtKapuaJobModelConverter {
             FieldSortCriteria sortCriteria = query.fieldSortCriteria(sortField, sortOrder);
             query.setSortCriteria(sortCriteria);
         }
-
+        query.setAskTotalCount(gwtJobTargetQuery.getAskTotalCount());
         return query;
     }
 
@@ -192,7 +192,7 @@ public class GwtKapuaJobModelConverter {
 
         query.setLimit(loadConfig.getLimit());
         query.setOffset(loadConfig.getOffset());
-
+        query.setAskTotalCount(gwtJobStepQuery.getAskTotalCount());
         return query;
     }
 
@@ -283,7 +283,7 @@ public class GwtKapuaJobModelConverter {
         query.setPredicate(andPredicate);
         query.setLimit(loadConfig.getLimit());
         query.setOffset(loadConfig.getOffset());
-
+        query.setAskTotalCount(gwtTriggerQuery.getAskTotalCount());
         return query;
     }
 
@@ -310,7 +310,7 @@ public class GwtKapuaJobModelConverter {
         query.setSortCriteria(query.fieldSortCriteria(sortField, sortOrder));
         query.setLimit(pagingLoadConfig.getLimit());
         query.setOffset(pagingLoadConfig.getOffset());
-
+        query.setAskTotalCount(gwtJobExecutionQuery.getAskTotalCount());
         return query;
     }
 

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -130,7 +130,7 @@ public class GwtTagServiceImpl extends KapuaRemoteServiceServlet implements GwtT
             TagQuery tagQuery = GwtKapuaTagModelConverter.convertTagQuery(loadConfig, gwtTagQuery);
 
             TagListResult tags = tagService.query(tagQuery);
-            totalLength = (int) tagService.count(tagQuery);
+            totalLength = tags.getTotalCount().intValue();
 
             if (!tags.isEmpty()) {
                 UserListResult userListResult = KapuaSecurityUtils.doPrivileged(new Callable<UserListResult>() {

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
@@ -78,7 +78,7 @@ public class GwtKapuaTagModelConverter {
         query.setSortCriteria(sortCriteria);
         query.setOffset(loadConfig.getOffset());
         query.setLimit(loadConfig.getLimit());
-
+        query.setAskTotalCount(gwtTagQuery.getAskTotalCount());
         return query;
     }
 }

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -251,7 +251,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
 
             // query
             UserListResult users = USER_SERVICE.query(userQuery);
-            totalLength = (int) USER_SERVICE.count(userQuery);
+            totalLength = users.getTotalCount().intValue();
 
             // If there are results
             if (!users.isEmpty()) {
@@ -344,7 +344,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
         try {
             AccessRoleQuery accessRoleQuery = GwtKapuaAuthorizationModelConverter.convertAccessRoleQuery(pagingLoadConfig, query);
             AccessRoleListResult accessRoleList = ACCESS_ROLE_SERVICE.query(accessRoleQuery);
-            totalLength = (int) ACCESS_ROLE_SERVICE.count(accessRoleQuery);
+            totalLength = accessRoleList.getTotalCount().intValue();
 
             for (AccessRole a : accessRoleList.getItems()) {
                 AccessInfo accessInfo = ACCESS_INFO_SERVICE.find(KapuaEid.parseCompactId(query.getScopeId()), a.getAccessInfoId());
@@ -370,7 +370,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
         try {
             UserQuery userQuery = GwtKapuaUserModelConverter.convertUserQuery(loadConfig, gwtUserQuery);
             UserListResult users = USER_SERVICE.query(userQuery);
-            totalLength = (int) USER_SERVICE.count(userQuery);
+            totalLength = users.getTotalCount().intValue();
 
             if (!users.isEmpty()) {
                 final UserQuery allUsersQuery = USER_FACTORY.newQuery(GwtKapuaCommonsModelConverter.convertKapuaId(accountId));
@@ -398,7 +398,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             KapuaExceptionHandler.handle(t);
         }
 
-        return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), totalLength);   
+        return new BasePagingLoadResult<GwtUser>(gwtUsers, loadConfig.getOffset(), totalLength);
     }
 
     /**

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/GwtKapuaUserModelConverter.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/GwtKapuaUserModelConverter.java
@@ -88,6 +88,7 @@ public class GwtKapuaUserModelConverter {
         }
         SortOrder sortOrder = loadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
         query.setPredicate(predicate);
+        query.setAskTotalCount(gwtUserQuery.getAskTotalCount());
         //
         // Return converted
         return query;

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -440,6 +440,10 @@ components:
           description: An Offset on the result size. Used to skip the first `n` items of a result set, with `n` equal to the value of `offset`
           type: integer
           default: 0
+        askTotalCount:
+          description: A flag to ask the total results count in the response, in addition to the data set as requested with the `offset` and `limit` parameters
+          type: boolean
+          default: false
       example:
         offset: 0
         limit: 50
@@ -485,6 +489,12 @@ components:
         size:
           description: The size of the list containing the items
           type: integer
+        totalCount:
+          description: The total count of the elements that matched the query. Present only if `askTotalCount` was `true` in the query object.
+          type: integer
+      required:
+        - limitedExceeded
+        - size
     kapuaCountResult:
       type: object
       properties:

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"limitExceeded", "size", "items"})
+@XmlType(propOrder = {"limitExceeded", "size", "items", "totalCount"})
 public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializable {
 
     /**
@@ -142,4 +142,19 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
      * @since 1.0.0
      */
     void sort(@NotNull Comparator<E> comparator);
+
+    /**
+     * Gets the total count of entries that match the predicate regardless of {@code limit} and {@code offset}
+     *
+     * @since 1.2.0
+     * @return The total count
+     */
+    Long getTotalCount();
+
+    /**
+     * Sets the total count of entries that match the predicate regardless of {@code limit} and {@code offset}
+     *
+     * @since 1.2.0
+     */
+    void setTotalCount(Long totalCount);
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -153,6 +153,24 @@ public interface KapuaQuery<E extends KapuaEntity> {
      */
     void setLimit(Integer limit);
 
+    /**
+     * Get the {@code askTotalCount} flag. If {@literal true}, the returning {@link KapuaListResult} will also return a value in
+     * the {@code totalCount} field, indicating how many entries matched the query regardless of {@code limit} and
+     * {@code offset}. If {@literal false}, {@code totalCount} will be {@literal null}.
+     *
+     * @since 1.2.0
+     * @return The value of {@code askTotalCount}
+     */
+    Boolean getAskTotalCount();
+
+    /**
+     * Set the {@code askTotalCount} flag.
+     *
+     * @param askTotalCount
+     * @since 1.2.0
+     */
+    void setAskTotalCount(Boolean askTotalCount);
+
     //
     // Predicates factory
 
@@ -208,4 +226,5 @@ public interface KapuaQuery<E extends KapuaEntity> {
      * @return
      */
     FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder);
+
 }


### PR DESCRIPTION
Introducing Total Count in queries. Now an `askTotalCount` flag can be set on a Query object so that the result also returns the total count of the objects that matched the query, in addition to the list of the objects that remains tied to the `limit` and `offset` parameters.

As a side effect, all the queries from the Console have been migrated from the "`query()` + `count()`" approach to single queries with `askTotalCount` set to `true`.

The flag is also available in REST APIs.

**Related Issue**
No related issues
