### PR TITLE
Remove propOrder from XmlType and Migrate all the XmlAccessType from FIELD to PROPERTY

### DIFF
--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndChainEndPoint.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndChainEndPoint.java
@@ -23,8 +23,7 @@ import org.apache.camel.Exchange;
 
 @XmlRootElement(name = "endChainEndPoint")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-})
+@XmlType()
 public class EndChainEndPoint implements EndPoint {
 
     @Override

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
@@ -22,9 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 
 @XmlRootElement(name = "endPoints")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "endPoints"
-})
+@XmlType
 public class EndPointContainer {
 
     private List<EndPoint> endPoints;

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/ParentEndPoint.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/ParentEndPoint.java
@@ -27,10 +27,7 @@ import org.eclipse.kapua.broker.core.message.MessageConstants;
 
 @XmlRootElement(name = "endPoint")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "regex",
-        "endPoints"
-})
+@XmlType
 public class ParentEndPoint implements EndPoint {
 
     @XmlTransient

--- a/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/SimpleEndPoint.java
+++ b/broker-core/src/main/java/org/eclipse/kapua/broker/core/router/SimpleEndPoint.java
@@ -25,10 +25,7 @@ import org.eclipse.kapua.broker.core.message.MessageConstants;
 
 @XmlRootElement(name = "simpleEndPoint")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "regex",
-        "endPoint"
-})
+@XmlType
 public class SimpleEndPoint implements EndPoint {
 
     @XmlTransient

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
@@ -28,7 +28,7 @@ import org.eclipse.kapua.model.KapuaUpdatableEntity;
  * @since 1.0
  */
 @XmlRootElement
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public interface ServiceConfig extends KapuaUpdatableEntity {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
@@ -11,6 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
+import javax.xml.bind.annotation.XmlType;
 import java.util.Properties;
 
 import org.eclipse.kapua.KapuaException;
@@ -21,6 +27,9 @@ import org.eclipse.kapua.model.KapuaUpdatableEntity;
  *
  * @since 1.0
  */
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType
 public interface ServiceConfig extends KapuaUpdatableEntity {
 
     /**
@@ -40,6 +49,7 @@ public interface ServiceConfig extends KapuaUpdatableEntity {
      *
      * @return
      */
+    @XmlElement(name = "pid")
     public String getPid();
 
     /**
@@ -55,6 +65,7 @@ public interface ServiceConfig extends KapuaUpdatableEntity {
      * @return
      * @throws KapuaException
      */
+    @XmlTransient
     public Properties getConfigurations() throws KapuaException;
 
     /**

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
@@ -20,18 +20,9 @@ import javax.persistence.Basic;
 import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Table;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-import javax.xml.bind.annotation.XmlType;
 import java.io.IOException;
 import java.util.Properties;
 
-@XmlRootElement
-@XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = {"pid", "configurations"})
 @Entity(name = "ServiceConfig")
 @Table(name = "sys_configuration")
 /**
@@ -43,12 +34,10 @@ public class ServiceConfigImpl extends AbstractKapuaUpdatableEntity implements S
 
     private static final long serialVersionUID = 8699765898092343484L;
 
-    @XmlElement(name = "pid")
     @Basic
     @Column(name = "pid")
     private String pid;
 
-    @XmlTransient
     @Basic
     @Column(name = "configurations")
     protected String configurations;

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
@@ -16,14 +16,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAnyAttribute;
-import javax.xml.bind.annotation.XmlAnyElement;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 
 import org.eclipse.kapua.model.config.metatype.KapuaTattribute;
@@ -54,23 +46,13 @@ import org.w3c.dom.Element;
  *
  * @since 1.0
  */
-@XmlRootElement(name = "Attribute", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-@XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(name = "Tattribute", propOrder = {
-        "value",
-        "any"
-})
+
 public class TattributeImpl implements KapuaTattribute {
 
-    @XmlElement(name = "Value", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
     protected List<String> value;
-    @XmlAnyElement(lax = true)
     protected List<Object> any;
-    @XmlAttribute(name = "adref", required = true)
     protected String adref;
-    @XmlAttribute(name = "content")
     protected String content;
-    @XmlAnyAttribute
     private Map<QName, String> otherAttributes = new HashMap<QName, String>();
 
     /**

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecord.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecord.java
@@ -20,7 +20,6 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-import org.eclipse.kapua.commons.service.event.store.api.EventStoreXmlRegistry;
 import org.eclipse.kapua.event.ServiceEvent.EventStatus;
 import org.eclipse.kapua.model.KapuaUpdatableEntity;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -29,21 +28,7 @@ import org.eclipse.kapua.model.xml.DateXmlAdapter;
 
 @XmlRootElement(name = "eventStoreRecord")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "contextId",
-        "timestamp",
-        "userId",
-        "service",
-        "entityType",
-        "scopeId",
-        "entityId",
-        "operation",
-        "inputs",
-        "outputs",
-        "status",
-        "note",
-}, //
-        factoryClass = EventStoreXmlRegistry.class, //
-        factoryMethod = "newEventStoreRecord")
+@XmlType(factoryClass = EventStoreXmlRegistry.class, factoryMethod = "newEventStoreRecord")
 public interface EventStoreRecord extends KapuaUpdatableEntity {
 
     public static final String TYPE = "eventStoreRecord";

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
@@ -25,12 +25,10 @@ import java.util.Iterator;
 import java.util.Set;
 
 @XmlRootElement(name = "jobTargetSublist")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class JobTargetSublist implements Iterable<KapuaId> {
 
-    @XmlElement(name = "targetId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private Set<KapuaId> targetIds = new HashSet<>();
 
     public JobTargetSublist() {
@@ -40,6 +38,8 @@ public class JobTargetSublist implements Iterable<KapuaId> {
         this.targetIds.addAll(targetIds);
     }
 
+    @XmlElement(name = "targetId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public Set<KapuaId> getTargetIds() {
         if (targetIds == null) {
             targetIds = new HashSet<>();

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
@@ -27,7 +27,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "channel")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"semanticParts"}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaChannel")
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaChannel")
 public interface KapuaChannel extends Channel {
 
     /**

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
@@ -35,18 +35,7 @@ import java.util.UUID;
  */
 @XmlRootElement(name = "message")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "id", //
-        "scopeId", //
-        "deviceId", //
-        "clientId", //
-        "receivedOn", //
-        "sentOn", //
-        "capturedOn", //
-        "position", //
-        "channel", //
-        "payload", //
-}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaMessage")
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newKapuaMessage")
 @XmlSeeAlso(KapuaDataMessage.class)
 public interface KapuaMessage<C extends KapuaChannel, P extends KapuaPayload> extends Message<C, P> {
 

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
@@ -32,7 +32,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "payload")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"metrics", "body"}, factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload")
+@XmlType(factoryClass = MessageXmlRegistry.class, factoryMethod = "newPayload")
 public interface KapuaPayload extends Payload {
 
     /**

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
@@ -14,12 +14,15 @@ package org.eclipse.kapua.message.xml;
 import org.eclipse.kapua.model.type.ObjectValueConverter;
 import org.eclipse.kapua.model.xml.XmlAdaptedNameTypeValueObject;
 
+import javax.xml.bind.annotation.XmlAccessOrder;
 import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorOrder;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "metric")
 @XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlAccessorOrder(XmlAccessOrder.ALPHABETICAL)
 public class XmlAdaptedMetric extends XmlAdaptedNameTypeValueObject {
 
     public Object getCastedValue() {

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -35,15 +35,15 @@ public class KapuaMetricsMapAdapterTest extends Assert {
                     "<payload>" + NEWLINE +
                     "   <metrics>" + NEWLINE +
                     "      <metric>" + NEWLINE +
-                    "         <valueType>string</valueType>" + NEWLINE +
                     "         <value>value1</value>" + NEWLINE +
+                    "         <valueType>string</valueType>" + NEWLINE +
                     "         <name>key1</name>" + NEWLINE +
                     "      </metric>" + NEWLINE +
                     "   </metrics>" + NEWLINE +
                     "</payload>" + NEWLINE;
 
     @Before
-    public void before() throws Exception {
+    public void before() {
         XmlUtil.setContextProvider(new MessageJAXBContextProvider());
     }
 
@@ -64,7 +64,7 @@ public class KapuaMetricsMapAdapterTest extends Assert {
     public void unmarshalWithAdapter() throws Exception {
         KapuaPayload metricsMap = new KapuaPayloadImpl();
         Map<String, Object> metrics = new HashMap<>();
-        metrics.put(String.valueOf("key1"), String.valueOf("value1"));
+        metrics.put("key1", "value1");
         metricsMap.setMetrics(metrics);
 
         KapuaPayload metricsMapResp = XmlUtil.unmarshal(METRICS_XML_STR, KapuaPayload.class);

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
@@ -23,14 +23,10 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.id.KapuaIdAdapter;
 
 @XmlRootElement(name = "entityNotFoundExceptionInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class EntityNotFoundExceptionInfo extends ExceptionInfo {
 
-    @XmlElement(name = "entityType")
     private String entityType;
-
-    @XmlElement(name = "entityId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId entityId;
 
     protected EntityNotFoundExceptionInfo() {
@@ -44,6 +40,7 @@ public class EntityNotFoundExceptionInfo extends ExceptionInfo {
         setEntityId(kapuaException.getEntityId());
     }
 
+    @XmlElement(name = "entityType")
     public String getEntityType() {
         return entityType;
     }
@@ -52,6 +49,8 @@ public class EntityNotFoundExceptionInfo extends ExceptionInfo {
         this.entityType = entityType;
     }
 
+    @XmlElement(name = "entityId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public KapuaId getEntityId() {
         return entityId;
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
@@ -21,10 +21,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "exceptionInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class ExceptionInfo extends ThrowableInfo {
 
-    @XmlElement(name = "kapuaErrorCode")
     private String kapuaErrorCode;
 
     public ExceptionInfo() {
@@ -35,6 +34,7 @@ public class ExceptionInfo extends ThrowableInfo {
         setKapuaErrorCode(kapuaErrorCode);
     }
 
+    @XmlElement(name = "kapuaErrorCode")
     public String getKapuaErrorCode() {
         return kapuaErrorCode;
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
@@ -20,13 +20,10 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "illegalArgumentExceptionInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class IllegalArgumentExceptionInfo extends ExceptionInfo {
 
-    @XmlElement(name = "argumentName")
     private String argumentName;
-
-    @XmlElement(name = "argumentValue")
     private String argumentValue;
 
     protected IllegalArgumentExceptionInfo() {
@@ -40,6 +37,7 @@ public class IllegalArgumentExceptionInfo extends ExceptionInfo {
         setArgumentValue(kapuaException.getArgumentValue());
     }
 
+    @XmlElement(name = "argumentName")
     public String getArgumenName() {
         return argumentName;
     }
@@ -48,6 +46,7 @@ public class IllegalArgumentExceptionInfo extends ExceptionInfo {
         this.argumentName = argumentName;
     }
 
+    @XmlElement(name = "argumentValue")
     public String getArgumentValue() {
         return argumentValue;
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
@@ -20,10 +20,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "illegalNullArgumentExceptionInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class IllegalNullArgumentExceptionInfo extends ExceptionInfo {
 
-    @XmlElement(name = "argumentName")
     private String argumentName;
 
     protected IllegalNullArgumentExceptionInfo() {
@@ -36,6 +35,7 @@ public class IllegalNullArgumentExceptionInfo extends ExceptionInfo {
         setArgumentName(kapuaException.getArgumentName());
     }
 
+    @XmlElement(name = "argumentName")
     public String getArgumenName() {
         return argumentName;
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
@@ -21,10 +21,9 @@ import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
 @XmlRootElement(name = "subjectUnauthorizedExceptionInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class SubjectUnauthorizedExceptionInfo extends ExceptionInfo {
 
-    @XmlElement(name = "permission")
     private Permission permission;
 
     protected SubjectUnauthorizedExceptionInfo() {
@@ -37,6 +36,7 @@ public class SubjectUnauthorizedExceptionInfo extends ExceptionInfo {
         setPermission(kapuaException.getPermission());
     }
 
+    @XmlElement(name = "permission")
     public Permission getPermission() {
         return permission;
     }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
@@ -19,26 +19,17 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
 
 import org.eclipse.kapua.app.api.core.settings.KapuaApiSetting;
 import org.eclipse.kapua.app.api.core.settings.KapuaApiSettingKeys;
 
 @XmlRootElement(name = "throwableInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class ThrowableInfo {
 
-    @XmlElement(name = "httpErrorCode")
     private int httpErrorCode;
-
-    @XmlElement(name = "message")
     private String message;
-
-    @XmlElement(name = "stackTrace")
     private String stackTrace;
-
-    @XmlTransient
-    private final boolean showStacktrace = KapuaApiSetting.getInstance().getBoolean(KapuaApiSettingKeys.API_EXCEPTION_STACKTRACE_SHOW, false);
 
     protected ThrowableInfo() {
         super();
@@ -48,6 +39,7 @@ public class ThrowableInfo {
         this.httpErrorCode = httpStatus.getStatusCode();
         this.message = throwable.getMessage();
         // Print stack trace
+        boolean showStacktrace = KapuaApiSetting.getInstance().getBoolean(KapuaApiSettingKeys.API_EXCEPTION_STACKTRACE_SHOW, false);
         if (showStacktrace) {
             StringWriter stringWriter = new StringWriter();
             throwable.printStackTrace(new PrintWriter(stringWriter));
@@ -56,6 +48,7 @@ public class ThrowableInfo {
 
     }
 
+    @XmlElement(name = "httpErrorCode")
     public int getHttpErrorCode() {
         return httpErrorCode;
     }
@@ -64,6 +57,7 @@ public class ThrowableInfo {
         this.httpErrorCode = httpErrorCode.getStatusCode();
     }
 
+    @XmlElement(name = "message")
     public String getMessage() {
         return message;
     }
@@ -72,6 +66,7 @@ public class ThrowableInfo {
         this.message = message;
     }
 
+    @XmlElement(name = "stackTrace")
     public String getStackTrace() {
         return stackTrace;
     }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
@@ -29,17 +29,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "accountCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"organizationName",
-        "organizationPersonName",
-        "organizationEmail",
-        "organizationPhoneNumber",
-        "organizationAddressLine1",
-        "organizationAddressLine2",
-        "organizationCity",
-        "organizationZipPostCode",
-        "organizationStateProvinceCounty",
-        "organizationCountry",
-        "expirationDate"}, factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
+@XmlType(factoryClass = AccountXmlRegistry.class, factoryMethod = "newAccountCreator")
 public interface AccountCreator extends KapuaNamedEntityCreator<Account> {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
@@ -24,29 +24,15 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 import java.io.Serializable;
 import java.util.Date;
 
-@XmlRootElement(name = "serviceEvent")
-@XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = {"id",
-        "contextId",
-        "timestamp",
-        "userId",
-        "service",
-        "entityType",
-        "scopeId",
-        "entityScopeId",
-        "entityId",
-        "operation",
-        "inputs",
-        "outputs",
-        "status",
-        "note",
-})
 /**
  * Service event bus event object
  *
  * @since 1.0
  *
  */
+@XmlRootElement(name = "serviceEvent")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType
 public class ServiceEvent implements Serializable {
 
     private static final long serialVersionUID = -6642016486673574115L;

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
@@ -31,7 +31,7 @@ import java.util.Date;
  *
  */
 @XmlRootElement(name = "serviceEvent")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class ServiceEvent implements Serializable {
 
@@ -55,51 +55,19 @@ public class ServiceEvent implements Serializable {
         SEND_ERROR
     }
 
-    @XmlElement(name = "id")
     private String id;
-
-    @XmlElement(name = "contextId")
     private String contextId;
-
-    @XmlElement(name = "timestamp")
-    @XmlJavaTypeAdapter(DateXmlAdapter.class)
     private Date timestamp;
-
-    @XmlElement(name = "userId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId userId;
-
-    @XmlElement(name = "service")
     private String service;
-
-    @XmlElement(name = "entityType")
     private String entityType;
-
-    @XmlElement(name = "scopeId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId scopeId;
-
-    @XmlElement(name = "entityScopeId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId entityScopeId;
-
-    @XmlElement(name = "entityId")
-    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     private KapuaId entityId;
-
-    @XmlElement(name = "operation")
     private String operation;
-
-    @XmlElement(name = "inputs")
     private String inputs;
-
-    @XmlElement(name = "outputs")
     private String outputs;
-
-    @XmlElement(name = "status")
     private EventStatus status;
-
-    @XmlElement(name = "note")
     private String note;
 
     /**
@@ -107,6 +75,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "id")
     public String getId() {
         return id;
     }
@@ -125,6 +94,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "contextId")
     public String getContextId() {
         return contextId;
     }
@@ -143,6 +113,8 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "timestamp")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
     public Date getTimestamp() {
         return timestamp;
     }
@@ -161,6 +133,8 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "userId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public KapuaId getUserId() {
         return userId;
     }
@@ -179,6 +153,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "service")
     public String getService() {
         return service;
     }
@@ -197,6 +172,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "entityType")
     public String getEntityType() {
         return entityType;
     }
@@ -215,6 +191,8 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "scopeId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public KapuaId getScopeId() {
         return scopeId;
     }
@@ -233,6 +211,8 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "entityScopeId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public KapuaId getEntityScopeId() {
         return entityScopeId;
     }
@@ -251,6 +231,8 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "entityId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
     public KapuaId getEntityId() {
         return entityId;
     }
@@ -269,6 +251,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "operation")
     public String getOperation() {
         return operation;
     }
@@ -287,6 +270,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "inputs")
     public String getInputs() {
         return inputs;
     }
@@ -305,6 +289,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "outputs")
     public String getOutputs() {
         return outputs;
     }
@@ -323,6 +308,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "status")
     public EventStatus getStatus() {
         return status;
     }
@@ -341,6 +327,7 @@ public class ServiceEvent implements Serializable {
      *
      * @return
      */
+    @XmlElement(name = "note")
     public String getNote() {
         return note;
     }

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
@@ -29,11 +29,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@XmlType(propOrder = {
-        "id",
-        "scopeId",
-        "createdOn",
-        "createdBy"})
+@XmlType
 public interface KapuaEntity extends KapuaSerializable {
 
     @XmlTransient

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
@@ -43,7 +43,7 @@ import javax.xml.bind.annotation.XmlType;
  *
  * @since 1.0.0
  */
-@XmlType(propOrder = {"name", "description"})
+@XmlType
 public interface KapuaNamedEntity extends KapuaUpdatableEntity {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
@@ -43,7 +43,7 @@ import javax.xml.bind.annotation.XmlType;
  * @param <E> {@link KapuaEntity} which this {@link KapuaEntityCreator} is for
  * @since 1.0.0
  */
-@XmlType(propOrder = {"name", "description"})
+@XmlType
 public interface KapuaNamedEntityCreator<E extends KapuaEntity> extends KapuaUpdatableEntityCreator<E> {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
@@ -29,11 +29,7 @@ import java.util.Properties;
  *
  * @since 1.0.0
  */
-@XmlType(propOrder = {
-        "modifiedOn",
-        "modifiedBy",
-        "optlock"
-})
+@XmlType
 public interface KapuaUpdatableEntity extends KapuaEntity {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
@@ -57,10 +57,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "AD", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(name = "Tad", propOrder = {
-        "option",
-        "any"
-}, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTad")
+@XmlType(name = "Tad", factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTad")
 public interface KapuaTad {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
@@ -11,6 +11,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.config.metatype;
 
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlAnyAttribute;
+import javax.xml.bind.annotation.XmlAnyElement;
+import javax.xml.bind.annotation.XmlAttribute;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
 import javax.xml.namespace.QName;
 import java.util.List;
 import java.util.Map;
@@ -39,6 +47,9 @@ import java.util.Map;
  *
  * @since 1.0
  */
+@XmlRootElement(name = "Attribute", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
+@XmlAccessorType(XmlAccessType.FIELD)
+@XmlType(name = "Tattribute")
 public interface KapuaTattribute {
 
     /**
@@ -56,6 +67,7 @@ public interface KapuaTattribute {
      * </pre>
      * <p>
      */
+    @XmlElement(name = "Value", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
     List<String> getValue();
 
     /**
@@ -73,6 +85,7 @@ public interface KapuaTattribute {
      * </pre>
      * <p>
      */
+    @XmlAnyElement(lax = true)
     List<Object> getAny();
 
     /**
@@ -87,6 +100,7 @@ public interface KapuaTattribute {
      *
      * @param value allowed object is {@link String }
      */
+    @XmlAttribute(name = "adref", required = true)
     void setAdref(String value);
 
     /**
@@ -94,6 +108,7 @@ public interface KapuaTattribute {
      *
      * @return possible object is {@link String }
      */
+    @XmlAttribute(name = "content")
     String getContent();
 
     /**
@@ -114,5 +129,6 @@ public interface KapuaTattribute {
      *
      * @return always non-null
      */
+    @XmlAnyAttribute
     Map<QName, String> getOtherAttributes();
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
@@ -48,7 +48,7 @@ import java.util.Map;
  * @since 1.0
  */
 @XmlRootElement(name = "Attribute", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(name = "Tattribute")
 public interface KapuaTattribute {
 

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
@@ -50,16 +50,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "Designate", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(name = "Tdesignate", propOrder = {
-        "object",
-        "any",
-        "pid",
-        "factoryPid",
-        "bundle",
-        "optional",
-        "merge",
-        "otherAttributes"
-}, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTdesignate")
+@XmlType(name = "Tdesignate", factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTdesignate")
 public interface KapuaTdesignate {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
@@ -47,13 +47,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "MetaData", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(name = "Tmetadata", propOrder = {
-        "OCD",
-        "designate",
-        "any",
-        "localization",
-        "otherAttributes"
-}, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTmetadata")
+@XmlType(name = "Tmetadata", factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTmetadata")
 public interface KapuaTmetadata {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
@@ -46,10 +46,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "Object", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(name = "Tobject", propOrder = {
-        "attribute",
-        "any"
-}, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTobject")
+@XmlType(name = "Tobject", factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaTobject")
 public interface KapuaTobject {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
@@ -47,9 +47,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "Option", namespace = "http://www.osgi.org/xmlns/metatype/v1.2.0")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(name = "Toption", propOrder = {
-        "any"
-}, factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaToption")
+@XmlType(name = "Toption", factoryClass = MetatypeXmlRegistry.class, factoryMethod = "newKapuaToption")
 public interface KapuaToption {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -33,7 +33,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"limitExceeded", "size", "items", "totalCount"})
+@XmlType
 public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializable {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
@@ -15,16 +15,16 @@ import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class XmlAdaptedNameTypeValueObject extends XmlAdaptedTypeValueObject {
 
-    @XmlElement(name = "name")
     private String name;
 
     public XmlAdaptedNameTypeValueObject() {
         super();
     }
 
+    @XmlElement(name = "name")
     public String getName() {
         return name;
     }

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
@@ -16,20 +16,18 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
 
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class XmlAdaptedTypeValueObject {
 
-    @XmlJavaTypeAdapter(ObjectTypeXmlAdapter.class)
-    @XmlElement(name = "valueType")
     private Class<?> valueType;
-
-    @XmlElement(name = "value")
     private String value;
 
     public XmlAdaptedTypeValueObject() {
         // Required by JAXB
     }
 
+    @XmlJavaTypeAdapter(ObjectTypeXmlAdapter.class)
+    @XmlElement(name = "valueType")
     public Class<?> getValueType() {
         return valueType;
     }
@@ -38,6 +36,7 @@ public class XmlAdaptedTypeValueObject {
         this.valueType = type;
     }
 
+    @XmlElement(name = "value")
     public String getValue() {
         return value;
     }

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
@@ -29,12 +29,7 @@ import org.eclipse.kapua.model.config.metatype.KapuaTocd;
  */
 @XmlRootElement(name = "configuration")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "id",
-        "name",
-        "definition",
-        "properties"
-}, factoryClass = ServiceConfigurationXmlRegistry.class, factoryMethod = "newComponentConfiguration")
+@XmlType(factoryClass = ServiceConfigurationXmlRegistry.class, factoryMethod = "newComponentConfiguration")
 public interface ServiceComponentConfiguration {
 
     /**

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
@@ -20,10 +20,9 @@ import javax.xml.bind.annotation.XmlElement;
  *
  * @since 1.0
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class ServiceXmlConfigPropertiesAdapted {
 
-    @XmlElement(name = "property")
     private ServiceXmlConfigPropertyAdapted[] properties;
 
     /**
@@ -37,6 +36,7 @@ public class ServiceXmlConfigPropertiesAdapted {
      *
      * @return
      */
+    @XmlElement(name = "property")
     public ServiceXmlConfigPropertyAdapted[] getProperties() {
         return properties;
     }

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
  *
  * @since 1.0
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class ServiceXmlConfigPropertyAdapted {
 
     @XmlEnum
@@ -45,31 +45,26 @@ public class ServiceXmlConfigPropertyAdapted {
     /**
      * The name of the property.
      */
-    @XmlAttribute(name = "name")
     private String name;
 
     /**
      * Whether the property value is an array.
      */
-    @XmlAttribute(name = "array")
     private boolean array;
 
     /**
      * Whether the property value is encrypted.
      */
-    @XmlAttribute(name = "encrypted")
     private boolean encrypted;
 
     /**
      * The property type.
      */
-    @XmlAttribute(name = "type")
     private ConfigPropertyType type;
 
     /**
      * The property value(s).
      */
-    @XmlElement(name = "value")
     private String[] values;
 
     public ServiceXmlConfigPropertyAdapted() {
@@ -85,6 +80,7 @@ public class ServiceXmlConfigPropertyAdapted {
         this.encrypted = false;
     }
 
+    @XmlAttribute(name = "name")
     public String getName() {
         return name;
     }
@@ -93,6 +89,7 @@ public class ServiceXmlConfigPropertyAdapted {
         this.name = name;
     }
 
+    @XmlAttribute(name = "array")
     public boolean getArray() {
         return array;
     }
@@ -101,6 +98,7 @@ public class ServiceXmlConfigPropertyAdapted {
         this.array = array;
     }
 
+    @XmlAttribute(name = "type")
     public ConfigPropertyType getType() {
         return type;
     }
@@ -109,6 +107,7 @@ public class ServiceXmlConfigPropertyAdapted {
         this.type = type;
     }
 
+    @XmlAttribute(name = "encrypted")
     public boolean isEncrypted() {
         return encrypted;
     }
@@ -117,6 +116,7 @@ public class ServiceXmlConfigPropertyAdapted {
         this.encrypted = encrypted;
     }
 
+    @XmlElement(name = "value")
     public String[] getValues() {
         return values;
     }

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -30,16 +30,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "channel")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "id", //
-        "scopeId", //
-        "clientId", //
-        "name", //
-        "firstMessageId", //
-        "firstMessageOn", //
-        "lastMessageId", //
-        "lastMessageOn" //
-})
+@XmlType
 public interface ChannelInfo extends Storable {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -30,15 +30,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "clientInfo")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "id", //
-        "scopeId", //
-        "clientId", //
-        "firstMessageId", //
-        "firstMessageOn", //
-        "lastMessageId", //
-        "lastMessageOn" //
-})
+@XmlType
 public interface ClientInfo extends Storable {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -34,20 +34,7 @@ import java.util.UUID;
  */
 @XmlRootElement(name = "message")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "id", //
-        "datastoreId", //
-        "timestamp", //
-        "scopeId", //
-        "deviceId", //
-        "clientId", //
-        "receivedOn", //
-        "sentOn", //
-        "capturedOn", //
-        "position", //
-        "channel", //
-        "payload", //
-}) //
+@XmlType
 public interface DatastoreMessage extends Storable {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
@@ -28,9 +28,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "metric")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name",
-        "type",
-        "value" })
+@XmlType
 public interface Metric<T> extends Comparable<T> {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -31,17 +31,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "metricInfo")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "id", //
-        "scopeId", //
-        "clientId", //
-        "channel", //
-        "name", //
-        "metricType", //
-        "firstMessageId", //
-        "firstMessageOn", //
-        "lastMessageId", //
-        "lastMessageOn" })
+@XmlType
 public interface MetricInfo extends Storable {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
@@ -32,7 +32,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "limitExceeded", "size", "items", "nextKey", "totalCount" })
+@XmlType
 public interface StorableListResult<E extends Storable> extends KapuaSerializable {
 
     /**

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortField.java
@@ -16,14 +16,11 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
 
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlRootElement(name = "sortField")
 public class XmlAdaptedSortField {
 
-    @XmlElement
     private String field;
-
-    @XmlElement
     private SortDirection direction;
 
     public XmlAdaptedSortField() {
@@ -34,6 +31,7 @@ public class XmlAdaptedSortField {
         this.field = field;
     }
 
+    @XmlElement
     public String getField() {
         return field;
     }
@@ -42,6 +40,7 @@ public class XmlAdaptedSortField {
         this.field = field;
     }
 
+    @XmlElement
     public SortDirection getDirection() {
         return direction;
     }

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
@@ -26,7 +26,7 @@ import javax.xml.bind.annotation.XmlType;
  * @since 1.0
  */
 @XmlRootElement(name = "channel")
-@XmlType(propOrder = {"method"}, factoryClass = RequestMessageXmlRegistry.class, factoryMethod = "newRequestChannel")
+@XmlType(factoryClass = RequestMessageXmlRegistry.class, factoryMethod = "newRequestChannel")
 public interface KapuaRequestChannel extends KapuaAppChannel {
 
     /**

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -19,13 +19,13 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kura bundle definition.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "bundle")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version", "id", "state" })
+@XmlType
 public class KuraBundle {
 
     @XmlElement(name = "name")
@@ -49,7 +49,7 @@ public class KuraBundle {
 
     /**
      * Set bundle name
-     * 
+     *
      * @param name
      */
     public void setName(String name) {
@@ -58,7 +58,7 @@ public class KuraBundle {
 
     /**
      * Get bundle version
-     * 
+     *
      * @return
      */
     public String getVersion() {
@@ -67,7 +67,7 @@ public class KuraBundle {
 
     /**
      * Set bundle version
-     * 
+     *
      * @param version
      */
     public void setVersion(String version) {
@@ -76,7 +76,7 @@ public class KuraBundle {
 
     /**
      * Get bundle identifier
-     * 
+     *
      * @return
      */
     public long getId() {
@@ -85,7 +85,7 @@ public class KuraBundle {
 
     /**
      * Set bundle identifier
-     * 
+     *
      * @param id
      */
     public void setId(long id) {
@@ -94,7 +94,7 @@ public class KuraBundle {
 
     /**
      * Get bundle state
-     * 
+     *
      * @return
      */
     public String getState() {
@@ -103,7 +103,7 @@ public class KuraBundle {
 
     /**
      * Set bundle state
-     * 
+     *
      * @param state
      */
     public void setState(String state) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -24,25 +24,19 @@ import javax.xml.bind.annotation.XmlType;
  *
  */
 @XmlRootElement(name = "bundle")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class KuraBundle {
 
-    @XmlElement(name = "name")
     public String name;
-
-    @XmlElement(name = "version")
     public String version;
-
-    @XmlElement(name = "id")
     public long id;
-
-    @XmlElement(name = "state")
     public String state;
 
     /**
      * Get bundle name
      */
+    @XmlElement(name = "name")
     public String getName() {
         return name;
     }
@@ -61,6 +55,7 @@ public class KuraBundle {
      *
      * @return
      */
+    @XmlElement(name = "version")
     public String getVersion() {
         return version;
     }
@@ -79,6 +74,7 @@ public class KuraBundle {
      *
      * @return
      */
+    @XmlElement(name = "id")
     public long getId() {
         return id;
     }
@@ -97,6 +93,7 @@ public class KuraBundle {
      *
      * @return
      */
+    @XmlElement(name = "state")
     public String getState() {
         return state;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
@@ -18,29 +18,29 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Kura bundles list definition.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "bundles")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class KuraBundles {
 
-    @XmlElement(name = "bundle")
     public KuraBundle[] bundles;
 
     /**
      * Get the bundles list
-     * 
+     *
      * @return
      */
+    @XmlElement(name = "bundle")
     public KuraBundle[] getBundles() {
         return bundles;
     }
 
     /**
      * Set the bundles list
-     * 
+     *
      * @param bundles
      */
     public void setBundles(KuraBundle[] bundles) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
@@ -31,12 +31,12 @@ import org.eclipse.kapua.service.device.call.kura.model.configuration.xml.KuraXm
  * It provides access to parsed ObjectClassDefintion associated to this Component.<br>
  * The configuration does not reuse the OSGi ObjectClassDefinition as the latter does not provide access to certain aspects such as the required attribute, the min and max values.<br>
  * Instead it returns the raw ObjectClassDefintion as parsed from the MetaType Information XML resource associated to this Component.
- * 
+ *
  * @since 1.0
- * 
+ *
  */
 @XmlRootElement(name = "configuration")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class KuraDeviceComponentConfiguration {
 
     /**
@@ -46,21 +46,17 @@ public class KuraDeviceComponentConfiguration {
      * Component Descriptor XML file; at runtime, the same value is also available
      * in the component.name and in the service.pid attributes of the Component Configuration.
      */
-    @XmlAttribute(name = "pid")
     private String componentId;
 
     /**
      * The raw ObjectClassDefinition as parsed from the MetaType
      * Information XML resource associated to this Component.
      */
-    @XmlElementRef(type = KapuaTocd.class)
     private TocdImpl definition;
 
     /**
      * The Dictionary of properties currently used by this component.
      */
-    @XmlElement(name = "properties")
-    @XmlJavaTypeAdapter(KuraXmlConfigPropertiesAdapter.class)
     private Map<String, Object> properties;
 
     // Required by JAXB
@@ -74,16 +70,17 @@ public class KuraDeviceComponentConfiguration {
      * The service's persistent identity is defined as the name attribute of the
      * Component Descriptor XML file; at runtime, the same value is also available
      * in the component.name and in the service.pid attributes of the Component Configuration.
-     * 
+     *
      * @return
      */
+    @XmlAttribute(name = "pid")
     public String getComponentId() {
         return componentId;
     }
 
     /**
      * Set the component identifier. Please refer to {@link KuraDeviceComponentConfiguration#getComponentId}
-     * 
+     *
      * @param componentId
      */
     public void setComponentId(String componentId) {
@@ -94,16 +91,17 @@ public class KuraDeviceComponentConfiguration {
      * Get the class definition.<br>
      * The raw ObjectClassDefinition as parsed from the MetaType
      * Information XML resource associated to this Component.
-     * 
+     *
      * @return
      */
+    @XmlElementRef(type = KapuaTocd.class)
     public KapuaTocd getDefinition() {
         return definition;
     }
 
     /**
      * Set the class definition. Please refer to {@link KuraDeviceComponentConfiguration#getDefinition}
-     * 
+     *
      * @param definition
      */
     public void setDefinition(KapuaTocd definition) {
@@ -113,16 +111,18 @@ public class KuraDeviceComponentConfiguration {
     /**
      * Get configuration properties.<br>
      * The Dictionary of properties currently used by this component.
-     * 
+     *
      * @return
      */
+    @XmlElement(name = "properties")
+    @XmlJavaTypeAdapter(KuraXmlConfigPropertiesAdapter.class)
     public Map<String, Object> getProperties() {
         return properties;
     }
 
     /**
      * Set configuration properties. Please refer to {@link KuraDeviceComponentConfiguration#getProperties}
-     * 
+     *
      * @param properties
      */
     public void setProperties(Map<String, Object> properties) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
@@ -21,15 +21,14 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * A container for a list of OSGi component configurations.
- * 
+ *
  * @since 1.0
- * 
+ *
  */
 @XmlRootElement(name = "configurations")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class KuraDeviceConfiguration {
 
-    @XmlElement(name = "configuration")
     private List<KuraDeviceComponentConfiguration> configurations;
 
     // Required by JAXB
@@ -41,7 +40,7 @@ public class KuraDeviceConfiguration {
 
     /**
      * Constructor
-     * 
+     *
      * @param accountName
      * @param clientId
      */
@@ -52,9 +51,10 @@ public class KuraDeviceConfiguration {
 
     /**
      * Get the device component configuration list
-     * 
+     *
      * @return
      */
+    @XmlElement(name = "configuration")
     public List<KuraDeviceComponentConfiguration> getConfigurations() {
         if (configurations == null) {
             configurations = new ArrayList<>();
@@ -65,7 +65,7 @@ public class KuraDeviceConfiguration {
 
     /**
      * Set the device component configuration list
-     * 
+     *
      * @param configurations
      */
     public void setConfigurations(List<KuraDeviceComponentConfiguration> configurations) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
@@ -17,14 +17,13 @@ import javax.xml.bind.annotation.XmlElement;
 
 /**
  * A container for XmlConfigPropertyAdapted organized into an array.
- * 
+ *
  * @since 1.0
- * 
+ *
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class KuraXmlConfigPropertiesAdapted {
 
-    @XmlElement(name = "property")
     private XmlConfigPropertyAdapted[] properties;
 
     /**
@@ -35,16 +34,17 @@ public class KuraXmlConfigPropertiesAdapted {
 
     /**
      * Get the adapted configuration properties array
-     * 
+     *
      * @return
      */
+    @XmlElement(name = "property")
     public XmlConfigPropertyAdapted[] getProperties() {
         return properties;
     }
 
     /**
      * Set the adapted configuration properties array
-     * 
+     *
      * @param properties
      */
     public void setProperties(XmlConfigPropertyAdapted[] properties) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
@@ -27,7 +27,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
  * @since 1.0
  *
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class XmlConfigPropertyAdapted {
 
     @XmlEnum
@@ -48,31 +48,26 @@ public class XmlConfigPropertyAdapted {
     /**
      * The name of the property.
      */
-    @XmlAttribute(name = "name")
     private String name;
 
     /**
      * Whether the property value is an array.
      */
-    @XmlAttribute(name = "array")
     private boolean array;
 
     /**
      * Whether the property value is encrypted.
      */
-    @XmlAttribute(name = "encrypted")
     private boolean encrypted;
 
     /**
      * The property type.
      */
-    @XmlAttribute(name = "type")
     private ConfigPropertyType type;
 
     /**
      * The property value(s).
      */
-    @XmlElement(name = "value")
     private String[] values;
 
     /**
@@ -82,7 +77,7 @@ public class XmlConfigPropertyAdapted {
     }
 
     /**
-     * Constructo
+     * Constructor
      *
      * @param name
      * @param type
@@ -103,6 +98,7 @@ public class XmlConfigPropertyAdapted {
      *
      * @return
      */
+    @XmlAttribute(name = "name")
     public String getName() {
         return name;
     }
@@ -121,6 +117,7 @@ public class XmlConfigPropertyAdapted {
      *
      * @return
      */
+    @XmlAttribute(name = "array")
     public boolean getArray() {
         return array;
     }
@@ -139,6 +136,7 @@ public class XmlConfigPropertyAdapted {
      *
      * @return
      */
+    @XmlAttribute(name = "type")
     public ConfigPropertyType getType() {
         return type;
     }
@@ -157,6 +155,7 @@ public class XmlConfigPropertyAdapted {
      *
      * @return
      */
+    @XmlAttribute(name = "encrypted")
     public boolean isEncrypted() {
         return encrypted;
     }
@@ -175,6 +174,7 @@ public class XmlConfigPropertyAdapted {
      *
      * @return
      */
+    @XmlElement(name = "value")
     public String[] getValues() {
         return values;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
@@ -23,9 +23,9 @@ import javax.xml.bind.annotation.XmlEnumValue;
  * Various flags help in the interpretation and semantics of the property value.<br>
  * For example, a property value might be an array or the property value might have been
  * encrypted.
- * 
+ *
  * @since 1.0
- * 
+ *
  */
 @XmlAccessorType(XmlAccessType.FIELD)
 public class XmlConfigPropertyAdapted {
@@ -82,8 +82,8 @@ public class XmlConfigPropertyAdapted {
     }
 
     /**
-     * Constructor
-     * 
+     * Constructo
+     *
      * @param name
      * @param type
      * @param values
@@ -100,7 +100,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Get the property name
-     * 
+     *
      * @return
      */
     public String getName() {
@@ -109,7 +109,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Set the property name
-     * 
+     *
      * @param name
      */
     public void setName(String name) {
@@ -118,7 +118,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Get the is array flag property
-     * 
+     *
      * @return
      */
     public boolean getArray() {
@@ -127,7 +127,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Set the is array flag property
-     * 
+     *
      * @param array
      */
     public void setArray(boolean array) {
@@ -136,7 +136,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Get the property type
-     * 
+     *
      * @return
      */
     public ConfigPropertyType getType() {
@@ -145,7 +145,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Set the property type
-     * 
+     *
      * @param type
      */
     public void setType(ConfigPropertyType type) {
@@ -154,7 +154,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Get the is encrypted flag property
-     * 
+     *
      * @return
      */
     public boolean isEncrypted() {
@@ -163,7 +163,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Set the is encrypted flag property
-     * 
+     *
      * @param encrypted
      */
     public void setEncrypted(boolean encrypted) {
@@ -172,7 +172,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Get property values
-     * 
+     *
      * @return
      */
     public String[] getValues() {
@@ -181,7 +181,7 @@ public class XmlConfigPropertyAdapted {
 
     /**
      * Set property values
-     * 
+     *
      * @param values
      */
     public void setValues(String[] values) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -19,13 +19,13 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kura bundle information.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "bundleInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version" })
+@XmlType
 public class KuraBundleInfo {
 
     @XmlElement(name = "name")
@@ -36,7 +36,7 @@ public class KuraBundleInfo {
 
     /**
      * Get the bundle name
-     * 
+     *
      * @return
      */
     public String getName() {
@@ -45,7 +45,7 @@ public class KuraBundleInfo {
 
     /**
      * Set the bundle name
-     * 
+     *
      * @param name
      */
     public void setName(String name) {
@@ -54,7 +54,7 @@ public class KuraBundleInfo {
 
     /**
      * Get the bundle version
-     * 
+     *
      * @return
      */
     public String getVersion() {
@@ -63,7 +63,7 @@ public class KuraBundleInfo {
 
     /**
      * Set the bundle version
-     * 
+     *
      * @param version
      */
     public void setVersion(String version) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -24,14 +24,11 @@ import javax.xml.bind.annotation.XmlType;
  *
  */
 @XmlRootElement(name = "bundleInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class KuraBundleInfo {
 
-    @XmlElement(name = "name")
     public String name;
-
-    @XmlElement(name = "version")
     public String version;
 
     /**
@@ -39,6 +36,7 @@ public class KuraBundleInfo {
      *
      * @return
      */
+    @XmlElement(name = "name")
     public String getName() {
         return name;
     }
@@ -57,6 +55,7 @@ public class KuraBundleInfo {
      *
      * @return
      */
+    @XmlElement(name = "version")
     public String getVersion() {
         return version;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -20,13 +20,13 @@ import javax.xml.bind.annotation.XmlType;
 
 /**
  * Kura deployment package.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "package")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version", "bundleInfos" })
+@XmlType
 public class KuraDeploymentPackage {
 
     @XmlElement(name = "name")
@@ -41,7 +41,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Get the deployment package name
-     * 
+     *
      * @return
      */
     public String getName() {
@@ -50,7 +50,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Set the deployment package name
-     * 
+     *
      * @param name
      */
     public void setName(String name) {
@@ -59,7 +59,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Get the deployment package version
-     * 
+     *
      * @return
      */
     public String getVersion() {
@@ -68,7 +68,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Set the deployment package version
-     * 
+     *
      * @param version
      */
     public void setVersion(String version) {
@@ -77,7 +77,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Get the bundle information array
-     * 
+     *
      * @return
      */
     public KuraBundleInfo[] getBundleInfos() {
@@ -86,7 +86,7 @@ public class KuraDeploymentPackage {
 
     /**
      * Set the bundle information array
-     * 
+     *
      * @param bundleInfos
      */
     public void setBundleInfos(KuraBundleInfo[] bundleInfos) {

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -25,18 +25,12 @@ import javax.xml.bind.annotation.XmlType;
  *
  */
 @XmlRootElement(name = "package")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class KuraDeploymentPackage {
 
-    @XmlElement(name = "name")
     public String name;
-
-    @XmlElement(name = "version")
     public String version;
-
-    @XmlElementWrapper(name = "bundles")
-    @XmlElement(name = "bundle")
     public KuraBundleInfo[] bundleInfos;
 
     /**
@@ -44,6 +38,7 @@ public class KuraDeploymentPackage {
      *
      * @return
      */
+    @XmlElement(name = "name")
     public String getName() {
         return name;
     }
@@ -62,6 +57,7 @@ public class KuraDeploymentPackage {
      *
      * @return
      */
+    @XmlElement(name = "version")
     public String getVersion() {
         return version;
     }
@@ -80,6 +76,8 @@ public class KuraDeploymentPackage {
      *
      * @return
      */
+    @XmlElementWrapper(name = "bundles")
+    @XmlElement(name = "bundle")
     public KuraBundleInfo[] getBundleInfos() {
         return bundleInfos;
     }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
@@ -18,29 +18,29 @@ import javax.xml.bind.annotation.XmlRootElement;
 
 /**
  * Kura deployment packages.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "packages")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class KuraDeploymentPackages {
 
-    @XmlElement(name = "package")
     public KuraDeploymentPackage[] deploymentPackages;
 
     /**
      * Get the deployment package array
-     * 
+     *
      * @return
      */
+    @XmlElement(name = "package")
     public KuraDeploymentPackage[] getDeploymentPackages() {
         return deploymentPackages;
     }
 
     /**
      * Set the deployment package array
-     * 
+     *
      * @param deploymentPackages
      */
     public void setDeploymentPackages(KuraDeploymentPackage[] deploymentPackages) {

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
@@ -30,12 +30,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "deviceAsset")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {//
-        "name", //
-        "channels" //
-}, //
-        factoryClass = DeviceAssetXmlRegistry.class, //
-        factoryMethod = "newDeviceAsset")
+@XmlType(factoryClass = DeviceAssetXmlRegistry.class, factoryMethod = "newDeviceAsset")
 public interface DeviceAsset {
 
     /**

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
@@ -26,23 +26,18 @@ import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannelMode;
 
 /**
  * XML friendly {@link DeviceAssetChannel}.
- * 
+ *
  * @since 1.0.0
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(name = "")
 public class XmlAdaptedDeviceAssetChannel extends XmlAdaptedNameTypeValueObject {
 
-    @XmlElement(name = "mode")
     private DeviceAssetChannelMode mode;
-
-    @XmlElement(name = "error")
     private String error;
-
-    @XmlElement(name = "timestamp")
-    @XmlJavaTypeAdapter(DateXmlAdapter.class)
     private Date timestamp;
 
+    @XmlElement(name = "mode")
     public DeviceAssetChannelMode getMode() {
         return mode;
     }
@@ -51,6 +46,7 @@ public class XmlAdaptedDeviceAssetChannel extends XmlAdaptedNameTypeValueObject 
         this.mode = mode;
     }
 
+    @XmlElement(name = "error")
     public String getError() {
         return error;
     }
@@ -59,6 +55,8 @@ public class XmlAdaptedDeviceAssetChannel extends XmlAdaptedNameTypeValueObject 
         this.error = error;
     }
 
+    @XmlElement(name = "timestamp")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
     public Date getTimestamp() {
         return timestamp;
     }

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  * @since 1.0
  */
 @XmlRootElement(name = "bundle")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceBundleXmlRegistry.class, factoryMethod = "newDeviceBundle")
 public interface DeviceBundle {
 

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
@@ -24,8 +24,8 @@ import java.util.List;
  *
  * @since 1.0
  */
-@XmlType(propOrder = { "bundles" }, factoryClass = DeviceBundleXmlRegistry.class, factoryMethod = "newBundleListResult")
 @XmlRootElement(name = "bundles")
+@XmlType(factoryClass = DeviceBundleXmlRegistry.class, factoryMethod = "newBundleListResult")
 public interface DeviceBundles extends KapuaSerializable {
 
     /**

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -27,17 +27,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "commandInput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "command",
-        "password",
-        "arguments",
-        "timeout",
-        "workingDir",
-        "body",
-        "environment",
-        "runAsynch",
-        "stdin"
-}, factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandInput")
+@XmlType(factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandInput")
 public interface DeviceCommandInput extends KapuaEntity {
 
     /**

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -26,14 +26,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "commandOutput")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "stderr",
-        "stdout",
-        "exceptionMessage",
-        "exceptionStack",
-        "exitCode",
-        "hasTimedout"
-}, factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandOutput")
+@XmlType(factoryClass = DeviceCommandXmlRegistry.class, factoryMethod = "newCommandOutput")
 public interface DeviceCommandOutput extends KapuaSerializable {
 
     /**

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -29,12 +29,7 @@ import java.util.Map;
  */
 @XmlRootElement(name = "configuration")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "id",
-        "name",
-        "definition",
-        "properties"
-}, factoryClass = DeviceConfigurationXmlRegistry.class, factoryMethod = "newComponentConfiguration")
+@XmlType(factoryClass = DeviceConfigurationXmlRegistry.class, factoryMethod = "newComponentConfiguration")
 public interface DeviceComponentConfiguration {
 
     /**

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
@@ -20,10 +20,9 @@ import javax.xml.bind.annotation.XmlElement;
  *
  * @since 1.0
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class DeviceXmlConfigPropertiesAdapted {
 
-    @XmlElement(name = "property")
     private DeviceXmlConfigPropertyAdapted[] properties;
 
     /**
@@ -37,6 +36,7 @@ public class DeviceXmlConfigPropertiesAdapted {
      *
      * @return
      */
+    @XmlElement(name = "property")
     public DeviceXmlConfigPropertyAdapted[] getProperties() {
         return properties;
     }

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
@@ -25,7 +25,7 @@ import javax.xml.bind.annotation.XmlEnumValue;
  *
  * @since 1.0
  */
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 public class DeviceXmlConfigPropertyAdapted {
 
     @XmlEnum
@@ -45,31 +45,26 @@ public class DeviceXmlConfigPropertyAdapted {
     /**
      * The name of the property.
      */
-    @XmlAttribute(name = "name")
     private String name;
 
     /**
      * Whether the property value is an array.
      */
-    @XmlAttribute(name = "array")
     private boolean array;
 
     /**
      * Whether the property value is encrypted.
      */
-    @XmlAttribute(name = "encrypted")
     private boolean encrypted;
 
     /**
      * The property type.
      */
-    @XmlAttribute(name = "type")
     private ConfigPropertyType type;
 
     /**
      * The property value(s).
      */
-    @XmlElement(name = "value")
     private String[] values;
 
     public DeviceXmlConfigPropertyAdapted() {
@@ -85,6 +80,7 @@ public class DeviceXmlConfigPropertyAdapted {
         this.encrypted = false;
     }
 
+    @XmlAttribute(name = "name")
     public String getName() {
         return name;
     }
@@ -93,6 +89,7 @@ public class DeviceXmlConfigPropertyAdapted {
         this.name = name;
     }
 
+    @XmlAttribute(name = "array")
     public boolean getArray() {
         return array;
     }
@@ -101,6 +98,7 @@ public class DeviceXmlConfigPropertyAdapted {
         this.array = array;
     }
 
+    @XmlAttribute(name = "type")
     public ConfigPropertyType getType() {
         return type;
     }
@@ -109,6 +107,7 @@ public class DeviceXmlConfigPropertyAdapted {
         this.type = type;
     }
 
+    @XmlAttribute(name = "encrypted")
     public boolean isEncrypted() {
         return encrypted;
     }
@@ -117,6 +116,7 @@ public class DeviceXmlConfigPropertyAdapted {
         this.encrypted = encrypted;
     }
 
+    @XmlElement(name = "value")
     public String[] getValues() {
         return values;
     }

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
@@ -24,8 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "snapshot")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "id",
-        "timestamp" }, factoryClass = DeviceSnapshotXmlRegistry.class, factoryMethod = "newDeviceSnapshot")
+@XmlType(factoryClass = DeviceSnapshotXmlRegistry.class, factoryMethod = "newDeviceSnapshot")
 public interface DeviceSnapshot {
 
     /**

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
@@ -28,7 +28,7 @@ import java.util.List;
  */
 @XmlRootElement(name = "snapshots")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "snapshots" }, factoryClass = DeviceSnapshotXmlRegistry.class, factoryMethod = "newDeviceSnapshots")
+@XmlType(factoryClass = DeviceSnapshotXmlRegistry.class, factoryMethod = "newDeviceSnapshots")
 public interface DeviceSnapshots extends KapuaSerializable {
 
     /**

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
@@ -25,10 +25,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "devicePackage")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "name",
-        "version",
-        "bundleInfos",
-        "installDate" }, factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackage")
+@XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackage")
 public interface DevicePackage {
 
     /**

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -26,13 +26,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "uninstallRequest")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "name",
-        "version",
-        "reboot",
-        "rebootDelay" },
-        factoryClass = DevicePackageXmlRegistry.class,
-        factoryMethod = "newDevicePackageUninstallRequest")
+@XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newDevicePackageUninstallRequest")
 public interface DevicePackageUninstallRequest {
 
     /**

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
@@ -21,13 +21,13 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageB
 
 /**
  * Device package bundle information.
- * 
+ *
  * @since 1.0
  *
  */
 @XmlRootElement(name = "bundleInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "name", "version" })
+@XmlType
 public class DevicePackageBundleInfoImpl implements DevicePackageBundleInfo {
 
     @XmlElement(name = "name")

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
@@ -26,16 +26,14 @@ import org.eclipse.kapua.service.device.management.packages.model.DevicePackageB
  *
  */
 @XmlRootElement(name = "bundleInfo")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType
 public class DevicePackageBundleInfoImpl implements DevicePackageBundleInfo {
 
-    @XmlElement(name = "name")
     public String name;
-
-    @XmlElement(name = "version")
     public String version;
 
+    @XmlElement(name = "name")
     public String getName() {
         return name;
     }
@@ -44,6 +42,7 @@ public class DevicePackageBundleInfoImpl implements DevicePackageBundleInfo {
         this.name = name;
     }
 
+    @XmlElement(name = "version")
     public String getVersion() {
         return version;
     }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
@@ -14,25 +14,17 @@ package org.eclipse.kapua.service.device.management.packages.model.internal;
 import java.util.ArrayList;
 import java.util.List;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfo;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfos;
 
 /**
  * Package bundle informations list container.
- * 
+ *
  * @since 1.0
  *
  */
-@XmlRootElement(name = "bundleInfos")
-@XmlAccessorType(XmlAccessType.FIELD)
 public class DevicePackageBundleInfosImpl implements DevicePackageBundleInfos {
 
-    @XmlElement(name = "bundleInfo")
     List<DevicePackageBundleInfo> bundleInfos;
 
     @Override

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -35,38 +35,7 @@ import java.util.Set;
  */
 @XmlRootElement(name = "device")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "groupId",
-        "clientId",
-        "connectionId",
-        "connection",
-        "status",
-        "displayName",
-        "lastEventId",
-        "lastEvent",
-        "serialNumber",
-        "modelId",
-        "modelName",
-        "imei",
-        "imsi",
-        "iccid",
-        "biosVersion",
-        "firmwareVersion",
-        "osVersion",
-        "jvmVersion",
-        "osgiFrameworkVersion",
-        "applicationFrameworkVersion",
-        "connectionInterface",
-        "connectionIp",
-        "applicationIdentifiers",
-        "acceptEncoding",
-        "customAttribute1",
-        "customAttribute2",
-        "customAttribute3",
-        "customAttribute4",
-        "customAttribute5",
-        "tagIds"
-}, factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDevice")
+@XmlType(factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDevice")
 public interface Device extends KapuaUpdatableEntity {
 
     String TYPE = "device";

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -35,36 +35,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "deviceCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "groupId",
-        "clientId",
-        "status",
-        "connectionId",
-        "lastEventId",
-        "displayName",
-        "serialNumber",
-        "modelId",
-        "modelName",
-        "imei",
-        "imsi",
-        "iccid",
-        "biosVersion",
-        "firmwareVersion",
-        "osVersion",
-        "jvmVersion",
-        "osgiFrameworkVersion",
-        "applicationFrameworkVersion",
-        "connectionInterface",
-        "connectionIp",
-        "applicationIdentifiers",
-        "acceptEncoding",
-        "customAttribute1",
-        "customAttribute2",
-        "customAttribute3",
-        "customAttribute4",
-        "customAttribute5"
-}, //
-        factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDeviceCreator")
+@XmlType(factoryClass = DeviceXmlRegistry.class, factoryMethod = "newDeviceCreator")
 public interface DeviceCreator extends KapuaUpdatableEntityCreator<Device> {
 
     /**

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -30,18 +30,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "deviceConnection")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "status",
-        "clientId",
-        "userId",
-        "allowUserChange",
-        "userCouplingMode",
-        "reservedUserId",
-        "protocol",
-        "clientIp",
-        "serverIp" }, //
-        factoryClass = DeviceConnectionXmlRegistry.class, //
-        factoryMethod = "newDeviceConnection")
+@XmlType(factoryClass = DeviceConnectionXmlRegistry.class, factoryMethod = "newDeviceConnection")
 public interface DeviceConnection extends KapuaUpdatableEntity {
 
     String TYPE = "deviceConnection";

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
@@ -31,13 +31,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "deviceConnectionOption")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {
-        "allowUserChange",
-        "userCouplingMode",
-        "reservedUserId",
-}, //
-        factoryClass = DeviceConnectionOptionXmlRegistry.class, //
-        factoryMethod = "newDeviceConnectionOption")
+@XmlType(factoryClass = DeviceConnectionOptionXmlRegistry.class, factoryMethod = "newDeviceConnectionOption")
 public interface DeviceConnectionOption extends KapuaUpdatableEntity {
 
     String TYPE = "deviceConnectionOption";

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -34,18 +34,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "deviceEvent")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "deviceId", //
-        "sentOn", //
-        "receivedOn", //
-        "position", //
-        "resource",  //
-        "action", //
-        "responseCode", //
-        "eventMessage" //
-}, //
-        factoryClass = DeviceEventXmlRegistry.class, //
-        factoryMethod = "newDeviceEvent")
+@XmlType(factoryClass = DeviceEventXmlRegistry.class, factoryMethod = "newDeviceEvent")
 public interface DeviceEvent extends KapuaEntity {
 
     String TYPE = "deviceEvent";

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "accessTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "tokenId" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newAccessTokenCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newAccessTokenCredentials")
 public interface AccessTokenCredentials extends SessionCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "apiKeyCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "apiKey" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newApiKeyCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newApiKeyCredentials")
 public interface ApiKeyCredentials extends LoginCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "jwtCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "jwt" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
 public interface JwtCredentials extends LoginCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "refreshTokenCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "tokenId", "refreshToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newRefreshTokenCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newRefreshTokenCredentials")
 public interface RefreshTokenCredentials extends LoginCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "usernamePasswordCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "username", "password" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
 public interface UsernamePasswordCredentials extends LoginCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -32,17 +32,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "credential")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "userId",
-        "credentialType",
-        "credentialKey",
-        "status",
-        "expirationDate",
-        "loginFailures",
-        "firstLoginFailure",
-        "loginFailuresReset",
-        "lockoutReset" }, //
-        factoryClass = CredentialXmlRegistry.class, //
-        factoryMethod = "newCredential") //
+@XmlType(factoryClass = CredentialXmlRegistry.class, factoryMethod = "newCredential")
 public interface Credential extends KapuaUpdatableEntity {
 
     String TYPE = "credential";

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -31,11 +31,7 @@ import java.util.Date;
  */
 @XmlRootElement(name = "credentialCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "userId",
-        "credentialType",
-        "credentialPlainKey",
-        "credentialStatus",
-        "expirationDate" }, factoryClass = CredentialXmlRegistry.class, factoryMethod = "newCredentialCreator")
+@XmlType(factoryClass = CredentialXmlRegistry.class, factoryMethod = "newCredentialCreator")
 public interface CredentialCreator extends KapuaEntityCreator<Credential> {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -33,16 +33,7 @@ import java.util.Date;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { //
-        "tokenId", //
-        "userId", //
-        "expiresOn", //
-        "refreshToken", //
-        "refreshExpiresOn", //
-        "invalidatedOn" //
-}, //
-        factoryClass = AccessTokenXmlRegistry.class, //
-        factoryMethod = "newAccessToken")
+@XmlType(factoryClass = AccessTokenXmlRegistry.class, factoryMethod = "newAccessToken")
 public interface AccessToken extends KapuaUpdatableEntity, Serializable {
 
     String TYPE = "accessToken";

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
@@ -27,7 +27,7 @@ import java.util.Date;
  * @since 1.0
  */
 @XmlRootElement
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = AccessTokenXmlRegistry.class, factoryMethod = "newAccessTokenCreator")
 public interface AccessTokenCreator extends KapuaEntityCreator<AccessToken> {
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
@@ -28,14 +28,7 @@ import java.util.Date;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "tokenId",
-        "userId",
-        "expiresOn",
-        "refreshToken",
-        "refreshExpiresOn"
-}, //
-        factoryClass = AccessTokenXmlRegistry.class, //
-        factoryMethod = "newAccessTokenCreator")
+@XmlType(factoryClass = AccessTokenXmlRegistry.class, factoryMethod = "newAccessTokenCreator")
 public interface AccessTokenCreator extends KapuaEntityCreator<AccessToken> {
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
@@ -33,9 +33,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "userId" }, //
-        factoryClass = AccessInfoXmlRegistry.class, //
-        factoryMethod = "newAccessInfo")
+@XmlType(factoryClass = AccessInfoXmlRegistry.class, factoryMethod = "newAccessInfo")
 public interface AccessInfo extends KapuaUpdatableEntity {
 
     String TYPE = "accessInfo";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -35,7 +35,7 @@ import java.util.Set;
  * @since 1.0.0
  */
 @XmlRootElement
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = AccessInfoXmlRegistry.class, factoryMethod = "newAccessInfoCreator")
 public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
 

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -36,11 +36,7 @@ import java.util.Set;
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { "userId",
-        "roleIds",
-        "permissions" },
-        factoryClass = AccessInfoXmlRegistry.class,
-        factoryMethod = "newAccessInfoCreator")
+@XmlType(factoryClass = AccessInfoXmlRegistry.class, factoryMethod = "newAccessInfoCreator")
 public interface AccessInfoCreator extends KapuaEntityCreator<AccessInfo> {
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
@@ -36,9 +36,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "accessPermission")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "accessInfoId", "permission" }, //
-        factoryClass = AccessPermissionXmlRegistry.class, //
-        factoryMethod = "newAccessPermission")
+@XmlType(factoryClass = AccessPermissionXmlRegistry.class, factoryMethod = "newAccessPermission")
 public interface AccessPermission extends KapuaEntity {
 
     String TYPE = "accessPermission";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
@@ -31,8 +31,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "accessPermissionCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "accessInfoId", "permission" },//
-        factoryClass = AccessPermissionXmlRegistry.class, factoryMethod = "newCreator")
+@XmlType(factoryClass = AccessPermissionXmlRegistry.class, factoryMethod = "newCreator")
 public interface AccessPermissionCreator extends KapuaEntityCreator<AccessPermission> {
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
@@ -40,9 +40,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "accessRole")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "accessInfoId", "roleId" }, //
-        factoryClass = AccessRoleXmlRegistry.class, //
-        factoryMethod = "newAccessRole")
+@XmlType(factoryClass = AccessRoleXmlRegistry.class, factoryMethod = "newAccessRole")
 public interface AccessRole extends KapuaEntity {
 
     String TYPE = "accessRole";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
@@ -31,8 +31,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "accessRoleCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "accessInfoId", "roleId" },//
-        factoryClass = AccessRoleXmlRegistry.class, factoryMethod = "newCreator")
+@XmlType(factoryClass = AccessRoleXmlRegistry.class, factoryMethod = "newCreator")
 public interface AccessRoleCreator extends KapuaEntityCreator<AccessRole> {
 
     /**

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -36,9 +36,7 @@ import java.util.Set;
  */
 @XmlRootElement(name = "domain")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"name",
-        "actions",
-        "groupable"})
+@XmlType
 public interface Domain extends KapuaEntity {//, org.eclipse.kapua.model.domain.Domain {
 
     String TYPE = "domain";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -35,15 +35,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "permission")
 @XmlAccessorType(XmlAccessType.FIELD)
-@XmlType(propOrder = { //
-        "domain", //
-        "action", //
-        "targetScopeId", //
-        "groupId", //
-        "forwardable" //
-}, //
-        factoryClass = PermissionXmlRegistry.class, //
-        factoryMethod = "newPermission")
+@XmlType(factoryClass = PermissionXmlRegistry.class, factoryMethod = "newPermission")
 public interface Permission {
 
     String WILDCARD = "*";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -34,7 +34,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  * @since 1.0.0
  */
 @XmlRootElement(name = "permission")
-@XmlAccessorType(XmlAccessType.FIELD)
+@XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = PermissionXmlRegistry.class, factoryMethod = "newPermission")
 public interface Permission {
 

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -37,10 +37,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "rolePermission")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "roleId",
-        "permission" }, //
-        factoryClass = RolePermissionXmlRegistry.class, //
-        factoryMethod = "newRolePermission")
+@XmlType(factoryClass = RolePermissionXmlRegistry.class, factoryMethod = "newRolePermission")
 public interface RolePermission extends KapuaEntity {
 
     String TYPE = "rolePermission";

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
@@ -31,8 +31,7 @@ import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
  */
 @XmlRootElement(name = "rolePermissionCreator")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "roleId", "permission" },//
-        factoryClass = RolePermissionXmlRegistry.class, factoryMethod = "newCreator")
+@XmlType(factoryClass = RolePermissionXmlRegistry.class, factoryMethod = "newCreator")
 public interface RolePermissionCreator extends KapuaEntityCreator<RolePermission> {
 
     /**


### PR DESCRIPTION
This PR refactors the JAXB annotations so that:

1. `propOrder` is removed from all entities, since it's not needed anymore
2. All `XmlAccessType.FIELD` are migrated to `XmlAccessType.PROPERTY` so that they all reflect getters and setters

**Related Issue**
No related issues

**Any side note on the changes made**
These changes can potentially break REST APIs according to the single contracts. It would be better to merge this after having proper REST API testing.