### PR TITLE
Fix shiro configuration

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
@@ -19,6 +19,7 @@ import org.eclipse.kapua.broker.core.plugin.Acl;
 import org.eclipse.kapua.broker.core.plugin.KapuaConnectionContext;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.device.registry.ConnectionUserCouplingMode;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
@@ -182,12 +183,12 @@ public class UserAuthenticationLogic extends AuthenticationLogic {
     }
 
     protected boolean[] checkPermissions(KapuaConnectionContext kcc) throws KapuaException {
-        boolean[] hasPermissions = new boolean[] {
-                authorizationService.isPermitted(permissionFactory.newPermission(BROKER_DOMAIN, Actions.connect, kcc.getScopeId())),
-                authorizationService.isPermitted(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.write, kcc.getScopeId())),
-                authorizationService.isPermitted(permissionFactory.newPermission(DATASTORE_DOMAIN, Actions.read, kcc.getScopeId())),
-                authorizationService.isPermitted(permissionFactory.newPermission(DATASTORE_DOMAIN, Actions.write, kcc.getScopeId()))
-        };
+        List<Permission> permissions = new ArrayList<>();
+        permissions.add(permissionFactory.newPermission(BROKER_DOMAIN, Actions.connect, kcc.getScopeId()));
+        permissions.add(permissionFactory.newPermission(DEVICE_MANAGEMENT_DOMAIN, Actions.write, kcc.getScopeId()));
+        permissions.add(permissionFactory.newPermission(DATASTORE_DOMAIN, Actions.read, kcc.getScopeId()));
+        permissions.add(permissionFactory.newPermission(DATASTORE_DOMAIN, Actions.write, kcc.getScopeId()));
+        boolean[] hasPermissions = authorizationService.isPermitted(permissions);
 
         if (!hasPermissions[BROKER_CONNECT_IDX]) {
             throw new KapuaIllegalAccessException(permissionFactory.newPermission(BROKER_DOMAIN, Actions.connect, kcc.getScopeId()).toString());

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/security/EnhModularRealmAuthorizer.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/security/EnhModularRealmAuthorizer.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.security;
+
+import java.util.Collection;
+import java.util.List;
+
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.shiro.authz.Authorizer;
+import org.apache.shiro.authz.ModularRealmAuthorizer;
+import org.apache.shiro.authz.Permission;
+import org.apache.shiro.realm.Realm;
+import org.apache.shiro.subject.PrincipalCollection;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Custom {@link Authorizer} to reduce the query amount using the isPermitted method with the Permission list or String array.
+ * To use this Authorizer a deeply modified shiro.ini is needed.
+ * Without these changes this Authorizer will not have any realm configured. (see shiro.ini for explanation)
+ * This authorizer takes the first valid configured realm and return the isPermitted evaluation skipping any aggregation strategy if more than one valid aggregator is defined.
+ *
+ */
+public class EnhModularRealmAuthorizer extends ModularRealmAuthorizer {
+
+    protected static final Logger logger = LoggerFactory.getLogger(EnhModularRealmAuthorizer.class);
+
+    public EnhModularRealmAuthorizer() {
+    }
+
+    public EnhModularRealmAuthorizer(Collection<Realm> realms) {
+        super(realms);
+    }
+
+    @Override
+    public boolean[] isPermitted(PrincipalCollection principals, List<Permission> permissions) {
+        assertRealmsConfigured();
+        if (CollectionUtils.isEmpty(permissions)) {
+            //return the first realm result
+            //the multiple realms case with aggregator should be handled or do we still have just one realm?
+            for (Realm realm : getRealms()) {
+                return ((Authorizer) realm).isPermitted(principals, permissions);
+            }
+        }
+        return new boolean[0];
+    }
+
+    @Override
+    public boolean[] isPermitted(PrincipalCollection principals, String... permissions) {
+        assertRealmsConfigured();
+        if (permissions != null && permissions.length>0) {
+            //return the first realm result
+            //the multiple realms case with aggregator should be handled or do we still have just one realm?
+            for (Realm realm : getRealms()) {
+                return ((Authorizer) realm).isPermitted(principals, permissions);
+            }
+        }
+        return new boolean[0];
+    }
+
+}

--- a/broker-core/src/main/resources/shiro.ini
+++ b/broker-core/src/main/resources/shiro.ini
@@ -15,6 +15,8 @@ securityManager.authenticator = $authenticator
 # Auth filters
 # kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
 
+#cacheManager = org.eclipse.kapua.broker.core.experimental.CacheManager
+#securityManager.cacheManager = $cacheManager
 
 ##########
 # Realms #
@@ -27,14 +29,26 @@ kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.rea
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
 
+########################
+#Authorization section #
+########################
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+#removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
+securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
 
-securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
-
-
-#edcCacheManager = com.eurotech.cloud.commons.service.security.KapuaCacheManager
-#securityManager.cacheManager = $edcCacheManager
+authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+#realms must be set again otherwise the authorizer will not have any.
+#The security manager (AuthorizingSecurityManager) is built in this way:
+#    AuthorizingSecurityManager()         //constructor
+#    setRealms(realms)                    //set realms (if any)
+#    afterRealmsSet()                     //set realms to authenticator (if any)
+#    setAuthorizer(Authorizer authorizer) //if any configured
+#    setAuthenticator()                   //if any custom authenticator is set
+#In this way the new authenticator must have the realms already configured once is set to the security manager.
+#Otherwise the security manager doesn't set it's own security manager to the authenticator
+authorizer.realms = $kapuaAuthorizingRealm
+securityManager.authorizer = $authorizer
 
 # SessionListeners only works with in the native SessionMode
 # This is not the mode we use when running in Tomcat.

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.utils;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.UnavailableSecurityManagerException;
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.config.IniSecurityManagerFactory;
+import org.apache.shiro.mgt.SecurityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import cucumber.api.java.en.Given;
+import cucumber.runtime.java.guice.ScenarioScoped;
+
+@ScenarioScoped
+public class InitShiro {
+
+    private static final Logger logger = LoggerFactory.getLogger(InitShiro.class);
+
+    @Given("^Init Security Context$")
+    public void start() throws IOException {
+        try {
+            SecurityManager securityManager = SecurityUtils.getSecurityManager();
+            logger.info("Found Shiro security manager {}", securityManager);
+        }
+        catch (UnavailableSecurityManagerException e) {
+            logger.info("Init shiro security manager...");
+            final URL shiroIniUrl = getClass().getResource("/shiro.ini");
+            Ini shiroIni = new Ini();
+            try (final InputStream input = shiroIniUrl.openStream()) {
+                shiroIni.load(input);
+            }
+            SecurityManager securityManager = new IniSecurityManagerFactory(shiroIni).getInstance();
+            SecurityUtils.setSecurityManager(securityManager);
+            logger.info("Init shiro security manager... DONE");
+        }
+    }
+
+    @Given("^Reset Security Context$")
+    public void stop() {
+        SecurityUtils.setSecurityManager(null);
+    }
+
+}

--- a/qa/common/src/main/resources/shiro.ini
+++ b/qa/common/src/main/resources/shiro.ini
@@ -1,0 +1,74 @@
+# =======================
+# Shiro INI configuration
+# =======================
+
+[main]
+# Objects and their properties are defined here,
+# Such as the securityManager, Realms and anything
+# else needed to build the SecurityManager
+
+#authenticator
+authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
+securityManager.authenticator = $authenticator
+
+#
+# Auth filters
+# kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
+
+#cacheManager = org.eclipse.kapua.broker.core.experimental.CacheManager
+#securityManager.cacheManager = $cacheManager
+
+##########
+# Realms #
+##########
+# Login
+kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
+kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
+kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+
+# Session
+kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
+
+########################
+#Authorization section #
+########################
+# Authorization
+kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+#removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
+securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
+
+authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+#realms must be set again otherwise the authorizer will not have any.
+#The security manager (AuthorizingSecurityManager) is built in this way:
+#    AuthorizingSecurityManager()         //constructor
+#    setRealms(realms)                    //set realms (if any)
+#    afterRealmsSet()                     //set realms to authenticator (if any)
+#    setAuthorizer(Authorizer authorizer) //if any configured
+#    setAuthenticator()                   //if any custom authenticator is set
+#In this way the new authenticator must have the realms already configured once is set to the security manager.
+#Otherwise the security manager doesn't set it's own security manager to the authenticator
+authorizer.realms = $kapuaAuthorizingRealm
+securityManager.authorizer = $authorizer
+
+# SessionListeners only works with in the native SessionMode
+# This is not the mode we use when running in Tomcat.
+#securityManager.sessionMode = native
+securityManager.sessionManager.globalSessionTimeout = -1
+securityManager.sessionManager.sessionValidationSchedulerEnabled = false
+
+securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
+
+[users]
+# The 'users' section is for simple deployments
+# when you only need a small number of statically-defined
+# set of User accounts.
+
+[roles]
+# The 'roles' section is for simple deployments
+# when you only need a small number of statically-defined
+# roles.
+
+[urls]
+# The 'urls' section is used for url-based security
+# in web applications.  We'll discuss this section in the
+# Web documentation

--- a/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account Credential Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Uncorrect Login While Lockout Policy Is Enabled
   Login as kapua-sys, create an account, create a user under that account (user1)
   Configure CredentialService of that account, set lockoutPolicy.enabled to true and lockoutPolicy.maxFailures to 2, leave other fields at default values
@@ -388,3 +392,7 @@ Feature: Account Credential Service Integration Tests
       | integer | lockoutPolicy.lockDuration | -1    |
     Then An exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account Device Registry Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Devices Under Account That Allows Infinite Child Devices
   Login as kapua-sys, create an account
   Configure DeviceRegistryService of that account, set infiniteChildDevices to true and maxNumberChildDevices to 0
@@ -121,3 +125,7 @@ Feature: Account Device Registry Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
@@ -17,6 +17,10 @@ Feature: Account expiration features
     Accounts have an expiration date. From this date onward the accounts are considered disabled
     and cannot be logged into anymore.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Account with future expiration date
     Set the expiration date of an account in the future. It must be possible to log into such
     account.
@@ -509,3 +513,7 @@ Feature: Account expiration features
     When I change the current account expiration date to "null"
     Then An exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountGroupService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountGroupService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account Group Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Groups Under Account That Allows Infinite Child Groups
   Login as kapua-sys, create an account
   Configure GroupService of that account, set infiniteChildGroups to true and maxNumberChildGroups to 0
@@ -118,3 +122,7 @@ Feature: Account Group Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountJobService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountJobService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account Job Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Jobs Under Account That Allows Infinite Child Devices
   Login as kapua-sys, create an account
   Configure JobRegistryService of that account, set infiniteChildJobs to true and maxNumberChildJobs to 0
@@ -121,3 +125,7 @@ Feature: Account Job Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountRoleService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountRoleService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account Role Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Roles Under Account That Allows Infinite Child Roles
   Login as kapua-sys, create an account
   Configure RoleRegistryService of that account, set infiniteChildRoles to true and maxNumberChildRoles to 0
@@ -119,3 +123,7 @@ Feature: Account Role Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountService.feature
@@ -14,6 +14,10 @@
 
 Feature: Account Service Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating A Valid Account
   Login as kapua-sys, create an account with all valid fields
   No exception should be thrown
@@ -384,3 +388,7 @@ Feature: Account Service Tests
     When I create 100 accounts in current scopeId
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountTagService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountTagService.feature
@@ -15,6 +15,9 @@
 
 Feature: Account Tag Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
 
   Scenario: Creating Tags Under Account That Allows Infinite Child Devices
   Login as kapua-sys, create an account
@@ -120,3 +123,7 @@ Feature: Account Tag Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/AccountUserService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountUserService.feature
@@ -15,6 +15,10 @@
 
 Feature: Account User Service Integration Tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Users Under Account That Allows Infinite Child Users
   Login as kapua-sys, create an account
   Configure UserService of that account, set infiniteChildUsers to true and maxNumberChildUsers to 0
@@ -119,3 +123,7 @@ Feature: Account User Service Integration Tests
       | integer | maxNumberChildEntities | 2     |
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
+++ b/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
@@ -16,6 +16,10 @@
 Feature: Self account find feature
   Finding self accounts require a different logic to be applied to the permission
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Find self account by id
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure account service
@@ -93,3 +97,7 @@ Feature: Self account find feature
     Given I login as user with name "test-user" and password "ToManySecrets123#"
     And I look for my account by name
     Then I am able to read my account info
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
+++ b/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
@@ -15,6 +15,10 @@
 
 Feature: Access Info Service CRUD tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Simple create
   Create a simple access info entry. Only a user is supplied. The entry must
   match the creator parameters.
@@ -718,3 +722,7 @@ Feature: Access Info Service CRUD tests
 
     Then I can compare access role objects
     Then I can compare access permission objects
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/DomainService.feature
+++ b/qa/integration/src/test/resources/features/authorization/DomainService.feature
@@ -15,6 +15,10 @@
 
 Feature: Domain Service tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Count domains in a blank database
   The default domain table must contain 20 preset entries.
 
@@ -135,3 +139,7 @@ Feature: Domain Service tests
       | test_name_3 | write,delete |
     When I query for domains with the name "test_name_2"
     Then I count 1
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/GroupService.feature
+++ b/qa/integration/src/test/resources/features/authorization/GroupService.feature
@@ -15,6 +15,10 @@
 
 Feature: Group Service tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Count groups in a blank database
   The default group table must be empty.
 
@@ -1045,3 +1049,7 @@ Feature: Group Service tests
     Then Device "Device1" is not in Assigned Devices of group "Group1"
     And No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/authorization/RoleService.feature
+++ b/qa/integration/src/test/resources/features/authorization/RoleService.feature
@@ -15,6 +15,10 @@
 
 Feature: Role Service tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
 Scenario: Regular role creation
     Create a regular role entry. The entry must match the creator details.
 
@@ -410,9 +414,12 @@ Scenario: Role object equality check
     Then The role comparator does its job
 
 Scenario: Role service related objects sanity checks
-    Check that the objects related to the shiro role service behave sanely.
+    Check that the objects related to the Security Context role service behave sanely.
 
     Then The role permission factory returns sane results
     Then The role permission object constructors are sane
     Then The role permission comparator does its job
 
+Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -16,6 +16,10 @@ Feature: Device Registry Integration
   Device Registy integration test scenarios. These scenarios test higher level device service functionality
   with all services live.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Set environment variables
 
     Given System property "commons.settings.hotswap" with value "true"
@@ -1527,3 +1531,7 @@ Feature: Device Registry Integration
       | 126          | test        | ENABLED | dev      |
     Then I find 0 devices
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -15,6 +15,10 @@
 Feature: Endpoint Info Service Integration Tests
   Integration test scenarios for Endpoint Info service
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Valid Endpoint
   Login as kapua-sys
   Create an endpoint with valid Schema, Domain Name and Port
@@ -750,4 +754,6 @@ Feature: Endpoint Info Service Integration Tests
     And I delete endpoint with schema "Schema2", domain "abc.com" and port 2222
     And I logout
 
-    
+Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -16,6 +16,10 @@
 Feature: Job Execution service CRUD tests
     The Job service is responsible for maintaining the status of the target step executions.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
 Scenario: Regular job execution creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -208,3 +212,6 @@ Scenario: Job execution factory sanity checks
 
     And I test the sanity of the job execution factory
 
+Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -16,6 +16,10 @@
 Feature: Job service CRUD tests
   The Job service is responsible for executing scheduled actions on various targets.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Regular job creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -251,3 +255,7 @@ Feature: Job service CRUD tests
 
     When I test the sanity of the job factory
     Then No exception was thrown
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
@@ -16,6 +16,10 @@
 Feature: Job step service CRUD tests
     The Job Step service is responsible for maintaining job steps.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
 Scenario: Regular step creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -187,3 +191,7 @@ Scenario: Delete a non-existing step
 Scenario: Step factory sanity checks
 
     Given I test the sanity of the step factory
+
+Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -16,6 +16,10 @@
 Feature: Job Target service CRUD tests
     The Job service is responsible for maintaining a list of job targets.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
 Scenario: Regular target creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
@@ -203,3 +207,6 @@ Scenario: Job target factory sanity checks
 
     When I test the sanity of the job target factory
 
+Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -15,6 +15,10 @@
 
 Feature: Trigger service tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Adding "Device Connect" Schedule With All Valid Parameters
     Login as kapua-sys user and create a job with name job0.
     Add schedule0 with a valid start date to the created job.
@@ -776,3 +780,7 @@ Feature: Trigger service tests
     And I search for the trigger with name "schedule0" in the database
     And There is no trigger with the name "schedule0" in the database
     Then I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/tag/TagService.feature
+++ b/qa/integration/src/test/resources/features/tag/TagService.feature
@@ -17,6 +17,10 @@ Feature: Tag Service
   used to attach tags to Devices, but could be used to tag eny kapua entity, like
   User for example.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Creating Unique Tag Without Description
   Login as kapua-sys, go to tags, try to create a tag with unique name without description.
   Kapua should not return any errors.
@@ -855,3 +859,7 @@ Feature: Tag Service
     When I asign tag "Tag1" to device "Device1"
     Then An exception was thrown
     Then I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -18,6 +18,10 @@ Feature: User and Credential expiration abd lockout features
   There is also expiration and status on user's credentials which are also tested.
   Additionally login failures and lockout and lockout resets are tested.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
 #
 # Credential state
 #
@@ -497,3 +501,7 @@ Feature: User and Credential expiration abd lockout features
     And I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then No exception was thrown
     And I logout
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
+++ b/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
@@ -17,6 +17,10 @@ Feature: Tenant service with Service Events
   Basic workflow of Account and User creation and deletion, where Service Events are
   being trigered on create, update and delete action on Account and User service.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Start event broker for all scenarios
 
     Given Start Event Broker
@@ -64,3 +68,7 @@ Feature: Tenant service with Service Events
   Scenario: Stop event broker for all scenarios
 
     Given Stop Event Broker
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserCredentialsI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserCredentialsI9n.feature
@@ -16,6 +16,10 @@
 Feature: Feature file for testing Password user credential
   This feature file provides test scenarios for user password credential.
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Create a valid user with valid password credential
     Creating a new user "kapua-a" in kapua-sys account with valid password credential.
     After that trying to login as "kapua-a" user.
@@ -306,3 +310,7 @@ Feature: Feature file for testing Password user credential
     And I expect the exception "KapuaAuthenticationException" with the text "kapua-a"
     Then I login as user with name "kapua-a" and password "ToManySecrets123#"
     And An exception was thrown
+
+Scenario: Reset Security Context for all scenarios
+
+  Given Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -15,6 +15,10 @@
 
 Feature: User role service integration tests
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Start datastore for all scenarios
 
     Given Start Datastore
@@ -1650,6 +1654,9 @@ Feature: User role service integration tests
 
     Given Stop Datastore
 
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context
 
 
 

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -16,6 +16,10 @@
 Feature: User Service Integration
   User Service integration scenarios
 
+Scenario: Init Security Context for all scenarios
+
+  Given Init Security Context
+
   Scenario: Start event broker for all scenarios
 
     Given Start Event Broker
@@ -212,3 +216,7 @@ Feature: User Service Integration
   Scenario: Stop event broker for all scenarios
 
     Given Stop Event Broker
+
+  Scenario: Reset Security Context for all scenarios
+
+    Given Reset Security Context

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization;
 
+import java.util.List;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
@@ -33,6 +35,16 @@ public interface AuthorizationService extends KapuaService {
      * @since 1.0.0
      */
     boolean isPermitted(Permission permission) throws KapuaException;
+
+    /**
+     * Returns if the user (the current logged user retrieved by thread context) is allowed to perform the operation identified by provided the permission.
+     *
+     * @param permission The permissions to check.
+     * @return an array representing the current user permissions.
+     * @throws KapuaException If there is no logged context.
+     * @since 1.0.0
+     */
+    boolean[] isPermitted(List<Permission> permission) throws KapuaException;
 
     /**
      * Checks if the user (the current logged user retrieved by thread context) is allowed to perform the operation identified by provided the permission.

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
-import java.util.ArrayList;
-import java.util.Collection;
 import java.util.Date;
 import java.util.UUID;
 
@@ -77,11 +75,7 @@ import org.apache.shiro.authc.ExpiredCredentialsException;
 import org.apache.shiro.authc.IncorrectCredentialsException;
 import org.apache.shiro.authc.LockedAccountException;
 import org.apache.shiro.authc.UnknownAccountException;
-import org.apache.shiro.mgt.DefaultSecurityManager;
-import org.apache.shiro.realm.Realm;
 import org.apache.shiro.session.Session;
-import org.apache.shiro.session.mgt.AbstractSessionManager;
-import org.apache.shiro.session.mgt.AbstractValidatingSessionManager;
 import org.apache.shiro.session.mgt.SimpleSession;
 import org.apache.shiro.subject.Subject;
 import org.jose4j.jws.AlgorithmIdentifiers;
@@ -116,38 +110,6 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
     private final RolePermissionFactory rolePermissionFactory = locator.getFactory(RolePermissionFactory.class);
     private final AccessPermissionService accessPermissionService = locator.getService(AccessPermissionService.class);
     private final AccessPermissionFactory accessPermissionFactory = locator.getFactory(AccessPermissionFactory.class);
-
-    static {
-        // Make the SecurityManager instance available to the entire application:
-        Collection<Realm> realms = new ArrayList<>();
-        try {
-            realms.add(new org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm());
-            realms.add(new org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm());
-        } catch (KapuaException e) {
-            LOG.error("Unable to build realms", e);
-            throw new ExceptionInInitializerError(e);
-        }
-
-        DefaultSecurityManager defaultSecurityManager = new DefaultSecurityManager();
-        defaultSecurityManager.setAuthenticator(new KapuaAuthenticator());
-        defaultSecurityManager.setRealms(realms);
-
-        SecurityUtils.setSecurityManager(defaultSecurityManager);
-
-        if (defaultSecurityManager.getSessionManager() instanceof AbstractSessionManager) {
-            ((AbstractSessionManager) defaultSecurityManager.getSessionManager()).setGlobalSessionTimeout(-1);
-            LOG.info("Shiro global session timeout set to indefinite.");
-        } else {
-            LOG.warn("Cannot set Shiro global session timeout to indefinite.");
-        }
-
-        if (defaultSecurityManager.getSessionManager() instanceof AbstractValidatingSessionManager) {
-            ((AbstractValidatingSessionManager) defaultSecurityManager.getSessionManager()).setSessionValidationSchedulerEnabled(false);
-            LOG.info("Shiro global session validator scheduler disabled.");
-        } else {
-            LOG.warn("Cannot disable Shiro session validator scheduler.");
-        }
-    }
 
     @Override
     public AccessToken login(LoginCredentials loginCredentials) throws KapuaException {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
@@ -11,6 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -41,9 +42,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
         }
         if (session.isTrustedMode()) {
             boolean[] returnedPermissions = new boolean[permissions.size()];
-            for (int i=0; i<permissions.size(); i++) {
-                returnedPermissions[i] = true;
-            }
+            Arrays.fill(returnedPermissions, true);
             return returnedPermissions;
         }
         else {


### PR DESCRIPTION
Brief description of the PR.
Remove hardcoded Shiro configuration and override the ModularRealmAuthorizer to use a more efficient check for multiple permissions at the same time.

**Related Issue**
none

**Description of the solution adopted**
The Shiro configuration was wrongly instantiated by code from the AuthorizationService. So any change done on shiro.ini had no effect (on broker side at least) since it was overwritten later by the AuthorizationService initialization.
The Shiro ModularRealmAuthorizer uses a for loop while checking for multiple permissions. For performance reason, on Kapua side, we would like to use a different method already exposed by the Authorizer.
The shiro.ini configuration is changed and the changes did are described inside the file.

**Screenshots**
none

**Any side note on the changes made**
none
