### PR TITLE
Fix MetricPredicate and add MetricExistsPredicate

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.service.datastore.DatastoreObjectFactory;
 import org.eclipse.kapua.service.datastore.MessageStoreService;
 import org.eclipse.kapua.service.datastore.client.model.InsertResponse;
 import org.eclipse.kapua.service.datastore.internal.mediator.ChannelInfoField;
-import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageField;
 import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
@@ -115,15 +114,8 @@ public class DataMessages extends AbstractKapuaResource {
 
         if (!Strings.isNullOrEmpty(metricName)) {
             if (metricMinValue == null && metricMaxValue == null) {
-                String term;
-                if (metricType != null) {
-                    String shortType = DatastoreUtils.getClientMetricFromAcronym(metricType.getType().getSimpleName().toLowerCase());
-                    term = String.format("metrics.%s.%s", metricName, shortType);
-                }
-                else {
-                    term = String.format("metrics.%s", metricName);
-                }
-                ExistsPredicate existsPredicate = STORABLE_PREDICATE_FACTORY.newExistsPredicate(term);
+                Class<V> type = metricType != null ? metricType.getType() : null;
+                ExistsPredicate existsPredicate = STORABLE_PREDICATE_FACTORY.newMetricExistsPredicate(metricName, type);
                 andPredicate.getPredicates().add(existsPredicate);
             } else {
                 V minValue = (V) ObjectValueConverter.fromString(metricMinValue, metricType.getType());

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricExistsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricExistsPredicate.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.model.query;
+
+/**
+ * Query predicate for matching messages with existing metrics
+ *
+ * @since 1.2.0
+ */
+public interface MetricExistsPredicate extends ExistsPredicate {
+
+    /**
+     * Gets the metric type to search.
+     * This is required because metric with the same name can have different types.
+     *
+     * @return The metric type
+     * @since 1.2.0
+     */
+    Class<?> getType();
+
+    /**
+     * Sets the metric type so search.
+     *
+     * @param type The metric type to search.
+     * @since 1.2.0
+     */
+    void setType(Class<?> type);
+
+}

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
@@ -78,6 +78,8 @@ public interface StorablePredicateFactory extends KapuaObjectFactory {
      */
     ExistsPredicate newExistsPredicate(String fieldName);
 
+    <V extends Comparable<V>> MetricExistsPredicate newMetricExistsPredicate(String fieldName, Class<V> type);
+
     OrPredicate newOrPredicate();
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
@@ -20,17 +20,17 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * Implementation of query predicate for checking if a field exists
- * 
+ *
  * @since 1.0
  *
  */
 public class ExistsPredicateImpl implements ExistsPredicate {
 
-    private String name;
+    protected String name;
 
     /**
      * Creates an exists predicate for the given field name
-     * 
+     *
      * @param name
      */
     public ExistsPredicateImpl(String name) {
@@ -39,7 +39,7 @@ public class ExistsPredicateImpl implements ExistsPredicate {
 
     /**
      * Creates an exists predicate concatenating the given fields name with a dot (useful for composite fileds)
-     * 
+     *
      * @param paths
      */
     public ExistsPredicateImpl(String... paths) {
@@ -68,7 +68,7 @@ public class ExistsPredicateImpl implements ExistsPredicate {
      */
     public ObjectNode toSerializedMap() throws DatamodelMappingException {
         ObjectNode rootNode = SchemaUtil.getObjectNode();
-        ObjectNode termNode = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(PredicateConstants.FIELD_KEY, (String) name) });
+        ObjectNode termNode = SchemaUtil.getField(new KeyValueEntry[] { new KeyValueEntry(PredicateConstants.FIELD_KEY, name) });
         rootNode.set(PredicateConstants.EXISTS_KEY, termNode);
         return rootNode;
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.datastore.model.query.AndPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ChannelMatchPredicate;
 import org.eclipse.kapua.service.datastore.model.query.ExistsPredicate;
+import org.eclipse.kapua.service.datastore.model.query.MetricExistsPredicate;
 import org.eclipse.kapua.service.datastore.model.query.MetricPredicate;
 import org.eclipse.kapua.service.datastore.model.query.OrPredicate;
 import org.eclipse.kapua.service.datastore.model.query.RangePredicate;
@@ -53,6 +54,11 @@ public class StorablePredicateFactoryImpl implements StorablePredicateFactory {
     @Override
     public ExistsPredicate newExistsPredicate(String fieldName) {
         return new ExistsPredicateImpl(fieldName);
+    }
+
+    @Override
+    public <V extends Comparable<V>> MetricExistsPredicate newMetricExistsPredicate(String fieldName, Class<V> type) {
+        return new MetricExistsPredicateImpl(fieldName, type);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes the current implementation of `MetricPredicate` and adds a new `MetricExistsPredicate` to cope with our Elasticsearch data schema

**Related Issue**
Fixes #2852 

**Description of the solution adopted**
`MetricPredicateImpl` has been reworked to match the "metrics.metricName.typ" notation; also `MetricExistsPredicate` has been created to match the schema notation. The current `ExistsPredicate` hasn't changed since it could be used for other fields