### PR TITLE
Correctly map ParamException in REST API

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
@@ -114,4 +114,19 @@ public class KapuaExceptionUtils {
         }
         return ee;
     }
+
+    /**
+     * Walks the "cause" hierarchy of a {@link Throwable} until a {@link KapuaException} is found, and returns it
+     *
+     * @param       t A {@link Throwable} whose "cause" hierarchy will be searched for a {@link KapuaException}
+     * @return        The first {@link KapuaException} in the "cause" hierarchy, or null if none is found
+     * @since         1.2.0
+     */
+    public static KapuaException extractKapuaException(Throwable t) {
+        if (t instanceof KapuaException || t == null) {
+            return (KapuaException) t;
+        } else {
+            return extractKapuaException(t.getCause());
+        }
+    }
 }

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -63,5 +63,9 @@
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jersey.core</groupId>
+            <artifactId>jersey-server</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/ParamExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/ParamExceptionMapper.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.app.api.core.exception.model.IllegalArgumentExceptionInfo;
+import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
+
+import org.glassfish.jersey.server.ParamException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class ParamExceptionMapper implements ExceptionMapper<ParamException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(ParamExceptionMapper.class);
+
+    @Override
+    public Response toResponse(ParamException paramException) {
+        KapuaIllegalArgumentException kapuaIllegalArgumentException;
+        KapuaException cause = KapuaExceptionUtils.extractKapuaException(paramException);
+        if (cause instanceof KapuaIllegalArgumentException) {
+            kapuaIllegalArgumentException = (KapuaIllegalArgumentException) cause;
+        } else {
+            kapuaIllegalArgumentException = new KapuaIllegalArgumentException(paramException.getParameterName(), null);
+        }
+        LOG.error("Illegal argument exception!", paramException);
+        return Response//
+                .status(Status.BAD_REQUEST) //
+                .entity(new IllegalArgumentExceptionInfo(Status.BAD_REQUEST, kapuaIllegalArgumentException)) //
+                .build();
+    }
+
+}

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -40,6 +40,11 @@
                 <artifactId>javax.servlet-api</artifactId>
                 <version>${javax-servlet-api.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.glassfish.jersey.core</groupId>
+                <artifactId>jersey-server</artifactId>
+                <version>${jersey.version}</version>
+            </dependency>
         </dependencies>
     </dependencyManagement>
 

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+
 /**
  * Device connection status.
  *
@@ -32,5 +34,15 @@ public enum DeviceConnectionStatus {
     /**
      * Value when andPredicate is null
      */
-    NULL
+    NULL;
+
+    public static DeviceConnectionStatus fromString(String value) throws KapuaIllegalArgumentException {
+        String ucValue = value.toUpperCase();
+        try {
+            return valueOf(ucValue);
+        } catch (Exception e) {
+            throw new KapuaIllegalArgumentException("connectionStatus", value);
+        }
+    }
+
 }


### PR DESCRIPTION
With this PR, the error showed by REST APIs when a value generates a `KapuaIllegalArgumentException` now shows the correct HTTP error code. Also, the `DeviceConnectionStatus` enum is now case insensitive when used as a REST API parameter.

**Related Issue**
No related issues
