### PR TITLE
Add NPM scope to swagger-cli

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -243,7 +243,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install -g swagger-cli</arguments>
+                            <arguments>install -g @apidevtools/swagger-cli</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
To generate OpenAPI specification files we leverage [swagger-cli](https://github.com/APIDevTools/swagger-cli/). With the latest release, 4.0.1, the package has been put under the `@apidevtools` NPM scope; the old package, `swagger-cli`, should act as a wrapper on the new package naming, except [it's not](https://github.com/APIDevTools/swagger-cli/issues/40). So to avoid any issue, it's better to depend on the new package avoiding to rely on the unscoped one.

**Related Issue**
No related issue
