### PR TITLE
Feature cache

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -219,6 +219,7 @@
                 <include>org.slf4j:slf4j-api</include>
                 <include>org.springframework.security:spring-security-core</include>
                 <include>org.yaml:snakeyaml</include>
+                <include>javax.cache:cache-api</include>
 
                 <include>${pom.groupId}:kapua-account-api</include>
                 <include>${pom.groupId}:kapua-account-internal</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -395,6 +395,11 @@
             <artifactId>percolator-client</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -108,6 +108,12 @@
             <artifactId>reflections</artifactId>
         </dependency>
 
+        <!-- Caching dependencies -->
+        <dependency>
+            <groupId>javax.cache</groupId>
+            <artifactId>cache-api</artifactId>
+        </dependency>
+
         <!-- -->
         <!-- Testing dependencies -->
         <dependency>

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.commons.configuration;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -50,7 +51,17 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<E extends 
             EntityManagerFactory entityManagerFactory,
             Class<S> serviceClass,
             Class<F> factoryClass) {
-        super(pid, domain, entityManagerFactory);
+        this(pid, domain, entityManagerFactory, null, serviceClass, factoryClass);
+    }
+
+    protected AbstractKapuaConfigurableResourceLimitedService(
+            String pid,
+            Domain domain,
+            EntityManagerFactory entityManagerFactory,
+            AbstractEntityCacheFactory abstractCacheFactory,
+            Class<S> serviceClass,
+            Class<F> factoryClass) {
+        super(pid, domain, entityManagerFactory, abstractCacheFactory);
         this.serviceClass = serviceClass;
         this.factoryClass = factoryClass;
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
@@ -16,6 +16,7 @@ import javax.validation.constraints.NotNull;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.service.internal.ServiceDAO;
@@ -53,12 +54,12 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
     private Domain domain;
     private String pid;
 
-    /**
-     * @deprecated this constructor will be removed in a next release (may be)
-     */
-    @Deprecated
     protected AbstractKapuaConfigurableService(String pid, Domain domain, EntityManagerFactory entityManagerFactory) {
-        super(entityManagerFactory);
+        this(pid, domain, entityManagerFactory, null);
+    }
+
+    protected AbstractKapuaConfigurableService(String pid, Domain domain, EntityManagerFactory entityManagerFactory, AbstractEntityCacheFactory abstractCacheFactory) {
+        super(entityManagerFactory, abstractCacheFactory);
         this.pid = pid;
         this.domain = domain;
     }
@@ -197,7 +198,7 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
     private ServiceConfig createConfig(ServiceConfig serviceConfig)
             throws KapuaException {
 
-        return entityManagerSession.doAction(em -> ServiceDAO.create(em, serviceConfig));
+        return entityManagerSession.doTransactedAction(em -> ServiceDAO.create(em, serviceConfig));
     }
 
     /**
@@ -209,7 +210,7 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
      */
     private ServiceConfig updateConfig(ServiceConfig serviceConfig)
             throws KapuaException {
-        return entityManagerSession.doAction(em -> {
+        return entityManagerSession.doTransactedAction(em -> {
             ServiceConfig oldServiceConfig = ServiceConfigDAO.find(em, serviceConfig.getScopeId(), serviceConfig.getId());
             if (oldServiceConfig == null) {
                 throw new KapuaEntityNotFoundException(ServiceConfig.TYPE, serviceConfig.getId());

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
@@ -261,7 +261,7 @@ public class RaiseServiceEventInterceptor implements MethodInterceptor {
         if (invocation.getThis() instanceof AbstractKapuaService) {
             try {
                 serviceEventBus.setStatus(newServiceEventStatus);
-                ((AbstractKapuaService) invocation.getThis()).getEntityManagerSession().doAction(EntityManagerContainer.<EventStoreRecord>create().onResultHandler(em -> {
+                ((AbstractKapuaService) invocation.getThis()).getEntityManagerSession().doTransactedAction(EntityManagerContainer.<EventStoreRecord>create().onResultHandler(em -> {
                     return EventStoreDAO.update(em,
                             ServiceEventUtil.mergeToEntity(EventStoreDAO.find(em, serviceEventBus.getScopeId(), KapuaEid.parseCompactId(serviceEventBus.getId())), serviceEventBus));
                 }));

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityCacheFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityCacheFactory.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.jpa;
+
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+
+public abstract class AbstractEntityCacheFactory implements CacheFactory {
+
+    private String idCacheName;
+
+    public AbstractEntityCacheFactory(String idCacheName) {
+        this.idCacheName = idCacheName;
+    }
+
+    public String getEntityIdCacheName() {
+        return idCacheName;
+    }
+
+    @Override
+    public EntityCache createCache() {
+        return new EntityCache(getEntityIdCacheName());
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/CacheFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/CacheFactory.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.jpa;
+
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+
+public interface CacheFactory {
+
+    EntityCache createCache();
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
@@ -11,9 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.internal;
 
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 import org.eclipse.kapua.commons.event.ServiceEventBusManager;
 import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
 import org.eclipse.kapua.commons.jpa.EntityManagerSession;
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
 import org.eclipse.kapua.event.ServiceEventBusException;
 import org.eclipse.kapua.event.ServiceEventBusListener;
 import org.eclipse.kapua.service.KapuaService;
@@ -29,6 +31,7 @@ public class AbstractKapuaService {
 
     protected EntityManagerFactory entityManagerFactory;
     protected EntityManagerSession entityManagerSession;
+    protected EntityCache entityCache;
 
     /**
      * @deprecated this constructor will be removed in a next release (may be)
@@ -37,8 +40,15 @@ public class AbstractKapuaService {
      */
     @Deprecated
     protected AbstractKapuaService(EntityManagerFactory entityManagerFactory) {
+        this(entityManagerFactory, null);
+    }
+
+    protected AbstractKapuaService(EntityManagerFactory entityManagerFactory, AbstractEntityCacheFactory abstractCacheFactory) {
         this.entityManagerFactory = entityManagerFactory;
         this.entityManagerSession = new EntityManagerSession(entityManagerFactory);
+        if (abstractCacheFactory != null) {
+            this.entityCache = abstractCacheFactory.createCache();
+        }
     }
 
     public EntityManagerSession getEntityManagerSession() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache;
+
+import org.eclipse.kapua.model.id.KapuaId;
+
+import java.io.Serializable;
+import java.util.Objects;
+
+public class ComposedKey implements Serializable {
+
+    private KapuaId scopeId;
+    private Serializable key;
+
+    public ComposedKey(KapuaId scopeId, Serializable key) {
+        this.scopeId = scopeId;
+        this.key = key;
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(scopeId, key);
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+        if (this == obj) {
+            return true;
+        }
+        if (obj == null) {
+            return false;
+        }
+        if (!(obj instanceof ComposedKey)) {
+            return false;
+        }
+        ComposedKey otherCacheKey = (ComposedKey) obj;
+        return Objects.equals(scopeId, otherCacheKey.getScopeId()) && Objects.equals(key,
+                otherCacheKey.getKey());
+    }
+
+    public KapuaId getScopeId() {
+        return scopeId;
+    }
+
+    public Serializable getKey() {
+        return key;
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache;
+
+import com.codahale.metrics.Counter;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.cache.Cache;
+import java.io.Serializable;
+
+public class EntityCache {
+
+    protected static final Logger LOGGER = LoggerFactory.getLogger(EntityCache.class);
+
+    private static final String MODULE = "commons";
+    private static final String COMPONENT = "cache";
+    private static final String ENTITY = "entity";
+    private static final String COUNT = "count";
+
+    protected Cache<Serializable, Serializable> idCache;
+    protected Cache<Serializable, Serializable> listsCache;  // listsCache does not use the same keys as idCache
+    protected Counter cacheMiss;
+    protected Counter cacheHit;
+    protected Counter cacheRemoval;
+
+    public EntityCache(String idCacheName) {
+        idCache = KapuaCacheManager.getCache(idCacheName);
+        listsCache = KapuaCacheManager.getCache(idCacheName + "_list");
+        cacheMiss = MetricServiceFactory.getInstance().getCounter(MODULE, COMPONENT, ENTITY, "miss", COUNT);
+        cacheHit = MetricServiceFactory.getInstance().getCounter(MODULE, COMPONENT, ENTITY, "hit", COUNT);
+        cacheRemoval = MetricServiceFactory.getInstance().getCounter(MODULE, COMPONENT, ENTITY, "removal", COUNT);
+    }
+
+    public KapuaEntity get(KapuaId scopeId, KapuaId kapuaId) {
+        if (kapuaId != null) {
+            KapuaEntity entity = (KapuaEntity) idCache.get(kapuaId);
+            entity = checkResult(scopeId, entity);
+            if (entity == null) {
+                cacheMiss.inc();
+            } else {
+                cacheHit.inc();
+            }
+            return entity;
+        }
+        return null;
+    }
+
+    public KapuaListResult getList(KapuaId scopeId, Serializable id) {
+        if (id != null) {
+            return checkResult(scopeId, (KapuaListResult) listsCache.get(new ComposedKey(scopeId, id)));
+        }
+        return null;
+    }
+
+    public void put(KapuaEntity entity) {
+        if (entity != null) {
+            idCache.put(entity.getId(), entity);
+        }
+    }
+
+    public void putList(KapuaId scopeId, Serializable id, KapuaListResult list) {
+        listsCache.put(new ComposedKey(scopeId, id), list);
+    }
+
+    public KapuaEntity remove(KapuaId scopeId, KapuaEntity entity) {
+        return remove(scopeId, entity.getId());
+    }
+
+    public KapuaEntity remove(KapuaId scopeId, KapuaId kapuaId) {
+        // First get the entity in order to perform a check of the scope id
+        if (kapuaId != null) {
+            KapuaEntity entity = get(scopeId, kapuaId);
+            if (entity != null) {
+                idCache.remove(kapuaId);
+                cacheRemoval.inc();
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    public KapuaListResult removeList(KapuaId scopeId, Serializable id) {
+        // First get the entity in order to perform a check of the scope id
+        if (id != null) {
+            KapuaListResult entity = getList(scopeId, id);
+            if (entity != null) {
+                listsCache.remove(new ComposedKey(scopeId, id));
+                return entity;
+            }
+        }
+        return null;
+    }
+
+    protected KapuaEntity checkResult(KapuaId scopeId, KapuaEntity entity) {
+        if (entity != null) {
+            if (scopeId == null) {
+                return entity;
+            } else if (entity.getScopeId() == null) {
+                return entity;
+            } else if (entity.getScopeId().equals(scopeId)) {
+                return entity;
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+
+    protected KapuaListResult checkResult(KapuaId scopeId, KapuaListResult entity) {
+        if (entity != null) {
+            if (entity.getSize() == 0) {
+                return entity;  // If the list is empty, I want to return the empty list
+            } else if (scopeId == null) {
+                return entity;
+            } else if (entity.getFirstItem().getScopeId() == null) {
+                return entity;
+            } else if (entity.getFirstItem().getScopeId().equals(scopeId)) {
+                return entity;
+            } else {
+                return null;
+            }
+        } else {
+            return null;
+        }
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
@@ -1,0 +1,117 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache;
+
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.setting.KapuaSettingException;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.eclipse.kapua.commons.util.KapuaFileUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.cache.Cache;
+import javax.cache.CacheException;
+import javax.cache.Caching;
+import javax.cache.configuration.Factory;
+import javax.cache.configuration.MutableConfiguration;
+import javax.cache.expiry.Duration;
+import javax.cache.expiry.ModifiedExpiryPolicy;
+import javax.cache.expiry.TouchedExpiryPolicy;
+import javax.cache.spi.CachingProvider;
+import java.io.Serializable;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
+
+public class KapuaCacheManager {
+
+    enum ExpiryPolicy {
+        MODIFIED,
+        TOUCHED
+    }
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(KapuaCacheManager.class);
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
+    private static final String CACHING_PROVIDER_CLASS_NAME = SYSTEM_SETTING.getString(SystemSettingKey.CACHING_PROVIDER);
+    private static final String DEFAULT_CACHING_PROVIDER_CLASS_NAME = "org.eclipse.kapua.commons.service.internal.cache.dummy.CachingProvider";
+    private static final long TTL = SYSTEM_SETTING.getLong(SystemSettingKey.CACHE_TTL, 60);
+    private static final String EXPIRY_POLICY = SYSTEM_SETTING.getString(SystemSettingKey.JCACHE_EXPIRY_POLICY, ExpiryPolicy.MODIFIED.name());
+    private static final Map<String, Cache<Serializable, Serializable>> CACHE_MAP = new ConcurrentHashMap<>();
+    private static final URI CACHE_CONFIG_URI = getCacheConfig();
+
+    private KapuaCacheManager() {
+    }
+
+    private static URI getCacheConfig() {
+        String configurationFileName = SystemSetting.getInstance().getString(SystemSettingKey.CACHE_CONFIG_URL);
+        URI uri = null;
+        if (configurationFileName != null) {
+            try {
+                uri = KapuaFileUtils.getAsURL(configurationFileName).toURI();
+            } catch (KapuaSettingException | URISyntaxException e) {
+                throw new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, e, String.format("Unable to load cache config file (%s)", configurationFileName));
+            }
+        }
+        StringBuilder stringBuilder = new StringBuilder();
+        stringBuilder.append("Cache configuration:\n\tCaching provider class name: ").append(CACHING_PROVIDER_CLASS_NAME);
+        stringBuilder.append("\n\tDefault caching provider class name: ").append(DEFAULT_CACHING_PROVIDER_CLASS_NAME);
+        stringBuilder.append("\n\tTTL: ").append(TTL);
+        stringBuilder.append("\n\tExpiry Policy: ").append(EXPIRY_POLICY);
+        stringBuilder.append("\n\tCache config URI: ").append(uri);
+        LOGGER.info("{}", stringBuilder);
+        return uri;
+    }
+
+    public static Cache<Serializable, Serializable> getCache(String cacheName) {
+        Cache<Serializable, Serializable> cache = CACHE_MAP.get(cacheName);
+        if (cache == null) {
+            synchronized (CACHE_MAP) {
+                cache = CACHE_MAP.get(cacheName);
+                if (cache == null) {
+                    Factory expiryPolicyFactory;
+                    if (ExpiryPolicy.TOUCHED.name().equals(EXPIRY_POLICY)) {
+                        expiryPolicyFactory = TouchedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, TTL));
+                    } else {
+                        expiryPolicyFactory = ModifiedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, TTL));
+                    }
+                    MutableConfiguration<Serializable, Serializable> config = new MutableConfiguration<>();
+                    config.setExpiryPolicyFactory(expiryPolicyFactory);
+                    CachingProvider cachingProvider;
+                    if (CACHING_PROVIDER_CLASS_NAME != null && CACHING_PROVIDER_CLASS_NAME.trim().length() > 0) {
+                        cachingProvider = Caching.getCachingProvider(CACHING_PROVIDER_CLASS_NAME);
+                    } else {
+                        try {
+                            cachingProvider = Caching.getCachingProvider();
+                        } catch (CacheException e) {
+                            LOGGER.warn("Error while loading the CachingProvider... Loading the default one ({}).", DEFAULT_CACHING_PROVIDER_CLASS_NAME);
+                            cachingProvider = Caching.getCachingProvider(DEFAULT_CACHING_PROVIDER_CLASS_NAME);
+                        }
+                    }
+                    cache = cachingProvider.getCacheManager(CACHE_CONFIG_URI, null).createCache(cacheName, config);
+                    CACHE_MAP.put(cacheName, cache);
+                    LOGGER.info("Created cache: {} - Expiry Policy: {} - TTL: {}", cacheName, EXPIRY_POLICY, TTL);
+                }
+            }
+        }
+        return cache;
+    }
+
+    public static void invalidateAll() {
+        CACHE_MAP.forEach((cacheKey, cache) -> cache.clear());
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/NamedEntityCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/NamedEntityCache.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache;
+
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.cache.Cache;
+import java.io.Serializable;
+
+public class NamedEntityCache extends EntityCache {
+
+    protected Cache<Serializable, Serializable> nameCache;
+
+    public NamedEntityCache(String idCacheName, String nameCacheName) {
+        super(idCacheName);
+        nameCache = KapuaCacheManager.getCache(nameCacheName);
+    }
+
+    public KapuaEntity get(KapuaId scopeId, String name) {
+        if (name != null) {
+            KapuaId entityId = (KapuaId) nameCache.get(name);
+            return get(scopeId, entityId);
+        }
+        return null;
+    }
+
+    @Override
+    public void put(KapuaEntity entity) {
+        if (entity != null) {
+            idCache.put(entity.getId(), entity);
+            nameCache.put(((KapuaNamedEntity) entity).getName(), entity.getId());
+        }
+    }
+
+    @Override
+    public KapuaEntity remove(KapuaId scopeId, KapuaId kapuaId) {
+        KapuaEntity kapuaEntity = super.remove(scopeId, kapuaId);
+        if (kapuaEntity != null) {
+            nameCache.remove(((KapuaNamedEntity) kapuaEntity).getName());
+        }
+        return kapuaEntity;
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/Cache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/Cache.java
@@ -1,0 +1,166 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache.dummy;
+
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.Configuration;
+import javax.cache.integration.CompletionListener;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+
+public class Cache<K, V> implements javax.cache.Cache<K, V> {
+
+    public Cache() {
+    }
+
+    @Override
+    public Object get(Object key) {
+        return null;
+    }
+
+    @Override
+    public Map getAll(Set keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void loadAll(Set keys, boolean replaceExistingValues, CompletionListener completionListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+    }
+
+    @Override
+    public Object getAndPut(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean putIfAbsent(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object key) {
+        return true;
+    }
+
+    @Override
+    public boolean remove(Object key, Object oldValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndRemove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(Object key, Object oldValue, Object newValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndReplace(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAll(Set keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAll() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+    }
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CacheManager getCacheManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isClosed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerCacheEntryListener(CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deregisterCacheEntryListener(CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object unwrap(Class clazz) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map invokeAll(Set keys, EntryProcessor entryProcessor, Object... arguments) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object invoke(Object key, EntryProcessor entryProcessor, Object... arguments) throws EntryProcessorException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Configuration getConfiguration(Class clazz) {
+        throw new UnsupportedOperationException();
+    }
+
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CacheManager.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache.dummy;
+
+import javax.cache.configuration.Configuration;
+import java.net.URI;
+import java.util.Properties;
+
+public class CacheManager implements javax.cache.CacheManager {
+
+    private static CacheManager instance;
+
+    private CacheManager() {
+    }
+
+    public static CacheManager getInstance() {
+        if (instance == null) {
+            synchronized (CacheManager.class) {
+                if (instance == null) {
+                    instance = new CacheManager();
+                }
+            }
+        }
+        return instance;
+    }
+
+    @Override
+    public CachingProvider getCachingProvider() {
+        return null;
+    }
+
+    @Override
+    public URI getURI() {
+        return null;
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        return null;
+    }
+
+    @Override
+    public Properties getProperties() {
+        return null;
+    }
+
+    @Override
+    public <K, V, C extends Configuration<K, V>> javax.cache.Cache createCache(String cacheName, C configuration) throws IllegalArgumentException {
+        return new Cache<>();
+    }
+
+    @Override
+    public <K, V> javax.cache.Cache getCache(String cacheName, Class<K> keyType, Class<V> valueType) {
+        return null;
+    }
+
+    @Override
+    public <K, V> javax.cache.Cache getCache(String cacheName) {
+        return null;
+    }
+
+    @Override
+    public Iterable<String> getCacheNames() {
+        return null;
+    }
+
+    @Override
+    public void destroyCache(String cacheName) {
+    }
+
+    @Override
+    public void enableManagement(String cacheName, boolean enabled) {
+    }
+
+    @Override
+    public void enableStatistics(String cacheName, boolean enabled) {
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public boolean isClosed() {
+        return false;
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> clazz) {
+        return null;
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CachingProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CachingProvider.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.internal.cache.dummy;
+
+import javax.cache.configuration.OptionalFeature;
+import java.net.URI;
+import java.util.Properties;
+
+public class CachingProvider implements javax.cache.spi.CachingProvider {
+    @Override
+    public javax.cache.CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {
+        return getCacheManager();
+    }
+
+    @Override
+    public ClassLoader getDefaultClassLoader() {
+        return null;
+    }
+
+    @Override
+    public URI getDefaultURI() {
+        return null;
+    }
+
+    @Override
+    public Properties getDefaultProperties() {
+        return null;
+    }
+
+    @Override
+    public javax.cache.CacheManager getCacheManager(URI uri, ClassLoader classLoader) {
+        return getCacheManager();
+    }
+
+    @Override
+    public javax.cache.CacheManager getCacheManager() {
+        return CacheManager.getInstance();
+    }
+
+    @Override
+    public void close() {
+    }
+
+    @Override
+    public void close(ClassLoader classLoader) {
+    }
+
+    @Override
+    public void close(URI uri, ClassLoader classLoader) {
+    }
+
+    @Override
+    public boolean isSupported(OptionalFeature optionalFeature) {
+        return false;
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -256,7 +256,28 @@ public enum SystemSettingKey implements SettingKey {
     /**
      * Allow System Settings to be updatable at runtime via System.setProperty()
      */
-    SETTINGS_HOTSWAP("commons.settings.hotswap");
+    SETTINGS_HOTSWAP("commons.settings.hotswap"),
+
+    /**
+     * Provide the classname for the Cache Provider
+     */
+    CACHING_PROVIDER("commons.cache.provider.classname"),
+    /**
+     * Size of the local cache for the KapuaTmetadata
+     */
+    TMETADATA_LOCAL_CACHE_SIZE_MAXIMUM("commons.cache.local.tmetadata.maxsize"),
+    /**
+     * Provide the CacheManager config file URL
+     */
+    CACHE_CONFIG_URL("commons.cache.config.url"),
+    /**
+     * Provide the Cache TTL
+     */
+    CACHE_TTL("commons.cache.config.ttl"),
+    /**
+     * Provide the JCache Expiry Policy. Allowed values: MODIFIED, TOUCHED
+     */
+    JCACHE_EXPIRY_POLICY("commons.cache.config.expiryPolicy");
 
     private String key;
 

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -91,3 +91,15 @@ commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEve
 commons.eventbus.transport.useEpoll=true
 
 commons.settings.hotswap=false
+
+#
+# Cache settings (please provide consistent values for these parameters)
+#
+# Provided dummy JCache implementation cache (no cache)
+commons.cache.provider.classname=org.eclipse.kapua.commons.service.internal.cache.dummy.CachingProvider
+# Additional cache configuration file (if any)
+#commons.cache.config.url=yourconfig.yaml
+#commons.cache.config.ttl=15
+#commons.cache.config.expiryPolicy=MODIFIED
+#
+commons.cache.local.tmetadata.maxsize=100

--- a/pom.xml
+++ b/pom.xml
@@ -1624,6 +1624,14 @@
                 <artifactId>swagger-ui</artifactId>
                 <version>${swagger-ui.version}</version>
             </dependency>
+
+            <!-- Caching dependencies -->
+            <dependency>
+                <groupId>javax.cache</groupId>
+                <artifactId>cache-api</artifactId>
+                <version>1.1.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 


### PR DESCRIPTION
This PR introduces a caching feature at the service level. This implementation is compliant with the [JCache specification](https://www.jcp.org/en/jsr/detail?id=107), meaning that each cache that implements the JCache interface can be used with this caching feature. 

**Related Issue**

_N/A_

**Description of the solution adopted**

The package `org.eclipse.kapua.commons.service.internal.cache` contains the `KapuaCacheManager`, which is responsible for instantiating a cache for each service, and the `EntityCache` class, which defines our basic cache implementation  (using entities Ids as keys) on top of JCache. `NamedEntityCache` extends `EntityCache` by providing an additional cache (using entities names as keys). 

**Screenshots**

_N/A_

**Any side note on the changes made**

Services require to be modified in order to implement the cache. 

Note also that this cache feature requires a JCache implementation to run, otherwise a 'dummy' cache is used.