### PR TITLE
Feature docker vagrant ssh options

### DIFF
--- a/deployment/docker/unix/docker-common.sh
+++ b/deployment/docker/unix/docker-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/docker/unix/docker-logs.sh
+++ b/deployment/docker/unix/docker-logs.sh
@@ -20,12 +20,12 @@ docker_common() {
     . ${SCRIPT_DIR}/docker-common.sh
 }
 
-docker_undeploy() {
-    docker-compose -f ${SCRIPT_DIR}/../compose/docker-compose.yml down
+docker_logs() {
+    docker-compose -f ${SCRIPT_DIR}/../compose/docker-compose.yml logs -f
 }
 
 docker_common
 
-echo "Undeploying Eclipse Kapua..."
-docker_undeploy || { echo "Undeploying Eclipse Kapua... ERROR!"; exit 1; }
-echo "Undeploying Eclipse Kapua... DONE!"
+echo "Opening Eclipse Kapua logs..."
+docker_logs  || { echo "Opening Eclipse Kapua logs... ERROR!"; exit 1; }
+echo "Opening Eclipse Kapua logs... DONE!"

--- a/deployment/docker/win/docker-deploy.ps1
+++ b/deployment/docker/win/docker-deploy.ps1
@@ -9,7 +9,9 @@
 # Contributors:
 #     Eurotech - initial implementation
 ###############################################################################
-Param (
+#Requires -Version 7
+
+Param(
     [switch]$logs = $false
 )
 

--- a/deployment/docker/win/docker-deploy.ps1
+++ b/deployment/docker/win/docker-deploy.ps1
@@ -9,6 +9,9 @@
 # Contributors:
 #     Eurotech - initial implementation
 ###############################################################################
+Param (
+    [switch]$logs = $false
+)
 
 $script_dir = Split-Path (Get-Variable MyInvocation).Value.MyCommand.Path
 $common_path = Join-Path $script_dir docker-common.ps1
@@ -17,17 +20,32 @@ $common_path = Join-Path $script_dir docker-common.ps1
 
 Write-Host "Deploying Eclipse Kapua..."
 
-If (Test-Path env:KAPUA_BROKER_DEBUG_PORT) {
-    If ($env:KAPUA_BROKER_DEBUG_SUSPEND -eq "true") {
+If (Test-Path env:KAPUA_BROKER_DEBUG_PORT)
+{
+    If ($env:KAPUA_BROKER_DEBUG_SUSPEND -eq "true")
+    {
         $env:KAPUA_BROKER_DEBUG_SUSPEND = "y"
-    } Else {
+    }
+    Else
+    {
         $env:KAPUA_BROKER_DEBUG_SUSPEND = "n"
     }
     docker-compose -f (Join-Path $script_dir .. compose docker-compose.yml) -f (Join-Path $script_dir .. compose docker-compose.broker-debug.yml) up -d
 }
-Else {
+Else
+{
     docker-compose -f (Join-Path $script_dir .. compose docker-compose.yml) up -d
 }
 
 Write-Host "Deploying Eclipse Kapua... DONE!"
-Write-Host "Run `"docker-compose -f $(Join-Path $script_dir .. compose docker-compose.yml) logs -f`" for container logs"
+
+If ($logs)
+{
+    Write-Host "Opening Eclipse Kapua logs..."
+    docker-compose -f $( Join-Path $script_dir .. compose docker-compose.yml ) logs -f
+    Write-Host "Opening Eclipse Kapua logs... DONE!"
+}
+Else
+{
+    Write-Host "Run `"docker-compose -f $( Join-Path $script_dir .. compose docker-compose.yml ) logs -f`" for container logs"
+}

--- a/deployment/docker/win/docker-logs.ps1
+++ b/deployment/docker/win/docker-logs.ps1
@@ -1,0 +1,22 @@
+###############################################################################
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial implementation
+###############################################################################
+
+$script_dir = Split-Path (Get-Variable MyInvocation).Value.MyCommand.Path
+$common_path = Join-Path $script_dir docker-common.ps1
+
+. $common_path
+
+Write-Host "Opening Eclipse Kapua logs..."
+
+docker-compose -f (Join-Path $script_dir .. compose docker-compose.yml) logs -f
+
+Write-Host "Opening Eclipse Kapua logs... DONE!"

--- a/deployment/docker/win/docker-logs.ps1
+++ b/deployment/docker/win/docker-logs.ps1
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial implementation
 ###############################################################################
+#Requires -Version 7
 
 $script_dir = Split-Path (Get-Variable MyInvocation).Value.MyCommand.Path
 $common_path = Join-Path $script_dir docker-common.ps1

--- a/deployment/docker/win/docker-undeploy.ps1
+++ b/deployment/docker/win/docker-undeploy.ps1
@@ -9,6 +9,7 @@
 # Contributors:
 #     Eurotech - initial implementation
 ###############################################################################
+#Requires -Version 7
 
 $script_dir = Split-Path (Get-Variable MyInvocation).Value.MyCommand.Path
 $common_path = Join-Path $script_dir docker-common.ps1

--- a/dev-tools/vagrant/destroy.sh
+++ b/dev-tools/vagrant/destroy.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+#*******************************************************************************
+# Copyright (c) 2020 Eurotech and/or its affiliates
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+#******************************************************************************
+
+set -e
+
+destroy() {
+    echo 'Destroying Vagrant machine...'
+    vagrant destroy -f $1 || { echo 'Destroying Vagrant machine... ERROR!'; exit 1; }
+    echo 'Destroying Vagrant machine... DONE!'
+}
+
+print_usage_destroy(){
+    echo "Usage: $(basename $0) help|base-box|develop" >&2
+}
+
+if [[ "$1" == 'develop' ]]; then
+    destroy $1
+elif [[ "$1" == 'base-box' ]]; then
+    destroy $1
+else
+    print_usage_destroy
+    exit 1
+fi

--- a/dev-tools/vagrant/ssh.sh
+++ b/dev-tools/vagrant/ssh.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+#*******************************************************************************
+# Copyright (c) 2020 Eurotech and/or its affiliates
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+#******************************************************************************
+
+set -e
+
+print_usage_ssh(){
+    echo "Usage: $(basename $0) help|develop" >&2
+}
+
+ssh() {
+    echo 'SSH into Vagrant machine...'
+    vagrant ssh $1 || { echo 'SSH into Vagrant machine... ERROR!'; exit 1; }
+    echo 'SSH into Vagrant machine... DONE!'
+}
+
+if [[ "$1" == 'develop' ]]; then
+    ssh $1
+else
+    print_usage_ssh
+    exit 1
+fi

--- a/dev-tools/vagrant/start.sh
+++ b/dev-tools/vagrant/start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -12,30 +12,42 @@
 #
 #******************************************************************************
 
-destroy_old_machines(){
-    vagrant destroy -f develop
+set -e
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+print_usage_start(){
+    echo "Usage: $(basename $0) help|base-box|develop [--ssh]" >&2
 }
 
 start_develop(){
-    echo 'Starting Kapua Vagrant develop machine...'
-
-    vagrant up
-
-    echo 'Starting Kapua Vagrant develop machine... DONE!'
-    echo "Please type 'vagrant ssh' to connect to the machine."
-    echo "Follow the instructions to start the Kapua components from the machine"
+    echo 'Starting Vagrant machine...'
+    vagrant up || { echo 'Starting Vagrant machine... ERROR!'; exit 1; }
+    echo 'Starting Vagrant machine... DONE!'
 }
 
-print_usage(){
-    echo "Usage: $(basename $0) help|base-box|develop" >&2
+start_ssh() {
+    if [[ "$2" == '--ssh' ]]; then
+        sh ${SCRIPT_DIR}/ssh.sh $1
+    else
+        echo "Unrecognised parameter: ${1}"
+        print_usage_start
+    fi
 }
 
-if [ "$1" == 'develop' ]; then
-    destroy_old_machines
+if [[ "$1" == 'develop' ]]; then
+    sh ${SCRIPT_DIR}/destroy.sh $1 || exit 1;
+
     start_develop
-elif [ "$1" == 'base-box' ]; then
-    sh baseBox/create.sh
+
+    if [[ -z "$2" ]]; then
+        echo "Please type './ssh.sh develop' to connect to the machine."
+    else
+        start_ssh $1 $2
+    fi
+
+elif [[ "$1" == 'base-box' ]]; then
+    sh ${SCRIPT_DIR}/baseBox/create.sh
 else
-    print_usage
+    print_usage_start
     exit 1
 fi


### PR DESCRIPTION
This PR adds options to start subsequent actions after executing Vagrant start and Docker deploy

**Related Issue**
_None_

**Description of the solution adopted**
Added/Edited scripts which not optionally allows for:

- Vagrant (`dev-tools/vagrant`)

     - Added `ssh.sh` as shortcut for `vagrant ssh {machineName}`
    - Added `destroy.sh` as shortcut for `vagrant destroy -f {machineName}`
    - `./start.sh develop --ssh` which automatically invokes `ssh.sh develop` to jump into the newly started machine
- Docker (`deployment/docker`)
    - Added `docker-logs.sh` as shortcut for `docker compose -f {composeFile} logs -f`
    - `./docker-deploy.sh --logs` which automatically invokes `docker-logs.sh` to open container logs right after the deploy.

Powershell script have been updated too

**Screenshots**
_None_

**Any side note on the changes made**
Just some cleanups and improvements.
Power shell script now forcibly require PowerShell at least version 7. See https://docs.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_requires?view=powershell-7#-version-nn