### PR TITLE
Added PackageDownloadRequest download restart option

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageInstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageInstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -69,6 +69,7 @@ public class PackageInstallDialog extends TabbedDialog {
 
     private FormPanel advancedOptionsForm;
     private Text advancedInfoText;
+    private CheckBox operationRestartField;
     private KapuaNumberField blockSizeField;
     private KapuaNumberField blockDelayField;
     private KapuaNumberField blockTimeoutField;
@@ -201,6 +202,7 @@ public class PackageInstallDialog extends TabbedDialog {
             operationRebootField.setFieldLabel(DEVICE_MSGS.packageInstallDpDialogOperationReboot());
             operationRebootField.setToolTip(DEVICE_MSGS.packageInstallDpDialogOperationRebootTooltip());
             operationRebootField.setBoxLabel("");
+            operationRebootField.setValue(Boolean.FALSE);
 
             operationRebootField.addListener(Events.Change, new Listener<BaseEvent>() {
 
@@ -249,6 +251,14 @@ public class PackageInstallDialog extends TabbedDialog {
             advancedInfoText.setText(DEVICE_MSGS.packageInstallDpDialogAdvancedTabInfo());
             advancedInfoText.setStyleAttribute("margin-bottom", "5px");
             advancedOptionsForm.add(advancedInfoText);
+
+            operationRestartField = new CheckBox();
+            operationRestartField.setName("restart");
+            operationRestartField.setFieldLabel(DEVICE_MSGS.packageInstallDpDialogOperationRestart());
+            operationRestartField.setToolTip(DEVICE_MSGS.packageInstallDpDialogOperationRestartTooltip());
+            operationRestartField.setBoxLabel("");
+            operationRestartField.setValue(Boolean.FALSE);
+            advancedOptionsForm.add(operationRestartField, formData);
 
             blockSizeField = new KapuaNumberField();
             blockSizeField.setName("installBlockSize");
@@ -367,6 +377,8 @@ public class PackageInstallDialog extends TabbedDialog {
         }
 
         // Advanced info
+        gwtPackageInstallRequest.setRestart(operationRestartField.getValue());
+
         nValue = blockSizeField.getValue();
         if (nValue != null) {
             gwtPackageInstallRequest.setBlockSize(nValue.intValue());

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -196,6 +196,7 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
             packageDownloadRequest.setRebootDelay(gwtPackageInstallRequest.getRebootDelay());
 
             AdvancedPackageDownloadOptions advancedOptions = packageDownloadRequest.getAdvancedOptions();
+            advancedOptions.setRestart(gwtPackageInstallRequest.getRestart());
             advancedOptions.setBlockSize(gwtPackageInstallRequest.getBlockSize());
             advancedOptions.setBlockDelay(gwtPackageInstallRequest.getBlockDelay());
             advancedOptions.setBlockTimeout(gwtPackageInstallRequest.getBlockTimeout());

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageInstallRequest.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageInstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -115,6 +115,14 @@ public class GwtPackageInstallRequest extends KapuaBaseModel {
 
     //
     // Advanced
+
+    public void setRestart(Boolean restart) {
+        set("restart", restart);
+    }
+
+    public Boolean getRestart() {
+        return get("restart");
+    }
 
     public void setBlockSize(Integer blockSize) {
         set("blockSize", blockSize);

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleDeviceMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -341,6 +341,8 @@ packageInstallDpDialogOperationRebootDelayTooltip=The delay after which the devi
 
 packageInstallDpDialogAdvancedTabTitle=Advanced Options
 packageInstallDpDialogAdvancedTabInfo=Control advanced properties of the operation.
+packageInstallDpDialogOperationRestart=Restart Download
+packageInstallDpDialogOperationRestartTooltip=Whether or not restart the download from the beginning.
 packageInstallDpDialogAdvancedBlockSize=Block Size [B]
 packageInstallDpDialogAdvancedBlockSizeTooltip=The size in Bytes of the blocks to transfer from the URI.
 packageInstallDpDialogAdvancedBlockDelay=Block Delay [ms]

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/PackageMetrics.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/app/PackageMetrics.java
@@ -119,6 +119,11 @@ public enum PackageMetrics {
     APP_METRIC_PACKAGE_DOWNLOAD_INSTALL_VERIFIER_URI("dp.install.verifier.uri"),
 
     /**
+     * @since 1.2.0
+     */
+    APP_METRIC_PACKAGE_DOWNLOAD_FORCE("dp.download.force"),
+
+    /**
      * @since 1.1.0
      */
     APP_METRIC_PACKAGE_DOWNLOAD_BLOCK_SIZE("dp.download.block.size"),

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/AdvancedPackageDownloadOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/AdvancedPackageDownloadOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -26,6 +26,22 @@ import javax.xml.bind.annotation.XmlType;
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DevicePackageXmlRegistry.class, factoryMethod = "newAdvancedPackageDownloadOptions")
 public interface AdvancedPackageDownloadOptions {
+
+    /**
+     * Gets whether or not to restart the download from the beginning.
+     *
+     * @return {@code true} if the download must be restarted from the beginning, {@code false} otherwise.
+     * @since 1.2.0
+     */
+    Boolean getRestart();
+
+    /**
+     * Sets whether or not to restart the download from the beginning.
+     *
+     * @param restart {@code true} if the download must be restarted from the beginning, {@code false} otherwise.
+     * @sicne 1.2.0
+     */
+    void setRestart(Boolean restart);
 
     /**
      * Gets the size in {@code Byte}s of the blocks to transfer from the URI.

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -212,6 +212,7 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         // Advanced ones
         AdvancedPackageDownloadOptions advancedOptions = packageDownloadRequest.getAdvancedOptions();
 
+        packageRequestPayload.setPackageDownloadRestart(advancedOptions.getRestart());
         packageRequestPayload.setPackageDownloadBlockSize(MoreObjects.firstNonNull(advancedOptions.getBlockSize(), PACKAGE_MANAGEMENT_SERVICE_SETTING.getInt(PackageManagementServiceSettingKeys.PACKAGE_MANAGEMENT_SERVICE_SETTING_DOWDLOAD_DEFAULT_BLOCK_SIZE)));
         packageRequestPayload.setPackageDownloadBlockDelay(MoreObjects.firstNonNull(advancedOptions.getBlockDelay(), PACKAGE_MANAGEMENT_SERVICE_SETTING.getInt(PackageManagementServiceSettingKeys.PACKAGE_MANAGEMENT_SERVICE_SETTING_DOWDLOAD_DEFAULT_BLOCK_DELAY)));
         packageRequestPayload.setPackageDownloadBlockTimeout(MoreObjects.firstNonNull(advancedOptions.getBlockTimeout(), PACKAGE_MANAGEMENT_SERVICE_SETTING.getInt(PackageManagementServiceSettingKeys.PACKAGE_MANAGEMENT_SERVICE_SETTING_DOWDLOAD_DEFAULT_BLOCK_TIMEOUT)));

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -100,6 +100,13 @@ public enum PackageAppProperties implements KapuaAppProperties {
      * @since 1.0.0
      */
     APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL("kapua.package.download.install"),
+
+    /**
+     * File download restart
+     *
+     * @since 1.1.0
+     */
+    APP_PROPERTY_PACKAGE_DOWNLOAD_RESTART("kapua.package.download.restart"),
 
     /**
      * File download block size

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -253,12 +253,34 @@ public class PackageRequestPayload extends KapuaPayloadImpl implements KapuaRequ
     /**
      * Set the is a download package and install flag
      *
-     * @param packageDownloadnstall
+     * @param packageDownloadInstall
      * @since 1.0.0
      */
-    public void setPackageDownloadnstall(Boolean packageDownloadnstall) {
-        if (packageDownloadnstall != null) {
-            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue(), packageDownloadnstall);
+    public void setPackageDownloadnstall(Boolean packageDownloadInstall) {
+        if (packageDownloadInstall != null) {
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL.getValue(), packageDownloadInstall);
+        }
+    }
+
+    /**
+     * Gets whether or not to restart the download from the beginning.
+     *
+     * @return {@code true} if the download must be restarted from the beginning, {@code false} otherwise.
+     * @since 1.2.0
+     */
+    public Boolean getPackageDownloadRestart() {
+        return (Boolean) getMetrics().get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_RESTART.getValue());
+    }
+
+    /**
+     * Sets whether or not to restart the download from the beginning.
+     *
+     * @param restart {@code true} if the download must be restarted from the beginning, {@code false} otherwise.
+     * @sicne 1.2.0
+     */
+    public void setPackageDownloadRestart(Boolean restart) {
+        if (restart != null) {
+            getMetrics().put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_RESTART.getValue(), restart);
         }
     }
 

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/AdvancedPackageDownloadOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/AdvancedPackageDownloadOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -20,6 +20,7 @@ import org.eclipse.kapua.service.device.management.packages.model.download.Advan
  */
 public class AdvancedPackageDownloadOptionsImpl implements AdvancedPackageDownloadOptions {
 
+    private Boolean restart;
     private Integer blockSize;
     private Integer blockDelay;
     private Integer blockTimeout;
@@ -43,6 +44,7 @@ public class AdvancedPackageDownloadOptionsImpl implements AdvancedPackageDownlo
     public AdvancedPackageDownloadOptionsImpl(AdvancedPackageDownloadOptions advancedPackageDownloadOptions) {
         super();
 
+        setRestart(advancedPackageDownloadOptions.getRestart());
         setBlockSize(advancedPackageDownloadOptions.getBlockSize());
         setBlockDelay(advancedPackageDownloadOptions.getBlockDelay());
         setBlockTimeout(advancedPackageDownloadOptions.getBlockTimeout());
@@ -50,6 +52,15 @@ public class AdvancedPackageDownloadOptionsImpl implements AdvancedPackageDownlo
         setInstallVerifierURI(advancedPackageDownloadOptions.getInstallVerifierURI());
     }
 
+    @Override
+    public Boolean getRestart() {
+        return restart;
+    }
+
+    @Override
+    public void setRestart(Boolean restart) {
+        this.restart = restart;
+    }
 
     @Override
     public Integer getBlockSize() {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kapua/kura/TranslatorAppPackageKapuaKura.java
@@ -59,6 +59,7 @@ public class TranslatorAppPackageKapuaKura extends AbstractTranslatorKapuaKura<P
         PROPERTIES_DICTIONARY.put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL, PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_INSTALL);
 
         // Download advanced properties
+        PROPERTIES_DICTIONARY.put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_RESTART, PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_FORCE);
         PROPERTIES_DICTIONARY.put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_SIZE, PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_BLOCK_SIZE);
         PROPERTIES_DICTIONARY.put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_DELAY, PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_BLOCK_DELAY);
         PROPERTIES_DICTIONARY.put(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_TIMEOUT, PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_TIMEOUT);
@@ -138,6 +139,7 @@ public class TranslatorAppPackageKapuaKura extends AbstractTranslatorKapuaKura<P
             metrics.put(PackageMetrics.APP_METRIC_PACKAGE_DOWNLOAD_PROTOCOL.getValue(), "HTTP");
             metrics.put(PROPERTIES_DICTIONARY.get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_PACKAGE_INSTALL).getValue(), kapuaPayload.isPackageDownloadInstall());
 
+            metrics.put(PROPERTIES_DICTIONARY.get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_RESTART).getValue(), kapuaPayload.getPackageDownloadRestart());
             metrics.put(PROPERTIES_DICTIONARY.get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_SIZE).getValue(), kapuaPayload.getPackageDownloadBlockSize());
             metrics.put(PROPERTIES_DICTIONARY.get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_DELAY).getValue(), kapuaPayload.getPackageDownloadBlockDelay());
             metrics.put(PROPERTIES_DICTIONARY.get(PackageAppProperties.APP_PROPERTY_PACKAGE_DOWNLOAD_BLOCK_TIMEOUT).getValue(), kapuaPayload.getPackageDownloadBlockTimeout());


### PR DESCRIPTION
This PR add support for the DEPLOY-V2 Kura option named `dp.download.force` which allows forcing to download the package from the beginning even if it is present in the filesystem of the device.

**Related Issue**
_None_

**Description of the solution adopted**
Added a new property in `PackageDownloadRequest`.`AdvancedPackageDownloadOptions ` named `restart`.

Added support in Console and REST-API

**Screenshots**
_None_

**Any side note on the changes made**
_None_