### PR TITLE
Fixed SemanticVersioning utility class and added jUnit test

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SemanticVersion.java
@@ -99,7 +99,7 @@ public class SemanticVersion {
      * @since 1.2.0
      */
     public boolean afterOrMatches(SemanticVersion other) {
-        return after(other) || match(other);
+        return after(other) || matches(other);
     }
 
     /**
@@ -112,14 +112,15 @@ public class SemanticVersion {
     public boolean after(SemanticVersion other) {
         if (getMajorVersion().after(other.getMajorVersion())) {
             return true;
-        }
+        } else if (getMajorVersion().matches(other.getMajorVersion())) {
 
-        if (getMinorVersion() != null && getMinorVersion().after(other.getMinorVersion())) {
-            return true;
-        }
-
-        if (getPatchVersion() != null && getPatchVersion().after(other.getPatchVersion())) {
-            return true;
+            if (getMinorVersion() != null && getMinorVersion().after(other.getMinorVersion())) {
+                return true;
+            } else if (getMinorVersion().matches(other.getMinorVersion())) {
+                if (getPatchVersion() != null && getPatchVersion().after(other.getPatchVersion())) {
+                    return true;
+                }
+            }
         }
 
         return false;
@@ -133,7 +134,7 @@ public class SemanticVersion {
      * @since 1.2.0
      */
     public boolean beforeOrMatches(SemanticVersion other) {
-        return before(other) || match(other);
+        return before(other) || matches(other);
     }
 
     /**
@@ -146,14 +147,15 @@ public class SemanticVersion {
     public boolean before(SemanticVersion other) {
         if (getMajorVersion().before(other.getMajorVersion())) {
             return true;
-        }
+        } else if (getMajorVersion().matches(other.getMajorVersion())) {
 
-        if (getMinorVersion() != null && getMinorVersion().before(other.getMinorVersion())) {
-            return true;
-        }
-
-        if (getPatchVersion() != null && getPatchVersion().before(other.getPatchVersion())) {
-            return true;
+            if (getMinorVersion() != null && getMinorVersion().before(other.getMinorVersion())) {
+                return true;
+            } else if (getMinorVersion().matches(other.getMinorVersion())) {
+                if (getPatchVersion() != null && getPatchVersion().before(other.getPatchVersion())) {
+                    return true;
+                }
+            }
         }
 
         return false;
@@ -166,13 +168,13 @@ public class SemanticVersion {
      * @return {@code true} if {@code this} {@link SemanticVersion} is matches the given {@link SemanticVersion}
      * @since 1.2.0
      */
-    public boolean match(SemanticVersion other) {
+    public boolean matches(SemanticVersion other) {
         return getVersionString().equals(other.getVersionString());
     }
 
     @Override
     public String toString() {
-        return versionString;
+        return getVersionString();
     }
 
     /**
@@ -252,6 +254,22 @@ public class SemanticVersion {
          * Compares {@code this} {@link VersionToken} with another {@link VersionToken}.
          *
          * @param other The {@link VersionToken} to use to compare.
+         * @return {@code true} if {@code this} {@link VersionToken} matches the given {@link VersionToken}
+         * @since 1.2.0
+         */
+        public boolean matches(VersionToken other) {
+            if (isIntegerComparison() && other.isIntegerComparison()) {
+                return getVersionInteger().equals(other.getVersionInteger());
+            } else {
+                return getVersionString().compareTo(other.getVersionString()) == 0;
+            }
+        }
+
+
+        /**
+         * Compares {@code this} {@link VersionToken} with another {@link VersionToken}.
+         *
+         * @param other The {@link VersionToken} to use to compare.
          * @return {@code true} if {@code this} {@link VersionToken} is before the given {@link VersionToken}
          * @since 1.2.0
          */
@@ -261,6 +279,11 @@ public class SemanticVersion {
             } else {
                 return getVersionString().compareTo(other.getVersionString()) < 0;
             }
+        }
+
+        @Override
+        public String toString() {
+            return getVersionString();
         }
     }
 }

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/SemanticVersionTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/SemanticVersionTest.java
@@ -1,0 +1,158 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.util;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class SemanticVersionTest extends Assert {
+
+    @Test
+    public void testAfterLiquibaseVersion() {
+        assertFalse(new SemanticVersion("3.0.5").after(new SemanticVersion("3.3.3")));
+    }
+
+    @Test
+    public void testAfterOrMatchesLiquibaseVersion() {
+        assertFalse(new SemanticVersion("3.0.5").afterOrMatches(new SemanticVersion("3.3.3")));
+    }
+
+    @Test
+    public void testMatchesLiquibaseVersion() {
+        assertFalse(new SemanticVersion("3.0.5").matches(new SemanticVersion("3.3.3")));
+    }
+
+    @Test
+    public void testBeforeOrMatchesLiquibaseVersion() {
+        assertTrue(new SemanticVersion("3.0.5").beforeOrMatches(new SemanticVersion("3.3.3")));
+    }
+
+    @Test
+    public void testBeforeLiquibaseVersion() {
+        assertTrue(new SemanticVersion("3.0.5").before(new SemanticVersion("3.3.3")));
+    }
+
+    @Test
+    public void testAfter() {
+        assertTrue(new SemanticVersion("1.1.0").after(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("1.0.1").after(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("1.1.1").after(new SemanticVersion("1.0.0")));
+
+        assertTrue(new SemanticVersion("2.0.0").after(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("2.0.0").after(new SemanticVersion("1.9.0")));
+        assertTrue(new SemanticVersion("2.0.0").after(new SemanticVersion("1.9.9")));
+
+        assertFalse(new SemanticVersion("1.0.0").after(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("0.1.0").after(new SemanticVersion("0.1.0")));
+        assertFalse(new SemanticVersion("0.0.1").after(new SemanticVersion("0.0.1")));
+
+        assertFalse(new SemanticVersion("1.0.0").after(new SemanticVersion("1.1.0")));
+        assertFalse(new SemanticVersion("1.0.0").after(new SemanticVersion("1.0.1")));
+        assertFalse(new SemanticVersion("1.0.0").after(new SemanticVersion("1.1.1")));
+
+        assertFalse(new SemanticVersion("1.0.0").after(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.0").after(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.9").after(new SemanticVersion("2.0.0")));
+    }
+
+    @Test
+    public void testAfterOrMatches() {
+        assertTrue(new SemanticVersion("1.1.0").afterOrMatches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("1.0.1").afterOrMatches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("1.1.1").afterOrMatches(new SemanticVersion("1.0.0")));
+
+        assertTrue(new SemanticVersion("2.0.0").afterOrMatches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("2.0.0").afterOrMatches(new SemanticVersion("1.9.0")));
+        assertTrue(new SemanticVersion("2.0.0").afterOrMatches(new SemanticVersion("1.9.9")));
+
+        assertTrue(new SemanticVersion("1.0.0").afterOrMatches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("0.1.0").afterOrMatches(new SemanticVersion("0.1.0")));
+        assertTrue(new SemanticVersion("0.0.1").afterOrMatches(new SemanticVersion("0.0.1")));
+
+        assertFalse(new SemanticVersion("1.0.0").afterOrMatches(new SemanticVersion("1.1.0")));
+        assertFalse(new SemanticVersion("1.0.0").afterOrMatches(new SemanticVersion("1.0.1")));
+        assertFalse(new SemanticVersion("1.0.0").afterOrMatches(new SemanticVersion("1.1.1")));
+
+        assertFalse(new SemanticVersion("1.0.0").afterOrMatches(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.0").afterOrMatches(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.9").afterOrMatches(new SemanticVersion("2.0.0")));
+    }
+
+    @Test
+    public void testMatches() {
+        assertFalse(new SemanticVersion("1.0.0").matches(new SemanticVersion("1.1.0")));
+        assertFalse(new SemanticVersion("1.0.0").matches(new SemanticVersion("1.0.1")));
+        assertFalse(new SemanticVersion("1.0.0").matches(new SemanticVersion("1.1.1")));
+
+        assertFalse(new SemanticVersion("1.0.0").matches(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.0").matches(new SemanticVersion("2.0.0")));
+        assertFalse(new SemanticVersion("1.9.9").matches(new SemanticVersion("2.0.0")));
+
+        assertTrue(new SemanticVersion("1.0.0").matches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("0.1.0").matches(new SemanticVersion("0.1.0")));
+        assertTrue(new SemanticVersion("0.0.1").matches(new SemanticVersion("0.0.1")));
+
+        assertFalse(new SemanticVersion("1.1.0").matches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.0.1").matches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.1.1").matches(new SemanticVersion("1.0.0")));
+
+        assertFalse(new SemanticVersion("2.0.0").matches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("2.0.0").matches(new SemanticVersion("1.9.0")));
+        assertFalse(new SemanticVersion("2.0.0").matches(new SemanticVersion("1.9.9")));
+    }
+
+    @Test
+    public void testBeforeOrMatches() {
+        assertTrue(new SemanticVersion("1.0.0").beforeOrMatches(new SemanticVersion("1.1.0")));
+        assertTrue(new SemanticVersion("1.0.0").beforeOrMatches(new SemanticVersion("1.0.1")));
+        assertTrue(new SemanticVersion("1.0.0").beforeOrMatches(new SemanticVersion("1.1.1")));
+
+        assertTrue(new SemanticVersion("1.0.0").beforeOrMatches(new SemanticVersion("2.0.0")));
+        assertTrue(new SemanticVersion("1.9.0").beforeOrMatches(new SemanticVersion("2.0.0")));
+        assertTrue(new SemanticVersion("1.9.9").beforeOrMatches(new SemanticVersion("2.0.0")));
+
+        assertTrue(new SemanticVersion("1.0.0").beforeOrMatches(new SemanticVersion("1.0.0")));
+        assertTrue(new SemanticVersion("0.1.0").beforeOrMatches(new SemanticVersion("0.1.0")));
+        assertTrue(new SemanticVersion("0.0.1").beforeOrMatches(new SemanticVersion("0.0.1")));
+
+        assertFalse(new SemanticVersion("1.1.0").beforeOrMatches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.0.1").beforeOrMatches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.1.1").beforeOrMatches(new SemanticVersion("1.0.0")));
+
+        assertFalse(new SemanticVersion("2.0.0").beforeOrMatches(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("2.0.0").beforeOrMatches(new SemanticVersion("1.9.0")));
+        assertFalse(new SemanticVersion("2.0.0").beforeOrMatches(new SemanticVersion("1.9.9")));
+    }
+
+    @Test
+    public void testBefore() {
+        assertTrue(new SemanticVersion("1.0.0").before(new SemanticVersion("1.1.0")));
+        assertTrue(new SemanticVersion("1.0.0").before(new SemanticVersion("1.0.1")));
+        assertTrue(new SemanticVersion("1.0.0").before(new SemanticVersion("1.1.1")));
+
+        assertTrue(new SemanticVersion("1.0.0").before(new SemanticVersion("2.0.0")));
+        assertTrue(new SemanticVersion("1.9.0").before(new SemanticVersion("2.0.0")));
+        assertTrue(new SemanticVersion("1.9.9").before(new SemanticVersion("2.0.0")));
+
+        assertFalse(new SemanticVersion("1.0.0").before(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("0.1.0").before(new SemanticVersion("0.1.0")));
+        assertFalse(new SemanticVersion("0.0.1").before(new SemanticVersion("0.0.1")));
+
+        assertFalse(new SemanticVersion("1.1.0").before(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.0.1").before(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("1.1.1").before(new SemanticVersion("1.0.0")));
+
+        assertFalse(new SemanticVersion("2.0.0").before(new SemanticVersion("1.0.0")));
+        assertFalse(new SemanticVersion("2.0.0").before(new SemanticVersion("1.9.0")));
+        assertFalse(new SemanticVersion("2.0.0").before(new SemanticVersion("1.9.9")));
+    }
+}


### PR DESCRIPTION
This PR fixes a bug with `SemanticVersioning` class.
This bug has been introduced with #2889 

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the login and added tests. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_