### PR TITLE
Upgraded commons-fileupload version from 1.3.2 to 1.4 - CVE-2016-1000031 - CWE-284

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
         <commons-codec.version>1.9</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
-        <commons-fileupload.versison>1.3.2</commons-fileupload.versison>
+        <commons-fileupload.versison>1.4</commons-fileupload.versison>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
         <commons-logging.version>1.2</commons-logging.version>


### PR DESCRIPTION
Brief description of the PR.
This PR bumps the version of `commons-fileupload` dependency to 1.4

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available.
CQ submitted: [CQ 21543](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=21543)

**Screenshots**
_None_

**Any side note on the changes made**