### PR TITLE
Liquibase Client improvements

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/KapuaDatabaseCheckUpdate.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/KapuaDatabaseCheckUpdate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,43 +11,39 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core;
 
-import java.util.Optional;
-
+import com.google.common.base.MoreObjects;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.google.common.base.MoreObjects;
-
 /**
  * Call Liquibase database schema check and update (if enabled)
- *
  */
 public class KapuaDatabaseCheckUpdate {
 
     private static final Logger logger = LoggerFactory.getLogger(KapuaDatabaseCheckUpdate.class);
 
-    public KapuaDatabaseCheckUpdate() throws Exception {
+    public KapuaDatabaseCheckUpdate() {
         logger.info("Kapua database schema check and update...");
         try {
             SystemSetting config = SystemSetting.getInstance();
-            if(config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
+            if (config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
                 logger.debug("Starting Liquibase embedded client.");
                 String dbUsername = config.getString(SystemSettingKey.DB_USERNAME);
                 String dbPassword = config.getString(SystemSettingKey.DB_PASSWORD);
                 String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
-                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, Optional.of(schema)).update();
+
+                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
                 logger.info("Kapua database schema check and update... DONE");
-            }
-            else {
+            } else {
                 logger.info("Kapua database schema check and update... skipping (not enabled by configuration) DONE");
             }
-        } catch (Throwable t) {
-            logger.error("Error in plugin installation.", t);
-            throw new SecurityException(t);
+        } catch (Exception e) {
+            logger.error("Error in plugin installation.", e);
+            throw new SecurityException(e);
         }
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.liquibase;
 
+import com.google.common.base.Strings;
 import liquibase.Liquibase;
 import liquibase.database.Database;
 import liquibase.database.DatabaseFactory;
@@ -21,6 +22,9 @@ import liquibase.resource.FileSystemResourceAccessor;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.SystemUtils;
+import org.eclipse.kapua.commons.liquibase.settings.LiquibaseClientSettingKeys;
+import org.eclipse.kapua.commons.liquibase.settings.LiquibaseClientSettings;
+import org.eclipse.kapua.commons.util.SemanticVersion;
 import org.reflections.Reflections;
 import org.reflections.scanners.ResourcesScanner;
 import org.slf4j.Logger;
@@ -28,15 +32,15 @@ import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.FileOutputStream;
-import java.io.FilenameFilter;
 import java.io.IOException;
 import java.net.URL;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Comparator;
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -44,39 +48,56 @@ public class KapuaLiquibaseClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(KapuaLiquibaseClient.class);
 
+    private static final SemanticVersion LIQUIBASE_TIMESTAMP_FIX_VERSION = new SemanticVersion("3.3.3"); // https://liquibase.jira.com/browse/CORE-1958
+
+    private static final LiquibaseClientSettings LIQUIBASE_CLIENT_SETTINGS = LiquibaseClientSettings.getInstance();
+
     private final String jdbcUrl;
     private final String username;
     private final String password;
-    private final Optional<String> schema;
+    private final String schema;
+    private final boolean runTimestampsFix;
 
-    public KapuaLiquibaseClient(String jdbcUrl, String username, String password, Optional<String> schema) {
+    public KapuaLiquibaseClient(String jdbcUrl, String username, String password, String schema) {
         this.jdbcUrl = jdbcUrl;
         this.username = username;
         this.password = password;
         this.schema = schema;
+
+        // Check wether or not fix the timestamp based on Liquibase version
+        boolean forceTimestampFix = LIQUIBASE_CLIENT_SETTINGS.getBoolean(LiquibaseClientSettingKeys.FORCE_TIMESTAMPS_FIX);
+        String currentLiquibaseVersionString = LIQUIBASE_CLIENT_SETTINGS.getString(LiquibaseClientSettingKeys.LIQUIBASE_VERSION);
+        SemanticVersion currentLiquibaseVersion = new SemanticVersion(currentLiquibaseVersionString);
+
+        runTimestampsFix = (currentLiquibaseVersion.afterOrMatches(LIQUIBASE_TIMESTAMP_FIX_VERSION) || forceTimestampFix);
     }
 
     public KapuaLiquibaseClient(String jdbcUrl, String username, String password) {
-        this(jdbcUrl, username, password, Optional.empty());
+        this(jdbcUrl, username, password, null);
     }
 
     public void update() {
         try {
             if (Boolean.parseBoolean(System.getProperty("LIQUIBASE_ENABLED", "true")) || Boolean.parseBoolean(System.getenv("LIQUIBASE_ENABLED"))) {
-                LOG.info("Running Liquibase update with schema: " + schema.toString());
+                LOG.info("Running Liquibase update with schema: {}", schema);
                 try (Connection connection = DriverManager.getConnection(jdbcUrl, username, password)) {
-                    loadResourcesStatic(connection, schema);
+                    File changelogDir = loadChangelogs();
+
+                    List<String> contexts = new ArrayList<>();
+                    if (!runTimestampsFix) {
+                        contexts.add("!fixTimestamps");
+                }
+
+                    executeMasters(connection, schema, changelogDir, contexts);
                 }
             }
         } catch (LiquibaseException | SQLException | IOException e) {
-            LOG.error("Error while running Liquibase scripts!", e);
+            LOG.error("Error while running Liquibase scripts: {}", e.getMessage(), e);
             throw new RuntimeException(e);
         }
     }
 
-    protected static synchronized void loadResourcesStatic(Connection connection, Optional<String> schema) throws LiquibaseException, IOException {
-        //
-        // Copy files to temporary directory
+    protected static synchronized File loadChangelogs() throws IOException {
         String tmpDirectory = SystemUtils.getJavaIoTmpDir().getAbsolutePath();
 
         File changelogTempDirectory = new File(tmpDirectory, "kapua-liquibase");
@@ -85,8 +106,8 @@ public class KapuaLiquibaseClient {
             FileUtils.deleteDirectory(changelogTempDirectory);
         }
 
-        changelogTempDirectory.mkdirs();
-        LOG.trace("Tmp dir: {}", changelogTempDirectory.getAbsolutePath());
+        boolean createdTmp = changelogTempDirectory.mkdirs();
+        LOG.trace("{} Tmp dir: {}", createdTmp ? "Created" : "Using", changelogTempDirectory.getAbsolutePath());
 
         Reflections reflections = new Reflections("liquibase", new ResourcesScanner());
         Set<String> changeLogs = reflections.getResources(Pattern.compile(".*\\.xml|.*\\.sql"));
@@ -94,8 +115,8 @@ public class KapuaLiquibaseClient {
             URL scriptUrl = KapuaLiquibaseClient.class.getResource("/" + script);
             File changelogFile = new File(changelogTempDirectory, script.replaceFirst("liquibase/", ""));
             if (changelogFile.getParentFile() != null && !changelogFile.getParentFile().exists()) {
-                LOG.trace("Creating parent dir: {}", changelogFile.getParentFile().getAbsolutePath());
-                changelogFile.getParentFile().mkdirs();
+                boolean createdParent = changelogFile.getParentFile().mkdirs();
+                LOG.trace("{} parent dir: {}", createdParent ? "Created" : "Using", changelogFile.getParentFile().getAbsolutePath());
             }
             try (FileOutputStream tmpStream = new FileOutputStream(changelogFile)) {
                 IOUtils.write(IOUtils.toString(scriptUrl), tmpStream);
@@ -103,40 +124,44 @@ public class KapuaLiquibaseClient {
             LOG.trace("Copied file: {}", changelogFile.getAbsolutePath());
         }
 
+        return changelogTempDirectory;
+    }
+
+    protected static void executeMasters(Connection connection, String schema, File changelogDir, List<String> contexts) throws LiquibaseException {
         //
         // Find and execute all master scripts
         LOG.info("Executing pre master files...");
-        executeMasters(connection, schema, changelogTempDirectory, "-master.pre.xml");
+        executeMasters(connection, schema, changelogDir, "-master.pre.xml", contexts);
         LOG.info("Executing pre master files... DONE!");
 
         LOG.info("Executing master files...");
-        executeMasters(connection, schema, changelogTempDirectory, "-master.xml");
+        executeMasters(connection, schema, changelogDir, "-master.xml", contexts);
         LOG.info("Executing master files... DONE!");
 
         LOG.info("Executing post master files...");
-        executeMasters(connection, schema, changelogTempDirectory, "-master.post.xml");
+        executeMasters(connection, schema, changelogDir, "-master.post.xml", contexts);
         LOG.info("Executing post master files... DONE!");
-
     }
 
-    private static void executeMasters(Connection connection, Optional<String> schema, File changelogTempDirectory, String preMaster) throws LiquibaseException {
-        List<File> masterChangelogs = Arrays.asList(changelogTempDirectory.listFiles((FilenameFilter) (dir, name) -> name.endsWith(preMaster)));
+    protected static void executeMasters(Connection connection, String schema, File changelogTempDirectory, String preMaster, List<String> contexts) throws LiquibaseException {
+        List<File> masterChangelogs = Arrays.asList(changelogTempDirectory.listFiles((dir, name) -> name.endsWith(preMaster)));
 
         LOG.info("\tMaster Liquibase files found: {}", masterChangelogs.size());
 
         LOG.trace("\tSorting master Liquibase files found.");
-        masterChangelogs.sort((f1, f2) -> f1.getAbsolutePath().compareTo(f2.getAbsolutePath()));
+        masterChangelogs.sort(Comparator.comparing(File::getAbsolutePath));
 
+        String ctx = contexts.isEmpty() ? null : String.join(",", contexts);
         for (File masterChangelog : masterChangelogs) {
-            LOG.info("\t\tExcuting liquibase script: {}", masterChangelog.getAbsolutePath());
+            LOG.info("\t\tExecuting liquibase script: {}...", masterChangelog.getAbsolutePath());
             Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
-            if (schema.isPresent()) {
-                database.setDefaultSchemaName(schema.get());
+            if (!Strings.isNullOrEmpty(schema)) {
+                database.setDefaultSchemaName(schema);
             }
             Liquibase liquibase = new Liquibase(masterChangelog.getAbsolutePath(), new FileSystemResourceAccessor(), database);
-            liquibase.update(null);
+            liquibase.update(ctx);
 
-            LOG.debug("\t\tExcuted liquibase script: {}", masterChangelog.getAbsolutePath());
+            LOG.debug("\t\tExecuting liquibase script: {}... DONE!", masterChangelog.getAbsolutePath());
         }
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -44,6 +44,13 @@ import java.util.List;
 import java.util.Set;
 import java.util.regex.Pattern;
 
+/**
+ * Client that execute {@link Liquibase} scripts.
+ * <p>
+ * It looks available scripts in {@code .xml} or {@code .sql} in the classpath.
+ *
+ * @since 1.0.0
+ */
 public class KapuaLiquibaseClient {
 
     private static final Logger LOG = LoggerFactory.getLogger(KapuaLiquibaseClient.class);
@@ -58,6 +65,27 @@ public class KapuaLiquibaseClient {
     private final String schema;
     private final boolean runTimestampsFix;
 
+    /**
+     * Constructor.
+     *
+     * @param jdbcUrl  The JDBC connection string.
+     * @param username The username to connect to to the database.
+     * @param password The password to connect to to the database.
+     * @since 1.0.0
+     */
+    public KapuaLiquibaseClient(String jdbcUrl, String username, String password) {
+        this(jdbcUrl, username, password, null);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param jdbcUrl  The JDBC connection string.
+     * @param username The username to connect to to the database.
+     * @param password The password to connect to to the database.
+     * @param schema   The schema name.
+     * @since 1.0.0
+     */
     public KapuaLiquibaseClient(String jdbcUrl, String username, String password, String schema) {
         this.jdbcUrl = jdbcUrl;
         this.username = username;
@@ -76,10 +104,11 @@ public class KapuaLiquibaseClient {
         LOG.info("Apply timestamp fix: {}", runTimestampsFix);
     }
 
-    public KapuaLiquibaseClient(String jdbcUrl, String username, String password) {
-        this(jdbcUrl, username, password, null);
-    }
-
+    /**
+     * Starts the looking and execution of the Liquibase Scripts.
+     *
+     * @since 1.0.0
+     */
     public void update() {
         try {
             if (Boolean.parseBoolean(System.getProperty("LIQUIBASE_ENABLED", "true")) || Boolean.parseBoolean(System.getenv("LIQUIBASE_ENABLED"))) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -70,6 +70,10 @@ public class KapuaLiquibaseClient {
         SemanticVersion currentLiquibaseVersion = new SemanticVersion(currentLiquibaseVersionString);
 
         runTimestampsFix = (currentLiquibaseVersion.afterOrMatches(LIQUIBASE_TIMESTAMP_FIX_VERSION) || forceTimestampFix);
+
+        LOG.info("Liquibase Version: {}", currentLiquibaseVersionString);
+        LOG.info("Force timestamp fix: {}", forceTimestampFix);
+        LOG.info("Apply timestamp fix: {}", runTimestampsFix);
     }
 
     public KapuaLiquibaseClient(String jdbcUrl, String username, String password) {
@@ -86,7 +90,7 @@ public class KapuaLiquibaseClient {
                     List<String> contexts = new ArrayList<>();
                     if (!runTimestampsFix) {
                         contexts.add("!fixTimestamps");
-                }
+                    }
 
                     executeMasters(connection, schema, changelogDir, contexts);
                 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/settings/LiquibaseClientSettingKeys.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/settings/LiquibaseClientSettingKeys.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.liquibase.settings;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+
+/**
+ * {@link LiquibaseClientSettings} {@link SettingKey}s
+ *
+ * @since 1.2.0
+ */
+public enum LiquibaseClientSettingKeys implements SettingKey {
+
+    /**
+     * Whether or not force the fix of the SQL timestamps.
+     *
+     * @since 1.2.0
+     */
+    FORCE_TIMESTAMPS_FIX("liquibaseClient.timestamps.fix.force"),
+
+    /**
+     * {@link liquibase.Liquibase} version.
+     *
+     * @since 1.2.0
+     */
+    LIQUIBASE_VERSION("liquibaseClient.liquibase.version");
+
+
+    /**
+     * The {@link String} {@link LiquibaseClientSettingKeys} name.
+     */
+    private final String key;
+
+    /**
+     * Constructor.
+     *
+     * @param key The {@link String} {@link LiquibaseClientSettingKeys} name.
+     * @since 1.2.0
+     */
+    private LiquibaseClientSettingKeys(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/settings/LiquibaseClientSettings.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/settings/LiquibaseClientSettings.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.liquibase.settings;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * @since 1.2.0
+ */
+public class LiquibaseClientSettings extends AbstractKapuaSetting<LiquibaseClientSettingKeys> {
+
+    private static final String CONFIG_RESOURCE_NAME = "liquibase-client-settings.properties";
+
+    private static final LiquibaseClientSettings INSTANCE = new LiquibaseClientSettings();
+
+    /**
+     * Constructor.
+     *
+     * @since 1.2.0
+     */
+    private LiquibaseClientSettings() {
+        super(CONFIG_RESOURCE_NAME);
+    }
+
+    /**
+     * Gets the {@link LiquibaseClientSettings} singleton instance.
+     *
+     * @return The {@link LiquibaseClientSettings} singleton instance.
+     * @since 1.2.0
+     */
+    public static LiquibaseClientSettings getInstance() {
+        return INSTANCE;
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
@@ -1,0 +1,266 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+/**
+ * Utility class to handle comparison between component versions.
+ *
+ * @see <a href="https://semver.org/">Semantic Versioning</a>.
+ * @since 1.2.0
+ */
+public class SemanticVersion {
+
+    private final String versionString;
+    private final VersionToken majorVersion;
+    private final VersionToken minorVersion;
+    private final VersionToken patchVersion;
+
+    /**
+     * Constructor.
+     * Parses the given {@link String} according to the rules defined by the <a href="https://semver.org/">Semantic Versioning</a>.
+     *
+     * @param version The {@link String} version to parse
+     * @since 1.2.0
+     */
+    public SemanticVersion(String version) {
+        this.versionString = version;
+
+        String[] versionSplitted = version.split("\\.");
+
+        majorVersion = new VersionToken(versionSplitted[0]);
+
+        if (versionSplitted.length > 1) {
+            minorVersion = new VersionToken(versionSplitted[1]);
+        } else {
+            minorVersion = null;
+        }
+
+        if (versionSplitted.length > 2) {
+            patchVersion = new VersionToken(versionSplitted[2]);
+        } else {
+            patchVersion = null;
+        }
+    }
+
+    /**
+     * Gets the original {@link String} provided.
+     *
+     * @return The original {@link String} provided.
+     * @since 1.2.0
+     */
+    public String getVersionString() {
+        return versionString;
+    }
+
+    /**
+     * Gets the major version.
+     *
+     * @return The major version.
+     * @since 1.2.0
+     */
+    public VersionToken getMajorVersion() {
+        return majorVersion;
+    }
+
+    /**
+     * Gets the minor version.
+     *
+     * @return The minor version.
+     * @since 1.2.0
+     */
+    public VersionToken getMinorVersion() {
+        return minorVersion;
+    }
+
+    /**
+     * Gets the patch version.
+     *
+     * @return The patch version.
+     * @since 1.2.0
+     */
+    public VersionToken getPatchVersion() {
+        return patchVersion;
+    }
+
+    /**
+     * Compares {@code this} {@link SemanticVersion} with another {@link SemanticVersion}.
+     *
+     * @param other The {@link SemanticVersion} to use to compare.
+     * @return {@code true} if {@code this} {@link SemanticVersion} is after or matches the given {@link SemanticVersion}
+     * @since 1.2.0
+     */
+    public boolean afterOrMatches(SemanticVersion other) {
+        return after(other) || match(other);
+    }
+
+    /**
+     * Compares {@code this} {@link SemanticVersion} with another {@link SemanticVersion}.
+     *
+     * @param other The {@link SemanticVersion} to use to compare.
+     * @return {@code true} if {@code this} {@link SemanticVersion} is after the given {@link SemanticVersion}
+     * @since 1.2.0
+     */
+    public boolean after(SemanticVersion other) {
+        if (getMajorVersion().after(other.getMajorVersion())) {
+            return true;
+        }
+
+        if (getMinorVersion() != null && getMinorVersion().after(other.getMinorVersion())) {
+            return true;
+        }
+
+        if (getPatchVersion() != null && getPatchVersion().after(other.getPatchVersion())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Compares {@code this} {@link SemanticVersion} with another {@link SemanticVersion}.
+     *
+     * @param other The {@link SemanticVersion} to use to compare.
+     * @return {@code true} if {@code this} {@link SemanticVersion} is before or matches the given {@link SemanticVersion}
+     * @since 1.2.0
+     */
+    public boolean beforeOrMatches(SemanticVersion other) {
+        return before(other) || match(other);
+    }
+
+    /**
+     * Compares {@code this} {@link SemanticVersion} with another {@link SemanticVersion}.
+     *
+     * @param other The {@link SemanticVersion} to use to compare.
+     * @return {@code true} if {@code this} {@link SemanticVersion} is before the given {@link SemanticVersion}
+     * @since 1.2.0
+     */
+    public boolean before(SemanticVersion other) {
+        if (getMajorVersion().before(other.getMajorVersion())) {
+            return true;
+        }
+
+        if (getMinorVersion() != null && getMinorVersion().before(other.getMinorVersion())) {
+            return true;
+        }
+
+        if (getPatchVersion() != null && getPatchVersion().before(other.getPatchVersion())) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Compares {@code this} {@link SemanticVersion} with another {@link SemanticVersion}.
+     *
+     * @param other The {@link SemanticVersion} to use to compare.
+     * @return {@code true} if {@code this} {@link SemanticVersion} is matches the given {@link SemanticVersion}
+     * @since 1.2.0
+     */
+    public boolean match(SemanticVersion other) {
+        return getVersionString().equals(other.getVersionString());
+    }
+
+    @Override
+    public String toString() {
+        return versionString;
+    }
+
+    /**
+     * Representation of the single token of a component version.
+     *
+     * @since 1.2.0
+     */
+    static class VersionToken {
+        String versionString;
+        Integer versionInteger;
+        boolean integerComparison;
+
+        /**
+         * Constructor.
+         *
+         * @param versionToken The version token.
+         * @since 1.2.0
+         */
+        VersionToken(String versionToken) {
+            try {
+                versionInteger = Integer.parseInt(versionToken);
+                integerComparison = true;
+            } catch (NumberFormatException e) {
+                versionInteger = null;
+                integerComparison = false;
+            }
+
+            versionString = versionToken;
+        }
+
+        /**
+         * Gets the {@link String} representation of the {@link VersionToken}.
+         *
+         * @return The {@link String} representation of the {@link VersionToken}.
+         * @since 1.2.0
+         */
+        public String getVersionString() {
+            return versionString;
+        }
+
+        /**
+         * Gets the {@link Integer} representation of the {@link VersionToken}, if available.
+         *
+         * @return The {@link String} representation of the {@link VersionToken} or {@code null} if token is not a {@link Integer}.
+         * @since 1.2.0
+         */
+        public Integer getVersionInteger() {
+            return versionInteger;
+        }
+
+        /**
+         * Returns whether or not {@code this} {@link VersionToken} can be compared as an {@link Integer}.
+         *
+         * @return {@true} if {@code this} {@link VersionToken} can be compared as a {@link Integer}, {@code false} otherwise.
+         */
+        public boolean isIntegerComparison() {
+            return integerComparison;
+        }
+
+
+        /**
+         * Compares {@code this} {@link VersionToken} with another {@link VersionToken}.
+         *
+         * @param other The {@link VersionToken} to use to compare.
+         * @return {@code true} if {@code this} {@link VersionToken} is after the given {@link VersionToken}
+         * @since 1.2.0
+         */
+        public boolean after(VersionToken other) {
+            if (isIntegerComparison() && other.isIntegerComparison()) {
+                return getVersionInteger() > other.getVersionInteger();
+            } else {
+                return getVersionString().compareTo(other.getVersionString()) > 0;
+            }
+        }
+
+        /**
+         * Compares {@code this} {@link VersionToken} with another {@link VersionToken}.
+         *
+         * @param other The {@link VersionToken} to use to compare.
+         * @return {@code true} if {@code this} {@link VersionToken} is before the given {@link VersionToken}
+         * @since 1.2.0
+         */
+        public boolean before(VersionToken other) {
+            if (isIntegerComparison() && other.isIntegerComparison()) {
+                return getVersionInteger() < other.getVersionInteger();
+            } else {
+                return getVersionString().compareTo(other.getVersionString()) < 0;
+            }
+        }
+    }
+}

--- a/commons/src/main/resources/liquibase-client-settings.properties
+++ b/commons/src/main/resources/liquibase-client-settings.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+liquibaseClient.liquibase.version=${liquibase.version}
+liquibaseClient.timestamps.fix.force=false

--- a/commons/src/main/resources/liquibase/1.2.0/changelog-event-store-1.2.0.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/changelog-event-store-1.2.0.xml
@@ -15,13 +15,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-event-store-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./sys-event-store-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./sys-housekeeper-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/1.2.0/changelog-system-configuration-1.2.0.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/changelog-system-configuration-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-system-configuration-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./system_configuration-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
@@ -19,7 +19,7 @@
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <changeSet id="changelog-event_store-1.2.0-timestamp" author="eurotech">
+    <changeSet id="changelog-event_store-1.2.0-timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="sys_event_store" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="sys_event_store" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="sys_event_store" columnName="event_on" newDataType="timestamp(3) DEFAULT ${now}"/>

--- a/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
@@ -15,13 +15,14 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-event-store-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-event_store-1.2.0-timestamp" author="eurotech">
+        <modifyDataType tableName="sys_event_store" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="sys_event_store" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="sys_event_store" columnName="event_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-event-store-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-housekeeper-1.2.0-timestamp" author="eurotech">
+        <modifyDataType tableName="sys_housekeeper_run" columnName="last_run_on" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
@@ -19,7 +19,7 @@
 
     <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
-    <changeSet id="changelog-housekeeper-1.2.0-timestamp" author="eurotech">
+    <changeSet id="changelog-housekeeper-1.2.0-timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="sys_housekeeper_run" columnName="last_run_on" newDataType="timestamp(3) NULL"/>
     </changeSet>
 

--- a/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-system_configuration-1.2.0.xml">
 
-    <changeSet id="changelog-system_configuration-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-system_configuration-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="sys_configuration" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="sys_configuration" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-system_configuration-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-system_configuration-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="sys_configuration" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="sys_configuration" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/changelog-event-store-master.pre.xml
+++ b/commons/src/main/resources/liquibase/changelog-event-store-master.pre.xml
@@ -10,11 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./1.0.0/changelog-event-store.xml" />
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-event-store.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-event-store-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/changelog-system-configurations-master.pre.xml
+++ b/commons/src/main/resources/liquibase/changelog-system-configurations-master.pre.xml
@@ -10,12 +10,13 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-system-configuration-0.2.0.xml" />
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-system-configuration-0.3.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-system-configuration-0.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-system-configuration-0.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-system-configuration-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/commons/src/test/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClientTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -25,7 +25,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Optional;
 
 @Category(JUnitTests.class)
 public class KapuaLiquibaseClientTest {
@@ -109,7 +108,7 @@ public class KapuaLiquibaseClientTest {
 
         // When
         try {
-            new KapuaLiquibaseClient(JDBC_URL, USERNAME, PASSWORD, Optional.of("foo")).update();
+            new KapuaLiquibaseClient(JDBC_URL, USERNAME, PASSWORD, "foo").update();
         } catch (Exception e) {
             // Then
             Assertions.assertThat(e).hasMessageContaining("Schema \"FOO\" not found");

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/AbstractCommonServiceTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/AbstractCommonServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,15 +18,13 @@ import org.eclipse.kapua.commons.jpa.CommonsEntityManagerFactory;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
 import org.eclipse.kapua.commons.jpa.SimpleSqlScriptExecutor;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.util.Optional;
 
 public abstract class AbstractCommonServiceTest {
 
@@ -66,14 +64,13 @@ public abstract class AbstractCommonServiceTest {
     }
 
     @BeforeClass
-    public static void tearUp()
-            throws KapuaException {
+    public static void tearUp() throws KapuaException {
 
         SystemSetting config = SystemSetting.getInstance();
         String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
         String jdbcUrl = JdbcConnectionUrlResolvers.resolveJdbcUrl();
 
-        new KapuaLiquibaseClient(jdbcUrl, "kapua", "kapua", Optional.ofNullable(schema)).update();
+        new KapuaLiquibaseClient(jdbcUrl, "kapua", "kapua", schema).update();
     }
 
     @AfterClass

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,18 +16,17 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.ConsoleJAXBContextProvider;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.xml.JAXBContextProvider;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.service.scheduler.quartz.SchedulerServiceInit;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import java.util.Optional;
 
 public class ConsoleListener implements ServletContextListener {
 
@@ -56,7 +55,7 @@ public class ConsoleListener implements ServletContextListener {
             }
 
             LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
-            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, Optional.of(schema)).update();
+            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
         }
 
         // start quarz scheduler

--- a/console/web/src/main/resources/logback.xml
+++ b/console/web/src/main/resources/logback.xml
@@ -19,7 +19,9 @@
         </encoder>
     </appender>
 
+    <logger name="liquibase" level="WARN"/>
+
     <root level="info">
-        <appender-ref ref="console" />
+        <appender-ref ref="console"/>
     </root>
 </configuration>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/changelog-job-engine-1.2.0.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/changelog-job-engine-1.2.0.xml
@@ -14,14 +14,9 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./job-engine-jbatch-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./queued_job-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job_engine_jbatch-1.2.0.xml">
 
-    <changeSet id="changelog-job_engine_jbatch-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_engine_jbatch-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="executioninstancedata" columnName="createtime" newDataType="timestamp(3) NULL"/>
         <modifyDataType tableName="executioninstancedata" columnName="endtime" newDataType="timestamp(3) NULL"/>
         <modifyDataType tableName="executioninstancedata" columnName="starttime" newDataType="timestamp(3) NULL"/>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
@@ -1,0 +1,30 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job_engine_jbatch-1.2.0.xml">
+
+    <changeSet id="changelog-job_engine_jbatch-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="executioninstancedata" columnName="createtime" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="executioninstancedata" columnName="endtime" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="executioninstancedata" columnName="starttime" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="executioninstancedata" columnName="updatetime" newDataType="timestamp(3) NULL"/>
+
+        <modifyDataType tableName="stepexecutioninstancedata" columnName="endTime" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="stepexecutioninstancedata" columnName="startTime" newDataType="timestamp(3) NULL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job_engine_jbatch-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-queued_job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_queued_job_execution" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_queued_job_execution" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job_engine_jbatch-1.2.0.xml">
 
-    <changeSet id="changelog-queued_job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-queued_job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_queued_job_execution" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_queued_job_execution" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
@@ -17,5 +17,6 @@
 
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-engine-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-engine-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-engine-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,24 +13,21 @@
 package org.eclipse.kapua.qa.common;
 
 import com.google.common.base.MoreObjects;
+import cucumber.api.java.After;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtilsWithResources;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.h2.tools.Server;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.ResultSet;
 import java.sql.SQLException;
-import java.util.Optional;
-
-import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtilsWithResources;
-import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
-import org.h2.tools.Server;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import cucumber.api.java.After;
-import cucumber.runtime.java.guice.ScenarioScoped;
 
 /**
  * Singleton for managing database creation and deletion inside Gherkin scenarios.
@@ -115,7 +112,7 @@ public class DBHelper {
             throw new RuntimeException(e);
         }
 
-        new KapuaLiquibaseClient(jdbcUrl, dbUsername, dbPassword, Optional.ofNullable(schema)).update();
+        new KapuaLiquibaseClient(jdbcUrl, dbUsername, dbPassword, schema).update();
     }
 
     public void close() {
@@ -165,9 +162,9 @@ public class DBHelper {
     public void dropAll() throws SQLException {
 
         String[] types = {"TABLE"};
-        ResultSet sqlResults = connection.getMetaData().getTables(null, null, "%" , types);
+        ResultSet sqlResults = connection.getMetaData().getTables(null, null, "%", types);
 
-        while(sqlResults.next()) {
+        while (sqlResults.next()) {
             String sqlStatement = String.format("DROP TABLE %s", sqlResults.getString("TABLE_NAME").toUpperCase());
             connection.prepareStatement(sqlStatement).execute();
         }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/AbstractMessageStoreServiceTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/AbstractMessageStoreServiceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 import java.sql.Connection;
 import java.sql.DriverManager;
 import java.sql.SQLException;
-import java.util.Optional;
 import java.util.Random;
 
 @Category(JUnitTests.class)
@@ -66,7 +65,7 @@ public abstract class AbstractMessageStoreServiceTest extends Assert {
 
             connection = DriverManager.getConnection(jdbcUrl, dbUsername, dbPassword);
 
-            new KapuaLiquibaseClient(jdbcUrl, dbUsername, dbPassword, Optional.ofNullable(schema)).update();
+            new KapuaLiquibaseClient(jdbcUrl, dbUsername, dbPassword, schema).update();
 
             //
             // Login

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -15,15 +15,14 @@ import com.google.common.base.MoreObjects;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.core.ServiceModuleBundle;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
-import java.util.Optional;
 
 public class RestApiListener implements ServletContextListener {
 
@@ -49,7 +48,7 @@ public class RestApiListener implements ServletContextListener {
 
             LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
 
-            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, Optional.of(schema)).update();
+            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
         }
 
         // Start service modules

--- a/rest-api/web/src/main/resources/logback.xml
+++ b/rest-api/web/src/main/resources/logback.xml
@@ -19,7 +19,9 @@
         </encoder>
     </appender>
 
+    <logger name="liquibase" level="WARN"/>
+
     <root level="info">
-        <appender-ref ref="console" />
+        <appender-ref ref="console"/>
     </root>
 </configuration>

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/account.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/account.xml
@@ -11,13 +11,13 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-  logicalFilePath="KapuaDB/changelog-account-0.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-account-0.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
     <changeSet id="changelog-account-0.2.0_createTable" author="eurotech">
         <createTable tableName="act_account">
@@ -28,8 +28,8 @@
             <column name="name" type="varchar(255)">
                 <constraints nullable="false" unique="true"/>
             </column>
-        
-            <column name="created_on" type="timestamp(3)" defaultValueComputed="${now}" />
+
+            <column name="created_on" type="timestamp(3)" defaultValueComputed="${now}"/>
             <column name="created_by" type="bigint(21) unsigned">
                 <constraints nullable="false"/>
             </column>
@@ -43,31 +43,31 @@
             <column name="org_name" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="org_person_name" type="varchar(255)" />
+            <column name="org_person_name" type="varchar(255)"/>
             <column name="org_email" type="varchar(255)">
                 <constraints nullable="false"/>
             </column>
-            <column name="org_phone_number" type="varchar(64)" />
-            <column name="org_address_line_1" type="varchar(255)" />
-            <column name="org_address_line_2" type="varchar(255)" />
-            <column name="org_address_line_3" type="varchar(255)" />
-            <column name="org_zip_postcode" type="varchar(255)" />
-            <column name="org_city" type="varchar(255)" />
-            <column name="org_state_province_county" type="varchar(255)" />
-            <column name="org_country" type="varchar(255)" />
-            
-            <column name="parent_account_path" type="varchar(64)" />
-            <column name="optlock" type="int unsigned" />
-            <column name="attributes" type="text" />
-            <column name="properties" type="text" />
+            <column name="org_phone_number" type="varchar(64)"/>
+            <column name="org_address_line_1" type="varchar(255)"/>
+            <column name="org_address_line_2" type="varchar(255)"/>
+            <column name="org_address_line_3" type="varchar(255)"/>
+            <column name="org_zip_postcode" type="varchar(255)"/>
+            <column name="org_city" type="varchar(255)"/>
+            <column name="org_state_province_county" type="varchar(255)"/>
+            <column name="org_country" type="varchar(255)"/>
+
+            <column name="parent_account_path" type="varchar(64)"/>
+            <column name="optlock" type="int unsigned"/>
+            <column name="attributes" type="text"/>
+            <column name="properties" type="text"/>
         </createTable>
-        
+
         <addForeignKeyConstraint constraintName="scope_id_fk" baseTableName="act_account" baseColumnNames="scope_id" referencedTableName="act_account" referencedColumnNames="id" onDelete="RESTRICT"/>
-        
+
         <createIndex tableName="act_account" indexName="idx_account_scope_id">
             <column name="scope_id"/>
         </createIndex>
-        
+
         <insert tableName="act_account">
             <column name="id" value="1"/>
             <column name="name" value="kapua-sys"/>
@@ -82,7 +82,7 @@
             <column name="parent_account_path" value="/1"/>
             <column name="optlock" value="0"/>
         </insert>
-        
+
         <rollback>
             <dropIndex tableName="act_account" indexName="idx_account_scope_id"/>
             <dropTable tableName="act_account"/>

--- a/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-account-1.2.0.xml">
 
-    <changeSet id="changelog-account-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-account-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="act_account" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="act_account" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="act_account" columnName="expiration_date" newDataType="timestamp(3) NULL"/>

--- a/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-account-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-account-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="act_account" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="act_account" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="act_account" columnName="expiration_date" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/1.2.0/changelog-account-1.2.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.2.0/changelog-account-1.2.0.xml
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-account-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./account-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
+++ b/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-account-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-account-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-account-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-account-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-device-management-operation-1.2.0.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-device-management-operation-1.2.0.xml
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job_device_management_registry-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./job_device_management_operation-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job_device-management-registry-1.2.0.xml">
 
-    <changeSet id="changelog-job_dvc_mgmt_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_dvc_mgmt_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="jbm_job_device_management_operation" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="jbm_job_device_management_operation" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job_device-management-registry-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-job_dvc_mgmt_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="jbm_job_device_management_operation" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="jbm_job_device_management_operation" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/management/job/internal/src/main/resources/liquibase/changelog-job-device-management-operation-master.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/changelog-job-device-management-operation-master.xml
@@ -16,5 +16,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-device-management-operation-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-device-management-operation-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-management-registry-1.2.0.xml">
 
-    <changeSet id="changelog-device_management_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-device_management_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="dvcm_device_management_operation" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvcm_device_management_operation" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvcm_device_management_operation" columnName="started_on" newDataType="timestamp(3) DEFAULT ${now}"/>

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
@@ -15,13 +15,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-management-registry-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-device_management_operation-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="dvcm_device_management_operation" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvcm_device_management_operation" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvcm_device_management_operation" columnName="started_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvcm_device_management_operation" columnName="ended_on" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-management-registry-1.2.0.xml">
 
-    <changeSet id="changelog-dvc-mgmt_operation_notification-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-dvc-mgmt_operation_notification-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="dvcm_device_management_operation_notification" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvcm_device_management_operation_notification" columnName="sent_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-management-registry-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-dvc-mgmt_operation_notification-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="dvcm_device_management_operation_notification" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvcm_device_management_operation_notification" columnName="sent_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device-1.2.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device-1.2.0.xml
@@ -15,13 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./device-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./device_connection-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./device_event-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-device-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="dvc_device" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvc_device" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <changeSet id="changelog-device-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-device-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="dvc_device" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvc_device" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-device_connection-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="dvc_device_connection" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvc_device_connection" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <changeSet id="changelog-device_connection-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-device_connection-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="dvc_device_connection" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvc_device_connection" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
@@ -15,13 +15,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-device_event-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="dvc_device_event" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvc_device_event" columnName="received_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="dvc_device_event" columnName="sent_on" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="dvc_device_event" columnName="pos_timestamp" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
 
-    <changeSet id="changelog-device_event-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-device_event-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="dvc_device_event" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvc_device_event" columnName="received_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="dvc_device_event" columnName="sent_on" newDataType="timestamp(3) NULL"/>

--- a/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
@@ -20,5 +20,6 @@
     <include relativeToChangelogFile="true" file="./0.3.1/changelog-device-0.3.1.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-device-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-device-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-device-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.2.0/changelog-endpoint-1.2.0.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.2.0/changelog-endpoint-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-endpoint-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./endpoint_info-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-endpoint-1.2.0.xml">
 
-    <changeSet id="changelog-endpoint-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-endpoint-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="endp_endpoint_info" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="endp_endpoint_info" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-endpoint-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-endpoint-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="endp_endpoint_info" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="endp_endpoint_info" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
@@ -16,5 +16,6 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-endpoint-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-endpoint-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-1.2.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-1.2.0.xml
@@ -14,14 +14,13 @@
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./job-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./job_execution-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./job_step-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./job_step_definition-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./job_target-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <changeSet id="changelog-job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_job" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <changeSet id="changelog-job-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_job" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
@@ -15,13 +15,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-job_execution-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_job_execution" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_execution" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_execution" columnName="started_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_execution" columnName="ended_on" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <changeSet id="changelog-job_execution-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_execution-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_job_execution" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job_execution" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job_execution" columnName="started_on" newDataType="timestamp(3) DEFAULT ${now}"/>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <changeSet id="changelog-job_step-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_job_step" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_step" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <changeSet id="changelog-job_step-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_step-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_job_step" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job_step" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <changeSet id="changelog-job_step_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_job_step_definition" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_step_definition" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <changeSet id="changelog-job_step_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_step_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_job_step_definition" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job_step_definition" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <changeSet id="changelog-job_target-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-job_target-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="job_job_target" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="job_job_target" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-job-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
+    <changeSet id="changelog-job_target-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="job_job_target" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="job_job_target" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
 
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -18,5 +18,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-job-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
@@ -15,13 +15,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./trigger-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./trigger_definition-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
@@ -15,13 +15,13 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-trigger-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="schdl_trigger" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="schdl_trigger" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="schdl_trigger" columnName="starts_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="schdl_trigger" columnName="ends_on" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
 
-    <changeSet id="changelog-trigger-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-trigger-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="schdl_trigger" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="schdl_trigger" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="schdl_trigger" columnName="starts_on" newDataType="timestamp(3) DEFAULT ${now}"/>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
 
-    <changeSet id="changelog-trigger_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-trigger_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="schdl_trigger_definition" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="schdl_trigger_definition" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-trigger_definition-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="schdl_trigger_definition" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="schdl_trigger_definition" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
@@ -18,5 +18,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-scheduler-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-scheduler-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-scheduler-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-scheduler-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authentication-1.2.0.xml">
 
-    <changeSet id="changelog-access_token-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-access_token-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="atht_access_token" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="atht_access_token" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="atht_access_token" columnName="expires_on" newDataType="timestamp(3) DEFAULT ${now}"/>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.2.0.xml">
+
+    <changeSet id="changelog-access_token-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="atht_access_token" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_access_token" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_access_token" columnName="expires_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_access_token" columnName="refresh_expires_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_access_token" columnName="invalidated_on" newDataType="timestamp(3) NULL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authentication-1.2.0.xml">
 
-    <changeSet id="changelog-credential-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-credential-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="atht_credential" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="atht_credential" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="atht_credential" columnName="expiration_date" newDataType="timestamp(3) NULL"/>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.2.0.xml">
+
+    <changeSet id="changelog-credential-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="atht_credential" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_credential" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="atht_credential" columnName="expiration_date" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="atht_credential" columnName="first_login_failure" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="atht_credential" columnName="login_failures_reset" newDataType="timestamp(3) NULL"/>
+        <modifyDataType tableName="atht_credential" columnName="lockout_reset" newDataType="timestamp(3) NULL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-access_info-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_access_info" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="athz_access_info" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-access_info-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-access_info-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_access_info" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="athz_access_info" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-access_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-access_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_access_permission" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>
 

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
@@ -15,13 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-access_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_access_permission" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-access_role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-access_role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_access_role" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>
 

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
@@ -15,13 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-access_role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_access_role" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-domain-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-domain-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_domain" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>
 

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
@@ -15,13 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-domain-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_domain" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-group-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_group" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="athz_group" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-group-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-group-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_group" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="athz_group" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_role" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="athz_role" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-role-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_role" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="athz_role" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <changeSet id="changelog-role_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-role_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="athz_role_permission" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>
 

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
@@ -15,13 +15,10 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-role_permission-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="athz_role_permission" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authentication-1.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authentication-1.2.0.xml
@@ -15,13 +15,9 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authentication-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./atht-access_token-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./atht-credential-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authorization-1.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authorization-1.2.0.xml
@@ -15,13 +15,14 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-authorization-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./athz-access_info-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-access_permission-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-access_role-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-domain-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-group-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-role-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./athz-role_permission-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -10,13 +10,14 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.2.0/changelog-authentication-0.2.0.xml" />
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-authentication-0.3.0.xml" />
-    <include relativeToChangelogFile="true" file="./1.0.0/changelog-authentication-1.0.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.2.0/changelog-authentication-0.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-authentication-0.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.0.0/changelog-authentication-1.0.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-authentication-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-authorization-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-authorization-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-authorization-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-authorization-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/1.2.0/changelog-tag-1.2.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.2.0/changelog-tag-1.2.0.xml
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-tag-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./tag-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
@@ -15,13 +15,11 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-tag-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-tag-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="tag_tag" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="tag_tag" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-tag-1.2.0.xml">
 
-    <changeSet id="changelog-tag-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-tag-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="tag_tag" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="tag_tag" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
     </changeSet>

--- a/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
+++ b/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
@@ -18,5 +18,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-tag-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-tag-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-tag-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-tag-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/1.2.0/changelog-user-1.2.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.2.0/changelog-user-1.2.0.xml
@@ -15,13 +15,8 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-user-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <include relativeToChangelogFile="true" file="./user-timestamp.xml"/>
 
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
@@ -17,7 +17,7 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-user-1.2.0.xml">
 
-    <changeSet id="changelog-user-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+    <changeSet id="changelog-user-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb" context="fixTimestamps">
         <modifyDataType tableName="usr_user" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="usr_user" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
         <modifyDataType tableName="usr_user" columnName="expiration_date" newDataType="timestamp(3) NULL"/>

--- a/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
@@ -15,13 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-device_management_registry-1.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-user-1.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-add_message.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation-add_log.xml"/>
-
-    <include relativeToChangelogFile="true" file="./device_management_operation-timestamp.xml"/>
-    <include relativeToChangelogFile="true" file="./device_management_operation_notification-timestamp.xml"/>
-
+    <changeSet id="changelog-user-1.2.0_timestamp" author="eurotech" dbms="mysql, mariadb">
+        <modifyDataType tableName="usr_user" columnName="created_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="usr_user" columnName="modified_on" newDataType="timestamp(3) DEFAULT ${now}"/>
+        <modifyDataType tableName="usr_user" columnName="expiration_date" newDataType="timestamp(3) NULL"/>
+    </changeSet>
 
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
+++ b/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-user-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-user-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-user-1.1.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-user-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -10,12 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,h2"/>
+    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR improves the LiquibaseClient to allow fix to TIMESTAMP columns on MariaDB and MySQL.
See  https://liquibase.jira.com/browse/CORE-1958

**Related Issue**
_None_

**Description of the solution adopted**
Added scripts to modify columns to add the subsecond part.
This script are run based on the version of Liquibase module. If after `3.3.3` the script will be executed. If executed prior to that version, the script will modify the columns without the subsecond part again. This fix can be also forced with an additional parameter.

**Screenshots**
_None_

**Any side note on the changes made**
Silenced the Liquibase Client log.
Added a utility class `SemanticVersion` to simplify handling of the component versions.