### PR TITLE
Add commons-collections to broker-core assembly

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -168,6 +168,7 @@
                 <include>com.tdunning:t-digest</include>
 
                 <include>commons-codec:commons-codec</include>
+                <include>commons-collections:commons-collections</include>
                 <include>commons-configuration:commons-configuration</include>
                 <include>commons-io:commons-io</include>
 

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -328,6 +328,10 @@
             <artifactId>commons-codec</artifactId>
         </dependency>
         <dependency>
+            <groupId>commons-collections</groupId>
+            <artifactId>commons-collections</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.liquibase</groupId>
             <artifactId>liquibase-core</artifactId>
         </dependency>
@@ -655,6 +659,14 @@
                                     <groupId>org.apache.commons</groupId>
                                     <artifactId>commons-lang3</artifactId>
                                     <version>${commons-lang.version}</version>
+                                    <type>jar</type>
+                                    <overWrite>true</overWrite>
+                                    <outputDirectory>target/broker_dependency</outputDirectory>
+                                </artifactItem>
+                                <artifactItem>
+                                    <groupId>commons-collections</groupId>
+                                    <artifactId>commons-collections</artifactId>
+                                    <version>${commons-collections.version}</version>
                                     <type>jar</type>
                                     <overWrite>true</overWrite>
                                     <outputDirectory>target/broker_dependency</outputDirectory>


### PR DESCRIPTION
After merging #2905, `commons-collection` is needed in `kapua-broker-core` but not included in the `broker` assembly. This PR fixes the issue.

**Related Issue**
Fixes #2918


