### PR TITLE
Move CORS filter to Shiro

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -13,18 +13,24 @@ package org.eclipse.kapua.app.api.core;
 
 import java.io.IOException;
 
-import javax.ws.rs.container.ContainerRequestContext;
-import javax.ws.rs.container.ContainerResponseContext;
-import javax.ws.rs.container.ContainerResponseFilter;
-import javax.ws.rs.core.MultivaluedMap;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletResponse;
 
-public class CORSResponseFilter implements ContainerResponseFilter {
+import org.apache.shiro.web.servlet.OncePerRequestFilter;
+import org.apache.shiro.web.util.WebUtils;
+
+public class CORSResponseFilter extends OncePerRequestFilter {
 
     @Override
-    public void filter(ContainerRequestContext requestContext, ContainerResponseContext responseContext) throws IOException {
-        MultivaluedMap<String, Object> headers = responseContext.getHeaders();
-        headers.add("Access-Control-Allow-Origin", "*");
-        headers.add("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-        headers.add("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization");
+    protected void doFilterInternal(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
+        HttpServletResponse httpResponse = WebUtils.toHttp(response);
+        httpResponse.addHeader("Access-Control-Allow-Origin", "*");
+        httpResponse.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
+        httpResponse.addHeader("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization");
+        chain.doFilter(request, response);
     }
+
 }

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
@@ -16,7 +16,6 @@ import java.util.HashMap;
 import javax.ws.rs.core.MediaType;
 import javax.xml.bind.JAXBException;
 
-import org.eclipse.kapua.app.api.core.CORSResponseFilter;
 import org.eclipse.kapua.app.api.core.KapuaSerializableBodyWriter;
 import org.eclipse.kapua.app.api.core.ListBodyWriter;
 import org.eclipse.kapua.app.api.core.MoxyJsonConfigContextResolver;
@@ -46,7 +45,6 @@ public class RestApisApplication extends ResourceConfig {
         register(RestApiJAXBContextProvider.class);
         register(KapuaSerializableBodyWriter.class);
         register(ListBodyWriter.class);
-        register(CORSResponseFilter.class);
         register(MoxyJsonConfigContextResolver.class);
 
         register(new ContainerLifecycleListener() {

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -14,6 +14,7 @@ securityManager.authenticator = $authenticator
 #
 # Auth filters
 kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthenticationFilter
+corsFilter = org.eclipse.kapua.app.api.core.CORSResponseFilter
 
 ##########
 # Realms #
@@ -49,79 +50,82 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 # The 'urls' section is used for url-based security
 # in web applications.  We'll discuss this section in the
 # Web documentation
-/v1/test                        = kapuaAuthcAccessToken
+/v1/test                        = corsFilter, kapuaAuthcAccessToken
 
 # Authentication
-/v1/authentication/info         = kapuaAuthcAccessToken
-/v1/authentication/logout       = kapuaAuthcAccessToken
-/v1/*/credentials.json          = kapuaAuthcAccessToken
-/v1/*/credentials.xml           = kapuaAuthcAccessToken
-/v1/*/credentials/**            = kapuaAuthcAccessToken
+/v1/authentication/info         = corsFilter, kapuaAuthcAccessToken
+/v1/authentication/logout       = corsFilter, kapuaAuthcAccessToken
+/v1/*/credentials.json          = corsFilter, kapuaAuthcAccessToken
+/v1/*/credentials.xml           = corsFilter, kapuaAuthcAccessToken
+/v1/*/credentials/**            = corsFilter, kapuaAuthcAccessToken
 
 # Authorization
-/v1/*/accessinfos.xml           = kapuaAuthcAccessToken
-/v1/*/accessinfos.json          = kapuaAuthcAccessToken
-/v1/*/accessinfos/**            = kapuaAuthcAccessToken
-/v1/*/domains.xml               = kapuaAuthcAccessToken
-/v1/*/domains.json              = kapuaAuthcAccessToken
-/v1/*/domains/**                = kapuaAuthcAccessToken
-/v1/*/groups.xml                = kapuaAuthcAccessToken
-/v1/*/groups.json               = kapuaAuthcAccessToken
-/v1/*/groups/**                 = kapuaAuthcAccessToken
-/v1/*/roles.xml                 = kapuaAuthcAccessToken
-/v1/*/roles.json                = kapuaAuthcAccessToken
-/v1/*/roles/**                  = kapuaAuthcAccessToken
+/v1/*/accessinfos.xml           = corsFilter, kapuaAuthcAccessToken
+/v1/*/accessinfos.json          = corsFilter, kapuaAuthcAccessToken
+/v1/*/accessinfos/**            = corsFilter, kapuaAuthcAccessToken
+/v1/*/domains.xml               = corsFilter, kapuaAuthcAccessToken
+/v1/*/domains.json              = corsFilter, kapuaAuthcAccessToken
+/v1/*/domains/**                = corsFilter, kapuaAuthcAccessToken
+/v1/*/groups.xml                = corsFilter, kapuaAuthcAccessToken
+/v1/*/groups.json               = corsFilter, kapuaAuthcAccessToken
+/v1/*/groups/**                 = corsFilter, kapuaAuthcAccessToken
+/v1/*/roles.xml                 = corsFilter, kapuaAuthcAccessToken
+/v1/*/roles.json                = corsFilter, kapuaAuthcAccessToken
+/v1/*/roles/**                  = corsFilter, kapuaAuthcAccessToken
 
 # Account
-/v1/*/accounts.xml              = kapuaAuthcAccessToken
-/v1/*/accounts.json             = kapuaAuthcAccessToken
-/v1/*/accounts/**               = kapuaAuthcAccessToken
+/v1/*/accounts.xml              = corsFilter, kapuaAuthcAccessToken
+/v1/*/accounts.json             = corsFilter, kapuaAuthcAccessToken
+/v1/*/accounts/**               = corsFilter, kapuaAuthcAccessToken
 
 # Datastore
-/v1/*/data/clients.xml          = kapuaAuthcAccessToken
-/v1/*/data/clients.json         = kapuaAuthcAccessToken
-/v1/*/data/clients/**           = kapuaAuthcAccessToken
-/v1/*/data/channels.xml         = kapuaAuthcAccessToken
-/v1/*/data/channels.json        = kapuaAuthcAccessToken
-/v1/*/data/channels/**          = kapuaAuthcAccessToken
-/v1/*/data/messages.xml         = kapuaAuthcAccessToken
-/v1/*/data/messages.json        = kapuaAuthcAccessToken
-/v1/*/data/messages/**          = kapuaAuthcAccessToken
-/v1/*/data/metrics.xml          = kapuaAuthcAccessToken
-/v1/*/data/metrics.json         = kapuaAuthcAccessToken
-/v1/*/data/metrics/**           = kapuaAuthcAccessToken
+/v1/*/data/clients.xml          = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/clients.json         = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/clients/**           = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/channels.xml         = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/channels.json        = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/channels/**          = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/messages.xml         = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/messages.json        = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/messages/**          = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/metrics.xml          = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/metrics.json         = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/metrics/**           = corsFilter, kapuaAuthcAccessToken
 
 # Device and Device Management
-/v1/*/devices.json              = kapuaAuthcAccessToken
-/v1/*/devices.xml               = kapuaAuthcAccessToken
-/v1/*/devices/**                = kapuaAuthcAccessToken
-/v1/*/deviceconnections.json    = kapuaAuthcAccessToken
-/v1/*/deviceconnections.xml     = kapuaAuthcAccessToken
-/v1/*/deviceconnections/**      = kapuaAuthcAccessToken
+/v1/*/devices.json              = corsFilter, kapuaAuthcAccessToken
+/v1/*/devices.xml               = corsFilter, kapuaAuthcAccessToken
+/v1/*/devices/**                = corsFilter, kapuaAuthcAccessToken
+/v1/*/deviceconnections.json    = corsFilter, kapuaAuthcAccessToken
+/v1/*/deviceconnections.xml     = corsFilter, kapuaAuthcAccessToken
+/v1/*/deviceconnections/**      = corsFilter, kapuaAuthcAccessToken
 
 # Endpoint
-/v1/*/endpointInfos.json        = kapuaAuthcAccessToken
-/v1/*/endpointInfos.xml         = kapuaAuthcAccessToken
-/v1/*/endpointInfos/**          = kapuaAuthcAccessToken
+/v1/*/endpointInfos.json        = corsFilter, kapuaAuthcAccessToken
+/v1/*/endpointInfos.xml         = corsFilter, kapuaAuthcAccessToken
+/v1/*/endpointInfos/**          = corsFilter, kapuaAuthcAccessToken
 
 # Jobs
-/v1/*/jobs.json                 = kapuaAuthcAccessToken
-/v1/*/jobs.xml                  = kapuaAuthcAccessToken
-/v1/*/jobs/**                   = kapuaAuthcAccessToken
+/v1/*/jobs.json                 = corsFilter, kapuaAuthcAccessToken
+/v1/*/jobs.xml                  = corsFilter, kapuaAuthcAccessToken
+/v1/*/jobs/**                   = corsFilter, kapuaAuthcAccessToken
 
 # Service Configurations
-/v1/*/serviceConfigurations     = kapuaAuthcAccessToken
-/v1/*/serviceConfigurations/**  = kapuaAuthcAccessToken
+/v1/*/serviceConfigurations     = corsFilter, kapuaAuthcAccessToken
+/v1/*/serviceConfigurations/**  = corsFilter, kapuaAuthcAccessToken
 
 # Streams
-/v1/*/streams/**                = kapuaAuthcAccessToken
+/v1/*/streams/**                = corsFilter, kapuaAuthcAccessToken
 
 # Tag
-/v1/*/tags.json                 = kapuaAuthcAccessToken
-/v1/*/tags.xml                  = kapuaAuthcAccessToken
-/v1/*/tags/**                   = kapuaAuthcAccessToken
+/v1/*/tags.json                 = corsFilter, kapuaAuthcAccessToken
+/v1/*/tags.xml                  = corsFilter, kapuaAuthcAccessToken
+/v1/*/tags/**                   = corsFilter, kapuaAuthcAccessToken
 
 # User
-/v1/*/users.json                = kapuaAuthcAccessToken
-/v1/*/users.xml                 = kapuaAuthcAccessToken
-/v1/*/users/**                  = kapuaAuthcAccessToken
+/v1/*/users.json                = corsFilter, kapuaAuthcAccessToken
+/v1/*/users.xml                 = corsFilter, kapuaAuthcAccessToken
+/v1/*/users/**                  = corsFilter, kapuaAuthcAccessToken
+
+# All other paths
+/v1/**                          = corsFilter


### PR DESCRIPTION
This PR moves the `CORSResponseFilter` from the Jersey logic to the Shiro logic. This is because when a request fails with `401 Unauthorized` error code, Shiro stops the request processing before reaching Jersey and the CORS filter and returns a response without the needed headers. The browser will then complain because it receives a response without such headers.

**Related Issue**
No related issue

**Description of the solution adopted**
`CORSResponseFilter` inherits now from Shiro `OncePerRequestFilter` and is added in the chain before `KapuaTokenAuthenticationFilter`
