### PR TITLE
Sorting in Devices REST simpleQuery

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -378,10 +378,10 @@ public class ServiceDAO {
         if (kapuaQuery.getSortCriteria() != null) {
             FieldSortCriteria sortCriteria = (FieldSortCriteria) kapuaQuery.getSortCriteria();
 
-            if (SortOrder.ASCENDING.equals(sortCriteria.getSortOrder())) {
-                order = cb.asc(extractAttribute(entityRoot, sortCriteria.getAttributeName()));
-            } else {
+            if (SortOrder.DESCENDING.equals(sortCriteria.getSortOrder())) {
                 order = cb.desc(extractAttribute(entityRoot, sortCriteria.getAttributeName()));
+            } else {
+                order = cb.asc(extractAttribute(entityRoot, sortCriteria.getAttributeName()));
             }
 
         } else {

--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId.yaml
@@ -29,6 +29,8 @@ paths:
         - $ref: '../deviceConnection/deviceConnection.yaml#/components/parameters/connectionStatus'
         - $ref: './device.yaml#/components/parameters/fetchAttributes'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -374,6 +374,22 @@ components:
       schema:
         type: boolean
         default: false
+    sortParam:
+      name: sortParam
+      in: query
+      description: The name of the parameter that will be used as a sorting key
+      schema:
+        type: string
+    sortDir:
+      name: sortDir
+      in: query
+      description: The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
+      schema:
+        type: string
+        enum:
+          - ASCENDING
+          - DESCENDING
+        default: ASCENDING
   schemas:
     kapuaId:
       type: string

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/SortOrder.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/SortOrder.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.query;
 
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+
 /**
  * Sort order
  */
@@ -23,4 +25,13 @@ public enum SortOrder {
      * Descending
      */
     DESCENDING;
+
+    public static SortOrder fromString(String value) throws KapuaIllegalArgumentException {
+        String ucValue = value.toUpperCase();
+        try {
+            return valueOf(ucValue);
+        } catch (Exception e) {
+            throw new KapuaIllegalArgumentException("sortOrder", value);
+        }
+    }
 }


### PR DESCRIPTION
This PR introduces sorting in Devices REST Simple Query. 

Two new query parameters are introduced:
- `sortParam`: the name of the parameters that should be used to sort the results
- `sortDir`: `ASCENDING` (default) or `DESCENDING`. Case-insensitive.

**Related Issue**
No related issues

**Any side note on the changes made**
The default sorting in `ServiceDAO` is now in `ASCENDING` order. The previous default was `DESCENDING`.