### PR TITLE
Added tests for Tag service

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/tag/RunTagServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/tag/RunTagServiceI9nTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.service.tag;
+
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = { "classpath:features/tag/TagService.feature"
+        },
+        glue = {"org.eclipse.kapua.service.tag.steps",
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.qa.common"
+        },
+        plugin = { "pretty",
+                "html:target/cucumber",
+                "json:target/cucumber.json" },
+        strict = true,
+        monochrome = true)
+
+public class RunTagServiceI9nTest {
+}

--- a/qa/integration/src/test/resources/features/tag/TagService.feature
+++ b/qa/integration/src/test/resources/features/tag/TagService.feature
@@ -17,51 +17,442 @@ Feature: Tag Service
   used to attach tags to Devices, but could be used to tag eny kapua entity, like
   User for example.
 
-  Background:
+  Scenario: Creating Unique Tag Without Description
+  Login as kapua-sys, go to tags, try to create a tag with unique name without description.
+  Kapua should not return any errors.
+
     Given I login as user with name "kapua-sys" and password "kapua-password"
-      And I configure the tag service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" without description
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    And I logout
 
-  Scenario: Start datastore for all scenarios
+  Scenario: Creating Non-unique Tag Without Description
+  Login as kapua-sys, go to tags, try to create a tag with non-unique name without description.
+  Kapua should return Exception.
 
-    Given Start Datastore
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" without description
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name Tag123 already exists."
+    When I create tag with name "Tag123" without description
+    Then An exception was thrown
+    Then I logout
 
-  Scenario: Start event broker for all scenarios
+  Scenario: Creating Tag With Short Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag with short name without description.
+  Kapua should not return any errors.
 
-    Given Start Event Broker
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "abc" without description
+    And Tag with name "abc" is searched
+    Then I find a tag with name "abc"
+    And I logout
 
-  Scenario: Start broker for all scenarios
+  Scenario: Creating Tag With Too Short Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag with too short name without description.
+  Kapua should not return any errors.
 
-    Given Start Broker
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Then I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value less than allowed min length. Min length is 3."
+    When I create tag with name "a" without description
+    Then An exception was thrown
+    And I logout
 
-  Scenario: Creating tag
-    Create a tag entry, with specified name. Name is only tag specific attribute.
-    Once created search for it and is should been created.
+  Scenario: Creating Tag With Long Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag with long (255 characters) name without description.
+  Kapua should not return any errors.
 
-    Given I create a tag with name "tagName"
-    When Tag with name "tagName" is searched
-    Then I find a tag with name "tagName"
-      And I logout
-      
-  Scenario: Deleting tag
-    Create a tag entry, with specified name. Name is only tag specific attribute.
-    Once created search and find it, then delete it.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh" without description
+    And Tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh" is searched
+    Then I find a tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh"
+    And I logout
 
-    Given I create a tag with name "tagName2"
-    When Tag with name "tagName2" is searched
-    Then I find and delete tag with name "tagName2"
-      And I logout
+  Scenario: Creating Tag With Too Long Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag with too long (256 characters) name without description.
+  Kapua should return Exception.
 
-  Scenario: Stop broker after all scenarios
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Then I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is 255."
+    When I create tag with name "aY5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh" without description
+    Then An exception was thrown
+    And I logout
 
-    Given Stop Broker
+  Scenario: Creating Tag With Permitted Symbols In Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag name with permitted ('-' and '_') symbols without description.
+  Kapua should not return any errors.
 
-  Scenario: Stop event broker for all scenarios
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag-12_3" without description
+    And Tag with name "Tag-12_3" is searched
+    Then I find a tag with name "Tag-12_3"
+    And No exception was thrown
+    And I logout
 
-    Given Stop Event Broker
+  Scenario: Creating Tag With Invalid Symbols In Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag name with invalid symbols without description.
+  Kapua should return Exception.
 
-  Scenario: Stop datastore after all scenarios
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    When I try to create tags with that include invalid symbols in name
+    Then An exception was thrown
+    And I logout
 
-    Given Stop Datastore
+  Scenario: Creating Tag Without a Name And Without Description
+  Login as kapua-sys, go to tags, try to create a tag name without a name.
+  Kapua should return an error.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Then I expect the exception "Exception"
+    When I create tag with name "" without description
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag With Numbers In Name Without Description
+  Login as kapua-sys, go to tags, try to create a tag that contains numbers.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "12345" without description
+    And Tag with name "12345" is searched
+    Then I find a tag with name "12345"
+    And I logout
+
+  Scenario: Creating Unique Tag With Unique Description
+  Login as kapua-sys, go to tags, try to create a unique tag with unique description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "Description-@12#$456"
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    And I logout
+
+  Scenario: Creating Unique Tag With Non-unique Description
+  Login as kapua-sys, go to tags, try to create two unique tags with same descriptions.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "Description1"
+    And I create tag with name "Tag456" and description "Description1"
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    When Tag with name "Tag456" is searched
+    And I find a tag with name "Tag456"
+    And I logout
+
+  Scenario: Creating Non-Unique Tag With Valid Description
+  Login as kapua-sys, go to tags, try to create non-unique tag with valid Description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "Description1"
+    Given I expect the exception "KapuaDuplicateNameException"
+    When I create tag with name "Tag123" and description "Description1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag With Short Name With Valid Description
+  Login as kapua-sys, go to tags, try to create tag with short name with valid Description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag" and description "Valid description 123"
+    And Tag with name "Tag" is searched
+    Then I find a tag with name "Tag"
+    And I logout
+
+  Scenario: Creating Tag With Too Short Name With Valid Description
+  Login as kapua-sys, go to tags, try to create tag with too short name with valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I expect the exception "Exception"
+    When I create tag with name "t" and description "Valid description 123"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag With Long Name With Valid Description
+  Login as kapua-sys, go to tags, try to create tag with long name with valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" and description "Valid description 123"
+    And Tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" is searched
+    Then I find a tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj"
+    And I logout
+
+  Scenario: Creating Tag With Too Long Name With Valid Description
+  Login as kapua-sys, go to tags, try to create tag with too long name with valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is 255."
+    When I create tag with name "aoAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" and description "Valid description 123"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag With Permitted Symbols In Name With Valid Description
+  Login as kapua-sys, go to tags, try to create tag with permitted symbols in name with valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag_12-3" and description "Valid description 123"
+    And Tag with name "Tag_12-3" is searched
+    Then I find a tag with name "Tag_12-3"
+    And I logout
+
+  Scenario: Creating Tag With Invalid Symbols In Name With Valid Description
+  Login as kapua-sys, go to tags, try to create a tag with invalid symbols with valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I expect the exception "Exception"
+    When I create tag with name "Tag@123" and description "Valid description 123"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag Without a Name And With Valid Description
+  Login as kapua-sys, go to tags, try to create a tag without a name with valid description.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    Given I expect the exception "KapuaIllegalNullArgumentException"
+    When I create tag with name "" and description "Valid description 123"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tag With Numbers In Name With Valid Description
+  Login as kapua-sys, go to tags, try to create a tag with numbers in name with valid description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "Valid-description@33-2"
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    And I logout
+
+  Scenario: Creating Unique Tag With Short Description
+  Login as kapua-sys, go to tags, try to create a tag with short description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "a"
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    And I logout
+
+  Scenario: Creating Unique Tag With Long Description
+  Login as kapua-sys, go to tags, try to create a tag with long description.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag123" and description "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj"
+    And Tag with name "Tag123" is searched
+    Then I find a tag with name "Tag123"
+    And I logout
+
+  Scenario: Changing Tag's Name To Unique One
+  Login as kapua-sys, go to tags, try to edit tag's name into a unique one.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    And Name of tag "Tag1" is changed into "Tag2"
+    And Tag with name "Tag2" is searched
+    Then I find a tag with name "Tag2"
+    When Tag with name "Tag1" is searched
+    Then Tag with name "Tag1" is not found
+    And I logout
+
+  Scenario: Changing Tag's Name To Non-Unique One
+  Login as kapua-sys, go to tags, try to edit tag's name to non-unique one.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    And I create tag with name "Tag2" without description
+    Given I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name Tag1 already exists."
+    When Name of tag "Tag2" is changed into "Tag1"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Tag's Name To Short One Without Description
+  Login as kapua-sys, go to tags, try to edit tag's name to short one.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    And Name of tag "Tag1" is changed into "abc"
+    And Tag with name "abc" is searched
+    Then I find a tag with name "abc"
+    And Tag with name "Tag1" is searched
+    Then Tag with name "Tag1" is not found
+    And I logout
+
+  Scenario: Changing Tag's Name To a Too Short One Without Description
+  Login as kapua-sys, go to tags, try to edit tag's name to a too short one.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value less than allowed min length. Min length is 3."
+    And Tag name is changed into name "a"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Tag's Name To a Long One Without Description
+  Login as kapua-sys, go to tags, try to edit tag's name to a long (255 characters) one.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    And Name of tag "Tag1" is changed into "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
+    And Tag with name "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX" is searched
+    Then I find a tag with name "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
+    And Tag with name "Tag1" is searched
+    Then Tag with name "Tag1" is not found
+    And I logout
+
+  Scenario: Changing Tag's Name To a Too Long One Without Description
+  Login as kapua-sys, go to tags, try to edit tag's name to a too long (256 characters) one.
+  Kapua should throw Exception.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value over than allowed max length. Max length is 255."
+    When Name of tag "Tag1" is changed into "aYXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
+    Then An exception was thrown
+    Then I logout
+
+  Scenario: Changing Tag's Name To Contain Permitted Symbols In Name Without Description
+  Login as kapua-sys, go to tags, try to edit tag's name to a name with permitted symbols.
+  Kapua should not return any errors.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When I create tag with name "Tag1" without description
+    And Tag name is changed into name "T-a-g_1"
+    And Tag with name "T-a-g_1" is searched
+    Then I find a tag with name "T-a-g_1"
+    And I logout

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -384,7 +384,7 @@ Feature: User Permission tests
       | tag     | delete |
     Then I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
-    Given I create a tag with name "tag_a"
+    Given I create tag with name "tag_a" without description
     When Tag with name "tag_a" is searched
     Then I find a tag with name "tag_a"
     Then I find and delete tag with name "tag_a"
@@ -1441,7 +1441,7 @@ Feature: User Permission tests
       | account | delete |
     And A device named "test_device"
     And I create a job with the name "test_job"
-    And I create a tag with name "test_tag"
+    And I create tag with name "test_tag" without description
     And I create the group with name "test_group"
     And I create the following role
       | scopeId | name      |

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -308,9 +308,8 @@ Feature: User role service integration tests
     And I add access role "test_role" to user "user1"
     And I logout
     Then I login as user with name "user1" and password "User@10031995"
-    And I create a tag with name "tag1"
-    And I find a tag with name "tag1"
-    And I try to edit tag to name "tag2"
+    And I create tag with name "tag1" without description
+    And Name of tag "tag1" is changed into "tag2"
     And I delete the tag with name "tag2"
     Then No exception was thrown
     And I logout
@@ -799,9 +798,9 @@ Feature: User role service integration tests
     And I find a job with name "TestJob"
     And I try to edit job to name "TestJob1"
     And I try to delete the job with name "TestJob1"
-    And I create a tag with name "Tag"
+    And I create tag with name "Tag" without description
     And I find a tag with name "Tag"
-    And I try to edit tag to name "Tag1"
+    And Name of tag "Tag" is changed into "Tag1"
     And I delete the tag with name "Tag1"
     And I create the following role
       | scopeId | name      |
@@ -1457,9 +1456,9 @@ Feature: User role service integration tests
     And I add access role "Role1" to user "SubUser" in account "SubAccount"
     And I logout
     And I login as user with name "SubUser" and password "User@10031995"
-    And I create a tag with name "TestTag"
+    And I create tag with name "TestTag" without description
     And I find a tag with name "TestTag"
-    And I try to edit tag to name "TestTag1"
+    And Name of tag "TestTag" is changed into "TestTag1"
     And I delete the tag with name "TestTag1"
     And No exception was thrown
     And I logout

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
@@ -118,12 +118,10 @@ import java.util.Vector;
 
 /**
  * Implementation of Gherkin steps used in DeviceRegistry.feature scenarios.
- *
+ * <p>
  * MockedLocator is used for Location Service. Mockito is used to mock other
  * services that the Device Registry services dependent on. Dependent services are: -
  * Authorization Service -
- *
- *
  */
 @ScenarioScoped
 public class DeviceRegistrySteps extends TestBase {
@@ -2551,16 +2549,16 @@ public class DeviceRegistrySteps extends TestBase {
 
     @Then("^I try to edit device to clientId \"([^\"]*)\"$")
     public void iTryToEditDeviceToName(String clientId) throws Exception {
-      Device device = (Device) stepData.get("Device");
-      device.setClientId(clientId);
+        Device device = (Device) stepData.get("Device");
+        device.setClientId(clientId);
 
-      try {
-          primeException();
-          Device newDevice = deviceRegistryService.update(device);
-          stepData.put("Device", newDevice);
-      } catch (KapuaException ex) {
-          verifyException(ex);
-      }
+        try {
+            primeException();
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("Device", newDevice);
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
     }
 
     @Then("^I find device with clientId \"([^\"]*)\"$")
@@ -2600,6 +2598,124 @@ public class DeviceRegistrySteps extends TestBase {
             }
         } catch (KapuaException ex) {
             verifyException(ex);
+        }
+    }
+
+    @And("^I asign tag to device$")
+    public void iAsignTagToDevice() throws Exception {
+        Tag tag = (Tag) stepData.get("tag");
+        Device device = (Device) stepData.get("Device");
+        try {
+            Set<KapuaId> tags = device.getTagIds();
+            tags.add(tag.getId());
+            device.setTagIds(tags);
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("tags", tags);
+            stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @And("^I asign tag \"([^\"]*)\" to device \"([^\"]*)\"$")
+    public void iAsignTagNamedToDevice(String tagName, String deviceName) throws Exception {
+        try {
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            DeviceListResult deviceList = deviceRegistryService.query(tmpQuery);
+            Device device = deviceList.getFirstItem();
+
+            TagQuery tagQuery = tagFactory.newQuery(getCurrentScopeId());
+            tagQuery.setPredicate(tagQuery.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
+            TagListResult tagList = tagService.query(tagQuery);
+            Tag tag = tagList.getFirstItem();
+
+            Set<KapuaId> tags = device.getTagIds();
+            tags.add(tag.getId());
+            device.setTagIds(tags);
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("tags", tags);
+            stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Given("^Tag \"([^\"]*)\" is assigned to device \"([^\"]*)\"$")
+    public void tagIsAsignedToDevice(String tagName, String deviceName) throws Throwable {
+        try {
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            DeviceListResult deviceList = deviceRegistryService.query(tmpQuery);
+            Device device = deviceList.getFirstItem();
+
+            TagQuery tagQuery = tagFactory.newQuery(getCurrentScopeId());
+            tagQuery.setPredicate(tagQuery.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
+            TagListResult tagList = tagService.query(tagQuery);
+            Tag tag = tagList.getFirstItem();
+
+            Set<KapuaId> tagIds = device.getTagIds();
+            assertTrue(tagIds.contains(tag.getId()));
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Given("^I unassign tag from device$")
+    public void iUnassignTagFromDevice() throws Exception {
+        Tag tag = (Tag) stepData.get("tag");
+        Device device = (Device) stepData.get("Device");
+        try {
+            Set<KapuaId> tagIds = device.getTagIds();
+            tagIds.remove(tag.getId());
+            device.setTagIds(tagIds);
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Given("^I unassign tag \"([^\"]*)\" from device \"([^\"]*)\"$")
+    public void iUnassignTagNamedFromDevice(String tagName, String deviceName) throws Exception {
+        try {
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            DeviceListResult deviceList = deviceRegistryService.query(tmpQuery);
+            Device device = deviceList.getFirstItem();
+
+            TagQuery tagQuery = tagFactory.newQuery(getCurrentScopeId());
+            tagQuery.setPredicate(tagQuery.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
+            TagListResult tagList = tagService.query(tagQuery);
+            Tag tag = tagList.getFirstItem();
+
+            Set<KapuaId> tagIds = device.getTagIds();
+            tagIds.remove(tag.getId());
+            device.setTagIds(tagIds);
+            Device newDevice = deviceRegistryService.update(device);
+            stepData.put("Device", newDevice);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Given("^Tag \"([^\"]*)\" is not assigned to device \"([^\"]*)\"$")
+    public void tagWithNameIsNotAsignedToDevice(String tagName, String deviceName) throws Throwable {
+        try {
+            DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
+            tmpQuery.setPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceName, AttributePredicate.Operator.EQUAL));
+            DeviceListResult deviceList = deviceRegistryService.query(tmpQuery);
+            Device device = deviceList.getFirstItem();
+
+            TagQuery tagQuery = tagFactory.newQuery(getCurrentScopeId());
+            tagQuery.setPredicate(tagQuery.attributePredicate(TagAttributes.NAME, tagName, AttributePredicate.Operator.EQUAL));
+            TagListResult tagList = tagService.query(tagQuery);
+            Tag tag = tagList.getFirstItem();
+
+            Set<KapuaId> tagIds = device.getTagIds();
+            assertFalse(tagIds.contains(tag.getId()));
+        } catch (Exception e) {
+            verifyException(e);
         }
     }
 }

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -20,7 +20,7 @@ Feature: Tag Service
     Create a tag entry, with specified name. Name is only tag specific attribute.
     Once created search for it and is should been created.
 
-    Given I create a tag with name "tagName"
+    Given Tag with name "tagName"
     When Tag with name "tagName" is searched
     Then I find a tag with name "tagName"
       
@@ -28,6 +28,6 @@ Feature: Tag Service
     Create a tag entry, with specified name. Name is only tag specific attribute.
     Once created search and find it, then delete it.
 
-    Given I create a tag with name "tagName2"
+    Given Tag with name "tagName2"
     When Tag with name "tagName2" is searched
     Then I find and delete tag with name "tagName2"


### PR DESCRIPTION
Added tests for creating and editing tags.

Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

Test scenarios for Tags are added in this PR.

**Related Issue**
None

**Description of the solution adopted**
Test scenarios that are added in this PR are checking functionalities regarding Tags. All scenarios are added to `TagService.feature.` Scenarios are testing if Tags are correctly created or edited.

**Screenshots**
/

**Any side note on the changes made**
@Coduz This PR has to be merged before PR #2815 which is still waiting for CQ. After this is merged, we will just rebase the #2815 and the CQ will not be needed any more, since the total lines count will be less than 1k.
