### PR TITLE
Remove db password print while log level set to DEBUG

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -115,9 +115,17 @@ public class KapuaLiquibaseClient {
 
         runTimestampsFix = (currentLiquibaseVersion.afterOrMatches(LIQUIBASE_TIMESTAMP_FIX_VERSION) || forceTimestampFix);
 
-        LOG.info("Liquibase Version: {}", currentLiquibaseVersionString);
-        LOG.info("Force timestamp fix: {}", forceTimestampFix);
-        LOG.info("Apply timestamp fix: {}", runTimestampsFix);
+        LOG.info("=================== KapuaLiquibaseClient configuration ===================");
+        LOG.info("|\tLiquibase Version: {}", currentLiquibaseVersionString);
+        LOG.info("|\tDB connection info");
+        LOG.info("|\t\tJDBC URL: {}", jdbcUrl);
+        LOG.info("|\t\tUsername: {}", username);
+        LOG.info("|\t\tPassword: ******");
+        LOG.info("|\t\tSchema:   {}", schema);
+        LOG.info("|\tTimestamp(3) fix info (eclipse/kapua#2889)");
+        LOG.info("|\t\tForce timestamp fix: {}", forceTimestampFix);
+        LOG.info("|\t\tApply timestamp fix: {}", runTimestampsFix);
+        LOG.info("==========================================================================");
     }
 
     /**
@@ -127,8 +135,9 @@ public class KapuaLiquibaseClient {
      */
     public void update() {
         try {
+            LOG.info("Running Liquibase scripts...");
             if (Boolean.parseBoolean(System.getProperty("LIQUIBASE_ENABLED", "true")) || Boolean.parseBoolean(System.getenv("LIQUIBASE_ENABLED"))) {
-                LOG.info("Running Liquibase update with schema: {}", schema);
+
                 try (Connection connection = DriverManager.getConnection(jdbcUrl, username, password)) {
                     File changelogDir = loadChangelogs();
 
@@ -139,10 +148,14 @@ public class KapuaLiquibaseClient {
 
                     executeMasters(connection, schema, changelogDir, contexts);
                 }
+
+                LOG.info("Running Liquibase scripts... DONE!");
+            } else {
+                LOG.info("Running Liquibase scripts... SKIPPED! Liquibase disabled by System property 'LIQUIBASE_ENABLED'...");
             }
         } catch (LiquibaseException | SQLException | IOException e) {
-            LOG.error("Error while running Liquibase scripts: {}", e.getMessage(), e);
-            throw new RuntimeException(e);
+            LOG.error("Running Liquibase scripts... ERROR! Error: {}", e.getMessage(), e);
+            throw new RuntimeException(e); // TODO: throw an appropriate exception!
         }
     }
 

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/server/util/ConsoleListener.java
@@ -28,44 +28,62 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+/**
+ * @since 1.0.0
+ */
 public class ConsoleListener implements ServletContextListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(ConsoleListener.class);
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
 
     private ServiceModuleBundle moduleBundle;
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
-        LOG.info("Initialize Console JABContext Provider");
-        JAXBContextProvider consoleProvider = new ConsoleJAXBContextProvider();
-        XmlUtil.setContextProvider(consoleProvider);
-
-        SystemSetting config = SystemSetting.getInstance();
-        if (config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
-            LOG.info("Initialize Liquibase embedded client.");
-            String dbUsername = config.getString(SystemSettingKey.DB_USERNAME);
-            String dbPassword = config.getString(SystemSettingKey.DB_PASSWORD);
-            String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
-
-            // initialize driver
-            try {
-                Class.forName(config.getString(SystemSettingKey.DB_JDBC_DRIVER));
-            } catch (ClassNotFoundException e) {
-                LOG.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
-            }
-
-            LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
-            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
-        }
-
-        // start quarz scheduler
-        LOG.info("Starting job scheduler...");
         try {
-            SchedulerServiceInit.initialize();
-        } catch (KapuaException e) {
-            LOG.error("Cannot start scheduler service: {}", e.getMessage(), e);
+            LOG.info("Initialize Console JABContext Provider...");
+            JAXBContextProvider consoleProvider = new ConsoleJAXBContextProvider();
+            XmlUtil.setContextProvider(consoleProvider);
+            LOG.info("Initialize Console JABContext Provider... DONE!");
+        } catch (Exception e) {
+            LOG.error("Initialize Console JABContext Provider... ERROR! Error: {}", e.getMessage(), e);
+            throw new ExceptionInInitializerError(e);
         }
-        LOG.info("Starting job scheduler... DONE");
+
+        if (SYSTEM_SETTING.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
+            try {
+                String dbUsername = SYSTEM_SETTING.getString(SystemSettingKey.DB_USERNAME);
+                String dbPassword = SYSTEM_SETTING.getString(SystemSettingKey.DB_PASSWORD);
+                String schema = MoreObjects.firstNonNull(
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA_ENV),
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA)
+                );
+
+                // Loading JDBC Driver
+                String jdbcDriver = SYSTEM_SETTING.getString(SystemSettingKey.DB_JDBC_DRIVER);
+                try {
+                    Class.forName(jdbcDriver);
+                } catch (ClassNotFoundException e) {
+                    LOG.warn("Could not find jdbc driver: {}. Subsequent DB operation failures may occur...", SYSTEM_SETTING.getString(SystemSettingKey.DB_JDBC_DRIVER));
+                }
+
+                // Starting Liquibase Client
+                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
+            } catch (Exception e) {
+                throw new ExceptionInInitializerError(e);
+            }
+        }
+
+        // Start Quartz scheduler
+        try {
+            LOG.info("Starting Quartz scheduler...");
+            SchedulerServiceInit.initialize();
+            LOG.info("Starting Quartz scheduler... DONE!");
+        } catch (Exception e) {
+            LOG.error("Starting Quartz scheduler... ERROR! Error: {}", e.getMessage(), e);
+            throw new ExceptionInInitializerError(e);
+        }
 
         // Start service modules
         try {
@@ -74,30 +92,35 @@ public class ConsoleListener implements ServletContextListener {
                 moduleBundle = new ServiceModuleBundle();
             }
             moduleBundle.startup();
-            LOG.info("Starting service modules...DONE");
-        } catch (KapuaException e) {
-            LOG.error("Cannot start service modules: {}", e.getMessage(), e);
+            LOG.info("Starting service modules... DONE!");
+        } catch (Exception e) {
+            LOG.error("Starting service modules... ERROR! Error: {}", e.getMessage(), e);
+            throw new ExceptionInInitializerError(e);
         }
     }
 
     @Override
     public void contextDestroyed(final ServletContextEvent event) {
-        // stop event modules
+        // Stop event modules
         try {
             LOG.info("Stopping service modules...");
             if (moduleBundle != null) {
                 moduleBundle.shutdown();
                 moduleBundle = null;
             }
-            LOG.info("Stopping service modules...DONE");
+            LOG.info("Stopping service modules... DONE!");
         } catch (KapuaException e) {
-            LOG.error("Cannot stop service modules: {}", e.getMessage(), e);
+            LOG.error("Stopping service modules... ERROR! Error: {}", e.getMessage(), e);
         }
 
-        // stop quarz scheduler
-        LOG.info("Stopping job scheduler...");
-        SchedulerServiceInit.close();
-        LOG.info("Stopping job scheduler... DONE");
+        // Stop Quartz scheduler
+        try {
+            LOG.info("Stopping Quartz scheduler...");
+            SchedulerServiceInit.close();
+            LOG.info("Stopping Quartz scheduler... DONE");
+        } catch (Exception e) {
+            LOG.info("Stopping Quartz scheduler... ERROR! Error: {}", e.getMessage(), e);
+        }
     }
 
 }

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiListener.java
@@ -24,31 +24,42 @@ import org.slf4j.LoggerFactory;
 import javax.servlet.ServletContextEvent;
 import javax.servlet.ServletContextListener;
 
+/**
+ * @since 1.0.0
+ */
 public class RestApiListener implements ServletContextListener {
 
     private static final Logger LOG = LoggerFactory.getLogger(RestApiListener.class);
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
 
     private ServiceModuleBundle moduleBundle;
 
     @Override
     public void contextInitialized(final ServletContextEvent event) {
-        SystemSetting config = SystemSetting.getInstance();
-        if (config.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
-            LOG.info("Initialize Liquibase embedded client.");
-            String dbUsername = config.getString(SystemSettingKey.DB_USERNAME);
-            String dbPassword = config.getString(SystemSettingKey.DB_PASSWORD);
-            String schema = MoreObjects.firstNonNull(config.getString(SystemSettingKey.DB_SCHEMA_ENV), config.getString(SystemSettingKey.DB_SCHEMA));
 
-            // initialize driver
+        if (SYSTEM_SETTING.getBoolean(SystemSettingKey.DB_SCHEMA_UPDATE, false)) {
             try {
-                Class.forName(config.getString(SystemSettingKey.DB_JDBC_DRIVER));
-            } catch (ClassNotFoundException e) {
-                LOG.warn("Could not find jdbc driver: {}", config.getString(SystemSettingKey.DB_JDBC_DRIVER));
+                String dbUsername = SYSTEM_SETTING.getString(SystemSettingKey.DB_USERNAME);
+                String dbPassword = SYSTEM_SETTING.getString(SystemSettingKey.DB_PASSWORD);
+                String schema = MoreObjects.firstNonNull(
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA_ENV),
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA)
+                );
+
+                // Loading JDBC Driver
+                String jdbcDriver = SYSTEM_SETTING.getString(SystemSettingKey.DB_JDBC_DRIVER);
+                try {
+                    Class.forName(jdbcDriver);
+                } catch (ClassNotFoundException e) {
+                    LOG.warn("Could not find jdbc driver: {}. Subsequent DB operation failures may occur...", SYSTEM_SETTING.getString(SystemSettingKey.DB_JDBC_DRIVER));
+                }
+
+                // Starting Liquibase Client
+                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
+            } catch (Exception e) {
+                throw new ExceptionInInitializerError(e);
             }
-
-            LOG.debug("Starting Liquibase embedded client update - URL: {}, user/pass: {}/{}", JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword);
-
-            new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
         }
 
         // Start service modules
@@ -58,24 +69,24 @@ public class RestApiListener implements ServletContextListener {
                 moduleBundle = new ServiceModuleBundle();
             }
             moduleBundle.startup();
-            LOG.info("Starting service modules...DONE");
+            LOG.info("Starting service modules... DONE!");
         } catch (KapuaException e) {
-            LOG.error("Cannot start service modules: {}", e.getMessage(), e);
+            LOG.error("Starting service modules... ERROR! Error: {}", e.getMessage(), e);
         }
     }
 
     @Override
     public void contextDestroyed(final ServletContextEvent event) {
-        // stop event modules
+        // Stop event modules
         try {
             LOG.info("Stopping service modules...");
             if (moduleBundle != null) {
                 moduleBundle.shutdown();
                 moduleBundle = null;
             }
-            LOG.info("Stopping service modules...DONE");
+            LOG.info("Stopping service modules... DONE!");
         } catch (KapuaException e) {
-            LOG.error("Cannot stop service modules: {}", e.getMessage(), e);
+            LOG.error("Stopping service modules... ERROR! Error: {}", e.getMessage(), e);
         }
     }
 


### PR DESCRIPTION
This PR removes the db password printout while log level is set to DEBUG.

**Related Issue**
_None_

**Description of the solution adopted**
Removed log line and improved logging in KapuaLiquibaseClient.

Output now looks like:
```
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - =================== KapuaLiquibaseClient configuration ===================
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |	Liquibase Version: 3.0.5
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |	DB connection info
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		JDBC URL: jdbc:h2:tcp://192.168.33.10:3306/kapuadb;schema=kapuadb
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		Username: kapua
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		Password: ******
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		Schema: kapuadb
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |	Timestamp(3) fix (eclipse/kapua#2889)
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		Force timestamp fix: false
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - |		Apply timestamp fix: false
12:28:19.295 [main] INFO  o.e.k.c.l.KapuaLiquibaseClient - ========================================================================+=

```

**Screenshots**
_None_

**Any side note on the changes made**
Improved exception logging and handling in ContextListeners
