### PR TITLE
Fixed method calls to EntityManagerSession methods

### DIFF
--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/JPAPersistenceManagerImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/JPAPersistenceManagerImpl.java
@@ -105,7 +105,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void createCheckpointData(CheckpointDataKey checkpointDataKey, CheckpointData checkpointData) {
         try {
-            entityManagerSession.onTransactedInsert(em -> JpaCheckpointDataDAO.create(em, checkpointDataKey, checkpointData));
+            entityManagerSession.doTransactedAction(em -> JpaCheckpointDataDAO.create(em, checkpointDataKey, checkpointData));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -114,7 +114,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateCheckpointData(CheckpointDataKey checkpointDataKey, CheckpointData checkpointData) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaCheckpointDataDAO.update(em, checkpointDataKey, checkpointData));
+            entityManagerSession.doTransactedAction(em -> JpaCheckpointDataDAO.update(em, checkpointDataKey, checkpointData));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -123,7 +123,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public CheckpointData getCheckpointData(CheckpointDataKey checkpointDataKey) {
         try {
-            JpaCheckpointData jpaCheckpointData = entityManagerSession.onResult(em -> JpaCheckpointDataDAO.find(em, checkpointDataKey));
+            JpaCheckpointData jpaCheckpointData = entityManagerSession.doAction(em -> JpaCheckpointDataDAO.find(em, checkpointDataKey));
             return jpaCheckpointData != null ? jpaCheckpointData.toCheckpointData() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -141,7 +141,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public JobInstance createJobInstance(String name, String appTag, String jobXml) {
         try {
-            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.onTransactedInsert(em -> JpaJobInstanceDataDAO.create(em, name, appTag, jobXml));
+            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.doTransactedAction(em -> JpaJobInstanceDataDAO.create(em, name, appTag, jobXml));
             return jpaJobInstanceData != null ? jpaJobInstanceData.toJobInstance() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -156,7 +156,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public int jobOperatorGetJobInstanceCount(String jobName, String appTag) {
         try {
-            return entityManagerSession.onResult(em -> JpaJobInstanceDataDAO.getJobInstanceCount(em, jobName, appTag));
+            return entityManagerSession.doAction(em -> JpaJobInstanceDataDAO.getJobInstanceCount(em, jobName, appTag));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -170,7 +170,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public List<Long> jobOperatorGetJobInstanceIds(String jobName, String appTag, int offset, int limit) {
         try {
-            return entityManagerSession.onResult(em -> JpaJobInstanceDataDAO.getJobInstanceIds(em, jobName, appTag, offset, limit));
+            return entityManagerSession.doAction(em -> JpaJobInstanceDataDAO.getJobInstanceIds(em, jobName, appTag, offset, limit));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -179,7 +179,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public Map<Long, String> jobOperatorGetExternalJobInstanceData() {
         try {
-            return entityManagerSession.onResult(JpaJobInstanceDataDAO::getExternalJobInstanceData);
+            return entityManagerSession.doAction(JpaJobInstanceDataDAO::getExternalJobInstanceData);
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -211,7 +211,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
      */
     public int purgeByName(String jobName) {
         try {
-            return entityManagerSession.onTransactedResult(em -> JpaJobInstanceDataDAO.deleteByName(em, jobName));
+            return entityManagerSession.doTransactedAction(em -> JpaJobInstanceDataDAO.deleteByName(em, jobName));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -224,7 +224,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public JobStatus createJobStatus(long jobInstanceId) {
         try {
-            JpaJobStatus jpaJobStatus = entityManagerSession.onTransactedInsert(em -> JpaJobStatusDAO.create(em, jobInstanceId));
+            JpaJobStatus jpaJobStatus = entityManagerSession.doTransactedAction(em -> JpaJobStatusDAO.create(em, jobInstanceId));
             return jpaJobStatus != null ? jpaJobStatus.toJobStatus() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -234,7 +234,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public JobStatus getJobStatus(long jobInstanceId) {
         try {
-            JpaJobStatus jpaJobStatus = entityManagerSession.onResult(em -> JpaJobStatusDAO.find(em, jobInstanceId));
+            JpaJobStatus jpaJobStatus = entityManagerSession.doAction(em -> JpaJobStatusDAO.find(em, jobInstanceId));
 
             JobStatus jobStatus;
             if (jpaJobStatus != null) {
@@ -244,7 +244,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
             }
 
             if (jobStatus.getJobInstance() == null) {
-                JobInstance jobInstance = entityManagerSession.onResult(em -> JpaJobInstanceDataDAO.find(em, jobInstanceId).toJobInstance());
+                JobInstance jobInstance = entityManagerSession.doAction(em -> JpaJobInstanceDataDAO.find(em, jobInstanceId).toJobInstance());
 
                 if (jobInstance == null) {
                     jobInstance = new JobInstanceImpl(jobInstanceId);
@@ -261,7 +261,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateJobStatus(long jobInstanceId, JobStatus jobStatus) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaJobStatusDAO.update(em, jobInstanceId, jobStatus));
+            entityManagerSession.doTransactedAction(em -> JpaJobStatusDAO.update(em, jobInstanceId, jobStatus));
         } catch (KapuaException e) {
             throw new PersistenceException(e);
         }
@@ -274,7 +274,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public RuntimeJobExecution createJobExecution(JobInstance jobInstance, Properties jobParameters, BatchStatus batchStatus) {
         try {
-            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.onTransactedInsert(em -> JpaExecutionInstanceDataDAO.create(em, jobInstance.getInstanceId(), jobParameters, batchStatus, new Timestamp(new Date().getTime())));
+            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.doTransactedAction(em -> JpaExecutionInstanceDataDAO.create(em, jobInstance.getInstanceId(), jobParameters, batchStatus, new Timestamp(new Date().getTime())));
 
             RuntimeJobExecution runtimeJobExecution = new RuntimeJobExecution(jobInstance, jpaExecutionInstanceData.getId());
             runtimeJobExecution.setBatchStatus(batchStatus.name());
@@ -290,7 +290,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public RuntimeFlowInSplitExecution createFlowInSplitExecution(JobInstance jobInstance, BatchStatus batchStatus) {
         try {
-            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.onTransactedInsert(em -> JpaExecutionInstanceDataDAO.create(em, jobInstance.getInstanceId(), null, batchStatus, new Timestamp(new Date().getTime())));
+            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.doTransactedAction(em -> JpaExecutionInstanceDataDAO.create(em, jobInstance.getInstanceId(), null, batchStatus, new Timestamp(new Date().getTime())));
 
             RuntimeFlowInSplitExecution runtimeFlowInSplitExecution = new RuntimeFlowInSplitExecution(jobInstance, jpaExecutionInstanceData.getId());
             runtimeFlowInSplitExecution.setBatchStatus(batchStatus.name());
@@ -325,7 +325,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
                     throw new IllegalArgumentException(timestampType.name());
             }
 
-            return entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, jobExecutionId, selectField));
+            return entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, jobExecutionId, selectField));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -334,7 +334,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public String jobOperatorQueryJobExecutionBatchStatus(long jobExecutionId) {
         try {
-            return entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.<BatchStatus>getJobExecutionField(em, jobExecutionId, JpaExecutionInstanceDataFields.BATCH_STATUS)).name();
+            return entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.<BatchStatus>getJobExecutionField(em, jobExecutionId, JpaExecutionInstanceDataFields.BATCH_STATUS)).name();
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -343,7 +343,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public String jobOperatorQueryJobExecutionExitStatus(long key) {
         try {
-            return entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, key, JpaExecutionInstanceDataFields.EXIT_STATUS));
+            return entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, key, JpaExecutionInstanceDataFields.EXIT_STATUS));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -357,7 +357,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public long jobOperatorQueryJobExecutionJobInstanceId(long key) throws NoSuchJobExecutionException {
         try {
-            Long jobInstanceId = entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, key, JpaExecutionInstanceDataFields.JOB_INSTANCE_ID));
+            Long jobInstanceId = entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, key, JpaExecutionInstanceDataFields.JOB_INSTANCE_ID));
 
             if (jobInstanceId != null) {
                 return jobInstanceId;
@@ -375,7 +375,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public Properties getParameters(long jobExecutionId) throws NoSuchJobExecutionException {
         try {
-            Properties jobParameters = entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, jobExecutionId, JpaExecutionInstanceDataFields.PARAMETERS));
+            Properties jobParameters = entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobExecutionField(em, jobExecutionId, JpaExecutionInstanceDataFields.PARAMETERS));
 
             if (jobParameters != null) {
                 return jobParameters;
@@ -392,7 +392,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateBatchStatusOnly(long executionInstanceDataId, BatchStatus batchStatus, Timestamp updatedOn) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatus(em, executionInstanceDataId, batchStatus, updatedOn));
+            entityManagerSession.doTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatus(em, executionInstanceDataId, batchStatus, updatedOn));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -401,7 +401,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateWithFinalExecutionStatusesAndTimestamps(long executionInstanceDataId, BatchStatus batchStatus, String exitStatus, Timestamp endedOn) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatusEnded(em, executionInstanceDataId, batchStatus, exitStatus, endedOn));
+            entityManagerSession.doTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatusEnded(em, executionInstanceDataId, batchStatus, exitStatus, endedOn));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -410,7 +410,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void markJobStarted(long executionInstanceDataId, Timestamp startedOn) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatusStarted(em, executionInstanceDataId, startedOn));
+            entityManagerSession.doTransactedAction(em -> JpaExecutionInstanceDataDAO.updateBatchStatusStarted(em, executionInstanceDataId, startedOn));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -419,8 +419,8 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public IJobExecution jobOperatorGetJobExecution(long jobExecutionId) {
         try {
-            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.find(em, jobExecutionId));
-            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.onResult(em -> JpaJobInstanceDataDAO.find(em, jpaExecutionInstanceData.getJobInstanceId()));
+            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.find(em, jobExecutionId));
+            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.doAction(em -> JpaJobInstanceDataDAO.find(em, jpaExecutionInstanceData.getJobInstanceId()));
 
             JobOperatorJobExecution jobExecution = jpaExecutionInstanceData.toJobExecution();
             jobExecution.setJobName(jpaJobInstanceData.getName());
@@ -434,7 +434,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public List<IJobExecution> jobOperatorGetJobExecutions(long jobInstanceId) {
         try {
-            List<JpaExecutionInstanceData> jpaExecutionInstanceDataResult = entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobExecutions(em, jobInstanceId));
+            List<JpaExecutionInstanceData> jpaExecutionInstanceDataResult = entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobExecutions(em, jobInstanceId));
             return jpaExecutionInstanceDataResult.stream().map(JpaExecutionInstanceData::toJobExecution).collect(Collectors.toList());
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -444,7 +444,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public Set<Long> jobOperatorGetRunningExecutions(String jobName) {
         try {
-            return entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getJobRunningExecutions(em, jobName));
+            return entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getJobRunningExecutions(em, jobName));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -453,7 +453,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public JobStatus getJobStatusFromExecution(long jobExecutionId) {
         try {
-            return entityManagerSession.onResult(em -> {
+            return entityManagerSession.doAction(em -> {
                 JpaExecutionInstanceData jpaExecutionInstanceData = JpaExecutionInstanceDataDAO.find(em, jobExecutionId);
 
                 JpaJobStatus jobStatus = JpaJobStatusDAO.find(em, jpaExecutionInstanceData.getJobInstanceId());
@@ -469,7 +469,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public String getTagName(long jobExecutionId) {
         try {
-            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.onResult(em -> {
+            JpaJobInstanceData jpaJobInstanceData = entityManagerSession.doAction(em -> {
                 JpaExecutionInstanceData jpaExecutionInstanceData = JpaExecutionInstanceDataDAO.find(em, jobExecutionId);
                 return JpaJobInstanceDataDAO.find(em, jpaExecutionInstanceData.getJobInstanceId());
             });
@@ -482,7 +482,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public long getMostRecentExecutionId(long jobInstanceId) {
         try {
-            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.onResult(em -> JpaExecutionInstanceDataDAO.getMostRecentByJobInstance(em, jobInstanceId));
+            JpaExecutionInstanceData jpaExecutionInstanceData = entityManagerSession.doAction(em -> JpaExecutionInstanceDataDAO.getMostRecentByJobInstance(em, jobInstanceId));
             return jpaExecutionInstanceData.getId();
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -495,7 +495,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public StepExecutionImpl createStepExecution(long jobExecutionId, StepContextImpl stepContext) {
         try {
-            JpaStepExecutionInstanceData jpaStepExecutionInstanceData = entityManagerSession.onTransactedInsert(em -> JpaStepExecutionInstanceDataDAO.insert(em, jobExecutionId, stepContext));
+            JpaStepExecutionInstanceData jpaStepExecutionInstanceData = entityManagerSession.doTransactedAction(em -> JpaStepExecutionInstanceDataDAO.insert(em, jobExecutionId, stepContext));
             return jpaStepExecutionInstanceData != null ? jpaStepExecutionInstanceData.toStepExecution() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -505,7 +505,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateStepExecution(StepContextImpl stepContext) {
         try {
-            entityManagerSession.onTransactedInsert(em -> JpaStepExecutionInstanceDataDAO.update(em, stepContext));
+            entityManagerSession.doTransactedAction(em -> JpaStepExecutionInstanceDataDAO.update(em, stepContext));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -514,7 +514,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public Map<String, StepExecution> getMostRecentStepExecutionsForJobInstance(long jobInstanceId) {
         try {
-            return entityManagerSession.onResult(em -> JpaStepExecutionInstanceDataDAO.getExternalJobInstanceData(em, jobInstanceId));
+            return entityManagerSession.doAction(em -> JpaStepExecutionInstanceDataDAO.getExternalJobInstanceData(em, jobInstanceId));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -523,7 +523,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public List<StepExecution> getStepExecutionsForJobExecution(long jobExecutionId) {
         try {
-            return entityManagerSession.onResult(em -> JpaStepExecutionInstanceDataDAO.getStepExecutionsByJobExecution(em, jobExecutionId));
+            return entityManagerSession.doAction(em -> JpaStepExecutionInstanceDataDAO.getStepExecutionsByJobExecution(em, jobExecutionId));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }
@@ -532,7 +532,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public StepExecution getStepExecutionByStepExecutionId(long stepExecId) {
         try {
-            JpaStepExecutionInstanceData jpaStepExecutionInstanceData = entityManagerSession.onResult(em -> JpaStepExecutionInstanceDataDAO.find(em, stepExecId));
+            JpaStepExecutionInstanceData jpaStepExecutionInstanceData = entityManagerSession.doAction(em -> JpaStepExecutionInstanceDataDAO.find(em, stepExecId));
             return jpaStepExecutionInstanceData != null ? jpaStepExecutionInstanceData.toStepExecution() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -545,7 +545,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public StepStatus createStepStatus(long stepExecutionId) {
         try {
-            JpaStepStatus jpaStepStatus = entityManagerSession.onTransactedInsert(em -> JpaStepStatusDAO.create(em, stepExecutionId));
+            JpaStepStatus jpaStepStatus = entityManagerSession.doTransactedAction(em -> JpaStepStatusDAO.create(em, stepExecutionId));
             return jpaStepStatus != null ? jpaStepStatus.toStepStatus() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -555,7 +555,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public StepStatus getStepStatus(long jobInstanceId, String stepName) {
         try {
-            JpaStepStatus jpaStepStatus = entityManagerSession.onResult(em -> JpaStepStatusDAO.getStepStatusByJobInstance(em, jobInstanceId, stepName));
+            JpaStepStatus jpaStepStatus = entityManagerSession.doAction(em -> JpaStepStatusDAO.getStepStatusByJobInstance(em, jobInstanceId, stepName));
             return jpaStepStatus != null ? jpaStepStatus.toStepStatus() : null;
         } catch (Exception e) {
             throw new PersistenceException(e);
@@ -565,7 +565,7 @@ public class JPAPersistenceManagerImpl extends AbstractKapuaService implements I
     @Override
     public void updateStepStatus(long stepExecutionId, StepStatus stepStatus) {
         try {
-            entityManagerSession.onTransactedAction(em -> JpaStepStatusDAO.update(em, stepExecutionId, stepStatus));
+            entityManagerSession.doTransactedAction(em -> JpaStepStatusDAO.update(em, stepExecutionId, stepStatus));
         } catch (Exception e) {
             throw new PersistenceException(e);
         }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobStatusDAO.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaJobStatusDAO.java
@@ -36,13 +36,15 @@ public class JpaJobStatusDAO {
         return jpaJobStatus;
     }
 
-    public static void update(EntityManager em, long jobInstanceId, JobStatus jobStatus) {
+    public static JpaJobStatus update(EntityManager em, long jobInstanceId, JobStatus jobStatus) {
         JpaJobStatus jpaJobStatus = find(em, jobInstanceId);
         jpaJobStatus.setObj(jobStatus);
 
         em.merge(jpaJobStatus);
         em.flush();
         em.refresh(jpaJobStatus);
+
+        return jpaJobStatus;
     }
 
     public static JpaJobStatus find(EntityManager em, long jobInstanceId) {

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaStepStatusDAO.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/persistence/jpa/JpaStepStatusDAO.java
@@ -39,13 +39,15 @@ public class JpaStepStatusDAO {
         return jpaStepStatus;
     }
 
-    public static void update(EntityManager em, long stepExecutionId, StepStatus stepStatus) {
+    public static JpaStepStatus update(EntityManager em, long stepExecutionId, StepStatus stepStatus) {
         JpaStepStatus jpaStepStatus = find(em, stepExecutionId);
         jpaStepStatus.setObj(stepStatus);
 
         em.merge(jpaStepStatus);
         em.flush();
         em.refresh(jpaStepStatus);
+
+        return jpaStepStatus;
     }
 
     public static JpaStepStatus find(EntityManager em, long jobInstanceId) {

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
@@ -113,7 +113,7 @@ public class JobStepDefinitionServiceImpl
 
         //
         // Do find
-        return entityManagerSession.onResult(em -> {
+        return entityManagerSession.doAction(em -> {
 
             JobStepDefinition jobStepDefinition = JobStepDefinitionDAO.findByName(em, name);
             if (jobStepDefinition != null) {

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
@@ -123,7 +123,7 @@ public class TriggerDefinitionServiceImpl extends AbstractKapuaService implement
 
         //
         // Do find
-        return entityManagerSession.onResult(em -> {
+        return entityManagerSession.doAction(em -> {
             TriggerDefinition triggerDefinition = TriggerDefinitionDAO.findByName(em, name);
             if (triggerDefinition != null) {
                 //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
@@ -103,7 +103,7 @@ public class DomainRegistryServiceImpl extends AbstractKapuaService implements D
 
         //
         // Do find
-        return entityManagerSession.onResult(em -> {
+        return entityManagerSession.doAction(em -> {
             Domain domain = DomainDAO.findByName(em, name);
 
             if (domain != null) {


### PR DESCRIPTION
Signed-off-by: Gianluca Barbon <gianluca.barbon@eurotech.com>

Updated wrong calls to EntityManagerSession methods.
Added return value on Job Engine DAO update methods.

**Related Issue**
_N/A_

**Description of the solution adopted**
_N/A_

**Screenshots**
_N/A_

**Any side note on the changes made**
_N/A_