### PR TITLE
Fix event bus instance leak

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
@@ -75,7 +75,7 @@ public class ServiceInspector {
                         KapuaRuntimeException.internalError(String.format("Invalid method signature: number of parameters %d, expected 1", paramsSize));
                     }
                     Class<?> paramClazz = enhancedMethod.getParameterTypes()[0];
-                    if (enhancedMethod.getParameterTypes()[0].equals(ServiceEvent.class)) {
+                    if (!enhancedMethod.getParameterTypes()[0].equals(ServiceEvent.class)) {
                         KapuaRuntimeException.internalError(String.format("Invalid method signature: type of parameters %s, expected ServiceEvent", paramClazz));
                     }
                 } catch (NoSuchMethodException | SecurityException e1) {

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedEventBroker.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedEventBroker.java
@@ -25,7 +25,9 @@ import org.apache.activemq.artemis.jms.server.config.JMSConfiguration;
 import org.apache.activemq.artemis.jms.server.config.impl.ConnectionFactoryConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.config.impl.JMSConfigurationImpl;
 import org.apache.activemq.artemis.jms.server.embedded.EmbeddedJMS;
+import org.apache.commons.lang3.StringUtils;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+//import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.qa.common.DBHelper;
 import org.eclipse.kapua.qa.common.Suppressed;
 import org.elasticsearch.common.UUIDs;
@@ -65,7 +67,10 @@ public class EmbeddedEventBroker {
         if (NO_EMBEDDED_SERVERS) {
             return;
         }
-        System.setProperty(SystemSettingKey.EVENT_BUS_URL.key(), "amqp://127.0.0.1:5672");
+        //set a default value if not set
+        if (StringUtils.isEmpty(System.getProperty(SystemSettingKey.EVENT_BUS_URL.key()))) {
+            System.setProperty(SystemSettingKey.EVENT_BUS_URL.key(), "amqp://127.0.0.1:5672");
+        }
         database.setup();
 
         logger.info("Starting new instance of Event Broker");


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>

Brief description of the PR.
Fix a possible leak on Event Bus.
When the Event Bus tries a re-start and, for some reason, the start throws an exception, the new instance will be not properly cleaned.
Added a clean-up 

**Related Issue**
none

**Description of the solution adopted**
none

**Screenshots**
none

**Any side note on the changes made**
none
