### PR TITLE
Fixed notification processing update retry strategy 

### DIFF
--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
@@ -111,9 +111,9 @@ public interface DeviceManagementRegistryManagerService extends KapuaService {
 
         DeviceManagementOperation deviceManagementOperation = null;
 
+        boolean failed;
         short attempts = 0;
         short limit = 3;
-        boolean failed = false;
         do {
             try {
                 deviceManagementOperation = getDeviceManagementOperation(scopeId, operationId);
@@ -127,6 +127,7 @@ public interface DeviceManagementRegistryManagerService extends KapuaService {
                 deviceManagementOperation = DEVICE_MANAGEMENT_OPERATION_REGISTRY_SERVICE.update(deviceManagementOperation);
 
                 LOG.info("Update DeviceManagementOperation {} with status {}...  SUCCEEDED!", operationId, finalStatus);
+                failed = false;
             } catch (Exception e) {
                 failed = true;
                 attempts++;


### PR DESCRIPTION
This PR fixes the processing of a DeviceManagementNotification retry strategy.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the logic which looped indefinitely in case of first update failed.

**Screenshots**
_None_

**Any side note on the changes made**
_None_