### PR TITLE
Add Job Target Restart button

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -41,6 +41,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
     private GwtJob gwtSelectedJob;
 
     private Button jobStartTargetButton;
+    private Button jobRestartTargetButton;
     private Button exportButton;
 
     public JobTabTargetsToolbar(GwtSession currentSession) {
@@ -85,6 +86,17 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
         jobStartTargetButton.disable();
         addExtraButton(jobStartTargetButton);
 
+        jobRestartTargetButton = new Button(JOB_MSGS.jobRestartTargetButton(), new KapuaIcon(IconSet.REPEAT), new SelectionListener<ButtonEvent>() {
+
+            @Override
+            public void componentSelected(ButtonEvent buttonEvent) {
+                JobTargetRestartTargetDialog dialog = new JobTargetRestartTargetDialog(gwtSelectedJob, gridSelectionModel.getSelectedItem());
+                dialog.show();
+            }
+        });
+        jobRestartTargetButton.disable();
+        addExtraButton(jobRestartTargetButton);
+
         exportButton = new Button(JOB_MSGS.exportToCSV(), new KapuaIcon(IconSet.FILE_TEXT_O),
                 new SelectionListener<ButtonEvent>() {
 
@@ -117,6 +129,7 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
         super.updateButtonEnablement();
 
         jobStartTargetButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.execute()));
+        jobRestartTargetButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.execute()));
         addEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.write()));
         deleteEntityButton
                 .setEnabled(selectedEntity != null && currentSession.hasPermission(JobSessionPermission.delete())
@@ -154,6 +167,9 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
                     if (jobStartTargetButton != null) {
                         jobStartTargetButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && currentSession.hasPermission(JobSessionPermission.execute()));
                     }
+                    if (jobRestartTargetButton != null) {
+                        jobRestartTargetButton.setEnabled(gridSelectionModel != null && gridSelectionModel.getSelectedItem() != null && currentSession.hasPermission(JobSessionPermission.execute()));
+                    }
                 }
             });
         } else {
@@ -165,6 +181,9 @@ public class JobTabTargetsToolbar extends EntityCRUDToolbar<GwtJobTarget> {
             }
             if (jobStartTargetButton != null) {
                 jobStartTargetButton.setEnabled(false);
+            }
+            if (jobRestartTargetButton != null) {
+                jobRestartTargetButton.setEnabled(false);
             }
             if (exportButton != null) {
                 exportButton.setEnabled(false);

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetRestartTargetDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetRestartTargetDialog.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.job.client.targets;
+
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.SimpleDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.job.client.messages.ConsoleJobMessages;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJob;
+import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTarget;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineService;
+import org.eclipse.kapua.app.console.module.job.shared.service.GwtJobEngineServiceAsync;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public class JobTargetRestartTargetDialog extends SimpleDialog {
+
+    private static final ConsoleJobMessages JOB_MSGS = GWT.create(ConsoleJobMessages.class);
+
+    private static final GwtJobEngineServiceAsync JOB_ENGINE_SERVICE = GWT.create(GwtJobEngineService.class);
+
+    private final GwtJob gwtJob;
+    private final GwtJobTarget gwtJobTarget;
+
+    public JobTargetRestartTargetDialog(GwtJob gwtJob, GwtJobTarget gwtJobTarget) {
+        this.gwtJob = gwtJob;
+        this.gwtJobTarget = gwtJobTarget;
+
+        DialogUtils.resizeDialog(this, 300, 135);
+    }
+
+    @Override
+    public void createBody() {
+        // No action needed
+    }
+
+    @Override
+    protected void addListeners() {
+        // No action needed
+    }
+
+    @Override
+    public void submit() {
+        JOB_ENGINE_SERVICE.restart(gwtJob.getScopeId(), gwtJob.getId(), gwtJobTarget.getId(), new AsyncCallback<Void>() {
+
+            @Override
+            public void onFailure(Throwable caught) {
+                ConsoleInfo.display(MSGS.popupError(), JOB_MSGS.jobStartTargetErrorMessage(caught.getLocalizedMessage()));
+                unmask();
+                hide();
+            }
+
+            @Override
+            public void onSuccess(Void result) {
+                ConsoleInfo.display(MSGS.popupInfo(), JOB_MSGS.jobStartTargetStartedMessage());
+                unmask();
+                hide();
+            }
+        });
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return JOB_MSGS.jobStartTargetDialogHeader(gwtJob.getJobName(), gwtJobTarget.getClientId());
+    }
+
+    @Override
+    public KapuaIcon getInfoIcon() {
+        return new KapuaIcon(IconSet.WARNING);
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return JOB_MSGS.jobStartTargetDialogInfo();
+    }
+}

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobEngineServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobEngineServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,7 @@ import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 import org.eclipse.kapua.service.job.execution.JobExecutionService;
 
 import java.util.ArrayList;
+import java.util.Collections;
 
 public class GwtJobEngineServiceImpl extends KapuaRemoteServiceServlet implements GwtJobEngineService {
 
@@ -114,11 +115,19 @@ public class GwtJobEngineServiceImpl extends KapuaRemoteServiceServlet implement
 
     @Override
     public void restart(String gwtScopeId, String gwtJobId) throws GwtKapuaException {
+        restart(gwtScopeId, gwtJobId, null);
+    }
+
+    @Override
+    public void restart(String gwtScopeId, String gwtJobId, String gwtJobTargetId) throws GwtKapuaException {
         GwtJobStartOptions gwtJobStartOptions = new GwtJobStartOptions();
         gwtJobStartOptions.setResetStepIndex(true);
         gwtJobStartOptions.setFromStepIndex(0);
-        gwtJobStartOptions.setTargetIdSublist(new ArrayList<String>());
-
+        if (gwtJobTargetId == null) {
+            gwtJobStartOptions.setTargetIdSublist(new ArrayList<String>());
+        } else {
+            gwtJobStartOptions.setTargetIdSublist(Collections.singletonList(gwtJobTargetId));
+        }
         start(gwtScopeId, gwtJobId, gwtJobStartOptions);
     }
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobEngineService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobEngineService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -32,5 +32,8 @@ public interface GwtJobEngineService extends RemoteService {
             throws GwtKapuaException;
 
     void restart(String gwtScopeId, String gwtJobId)
+            throws GwtKapuaException;
+
+    void restart(String gwtScopeId, String gwtJobId, String gwtJobTargetId)
             throws GwtKapuaException;
 }

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/client/messages/ConsoleJobMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0
@@ -66,6 +66,12 @@ jobRestartDialogHeader=Restart Job: {0}
 jobRestartDialogInfo=Restart the selected job?<br><br>Please note that restarting the job, all the targets will restart the processing from the first step, regardless of their current step.
 jobRestartRestartedMessage=Job successfully restarted.
 jobRestartErrorMessage=Error restarting job: {0}
+
+jobRestartTargetButton=Restart
+jobRestartTargetDialogHeader=Restart Job {0} for target {1}
+jobRestartTargetDialogInfo=Restart the selected job for the selected target?<br><br>Please note that restarting the job, the target will restart the processing from the first step, regardless of its current step.
+jobRestartTargetRestartedMessage=Job successfully restarted.
+jobRestartTargetErrorMessage=Error restarting job: {0}
 
 #
 # Add dialog


### PR DESCRIPTION
This PR adds a Restart button in the Job Targets grid. By clicking this button, the Job execution will restart from step 0 only for the selected target.

**Related Issue**
No related issues
