### PR TITLE
Fixed broken report links

### DIFF
--- a/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
+++ b/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -55,6 +55,11 @@
         </fileSet>
 
         <fileSet>
+            <outputDirectory>authorization-service</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/AuthorizationServiceI9n</directory>
+        </fileSet>
+
+        <fileSet>
             <outputDirectory>user-service-i9n</outputDirectory>
             <directory>../../qa/integration/target/cucumber/UserServiceI9n</directory>
         </fileSet>
@@ -85,12 +90,27 @@
         </fileSet>
 
         <fileSet>
+            <outputDirectory>device-broker-ipConfigFile-i9n</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/DeviceBrokerIpConfigFileI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>device-broker-ipSysEnv-i9n</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/DeviceBrokerIpSysEnvI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>device-broker-ipUndefined-i9n</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/DeviceBrokerIpUndefinedI9n</directory>
+        </fileSet>
+
+        <fileSet>
             <outputDirectory>device-data-i9n</outputDirectory>
             <directory>../../qa/integration/target/cucumber/DeviceDataI9n</directory>
         </fileSet>
 
         <fileSet>
-            <outputDirectory>broker-ACL-i9n</outputDirectory>
+            <outputDirectory>device-broker-ACL-i9n</outputDirectory>
             <directory>../../qa/integration/target/cucumber/BrokerACLI9n</directory>
         </fileSet>
 
@@ -110,8 +130,13 @@
         </fileSet>
 
         <fileSet>
-            <outputDirectory>tag-service-i9n</outputDirectory>
-            <directory>../../qa/integration/target/cucumber/TagService</directory>
+            <outputDirectory>job-engine-online-device</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/JobEngineOnlineDeviceI9n</directory>
+        </fileSet>
+
+        <fileSet>
+            <outputDirectory>job-engine-offline-device</outputDirectory>
+            <directory>../../qa/integration/target/cucumber/JobEngineOfflineDeviceI9n</directory>
         </fileSet>
         </fileSets>
 

--- a/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
+++ b/dev-tools/cucumber-reports/src/main/resources/html/cucumber/index.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <!--
-    Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -52,8 +52,8 @@
                     <li><a href="user-service/index.html">User service</a></li>
                     <li><a href="account-service/index.html">Account service</a></li>
                     <li><a href="device-registry-service/index.html">Device registry service</a></li>
-                    <li><a href="authorization-service/index.html">Authorization service</a></li>
                     <li><a href="job-service/index.html">Job service</a></li>
+                    <li><a href="tag-service/index.html">Tag service</a></li>
                     <!--li>Other service</li-->
                   </ul>
                 </div>
@@ -66,6 +66,7 @@
                     are real services and are not mocked.
                   </p>
                   <ul>
+                    <li><a href="authorization-service/index.html">Authorization service</a></li>
                     <li><a href="user-service-i9n/index.html">User service</a></li>
                     <li><a href="user-service-lockout-i9n/index.html">User lockout tests</a></li>
                     <li><a href="device-service-i9n/index.html">Device service</a></li>
@@ -80,7 +81,9 @@
                     <li><a href="connection-user-coupling-i9n/index.html">Tests for management of connection and user copuling</a></li>
                     <li><a href="datastore-transport-i9n/index.html">Datastore with transport client</a></li>
                     <li><a href="datastore-rest-i9n/index.html">Datastore with REST interface</a></li>
-                    <li><a href="tag-service-i9n/index.html">Tagging service tests</a></li>
+                    <li><a href="job-engine-online-device/index.html">Job engine service tests with online device</a></li>
+                    <li><a href="job-engine-offline-device/index.html">Job engine service tests with offline device</a></li>
+
                     <!--li>Other service</li-->
                   </ul>
                 </div>

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOfflineDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOfflineDeviceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,8 +28,8 @@ import org.junit.runner.RunWith;
                 "org.eclipse.kapua.service.device.registry.steps",
         },
         plugin = { "pretty",
-                "html:target/cucumber",
-                "json:target/cucumber.json" },
+                "html:target/cucumber/JobEngineServiceOfflineDeviceI9n",
+                "json:target/JobEngineServiceOfflineDeviceI9n_cucumber.json" },
         strict = true,
         monochrome = true)
 public class RunJobEngineServiceOfflineDeviceI9nTest {

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOnlineDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobEngine/RunJobEngineServiceOnlineDeviceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -30,8 +30,8 @@ import org.junit.runner.RunWith;
                 "org.eclipse.kapua.service.device.registry.steps",
         },
         plugin = { "pretty",
-                "html:target/cucumber",
-                "json:target/cucumber.json" },
+                "html:target/cucumber/JobEngineOnlineDeviceI9n",
+                "json:target/JobEngineOnlineDeviceI9n_cucumber.json" },
         strict = true,
         monochrome = true)
 public class RunJobEngineServiceOnlineDeviceI9nTest {


### PR DESCRIPTION
Brief description of the PR.
Fixed broken report links.

**Related Issue**
This PR fixes/closes #2804 

**Description of the solution adopted**
Updated `kapua-cucumber-report.xml` and `index.html` files from `dev-tools` module to fix the broken links. Updated runner classes for `jobEngineService` tests and added new links to display the results.

**Screenshots**
_None_

**Any side note on the changes made**
This PR is based on the work done in PR #2801, and it should be merged after it. 
