### PR TITLE
Added Integration Tests For Accounts

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
@@ -19,28 +19,43 @@ import org.junit.runner.RunWith;
 
 @RunWith(CucumberWithProperties.class)
 @CucumberOptions(
-        features = {"classpath:features/account/AccountExpirationI9n.feature",
-                    "classpath:features/account/FindSelfAccount.feature"},
+        features = {
+                "classpath:features/account/AccountService.feature",
+                "classpath:features/account/AccountExpirationI9n.feature",
+                "classpath:features/account/FindSelfAccount.feature",
+                "classpath:features/account/AccountGroupService.feature",
+                "classpath:features/account/AccountDeviceRegistryService.feature",
+                "classpath:features/account/AccountJobService.feature",
+                "classpath:features/account/AccountRoleService.feature",
+                "classpath:features/account/AccountTagService.feature",
+                "classpath:features/account/AccountUserService.feature",
+                "classpath:features/account/AccountCredentialService.feature"
+                },
         glue = {"org.eclipse.kapua.qa.common",
                 "org.eclipse.kapua.service.account.steps",
-                "org.eclipse.kapua.service.user.steps"
-               },
-        plugin = {"pretty", 
-                  "html:target/cucumber/AccountServiceI9n",
-                  "json:target/AccountServiceI9n_cucumber.json"
-                 },
+                "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.service.authorization.steps",
+                "org.eclipse.kapua.service.device.registry.steps",
+                "org.eclipse.kapua.service.job.steps",
+                "org.eclipse.kapua.service.tag.steps"
+        },
+        plugin = {"pretty",
+                "html:target/cucumber/AccountServiceI9n",
+                "json:target/AccountServiceI9n_cucumber.json"
+        },
         strict = true,
         monochrome = true)
-@CucumberProperty(key="DOCKER_HOST", value= "")
-@CucumberProperty(key="DOCKER_CERT_PATH", value= "")
-@CucumberProperty(key="commons.db.schema.update", value= "")
-@CucumberProperty(key="commons.db.connection.host", value= "")
-@CucumberProperty(key="commons.db.connection.port", value= "")
-@CucumberProperty(key="datastore.elasticsearch.nodes", value= "")
-@CucumberProperty(key="datastore.elasticsearch.port", value= "")
-@CucumberProperty(key="datastore.client.class", value= "")
-@CucumberProperty(key="commons.eventbus.url", value= "")
-@CucumberProperty(key="certificate.jwt.private.key", value= "")
-@CucumberProperty(key="certificate.jwt.certificate", value= "")
-@CucumberProperty(key="broker.ip", value= "")
-public class RunAccountServiceI9nTest {}
+@CucumberProperty(key = "DOCKER_HOST", value = "")
+@CucumberProperty(key = "DOCKER_CERT_PATH", value = "")
+@CucumberProperty(key = "commons.db.schema.update", value = "")
+@CucumberProperty(key = "commons.db.connection.host", value = "")
+@CucumberProperty(key = "commons.db.connection.port", value = "")
+@CucumberProperty(key = "datastore.elasticsearch.nodes", value = "")
+@CucumberProperty(key = "datastore.elasticsearch.port", value = "")
+@CucumberProperty(key = "datastore.client.class", value = "")
+@CucumberProperty(key = "commons.eventbus.url", value = "")
+@CucumberProperty(key = "certificate.jwt.private.key", value = "")
+@CucumberProperty(key = "certificate.jwt.certificate", value = "")
+@CucumberProperty(key = "broker.ip", value = "")
+public class RunAccountServiceI9nTest {
+}

--- a/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
@@ -1,0 +1,88 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@credential
+@integration
+
+Feature: Account Credential Service Integration Tests
+
+  Scenario: Uncorrect Login While Lockout Policy Is Enabled
+  Login as kapua-sys, create an account, create a user under that account (user1)
+  Configure CredentialService of that account, set lockoutPolicy.enabled to true and lockoutPolicy.maxFailures to 2, leave other fields at default values
+  Login twice as user1 with wrong password
+  Try to login again with correct credentials
+  User should be locked
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure credential service
+      | type    | name                       | value  |
+      | boolean | lockoutPolicy.enabled      | true   |
+      | integer | lockoutPolicy.maxFailures  | 2      |
+      | integer | lockoutPolicy.resetAfter   | 3600   |
+      | integer | lockoutPolicy.lockDuration | 108000 |
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    When A generic user
+      | name  | displayName | email             | phoneNumber     | status  | userType |
+      | user1 | Test User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    Then I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "user1" and password "wrongpassword"
+    Then An exception was thrown
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "user1" and password "wrongAgain"
+    Then An exception was thrown
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then An exception was thrown
+
+  Scenario: Uncorrect Login While Lockout Policy Is Disabled
+  Login as kapua-sys, create an account, create a user under that account (user1)
+  Configure CredentialService of that account, set lockoutPolicy.enabled to false and lockoutPolicy.maxFailures to 2, leave other fields at default values
+  Login twice as user1 with wrong password
+  Try to login again with correct credentials
+  There should be no problems as  lockoutPolicy is disabled
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure credential service
+      | type    | name                       | value  |
+      | boolean | lockoutPolicy.enabled      | false  |
+      | integer | lockoutPolicy.maxFailures  | 2      |
+      | integer | lockoutPolicy.resetAfter   | 3600   |
+      | integer | lockoutPolicy.lockDuration | 108000 |
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    When A generic user
+      | name  | displayName | email             | phoneNumber     | status  | userType |
+      | user1 | Test User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name  | password          | enabled |
+      | user1 | ToManySecrets123# | true    |
+    Then I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "user1" and password "wrongpassword"
+    Then An exception was thrown
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "user1" and password "wrongAgain"
+    Then An exception was thrown
+    When I login as user with name "user1" and password "ToManySecrets123#"
+    Then No exception was thrown
+    Then I logout

--- a/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@device
+@integration
+
+Feature: Account Device Registry Service Integration Tests
+
+  Scenario: Creating Devices Under Account That Allows Infinite Child Devices
+  Login as kapua-sys, create an account
+  Configure DeviceRegistryService of that account, set infiniteChildDevices to true and maxNumberChildDevices to 0
+  Create a few Devices
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create a device with name "Device1"
+    And I create a device with name "Device2"
+    And I create a device with name "Device3"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Devices Under Account That Has Limited Child Devices
+  Login as kapua-sys, create an account
+  Configure DeviceRegistryService of that account, set infiniteChildDevices to false and maxNumberChildDevices to 3
+  Create a few Devices
+  Only 3 Devices should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the device registry service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Given I select account "acc1"
+    When I create a device with name "Device1"
+    And I create a device with name "Device2"
+    And I create a device with name "Device3"
+    Then No exception was thrown
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create a device with name "Device4"
+    Then An exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountGroupService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountGroupService.feature
@@ -1,0 +1,120 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@group
+@integration
+
+Feature: Account Group Service Integration Tests
+
+  Scenario: Creating Groups Under Account That Allows Infinite Child Groups
+  Login as kapua-sys, create an account
+  Configure GroupService of that account, set infiniteChildGroups to true and maxNumberChildGroups to 0
+  Create a few groups
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Then I select account "acc1"
+    And I create a group with name "Group1"
+    And I create a group with name "Group2"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Groups Under Account That Has Limited Child Groups
+  Login as kapua-sys, create an account
+  Configure GroupService of that account, set infiniteChildGroups to false and maxNumberChildGroups to 3
+  Create a few groups
+  Only 3 Groups should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Then I select account "acc1"
+    And I create a group with name "Group1"
+    And I create a group with name "Group2"
+    And I create a group with name "Group3"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    And I create a group with name "Group4"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Groups Under Account That Does Not Allow Groups
+  Login as kapua-sys, create an account
+  Configure GroupService of that account, set infiniteChildGroups to false and maxNumberChildGroups to 0
+  Try to create a group
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then I select account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    And I create a group with name "Group1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Groups And Than Setting Group Service So It Does Not Allow Groups
+  Login as kapua-sys, create an account
+  Configure GroupService of that account, set infiniteChildGroups to true
+  Create a few Groups
+  Configure GroupService of that account, set infiniteChildGroups to false
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Then I select account "acc1"
+    And I create a group with name "Group1"
+    And I create a group with name "Group2"
+    Given I expect the exception "KapuaConfigurationException" with the text "*"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Groups And Then Changing InfiniteChildGroups To False And Set MaxNumberChildGroups
+  Login as kapua-sys, create an account
+  Configure GroupService of that account, set infiniteChildGroups to true
+  Create 2 Groups
+  Configure GroupService of that account, set infiniteChildGroups to false and maxNumberChildGroups to 2
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Then I select account "acc1"
+    And I create a group with name "Group1"
+    And I create a group with name "Group2"
+    And I configure the group service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 2     |
+    Then No exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountJobService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountJobService.feature
@@ -1,0 +1,123 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@job
+@integration
+
+Feature: Account Job Service Integration Tests
+
+  Scenario: Creating Jobs Under Account That Allows Infinite Child Devices
+  Login as kapua-sys, create an account
+  Configure JobRegistryService of that account, set infiniteChildJobs to true and maxNumberChildJobs to 0
+  Create a few Jobs
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create a job with the name "job1"
+    And I create a job with the name "job2"
+    And I create a job with the name "job3"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Jobs Under Account That Has Limited Child Jobs
+  Login as kapua-sys, create an account
+  Configure JobRegistryService of that account, set infiniteChildJobs to false and maxNumberChildJobs to 3
+  Create a few Jobs
+  Only 3 Jobs should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Given I select account "acc1"
+    When I create a job with the name "job1"
+    And I create a job with the name "job2"
+    And I create a job with the name "job3"
+    Then No exception was thrown
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create a job with the name "job4"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Jobs Under Account That Does Not Allow Jobs
+  Login as kapua-sys, create an account
+  Configure JobRegistryService of that account, set infiniteChildJobs to false and maxNumberChildJobs to 0
+  Try to create a job
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create a job with the name "job1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Jobs And Than Setting Job Service So It Does Not Allow Jobs
+  Login as kapua-sys, create an account
+  Configure JobRegistryService of that account, set infiniteChildJobs to true
+  Create a few Jobs
+  Configure JobRegistryService of that account, set infiniteChildJobs to false
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create a job with the name "job1"
+    When I create a job with the name "job2"
+    When I create a job with the name "job3"
+    Given I expect the exception "KapuaConfigurationException" with the text "*"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Jobs And Then Changing Job Service Values
+  Login as kapua-sys, create an account
+  Configure JobRegistryService of that account, set infiniteChildJobs to true
+  Create 2 Jobs
+  Configure JobRegistryService of that account, set infiniteChildJobs to false and maxNumberChildJobs to 2
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create a job with the name "job1"
+    When I create a job with the name "job2"
+    When I configure the job service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 2     |
+    Then No exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountRoleService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountRoleService.feature
@@ -1,0 +1,121 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@role
+@integration
+
+Feature: Account Role Service Integration Tests
+
+  Scenario: Creating Roles Under Account That Allows Infinite Child Roles
+  Login as kapua-sys, create an account
+  Configure RoleRegistryService of that account, set infiniteChildRoles to true and maxNumberChildRoles to 0
+  Create a few Roles
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create role "role1" in account "acc1"
+    And I create role "role2" in account "acc1"
+    And I create role "role3" in account "acc1"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Roles Under Account That Has Limited Child Roles
+  Login as kapua-sys, create an account
+  Configure RoleRegistryService of that account, set infiniteChildRoles to false and maxNumberChildRoles to 3
+  Create a few Roles
+  Only 3 Roles should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Given I select account "acc1"
+    When I create role "role1" in account "acc1"
+    And I create role "role2" in account "acc1"
+    And I create role "role3" in account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create role "role4" in account "acc1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Roles Under Account That Does Not Allow Roles
+  Login as kapua-sys, create an account
+  Configure RoleRegistryService of that account, set infiniteChildRoles to false and maxNumberChildRoles to 0
+  Try to create a group
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create role "role4" in account "acc1"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Roles And Than Setting Role Service So It Does Not Allow Roles
+  Login as kapua-sys, create an account
+  Configure RoleRegistryService of that account, set infiniteChildRoles to true
+  Create a few Roles
+  Configure RoleRegistryService of that account, set infiniteChildRoles to false
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create role "role1" in account "acc1"
+    When I create role "role2" in account "acc1"
+    Given I expect the exception "KapuaConfigurationException" with the text "*"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Roles And Then Changing Role Service Values
+  Login as kapua-sys, create an account
+  Configure RoleRegistryService of that account, set infiniteChildRoles to true
+  Create 2 Roles
+  Configure RoleRegistryService of that account, set infiniteChildRoles to false and maxNumberChildRoles to 2
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create role "role1" in account "acc1"
+    When I create role "role2" in account "acc1"
+    And I configure the role service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 2     |
+    Then No exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountService.feature
@@ -1,0 +1,57 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@integration
+
+Feature: Account Service Tests
+
+  Scenario: Creating A Valid Account
+  Login as kapua-sys, create an account with all valid fields
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create an account with name "account-1", organization name "organization" and email adress "org@abc.com"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating An Account With Unique Name
+  Login as kapua-sys, create two accounts with different names
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create an account with name "account-1", organization name "organization1" and email adress "org1@abc.com"
+    And I select account "kapua-sys"
+    When I create an account with name "account-2", organization name "organization2" and email adress "org2@abc.com"
+    Then No exception was thrown
+    And I logout
+
+
+  Scenario: Creating An Account With Non-unique Name
+  Login as kapua-sys, create an account and create another one with same name
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create an account with name "account-1", organization name "organization" and email adress "org@abc.com"
+    And I select account "kapua-sys"
+    Given I expect the exception "KapuaDuplicateNameException" with the text "*"
+    When I create an account with name "account-1", organization name "organization2" and email adress "org2@abc.com"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating An Account With Numbers And Valid Symbols In Name
+  Login as kapua-sys, create an account with numbers and '-' in name
+  No exception should be thrown, dash and numbers are allowed
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create an account with name "1231-2323", organization name "organization" and email adress "org@abc.com"
+    Then No exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountTagService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountTagService.feature
@@ -1,0 +1,122 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@tag
+@integration
+
+Feature: Account Tag Service Integration Tests
+
+
+  Scenario: Creating Tags Under Account That Allows Infinite Child Devices
+  Login as kapua-sys, create an account
+  Configure TagService of that account, set infiniteChildTags to true and maxNumberChildTags to 0
+  Create a few Tags
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create tag with name "tag1" without description
+    And I create tag with name "tag2" without description
+    And I create tag with name "tag3" without description
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Tags Under Account That Has Limited Child Tags
+  Login as kapua-sys, create an account
+  Configure TagService of that account, set infiniteChildTags to false and maxNumberChildTags to 3
+  Create a few Tags
+  Only 3 Tags should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Given I select account "acc1"
+    When I create tag with name "tag1" without description
+    And I create tag with name "tag2" without description
+    And I create tag with name "tag3" without description
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create tag with name "tag4" without description
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tags Under Account That Does Not Allow Tags
+  Login as kapua-sys, create an account
+  Configure TagService of that account, set infiniteChildTags to false and maxNumberChildTags to 0
+  Try to create a group
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create tag with name "tag1" without description
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tags And Than Setting Tag Service So It Does Not Allow Tags
+  Login as kapua-sys, create an account
+  Configure TagService of that account, set infiniteChildTags to true
+  Create a few Tags
+  Configure TagService of that account, set infiniteChildTags to false
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create tag with name "tag1" without description
+    When I create tag with name "tag2" without description
+    Given I expect the exception "KapuaConfigurationException" with the text "*"
+    When I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Tags And Then Changing Tag Service Values
+  Login as kapua-sys, create an account
+  Configure TagService of that account, set infiniteChildTags to true
+  Create 2 Tags
+  Configure TagService of that account, set infiniteChildTags to false and maxNumberChildTags to 2
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create tag with name "tag1" without description
+    When I create tag with name "tag2" without description
+    When I configure the tag service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 2     |
+    Then No exception was thrown
+    And I logout

--- a/qa/integration/src/test/resources/features/account/AccountUserService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountUserService.feature
@@ -1,0 +1,121 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@account
+@user
+@integration
+
+Feature: Account User Service Integration Tests
+
+  Scenario: Creating Users Under Account That Allows Infinite Child Users
+  Login as kapua-sys, create an account
+  Configure UserService of that account, set infiniteChildUsers to true and maxNumberChildUsers to 0
+  Create a few Users
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create user with name "user1"
+    And I create user with name "user2"
+    And I create user with name "user3"
+    Then No exception was thrown
+    And I logout
+
+  Scenario: Creating Users Under Account That Has Limited Child Users
+  Login as kapua-sys, create an account
+  Configure UserService of that account, set infiniteChildUsers to false and maxNumberChildUsers to 3
+  Create a few Users
+  Only 3 Users should be created, creating more will throw an Exception
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 3     |
+    Given I select account "acc1"
+    When I create user with name "user1"
+    And I create user with name "user2"
+    And I create user with name "user3"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create user with name "user4"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Users Under Account That Does Not Allow Users
+  Login as kapua-sys, create an account
+  Configure UserService of that account, set infiniteChildUsers to false and maxNumberChildUsers to 0
+  Try to create a user
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
+    When I create user with name "user0"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Users And Than Setting User Service So It Does Not Allow Users
+  Login as kapua-sys, create an account
+  Configure UserService of that account, set infiniteChildUsers to true
+  Create a few Users
+  Configure UserService of that account, set infiniteChildUsers to false
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create user with name "user0"
+    And I create user with name "user1"
+    Given I expect the exception "KapuaConfigurationException" with the text "*"
+    When I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 0     |
+    Then An exception was thrown
+    And I logout
+
+  Scenario: Creating Users And Then Changing User Service Values
+  Login as kapua-sys, create an account
+  Configure UserService of that account, set infiniteChildUsers to true
+  Create 2 Users
+  Configure UserService of that account, set infiniteChildUsers to false and maxNumberChildUsers to 2
+  No exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 0     |
+    Given I select account "acc1"
+    When I create user with name "user0"
+    And I create user with name "user1"
+    When I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | false |
+      | integer | maxNumberChildEntities | 2     |
+    Then No exception was thrown
+    And I logout

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -196,6 +196,21 @@ public class AccountServiceSteps extends TestBase {
         }
     }
 
+    @When("^I create (\\d+) accounts in current scopeId?$")
+    public void createAccountsInCurrentScopeId(int numberOfAccounts)
+            throws Exception {
+
+        for (int i = 0; i < numberOfAccounts; i++) {
+            AccountCreator accountCreator = prepareRegularAccountCreator(getCurrentScopeId(), "account" + i);
+            try {
+                primeException();
+                Account account = accountService.create(accountCreator);
+            } catch (KapuaException ex) {
+                verifyException(ex);
+            }
+        }
+    }
+
     @Given("^An existing account that expires on \"(.*)\" with the name \"(.*)\"$")
     public void createTestAccountWithName(String expirationDateStr, String name)
             throws Exception {
@@ -973,6 +988,26 @@ public class AccountServiceSteps extends TestBase {
             verifyException(ex);
         }
     }
+
+    @When("^I query for all sub-accounts in \"([^\"]*)\"$")
+    public void queryForAllAccountsInCurrentScopeId(String accountName) throws Exception {
+        Account tmpAccount = accountService.findByName(accountName);
+        AccountQuery query = accountFactory.newQuery(tmpAccount.getId());
+        try {
+            primeException();
+            AccountListResult accList = accountService.query(query);
+            stepData.put("NumberOfFoundAccounts", accList.getSize());
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
+    @When("^I find (\\d+) accounts?$")
+    public void iFindAccounts(int numberOfAccounts) {
+        int foundAccounts = (int) stepData.get("NumberOfFoundAccounts");
+        assertEquals(foundAccounts, numberOfAccounts);
+    }
+
 
     // *****************
     // * Inner Classes *

--- a/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -267,7 +267,7 @@ public class TagServiceSteps extends TestBase {
      */
     private TagCreator tagCreatorCreatorWithoutDescription(String tagName) {
 
-        TagCreator tagCreator = tagFactory.newCreator(SYS_SCOPE_ID);
+        TagCreator tagCreator = tagFactory.newCreator(getCurrentScopeId());
         tagCreator.setName(tagName);
 
         return tagCreator;

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -640,6 +640,23 @@ public class UserServiceSteps extends TestBase {
         }
     }
 
+    @When("^I try to login as user with name \"(.*)\" with wrong password (\\d+) times$")
+    public void loginUserNTimes(String userName, int n) throws Exception {
+
+        String password = "wrongPassword";
+        LoginCredentials credentials = credentialsFactory.newUsernamePasswordCredentials(userName, password);
+        authenticationService.logout();
+
+        for (int i = 0; i < n; i++) {
+            primeException();
+            try {
+                authenticationService.login(credentials);
+            } catch (KapuaException e) {
+                verifyException(e);
+            }
+        }
+    }
+
     @Then("^I try to delete user \"(.*)\"$")
     public void thenDeleteUser(String userName) throws Exception {
 


### PR DESCRIPTION
Added tests that are testing the creation of account and sub-accounts. Also added tests for configuring services such as CredentialService, UserService, TagService, JobService, DeviceRegistryService and GroupService.

Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

Integration tests for Account service are added in this PR.

**Related Issue**
None

**Description of the solution adopted**
In this PR I created new feature files that are testing if Account service is working correctly.

**Screenshots**
/

**Any side note on the changes made**
@Coduz This PR has to be merged before PR #2864 which is still waiting for CQ. After this is merged, we will just rebase the #2864 and the CQ will not be needed any more, since the total lines count will be less than 1k.
