### PR TITLE
Fix Liquibase foreign keys definition for ON DETELE CASCADE

### DIFF
--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/account-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/account-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-account-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="sys_configuration"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_sys_configuration_scopeId"
+                                  baseTableName="sys_configuration"/>
+        <addForeignKeyConstraint constraintName="fk_sys_configuration_scopeId"
+                                 baseTableName="sys_configuration"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/atht_access_token-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/atht_access_token-foreignkey_delete_cascade.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-atht_access_token-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_access_token"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_access_token"/>
+                <tableExists tableName="usr_user"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_atht_access_token_scopeId"
+                                  baseTableName="atht_access_token"/>
+        <addForeignKeyConstraint constraintName="fk_atht_access_token_scopeId"
+                                 baseTableName="atht_access_token"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_atht_access_token_userId"
+                                  baseTableName="atht_access_token"/>
+        <addForeignKeyConstraint constraintName="fk_atht_access_token_userId"
+                                 baseTableName="atht_access_token"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="usr_user"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/atht_credential-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/atht_credential-foreignkey_delete_cascade.xml
@@ -1,0 +1,50 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-atht_credential-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_credential"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_credential"/>
+                <tableExists tableName="usr_user"/>
+            </and>
+        </preConditions>
+        <dropForeignKeyConstraint constraintName="fk_atht_credential_scopeId"
+                                  baseTableName="atht_credential"/>
+        <addForeignKeyConstraint constraintName="fk_atht_credential_scopeId"
+                                 baseTableName="atht_credential"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+        <dropForeignKeyConstraint constraintName="fk_atht_credential_userId"
+                                  baseTableName="atht_credential"/>
+        <addForeignKeyConstraint constraintName="fk_atht_credential_userId"
+                                 baseTableName="atht_credential"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="usr_user"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_access_info-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_access_info-foreignkey_delete_cascade.xml
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-athz_access_info-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_access_info"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="athz_access_info"/>
+                <tableExists tableName="usr_user"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_athz_access_info_scopeId"
+                                  baseTableName="athz_access_info"/>
+        <addForeignKeyConstraint constraintName="fk_athz_access_info_scopeId"
+                                 baseTableName="athz_access_info"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_athz_access_info_userId"
+                                  baseTableName="athz_access_info"/>
+        <addForeignKeyConstraint constraintName="fk_athz_access_info_userId"
+                                 baseTableName="athz_access_info"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="usr_user"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_group-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_group-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-athz_group-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_group"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_athz_group_scopeId"
+                                  baseTableName="athz_group"/>
+        <addForeignKeyConstraint constraintName="fk_athz_group_scopeId"
+                                 baseTableName="athz_group"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_role-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/athz_role-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-athz_role-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_role"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_athz_role_scopeId"
+                                  baseTableName="athz_role"/>
+        <addForeignKeyConstraint constraintName="fk_athz_role_scopeId"
+                                 baseTableName="athz_role"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/changelog-foreignkeys-1.2.0.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/changelog-foreignkeys-1.2.0.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <include relativeToChangelogFile="true" file="./account-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./atht_credential-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./atht_access_token-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./athz_access_info-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./athz_group-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./athz_role-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./device-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./device-connection-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./device-tag-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./job-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./job_step_definition-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./trigger-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./user-foreignkey_delete_cascade.xml"/>
+
+    <include relativeToChangelogFile="true" file="./tag-foreignkey_delete_cascade.xml"/>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-connection-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-connection-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-device-connection-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_connection"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_dvc_device_connection_scopeId"
+                                  baseTableName="dvc_device_connection"/>
+        <addForeignKeyConstraint constraintName="fk_dvc_device_connection_scopeId"
+                                 baseTableName="dvc_device_connection"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-foreignkey_delete_cascade.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-device-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="dvc_device"/>
+                <tableExists tableName="athz_group"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_dvc_device_scopeId"
+                                  baseTableName="dvc_device"/>
+        <addForeignKeyConstraint constraintName="fk_dvc_device_scopeId"
+                                 baseTableName="dvc_device"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_dvc_device_groupId"
+                                  baseTableName="dvc_device"/>
+        <addForeignKeyConstraint constraintName="fk_dvc_device_groupId"
+                                 baseTableName="dvc_device"
+                                 baseColumnNames="group_id"
+                                 referencedTableName="athz_group"
+                                 referencedColumnNames="id"
+                                 onDelete="SET NULL"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-tag-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/device-tag-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-device-tag-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="dvc_device_tag"/>
+                <tableExists tableName="tag_tag"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_dvc_device_tag_tagId"
+                                  baseTableName="dvc_device_tag"/>
+        <addForeignKeyConstraint constraintName="fk_dvc_device_tag_tagId"
+                                 baseTableName="dvc_device_tag"
+                                 baseColumnNames="tag_id"
+                                 referencedTableName="tag_tag"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/job-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/job-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-job-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="job_job"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_job_job_scopeId"
+                                  baseTableName="job_job"/>
+        <addForeignKeyConstraint constraintName="fk_job_job_scopeId"
+                                 baseTableName="job_job"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/job_step_definition-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/job_step_definition-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-job-step-definition-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="job_job_step_definition"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_job_job_step_definition_scopeId"
+                                  baseTableName="job_job_step_definition"/>
+        <addForeignKeyConstraint constraintName="fk_job_job_step_definition_scopeId"
+                                 baseTableName="job_job_step_definition"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/tag-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/tag-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-tag-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="tag_tag"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_tag_tag_scopeId"
+                                  baseTableName="tag_tag"/>
+        <addForeignKeyConstraint constraintName="fk_tag_tag_scopeId"
+                                 baseTableName="tag_tag"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/trigger-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/trigger-foreignkey_delete_cascade.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-trigger-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="schdl_trigger"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_trigger_scopeId"
+                                  baseTableName="schdl_trigger"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_trigger_scopeId"
+                                 baseTableName="schdl_trigger"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.2.0/user-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.2.0/user-foreignkey_delete_cascade.xml
@@ -1,0 +1,38 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.2.0.xml">
+
+    <changeSet id="changelog-user-foreignkey-1.2.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="usr_user"/>
+                <tableExists tableName="act_account"/>
+            </and>
+        </preConditions>
+
+        <dropForeignKeyConstraint constraintName="fk_usr_user_scopeId"
+                                  baseTableName="usr_user"/>
+        <addForeignKeyConstraint constraintName="fk_usr_user_scopeId"
+                                 baseTableName="usr_user"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/changelog-foreignkeys-master.post.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/changelog-foreignkeys-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -10,11 +10,12 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
- <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
 
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-foreignkeys-0.3.0.xml" />
+    <include relativeToChangelogFile="true" file="./0.3.0/changelog-foreignkeys-0.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.2.0/changelog-foreignkeys-1.2.0.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
@@ -19,5 +19,6 @@
 
     <include relativeToChangelogFile="true" file="./trigger-timestamp.xml"/>
     <include relativeToChangelogFile="true" file="./trigger_definition-timestamp.xml"/>
+    <include relativeToChangelogFile="true" file="./scheduler_engine_quartz-delete_cascade.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/scheduler_engine_quartz-delete_cascade.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/scheduler_engine_quartz-delete_cascade.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-scheduler-1.2.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-scheduler_engine_quartz-1.2.0-delete_cascade" author="eurotech">
+
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_qrtz_triggers"
+                                  baseTableName="schdl_qrtz_triggers"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_qrtz_triggers"
+                                 baseTableName="schdl_qrtz_triggers"
+                                 baseColumnNames="sched_name,job_name,job_group"
+                                 referencedTableName="schdl_qrtz_job_details"
+                                 referencedColumnNames="sched_name,job_name,job_group"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_qrtz_simple_triggers"
+                                  baseTableName="schdl_qrtz_simple_triggers"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_qrtz_simple_triggers"
+                                 baseTableName="schdl_qrtz_simple_triggers"
+                                 baseColumnNames="sched_name,trigger_name,trigger_group"
+                                 referencedTableName="schdl_qrtz_triggers"
+                                 referencedColumnNames="sched_name,trigger_name,trigger_group"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_qrtz_cron_triggers"
+                                  baseTableName="schdl_qrtz_cron_triggers"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_qrtz_cron_triggers"
+                                 baseTableName="schdl_qrtz_cron_triggers"
+                                 baseColumnNames="sched_name,trigger_name,trigger_group"
+                                 referencedTableName="schdl_qrtz_triggers"
+                                 referencedColumnNames="sched_name,trigger_name,trigger_group"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_qrtz_simprop_triggers"
+                                  baseTableName="schdl_qrtz_simprop_triggers"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_qrtz_simprop_triggers"
+                                 baseTableName="schdl_qrtz_simprop_triggers"
+                                 baseColumnNames="sched_name,trigger_name,trigger_group"
+                                 referencedTableName="schdl_qrtz_triggers"
+                                 referencedColumnNames="sched_name,trigger_name,trigger_group"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+        <dropForeignKeyConstraint constraintName="fk_schdl_qrtz_blob_triggers"
+                                  baseTableName="schdl_qrtz_blob_triggers"/>
+        <addForeignKeyConstraint constraintName="fk_schdl_qrtz_blob_triggers"
+                                 baseTableName="schdl_qrtz_blob_triggers"
+                                 baseColumnNames="sched_name,trigger_name,trigger_group"
+                                 referencedTableName="schdl_qrtz_triggers"
+                                 referencedColumnNames="sched_name,trigger_name,trigger_group"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+
+    </changeSet>
+</databaseChangeLog>


### PR DESCRIPTION
On module `kapua-foreignkeys` the definition of the foreignkeys used an attribute `deleteCascade=true` which is no longer taken into consideration with the latest version of Liquibase. Proper attributo to use is `onDelete="CASCADE"`.

See [Liquibase Jira Bug 3278](https://liquibase.jira.com/browse/CORE-3278)

**Related Issue**
_None_

**Description of the solution adopted**
Removed foreign keys per table and re-added with proper definition.

**Screenshots**
_None_

**Any side note on the changes made**
_None_