### PR TITLE
Fixed exception messages missing the positional argument number

### DIFF
--- a/service/device/management/job/api/src/main/resources/job-device-management-trigger-service-error-messages.properties
+++ b/service/device/management/job/api/src/main/resources/job-device-management-trigger-service-error-messages.properties
@@ -9,4 +9,4 @@
 # Contributors:
 #     Eurotech - initial API and implementation
 ###############################################################################
-PROCESS_ON_CONNECT=Error when processing device connect event to start job for scopeId: {} - deviceId {}
+PROCESS_ON_CONNECT=Error when processing device connect event to start job for scopeId: {0} - deviceId {1}

--- a/service/scheduler/quartz/src/main/resources/quartz-trigger-driver-error-messages.properties
+++ b/service/scheduler/quartz/src/main/resources/quartz-trigger-driver-error-messages.properties
@@ -10,6 +10,6 @@
 #     Eurotech - initial API and implementation
 ###############################################################################
 SCHEDULER_NOT_AVAILABLE=Cannot get the scheduler from Quartz
-CANNOT_ADD_JOB=Cannot add Quarzt Job to scheduler for: {} with key: {}
-CANNOT_SCHEDULE_JOB=Cannot schedule Quartz Job for id: {}
-TRIGGER_NEVER_FIRES=The trigger {} will never fires
+CANNOT_ADD_JOB=Cannot add Quarzt Job to scheduler for: {0} with key: {1}
+CANNOT_SCHEDULE_JOB=Cannot schedule Quartz Job for id: {0}
+TRIGGER_NEVER_FIRES=The trigger {0} will never fires


### PR DESCRIPTION
This PR fixes exception messages that were mistakenly missing the positional argument numbers, which is required by MessageFormat while SLF4J Logger messages requires only `{}`

**Related Issue**
_None_

**Description of the solution adopted**
Added positional argument numbers.

**Screenshots**
_None_

**Any side note on the changes made**
_None_