### PR TITLE
DeviceManagementOperationService.findByOperationId feature

### DIFF
--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
@@ -25,11 +25,9 @@ import org.eclipse.kapua.service.device.management.message.notification.Operatio
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationCreator;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationProperty;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventCreator;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
@@ -111,14 +109,7 @@ public abstract class AbstractDeviceManagementServiceImpl {
     }
 
     protected void closeManagementOperation(KapuaId scopeId, KapuaId deviceId, KapuaId operationId, KapuaResponseMessage<?, ?> responseMessageMessage) throws KapuaException {
-        DeviceManagementOperationQuery query = DEVICE_MANAGEMENT_OPERATION_FACTORY.newQuery(scopeId);
-        query.setPredicate(
-                query.andPredicate(
-                        query.attributePredicate(DeviceManagementOperationAttributes.DEVICE_ID, deviceId),
-                        query.attributePredicate(DeviceManagementOperationAttributes.OPERATION_ID, operationId)
-                )
-        );
-        DeviceManagementOperation deviceManagementOperation = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.query(query).getFirstItem();
+        DeviceManagementOperation deviceManagementOperation = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.findByOperationId(scopeId, operationId);
 
         if (deviceManagementOperation == null) {
             throw new KapuaEntityNotFoundException(DeviceManagementOperation.TYPE, operationId);

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
@@ -30,11 +30,8 @@ import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperat
 import org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService;
 import org.eclipse.kapua.service.device.management.message.notification.OperationStatus;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationListResult;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationProperty;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotification;
 import org.eclipse.kapua.service.job.targets.JobTarget;
@@ -230,11 +227,7 @@ public class JobDeviceManagementOperationManagerServiceImpl implements JobDevice
      * @since 1.1.0
      */
     private DeviceManagementOperation getDeviceManagementOperation(KapuaId scopeId, KapuaId operationId) throws KapuaException {
-        DeviceManagementOperationQuery deviceManagementOperationQuery = DEVICE_MANAGEMENT_OPERATION_FACTORY.newQuery(scopeId);
-        deviceManagementOperationQuery.setPredicate(deviceManagementOperationQuery.attributePredicate(DeviceManagementOperationAttributes.OPERATION_ID, operationId));
-
-        DeviceManagementOperationListResult deviceManagementOperationListResult = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.query(deviceManagementOperationQuery);
-        DeviceManagementOperation deviceManagementOperation = deviceManagementOperationListResult.getFirstItem();
+        DeviceManagementOperation deviceManagementOperation = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.findByOperationId(scopeId, operationId);
 
         if (deviceManagementOperation == null) {
             throw new KapuaEntityNotFoundException(DeviceManagementOperation.TYPE, operationId);

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
@@ -21,11 +21,8 @@ import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.device.management.message.notification.OperationStatus;
 import org.eclipse.kapua.service.device.management.registry.manager.exception.ManagementOperationNotificationProcessingException;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationListResult;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationProperty;
-import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotification;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationAttributes;
@@ -168,11 +165,7 @@ public interface DeviceManagementRegistryManagerService extends KapuaService {
     }
 
     default DeviceManagementOperation getDeviceManagementOperation(KapuaId scopeId, KapuaId operationId) throws KapuaException {
-        DeviceManagementOperationQuery query = DEVICE_MANAGEMENT_OPERATION_FACTORY.newQuery(scopeId);
-        query.setPredicate(query.attributePredicate(DeviceManagementOperationAttributes.OPERATION_ID, operationId));
-
-        DeviceManagementOperationListResult operations = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.query(query);
-        DeviceManagementOperation deviceManagementOperation = operations.getFirstItem();
+        DeviceManagementOperation deviceManagementOperation = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.findByOperationId(scopeId, operationId);
 
         if (deviceManagementOperation == null) {
             throw new KapuaEntityNotFoundException(DeviceManagementOperation.TYPE, operationId);

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationRegistryService.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,14 +12,23 @@
 package org.eclipse.kapua.service.device.management.registry.operation;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
 
-public interface DeviceManagementOperationRegistryService
-        extends
-        KapuaEntityService<DeviceManagementOperation, DeviceManagementOperationCreator>,
-        KapuaUpdatableEntityService<DeviceManagementOperation> {
+public interface DeviceManagementOperationRegistryService extends KapuaEntityService<DeviceManagementOperation, DeviceManagementOperationCreator>, KapuaUpdatableEntityService<DeviceManagementOperation> {
+
+    /**
+     * Gets a {@link DeviceManagementOperation} by its {@link DeviceManagementOperation#getOperationId()}
+     *
+     * @param scopeId     The {@link DeviceManagementOperation#getScopeId()}
+     * @param operationId The {@link DeviceManagementOperation#getOperationId()}.
+     * @return The {@link DeviceManagementOperation} found, or {@code null}
+     * @throws KapuaException
+     * @since 1.2.0
+     */
+    DeviceManagementOperation findByOperationId(KapuaId scopeId, KapuaId operationId) throws KapuaException;
 
     /**
      * Returns the {@link DeviceManagementOperationListResult} with elements matching the provided query.
@@ -30,7 +39,6 @@ public interface DeviceManagementOperationRegistryService
      * @since 1.0.0
      */
     @Override
-    DeviceManagementOperationListResult query(KapuaQuery<DeviceManagementOperation> query)
-            throws KapuaException;
+    DeviceManagementOperationListResult query(KapuaQuery<DeviceManagementOperation> query) throws KapuaException;
 
 }

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
@@ -24,8 +24,10 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationCreator;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationListResult;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementRegistryDomains;
 import org.eclipse.kapua.service.device.registry.Device;
@@ -122,6 +124,24 @@ public class DeviceManagementOperationRegistryServiceImpl extends AbstractKapuaS
         //
         // Do find
         return entityManagerSession.onResult(em -> DeviceManagementOperationDAO.find(em, scopeId, entityId));
+    }
+
+    @Override
+    public DeviceManagementOperation findByOperationId(KapuaId scopeId, KapuaId operationId) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(operationId, "operationId");
+
+        // Check Access
+        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(DeviceManagementRegistryDomains.DEVICE_MANAGEMENT_REGISTRY_DOMAIN, Actions.read, scopeId));
+
+        //
+        // Do find
+        DeviceManagementOperationQuery query = new DeviceManagementOperationQueryImpl(scopeId);
+        query.setPredicate(query.attributePredicate(DeviceManagementOperationAttributes.OPERATION_ID, operationId));
+
+        return entityManagerSession.onResult(em -> DeviceManagementOperationDAO.query(em, query)).getFirstItem();
     }
 
     @Override


### PR DESCRIPTION
This PR adds `findByOperationId` method to `DeviceManagementOperationService` to allow retrieval of a `DeviceManagementOperation` by its `DeviceManagementOperation.operationId`.

**Related Issue**
_None_

**Description of the solution adopted**
Added method to API and implementation.

**Screenshots**
_None_

**Any side note on the changes made**
_None_