### PR TITLE
Cache added to services

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableServiceCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableServiceCache.java
@@ -9,19 +9,17 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.commons.configuration;
 
-import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 
-/**
- * Cache factory definition
- */
-public interface CacheFactory {
+public class AbstractKapuaConfigurableServiceCache extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private AbstractKapuaConfigurableServiceCache() {
+        super("AbstractKapuaConfigurableServiceCacheId");
+    }
+
+    protected static AbstractKapuaConfigurableServiceCache getInstance() {
+        return new AbstractKapuaConfigurableServiceCache();
+    }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractNamedEntityCacheFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractNamedEntityCacheFactory.java
@@ -12,16 +12,23 @@
 package org.eclipse.kapua.commons.jpa;
 
 import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.service.internal.cache.NamedEntityCache;
 
-/**
- * Cache factory definition
- */
-public interface CacheFactory {
+public abstract class AbstractNamedEntityCacheFactory extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private String nameCacheName;
+
+    public AbstractNamedEntityCacheFactory(String idCacheName, String nameCacheName) {
+        super(idCacheName);
+        this.nameCacheName = nameCacheName;
+    }
+
+    public String getEntityNameCacheName() {
+        return nameCacheName;
+    }
+
+    @Override
+    public EntityCache createCache() {
+        return new NamedEntityCache(getEntityIdCacheName(), getEntityNameCacheName());
+    }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -27,7 +27,7 @@ public interface EntityManagerCallback<T> {
      * WARNING!<br>
      * The transactionality (if needed by the code) must be managed internally to this method.<br>
      * The caller method performs only a rollback (if the transaction is active and an error occurred)!<br>
-     * @see EntityManagerSession#onInsert(EntityManagerInsertCallback)
+     * @see EntityManagerSession#doAction(EntityManagerContainer)
      *
      * @param entityManager
      * @return

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
@@ -98,9 +98,10 @@ public class EventStoreDAO {
      * @param em
      * @param scopeId
      * @param eventId
+     * @return deleted entity
      * @throws KapuaEntityNotFoundException
      */
-    public static void delete(EntityManager em, KapuaId scopeId, KapuaId eventId) throws KapuaEntityNotFoundException {
-        ServiceDAO.delete(em, EventStoreRecordImpl.class, scopeId, eventId);
+    public static EventStoreRecord delete(EntityManager em, KapuaId scopeId, KapuaId eventId) throws KapuaEntityNotFoundException {
+        return ServiceDAO.delete(em, EventStoreRecordImpl.class, scopeId, eventId);
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
@@ -102,10 +102,7 @@ public class EventStoreServiceImpl extends AbstractKapuaService implements Event
 
         //
         // Do delete
-        entityManagerSession.doTransactedAction(em -> {
-            EventStoreDAO.delete(em, scopeId, kapuaEventId);
-            return (EventStoreRecord)null;
-        });
+        entityManagerSession.doTransactedAction(em -> EventStoreDAO.delete(em, scopeId, kapuaEventId));
     }
 
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
@@ -43,6 +43,12 @@ public class AbstractKapuaService {
         this(entityManagerFactory, null);
     }
 
+    /**
+     * Constructor.
+     *
+     * @param entityManagerFactory the EntityManager factory.
+     * @param abstractCacheFactory the service cache factory.
+     */
     protected AbstractKapuaService(EntityManagerFactory entityManagerFactory, AbstractEntityCacheFactory abstractCacheFactory) {
         this.entityManagerFactory = entityManagerFactory;
         this.entityManagerSession = new EntityManagerSession(entityManagerFactory);

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -39,10 +39,7 @@ import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.model.query.predicate.OrPredicate;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
-import org.eclipse.kapua.service.authorization.access.AccessInfoAttributes;
 import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
-import org.eclipse.kapua.service.authorization.access.AccessInfoListResult;
-import org.eclipse.kapua.service.authorization.access.AccessInfoQuery;
 import org.eclipse.kapua.service.authorization.access.AccessInfoService;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult;
@@ -249,6 +246,7 @@ public class ServiceDAO {
      * @param clazz    The {@link KapuaEntity} class. This must be the implementing {@code class}.
      * @param scopeId  The {@link KapuaEntity} scopeId of the entity to be deleted.
      * @param entityId The {@link KapuaEntity} {@link KapuaId} of the entity to be deleted.
+     * @return The deleted {@link KapuaEntity}.
      * @throws KapuaEntityNotFoundException If the {@link KapuaEntity} does not exists.
      * @since 1.0.0
      */
@@ -795,16 +793,12 @@ public class ServiceDAO {
         try {
             KapuaId userId = kapuaSession.getUserId();
 
-            AccessInfoQuery accessInfoQuery = ACCESS_INFO_FACTORY.newQuery(kapuaSession.getScopeId());
-            accessInfoQuery.setPredicate(query.attributePredicate(AccessInfoAttributes.USER_ID, userId));
-
-            AccessInfoListResult accessInfos = KapuaSecurityUtils.doPrivileged(() -> ACCESS_INFO_SERVICE.query(accessInfoQuery));
+            AccessInfo accessInfo = KapuaSecurityUtils.doPrivileged(() -> ACCESS_INFO_SERVICE.findByUserId(kapuaSession.getScopeId(), userId));
 
             List<Permission> groupPermissions = new ArrayList<>();
-            if (!accessInfos.isEmpty()) {
+            if (accessInfo!=null) {
 
-                AccessInfo accessInfo = accessInfos.getFirstItem();
-                AccessPermissionListResult accessPermissions = KapuaSecurityUtils.doPrivileged(() -> ACCESS_PERMISSION_SERVICE.findByAccessInfoId(accessInfo.getScopeId(), accessInfo.getId()));
+                        AccessPermissionListResult accessPermissions = KapuaSecurityUtils.doPrivileged(() -> ACCESS_PERMISSION_SERVICE.findByAccessInfoId(accessInfo.getScopeId(), accessInfo.getId()));
 
                 for (AccessPermission ap : accessPermissions.getItems()) {
                     if (checkGroupPermission(domain, groupPermissions, ap.getPermission())) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/ComposedKey.java
@@ -16,6 +16,9 @@ import org.eclipse.kapua.model.id.KapuaId;
 import java.io.Serializable;
 import java.util.Objects;
 
+/**
+ * This class is needed to define the keys for the {@link EntityCache#listsCache}.
+ */
 public class ComposedKey implements Serializable {
 
     private KapuaId scopeId;

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/EntityCache.java
@@ -22,10 +22,15 @@ import org.slf4j.LoggerFactory;
 import javax.cache.Cache;
 import java.io.Serializable;
 
+/**
+ * The basic cache class, it contains two {@link Cache} objects.
+ * The {@code idCache} cache contains {@link KapuaEntity} objects, while the {@code listsCache} contains {@link KapuaListResult} objects.
+ */
 public class EntityCache {
 
     protected static final Logger LOGGER = LoggerFactory.getLogger(EntityCache.class);
 
+    // metrics naming variables
     private static final String MODULE = "commons";
     private static final String COMPONENT = "cache";
     private static final String ENTITY = "entity";
@@ -37,6 +42,12 @@ public class EntityCache {
     protected Counter cacheHit;
     protected Counter cacheRemoval;
 
+    /**
+     * The constructor initializes the {@link #idCache} and the {@link #listsCache}.
+     * It also initializes metrics counters for analysis ({@link #cacheMiss}, {@link #cacheHit} and {@link #cacheRemoval} counters).
+     *
+     * @param idCacheName
+     */
     public EntityCache(String idCacheName) {
         idCache = KapuaCacheManager.getCache(idCacheName);
         listsCache = KapuaCacheManager.getCache(idCacheName + "_list");
@@ -105,6 +116,14 @@ public class EntityCache {
         return null;
     }
 
+    /**
+     * Checks that the scopeId of the entity matches the provided one.
+     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.service.internal.ServiceDAO} class.
+     *
+     * @param scopeId a {@link KapuaId} representing the scopeId
+     * @param entity the {@link KapuaEntity} to be checked
+     * @return the provided entity if it has the required scopeId, null otherwise
+     */
     protected KapuaEntity checkResult(KapuaId scopeId, KapuaEntity entity) {
         if (entity != null) {
             if (scopeId == null) {
@@ -121,6 +140,14 @@ public class EntityCache {
         }
     }
 
+    /**
+     * Checks that the scopeId of the entity matches the provided one.
+     * This mimics the checks that are performed in the 'find' method of the {@link org.eclipse.kapua.commons.service.internal.ServiceDAO} class.
+     *
+     * @param scopeId a {@link KapuaId} representing the scopeId
+     * @param entity the {@link KapuaListResult} entity to be checked
+     * @return the provided entity if it has the required scopeId, null otherwise
+     */
     protected KapuaListResult checkResult(KapuaId scopeId, KapuaListResult entity) {
         if (entity != null) {
             if (entity.getSize() == 0) {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
@@ -36,6 +36,10 @@ import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 
+/**
+ * Class responsible for managing the various caches that are instantiated.
+ * All the caches are stored in a Map, where the keys are the cache names and the value are the caches themselves.
+ */
 public class KapuaCacheManager {
 
     enum ExpiryPolicy {
@@ -56,6 +60,11 @@ public class KapuaCacheManager {
     private KapuaCacheManager() {
     }
 
+    /**
+     * Gets the URI with the cache config file path.
+     *
+     * @return the URI with the cache config file path
+     */
     private static URI getCacheConfig() {
         String configurationFileName = SystemSetting.getInstance().getString(SystemSettingKey.CACHE_CONFIG_URL);
         URI uri = null;
@@ -76,6 +85,12 @@ public class KapuaCacheManager {
         return uri;
     }
 
+    /**
+     * Method responsible for getting an existing cache, or instantiating a new cache if the searched one does not exists yet.
+     *
+     * @param cacheName the name of the cache.
+     * @return the Cache object containing the desired cache.
+     */
     public static Cache<Serializable, Serializable> getCache(String cacheName) {
         Cache<Serializable, Serializable> cache = CACHE_MAP.get(cacheName);
         if (cache == null) {
@@ -110,6 +125,9 @@ public class KapuaCacheManager {
         return cache;
     }
 
+    /**
+     * Utility method to cleanup the whole cache.
+     */
     public static void invalidateAll() {
         CACHE_MAP.forEach((cacheKey, cache) -> cache.clear());
     }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/Cache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/Cache.java
@@ -20,6 +20,12 @@ import java.util.Iterator;
 import java.util.Map;
 import java.util.Set;
 
+/**
+ * Dummy Cache implementation, returns always null.
+ *
+ * @param <K>
+ * @param <V>
+ */
 public class Cache<K, V> implements javax.cache.Cache<K, V> {
 
     public Cache() {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CacheManager.java
@@ -15,6 +15,9 @@ import javax.cache.configuration.Configuration;
 import java.net.URI;
 import java.util.Properties;
 
+/**
+ * Dummy cache manager needed to instantiate {@link Cache}
+ */
 public class CacheManager implements javax.cache.CacheManager {
 
     private static CacheManager instance;

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CachingProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/dummy/CachingProvider.java
@@ -15,6 +15,9 @@ import javax.cache.configuration.OptionalFeature;
 import java.net.URI;
 import java.util.Properties;
 
+/**
+ * Dummy caching provider needed to instantiate {@link Cache}
+ */
 public class CachingProvider implements javax.cache.spi.CachingProvider {
     @Override
     public javax.cache.CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -89,3 +89,15 @@ commons.eventbus.producerPool.evictionInterval=600000
 commons.eventbus.consumerPool.size=10
 commons.eventbus.messageSerializer=org.eclipse.kapua.commons.event.XmlServiceEventMarshaler
 commons.eventbus.transport.useEpoll=true
+
+#
+# Cache settings (please provide consistent values for these parameters)
+#
+# Provided dummy JCache implementation cache (no cache)
+commons.cache.provider.classname=org.eclipse.kapua.commons.service.internal.cache.dummy.CachingProvider
+# Additional cache configuration file (if any)
+#commons.cache.config.url=yourconfig.yaml
+#commons.cache.config.ttl=15
+#commons.cache.config.expiryPolicy=MODIFIED
+#
+commons.cache.local.tmetadata.maxsize=100

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCacheFactory.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCacheFactory.java
@@ -9,19 +9,20 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.account.internal;
 
-import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.jpa.AbstractNamedEntityCacheFactory;
 
 /**
- * Cache factory definition
+ * Cache factory for the {@link AccountServiceImpl}
  */
-public interface CacheFactory {
+public class AccountCacheFactory extends AbstractNamedEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private AccountCacheFactory() {
+        super("AccountId", "AccountName");
+    }
+
+    protected static AccountCacheFactory getInstance() {
+        return new AccountCacheFactory();
+    }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
@@ -131,10 +131,11 @@ public class AccountDAO {
      * @param em
      * @param scopeId
      * @param accountId
+     * @return The deleted {@link Account}
      * @throws KapuaEntityNotFoundException
      *             If the {@link Account} is not found
      */
-    public static void delete(EntityManager em, KapuaId scopeId, KapuaId accountId) throws KapuaEntityNotFoundException {
-        ServiceDAO.delete(em, AccountImpl.class, scopeId, accountId);
+    public static Account delete(EntityManager em, KapuaId scopeId, KapuaId accountId) throws KapuaEntityNotFoundException {
+        return ServiceDAO.delete(em, AccountImpl.class, scopeId, accountId);
     }
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 , 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016 , 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.account.internal;
 
 import org.apache.commons.lang3.StringUtils;
-
 import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaDuplicateNameInAnotherAccountError;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
@@ -24,6 +23,7 @@ import org.eclipse.kapua.KapuaMaxNumberOfItemsReachedException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.service.internal.cache.NamedEntityCache;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
@@ -46,7 +46,6 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 
 import javax.inject.Inject;
 import javax.persistence.TypedQuery;
-
 import java.util.Map;
 import java.util.Objects;
 
@@ -71,7 +70,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
      * @since 1.0.0
      */
     public AccountServiceImpl() {
-        super(AccountService.class.getName(), AccountDomains.ACCOUNT_DOMAIN, AccountEntityManagerFactory.getInstance(), AccountService.class, AccountFactory.class);
+        super(AccountService.class.getName(), AccountDomains.ACCOUNT_DOMAIN, AccountEntityManagerFactory.getInstance(), AccountCacheFactory.getInstance(), AccountService.class, AccountFactory.class);
     }
 
     @Override
@@ -204,24 +203,24 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         }
 
         //
+        // Verify unchanged parent account ID and parent account path
+        if (!Objects.equals(oldAccount.getScopeId(), account.getScopeId())) {
+            throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.scopeId");
+        }
+        if (!oldAccount.getParentAccountPath().equals(account.getParentAccountPath())) {
+            throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.parentAccountPath");
+        }
+        if (!oldAccount.getName().equals(account.getName())) {
+            throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.name");
+        }
+
+        //
         // Do update
-        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
-
-            //
-            // Verify unchanged parent account ID and parent account path
-            if (!Objects.equals(oldAccount.getScopeId(), account.getScopeId())) {
-                throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.scopeId");
-            }
-            if (!oldAccount.getParentAccountPath().equals(account.getParentAccountPath())) {
-                throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.parentAccountPath");
-            }
-            if (!oldAccount.getName().equals(account.getName())) {
-                throw new KapuaAccountException(KapuaAccountErrorCodes.ILLEGAL_ARGUMENT, null, "account.name");
-            }
-
-            // Update
-            return AccountDAO.update(em, account);
-        }));
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> AccountDAO.update(em, account))
+                .onBeforeHandler(() -> {
+                    entityCache.remove(null, account);
+                    return null;
+                }));
     }
 
     @Override
@@ -229,8 +228,8 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
     public void delete(KapuaId scopeId, KapuaId accountId) throws KapuaException {
         //
         // Argument validation
-        ArgumentValidator.notNull(accountId, "scopeId");
-        ArgumentValidator.notNull(scopeId, "accountId");
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(accountId, "accountId");
 
         //
         // Check Access
@@ -245,26 +244,25 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do delete
-        entityManagerSession.doTransactedAction(em -> {
+        entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
             // Entity needs to be loaded in the context of the same EntityManger to be able to delete it afterwards
-            Account accountx = AccountDAO.find(em, scopeId, accountId);
-            if (accountx == null) {
+            Account account = AccountDAO.find(em, scopeId, accountId);
+            if (account == null) {
                 throw new KapuaEntityNotFoundException(Account.TYPE, accountId);
             }
 
             // do not allow deletion of the kapua admin account
             SystemSetting settings = SystemSetting.getInstance();
-            if (settings.getString(SystemSettingKey.SYS_PROVISION_ACCOUNT_NAME).equals(accountx.getName())) {
+            if (settings.getString(SystemSettingKey.SYS_PROVISION_ACCOUNT_NAME).equals(account.getName())) {
                 throw new KapuaIllegalAccessException(action.name());
             }
 
-            if (settings.getString(SystemSettingKey.SYS_ADMIN_USERNAME).equals(accountx.getName())) {
+            if (settings.getString(SystemSettingKey.SYS_ADMIN_USERNAME).equals(account.getName())) {
                 throw new KapuaIllegalAccessException(action.name());
             }
 
-            AccountDAO.delete(em, scopeId, accountId);
-            return null;//TODO change the DAO delete method
-        });
+            return AccountDAO.delete(em, scopeId, accountId);
+        }).onAfterHandler((emptyParam) -> entityCache.remove(scopeId, accountId)));
     }
 
     @Override
@@ -308,15 +306,20 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do find
-        //TODO fix it, example using new container
-        return entityManagerSession.doAction(em -> {
-                Account account = AccountDAO.findByName(em, name);
-                if (account != null) {
-                    checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
+        return entityManagerSession.doAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
+                    Account account = AccountDAO.findByName(em, name);
+                    if (account != null) {
+                        checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
+                    }
+                    return account;
                 }
-                return account;
+        ).onBeforeHandler(() -> {
+            Account account = (Account) ((NamedEntityCache) entityCache).get(null, name);
+            if (account != null) {  // TODO: can this be put in the onAfterResultHandler ?
+                checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
             }
-         );
+            return account;
+        }).onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
@@ -335,7 +338,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         //
         // Check Access
         checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
-        return entityManagerSession.doAction(em -> {
+        return entityManagerSession.doAction(EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> {
             AccountListResult result = null;
             TypedQuery<Account> q;
             q = em.createNamedQuery("Account.findChildAccountsRecursive", Account.class);
@@ -344,7 +347,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             result = new AccountListResultImpl();
             result.addItems(q.getResultList());
             return result;
-        });
+        }));
     }
 
     @Override
@@ -359,7 +362,9 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do query
-        return entityManagerSession.doAction(em -> AccountDAO.query(em, query));
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> AccountDAO.query(em, query))
+        );
     }
 
     @Override
@@ -374,7 +379,9 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do count
-        return entityManagerSession.doAction(em -> AccountDAO.count(em, query));
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<Long>create().onResultHandler(em -> AccountDAO.count(em, query))
+        );
     }
 
     /**
@@ -392,7 +399,11 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do find
-        return entityManagerSession.doAction(em -> AccountDAO.find(em, null, accountId));
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<Account>create().onResultHandler(em -> AccountDAO.find(em, null, accountId))
+                        .onBeforeHandler(() -> (Account) entityCache.get(null, accountId))
+                        .onAfterHandler((entity) -> entityCache.put(entity))
+        );
     }
 
     private AccountListResult findChildAccountsTrusted(KapuaId accountId)
@@ -404,7 +415,10 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do find
-        return entityManagerSession.doAction(em -> AccountDAO.query(em, new AccountQueryImpl(accountId)));
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> AccountDAO.query(em,
+                        new AccountQueryImpl(accountId)))
+        );
     }
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
@@ -108,7 +108,7 @@ public class DeviceConnectionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceConnectionId
-     * @return deleted entity
+     * @return the deleted {@link DeviceConnection}
      * @throws KapuaEntityNotFoundException If the {@link DeviceConnection} is not found.
      */
     public static DeviceConnection delete(EntityManager em, KapuaId scopeId, KapuaId deviceConnectionId) throws KapuaEntityNotFoundException {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
@@ -169,7 +169,7 @@ public class DeviceDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param deviceId
-     * @return deleted entity
+     * @return the deleted {@link Device}
      * @throws KapuaEntityNotFoundException If {@link Device} is not found.
      */
     public static Device delete(EntityManager em, KapuaId scopeId, KapuaId deviceId) throws KapuaEntityNotFoundException {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCache.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCache.java
@@ -1,0 +1,88 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.internal;
+
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.service.internal.cache.KapuaCacheManager;
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.device.registry.Device;
+
+import javax.cache.Cache;
+import java.io.Serializable;
+
+/**
+ * {@link DeviceRegistryServiceImpl} dedicated cache.
+ * Extends the {@link EntityCache} by providing two further {@link Cache} objects,
+ * called {@code deviceByClientIdCache} and {@code deviceByConnectionIdCache}.
+ * The {@code deviceByClientIdCache} cache adopts the clientId as key and the entity id as value,
+ * while the {@code deviceByConnectionIdCache} cache adopts the connectionId as key and the entity id as value.
+ * In such a way the correspondence with {@link EntityCache#idCache} is preserved.
+ */
+public class DeviceRegistryCache extends EntityCache {
+
+    protected Cache<Serializable, Serializable> deviceByClientIdCache;
+    protected Cache<Serializable, Serializable> deviceByConnectionIdCache;
+
+    public DeviceRegistryCache(String idCacheName, String deviceByClientIdCacheName, String deviceByConnectionIdCacheName) {
+        super(idCacheName);
+        deviceByClientIdCache = KapuaCacheManager.getCache(deviceByClientIdCacheName);
+        deviceByConnectionIdCache = KapuaCacheManager.getCache(deviceByConnectionIdCacheName);
+    }
+
+    public KapuaEntity getByClientId(KapuaId scopeId, String clientId) {
+        if (clientId != null) {
+            KapuaId entityId = (KapuaId) deviceByClientIdCache.get(clientId);
+            return get(scopeId, entityId);
+        }
+        return null;
+    }
+
+    public KapuaEntity getByDeviceConnectionId(KapuaId scopeId, KapuaId deviceConnectionId) {
+        if (deviceConnectionId != null) {
+            KapuaId entityId = (KapuaId) deviceByConnectionIdCache.get(deviceConnectionId);
+            return get(scopeId, entityId);
+        }
+        return null;
+    }
+
+    @Override
+    public void put(KapuaEntity entity) {
+        if (entity != null) {
+            idCache.put(entity.getId(), entity);
+            deviceByClientIdCache.put(((Device) entity).getClientId(), entity.getId());
+            if (((Device) entity).getConnectionId() != null) {
+                deviceByConnectionIdCache.put(((Device) entity).getConnectionId(), entity.getId());
+            }
+        }
+    }
+
+    @Override
+    public KapuaEntity remove(KapuaId scopeId, KapuaId kapuaId) {
+        KapuaEntity kapuaEntity = super.remove(scopeId, kapuaId);
+        if (kapuaEntity != null) {
+            deviceByClientIdCache.remove(((Device) kapuaEntity).getClientId());
+            if (((Device) kapuaEntity).getConnectionId() != null) {
+                deviceByConnectionIdCache.remove(((Device) kapuaEntity).getConnectionId());
+            }
+        }
+        return kapuaEntity;
+    }
+
+    public KapuaEntity removeByDeviceConnectionId(KapuaId scopeId, KapuaId deviceConnectionId) {
+        KapuaEntity kapuaEntity = getByDeviceConnectionId(scopeId, deviceConnectionId);
+        if (kapuaEntity != null) {
+            return remove(kapuaEntity.getScopeId(), kapuaEntity.getId());
+        }
+        return null;
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCacheFactory.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCacheFactory.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.internal;
+
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+
+/**
+ * Cache factory for the {@link DeviceRegistryServiceImpl}
+ */
+public class DeviceRegistryCacheFactory extends AbstractEntityCacheFactory {
+
+    public DeviceRegistryCacheFactory() {
+        super("DeviceId");
+    }
+
+    /**
+     * @return a {@link DeviceRegistryCache} instance.
+     */
+    @Override
+    public EntityCache createCache() {
+        return new DeviceRegistryCache(getEntityIdCacheName(), "DeviceClientId", "DeviceConnectionId");
+    }
+
+    public static DeviceRegistryCacheFactory getInstance() {
+        return new DeviceRegistryCacheFactory();
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -17,6 +17,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaMaxNumberOfItemsReachedException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -51,7 +52,8 @@ public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResource
      * @param deviceEntityManagerFactory
      */
     public DeviceRegistryServiceImpl(DeviceEntityManagerFactory deviceEntityManagerFactory) {
-        super(DeviceRegistryService.class.getName(), DeviceDomains.DEVICE_DOMAIN, deviceEntityManagerFactory, DeviceRegistryService.class, DeviceFactory.class);
+        super(DeviceRegistryService.class.getName(), DeviceDomains.DEVICE_DOMAIN, deviceEntityManagerFactory,
+                DeviceRegistryCacheFactory.getInstance(), DeviceRegistryService.class, DeviceFactory.class);
     }
 
     /**
@@ -81,67 +83,75 @@ public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResource
             throw new KapuaDuplicateNameException(deviceCreator.getClientId());
         }
 
-        return entityManagerSession.doTransactedAction(entityManager -> DeviceDAO.create(entityManager, deviceCreator));
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Device>create().onResultHandler(entityManager -> DeviceDAO.create(entityManager, deviceCreator)));
     }
 
     @Override
     public Device update(Device device) throws KapuaException {
         DeviceValidation.validateUpdatePreconditions(device);
 
-        return entityManagerSession.doTransactedAction(entityManager -> {
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Device>create().onResultHandler(entityManager -> {
             Device currentDevice = DeviceDAO.find(entityManager, device.getScopeId(), device.getId());
             if (currentDevice == null) {
                 throw new KapuaEntityNotFoundException(Device.TYPE, device.getId());
             }
             // Update
             return DeviceDAO.update(entityManager, device);
-        });
+        }).onBeforeHandler(() -> {
+                    entityCache.remove(device.getScopeId(), device);
+                    return null;
+                }
+            ));
     }
 
     @Override
     public Device find(KapuaId scopeId, KapuaId entityId) throws KapuaException {
         DeviceValidation.validateFindPreconditions(scopeId, entityId);
 
-        return entityManagerSession.doAction(entityManager -> DeviceDAO.find(entityManager, scopeId, entityId));
+        return entityManagerSession.doAction(EntityManagerContainer.<Device>create().onResultHandler(entityManager -> DeviceDAO.find(entityManager, scopeId, entityId))
+                .onBeforeHandler(() -> (Device) entityCache.get(scopeId, entityId))
+                .onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
     public DeviceListResult query(KapuaQuery<Device> query) throws KapuaException {
         DeviceValidation.validateQueryPreconditions(query);
 
-        return entityManagerSession.doAction(entityManager -> DeviceDAO.query(entityManager, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<DeviceListResult>create().onResultHandler(entityManager -> DeviceDAO.query(entityManager, query)));
     }
 
     @Override
     public long count(KapuaQuery<Device> query) throws KapuaException {
         DeviceValidation.validateCountPreconditions(query);
 
-        return entityManagerSession.doAction(entityManager -> DeviceDAO.count(entityManager, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<Long>create().onResultHandler(entityManager -> DeviceDAO.count(entityManager, query)));
     }
 
     @Override
     public void delete(KapuaId scopeId, KapuaId deviceId) throws KapuaException {
         DeviceValidation.validateDeletePreconditions(scopeId, deviceId);
 
-        entityManagerSession.doTransactedAction(entityManager -> DeviceDAO.delete(entityManager, scopeId, deviceId));
+        entityManagerSession.doTransactedAction(EntityManagerContainer.create().onResultHandler(entityManager -> DeviceDAO.delete(entityManager, scopeId, deviceId))
+                .onAfterHandler((emptyParam) -> entityCache.remove(scopeId, deviceId)));
     }
 
     @Override
     public Device findByClientId(KapuaId scopeId, String clientId) throws KapuaException {
         DeviceValidation.validateFindByClientIdPreconditions(scopeId, clientId);
+        Device device = (Device) ((DeviceRegistryCache) entityCache).getByClientId(scopeId, clientId);
+        if (device==null) {
+            DeviceQueryImpl query = new DeviceQueryImpl(scopeId);
+            query.setPredicate(query.attributePredicate(DeviceAttributes.CLIENT_ID, clientId));
+            query.setFetchAttributes(Lists.newArrayList(DeviceAttributes.CONNECTION, DeviceAttributes.LAST_EVENT));
 
-        DeviceQueryImpl query = new DeviceQueryImpl(scopeId);
-        query.setPredicate(query.attributePredicate(DeviceAttributes.CLIENT_ID, clientId));
-        query.setFetchAttributes(Lists.newArrayList(DeviceAttributes.CONNECTION, DeviceAttributes.LAST_EVENT));
-
-        //
-        // Query and parse result
-        Device device = null;
-        DeviceListResult result = query(query);
-        if (!result.isEmpty()) {
-            device = result.getFirstItem();
+            //
+            // Query and parse result
+            DeviceListResult result = query(query);
+            if (!result.isEmpty()) {
+                device = result.getFirstItem();
+                entityCache.put(device);
+            }
         }
-
         return device;
     }
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
@@ -129,9 +129,10 @@ public class JobStepDAO {
      * @param em
      * @param scopeId
      * @param jobStepId
+     * @return the deleted entity
      * @throws KapuaEntityNotFoundException If the {@link JobStep} is not found
      */
-    public static void delete(EntityManager em, KapuaId scopeId, KapuaId jobStepId) throws KapuaEntityNotFoundException {
-        ServiceDAO.delete(em, JobStepImpl.class, scopeId, jobStepId);
+    public static JobStep delete(EntityManager em, KapuaId scopeId, KapuaId jobStepId) throws KapuaEntityNotFoundException {
+        return ServiceDAO.delete(em, JobStepImpl.class, scopeId, jobStepId);
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCache.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCache.java
@@ -9,32 +9,35 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.service.internal.cache;
+package org.eclipse.kapua.service.authorization.access.shiro;
 
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.service.internal.cache.KapuaCacheManager;
 import org.eclipse.kapua.model.KapuaEntity;
-import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
 
 import javax.cache.Cache;
 import java.io.Serializable;
 
 /**
- * Extends the {@link EntityCache} by providing a further {@link Cache} object, called {@code nameCache}.
- * The {@code nameCache} cache adopts the entity name as key and the entity id as value.
+ * {@link AccessInfoServiceImpl} dedicated cache.
+ * Extends the {@link EntityCache} by providing a further {@link Cache} object, called {@code accessInfoByUserIdCache}.
+ * The {@code accessInfoByUserIdCache} cache adopts the userId as key and the entity id as value.
  * In such a way the correspondence with {@link EntityCache#idCache} is preserved.
  */
-public class NamedEntityCache extends EntityCache {
+public class AccessInfoCache extends EntityCache {
 
-    protected Cache<Serializable, Serializable> nameCache;
+    protected Cache<Serializable, Serializable> accessInfoByUserIdCache;
 
-    public NamedEntityCache(String idCacheName, String nameCacheName) {
+    public AccessInfoCache(String idCacheName, String nameCacheName) {
         super(idCacheName);
-        nameCache = KapuaCacheManager.getCache(nameCacheName);
+        accessInfoByUserIdCache = KapuaCacheManager.getCache(nameCacheName);
     }
 
-    public KapuaEntity get(KapuaId scopeId, String name) {
-        if (name != null) {
-            KapuaId entityId = (KapuaId) nameCache.get(name);
+    public KapuaEntity getByUserId(KapuaId scopeId, KapuaId userId) {
+        if (userId != null) {
+            KapuaId entityId = (KapuaId) accessInfoByUserIdCache.get(userId);
             return get(scopeId, entityId);
         }
         return null;
@@ -44,7 +47,7 @@ public class NamedEntityCache extends EntityCache {
     public void put(KapuaEntity entity) {
         if (entity != null) {
             idCache.put(entity.getId(), entity);
-            nameCache.put(((KapuaNamedEntity) entity).getName(), entity.getId());
+            accessInfoByUserIdCache.put(((AccessInfo) entity).getUserId(), entity.getId());
         }
     }
 
@@ -52,7 +55,7 @@ public class NamedEntityCache extends EntityCache {
     public KapuaEntity remove(KapuaId scopeId, KapuaId kapuaId) {
         KapuaEntity kapuaEntity = super.remove(scopeId, kapuaId);
         if (kapuaEntity != null) {
-            nameCache.remove(((KapuaNamedEntity) kapuaEntity).getName());
+            accessInfoByUserIdCache.remove(((AccessInfo) kapuaEntity).getUserId());
         }
         return kapuaEntity;
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheFactory.java
@@ -9,19 +9,29 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.authorization.access.shiro;
 
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
 
 /**
- * Cache factory definition
+ * Cache factory for the {@link AccessInfoImpl}
  */
-public interface CacheFactory {
+public class AccessInfoCacheFactory extends AbstractEntityCacheFactory {
+
+    public AccessInfoCacheFactory() {
+        super("AccessInfoId");
+    }
 
     /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
+     * @return an {@link AccessInfoCache}
      */
-    EntityCache createCache();
+    @Override
+    public EntityCache createCache() {
+        return new AccessInfoCache(getEntityIdCacheName(), "AccessInfoUserIdId");
+    }
+
+    protected static AccessInfoCacheFactory getInstance() {
+        return new AccessInfoCacheFactory();
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
@@ -91,7 +91,7 @@ public class AccessInfoDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessInfoId
-     * @return deleted entity
+     * @return the deleted {@link AccessInfo}
      * @throws KapuaEntityNotFoundException If {@link AccessInfo} is nott found.
      * @since 1.0.0
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.authorization.access.shiro;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
+import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
@@ -63,7 +64,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
      * @since 1.0.0
      */
     public AccessInfoServiceImpl() {
-        super(AuthorizationEntityManagerFactory.getInstance());
+        super(AuthorizationEntityManagerFactory.getInstance(), AccessInfoCacheFactory.getInstance());
     }
 
     @Override
@@ -103,7 +104,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
             }
         }
 
-        return entityManagerSession.doTransactedAction(em -> {
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessInfo>create().onResultHandler(em -> {
             AccessInfo accessInfo = AccessInfoDAO.create(em, accessInfoCreator);
 
             if (!accessInfoCreator.getPermissions().isEmpty()) {
@@ -131,7 +132,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
             }
 
             return accessInfo;
-        });
+        }));
     }
 
     @Override
@@ -147,7 +148,10 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, scopeId));
 
-        return entityManagerSession.doAction(em -> AccessInfoDAO.find(em, scopeId, accessInfoId));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessInfo>create().onResultHandler(em -> AccessInfoDAO.find(em, scopeId, accessInfoId))
+                .onBeforeHandler(() -> (AccessInfo) entityCache.get(scopeId, accessInfoId))
+                .onAfterHandler((entity) -> entityCache.put(entity))
+        );
     }
 
     @Override
@@ -164,12 +168,14 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, scopeId));
         AccessInfoQuery query = accessInfoFactory.newQuery(scopeId);
         query.setPredicate(query.attributePredicate(AccessInfoAttributes.USER_ID, userId));
-        AccessInfoListResult result = entityManagerSession.doAction(em -> AccessInfoDAO.query(em, query));
-        if (!result.isEmpty()) {
-            return result.getFirstItem();
-        } else {
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessInfo>create().onResultHandler(em -> {
+            AccessInfoListResult result = AccessInfoDAO.query(em, query);
+            if (!result.isEmpty()) {
+                return result.getFirstItem();
+            }
             return null;
-        }
+        }).onBeforeHandler(() -> (AccessInfo) ((AccessInfoCache) entityCache).getByUserId(scopeId, userId))
+                .onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
@@ -184,7 +190,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessInfoDAO.query(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessInfoListResult>create().onResultHandler(em -> AccessInfoDAO.query(em, query)));
     }
 
     @Override
@@ -199,7 +205,7 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessInfoDAO.count(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<Long>create().onResultHandler(em -> AccessInfoDAO.count(em, query)));
     }
 
     @Override
@@ -210,13 +216,15 @@ public class AccessInfoServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.doTransactedAction(em -> {
-            if (AccessInfoDAO.find(em, scopeId, accessInfoId) == null) {
-                throw new KapuaEntityNotFoundException(AccessInfo.TYPE, accessInfoId);
-            }
-
-            return AccessInfoDAO.delete(em, scopeId, accessInfoId);
-        });
+        entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessInfo>create().onResultHandler(em -> {
+                    // TODO: check if it is correct to remove this statement (already thrown by the delete method, but
+                    //  without TYPE)
+                    if (AccessInfoDAO.find(em, scopeId, accessInfoId) == null) {
+                        throw new KapuaEntityNotFoundException(AccessInfo.TYPE, accessInfoId);
+                    }
+                    return AccessInfoDAO.delete(em, scopeId, accessInfoId);
+                }
+        ).onAfterHandler((emptyParam) -> entityCache.remove(scopeId, accessInfoId)));
     }
 
     //@ListenServiceEvent(fromAddress="account")

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCacheFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCacheFactory.java
@@ -9,19 +9,20 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.authorization.access.shiro;
 
-import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 
 /**
- * Cache factory definition
+ * Cache factory for the {@link AccessPermissionServiceImpl}
  */
-public interface CacheFactory {
+public class AccessPermissionCacheFactory extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private AccessPermissionCacheFactory() {
+        super("AccessPermissionId");
+    }
+
+    protected static AccessPermissionCacheFactory getInstance() {
+        return new AccessPermissionCacheFactory();
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
@@ -91,7 +91,7 @@ public class AccessPermissionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessPermissionId
-     * @return deleted entity
+     * @return the deleted {@link AccessPermission}
      * @throws KapuaEntityNotFoundException
      *             If {@link AccessPermission} is not found.
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.authorization.access.shiro;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -49,7 +50,7 @@ import java.util.Map;
 public class AccessPermissionServiceImpl extends AbstractKapuaService implements AccessPermissionService {
 
     public AccessPermissionServiceImpl() {
-        super(AuthorizationEntityManagerFactory.getInstance());
+        super(AuthorizationEntityManagerFactory.getInstance(), AccessPermissionCacheFactory.getInstance());
     }
 
     @Override
@@ -107,7 +108,7 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
 
         //
         // Do create
-        return entityManagerSession.doTransactedAction(em -> {
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessPermission>create().onResultHandler(em -> {
             //
             // Check that accessInfo exists
             AccessInfo accessInfo = AccessInfoDAO.find(em, accessPermissionCreator.getScopeId(), accessPermissionCreator.getAccessInfoId());
@@ -117,7 +118,7 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
             }
 
             return AccessPermissionDAO.create(em, accessPermissionCreator);
-        });
+        }).onAfterHandler((entity) -> entityCache.removeList(entity.getScopeId(), entity.getAccessInfoId())));
     }
 
     @Override
@@ -131,13 +132,19 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.doTransactedAction(em -> {
-            if (AccessPermissionDAO.find(em, scopeId, accessPermissionId) == null) {
+        entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessPermission>create().onResultHandler(em -> {
+            // TODO: check if it is correct to remove this statement (already thrown by the delete method, but
+            //  without TYPE)
+            AccessPermission accessPermission = AccessPermissionDAO.find(em, scopeId, accessPermissionId);
+            if (accessPermission == null) {
                 throw new KapuaEntityNotFoundException(AccessPermission.TYPE, accessPermissionId);
             }
 
             return AccessPermissionDAO.delete(em, scopeId, accessPermissionId);
-        });
+        }).onAfterHandler((entity) -> {
+            entityCache.remove(scopeId, accessPermissionId);
+            entityCache.removeList(scopeId, entity.getAccessInfoId());
+        }));
     }
 
     @Override
@@ -153,7 +160,9 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, scopeId));
 
-        return entityManagerSession.doAction(em -> AccessPermissionDAO.find(em, scopeId, accessPermissionId));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessPermission>create().onResultHandler(em -> AccessPermissionDAO.find(em, scopeId, accessPermissionId))
+                .onBeforeHandler(() -> (AccessPermission) entityCache.get(scopeId, accessPermissionId))
+                .onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
@@ -163,11 +172,26 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         ArgumentValidator.notNull(accessInfoId, "accessInfoId");
 
         //
-        // Build query
-        AccessPermissionQuery query = new AccessPermissionQueryImpl(scopeId);
-        query.setPredicate(query.attributePredicate(AccessPermissionAttributes.ACCESS_INFO_ID, accessInfoId));
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN,
+                Actions.read, scopeId));
 
-        return query(query);
+        AccessPermissionListResult listResult = (AccessPermissionListResult) entityCache.getList(scopeId,
+                accessInfoId);
+        if (listResult == null) {
+
+            //
+            // Build query
+            AccessPermissionQuery query = new AccessPermissionQueryImpl(scopeId);
+            query.setPredicate(query.attributePredicate(AccessPermissionAttributes.ACCESS_INFO_ID, accessInfoId));
+
+            listResult = query(query);
+            entityCache.putList(scopeId, accessInfoId, listResult);
+        }
+        return listResult;
     }
 
     @Override
@@ -182,7 +206,7 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessPermissionDAO.query(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessPermissionListResult>create().onResultHandler(em -> AccessPermissionDAO.query(em, query)));
     }
 
     @Override
@@ -197,6 +221,6 @@ public class AccessPermissionServiceImpl extends AbstractKapuaService implements
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessPermissionDAO.count(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<Long>create().onResultHandler(em -> AccessPermissionDAO.count(em, query)));
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactory.java
@@ -9,19 +9,20 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.authorization.access.shiro;
 
-import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 
 /**
- * Cache factory definition
+ * Cache factory for the {@link AccessRoleServiceImpl}
  */
-public interface CacheFactory {
+public class AccessRoleCacheFactory extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private AccessRoleCacheFactory() {
+        super("AccessRoleId");
+    }
+
+    protected static AccessRoleCacheFactory getInstance() {
+        return new AccessRoleCacheFactory();
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
@@ -90,7 +90,7 @@ public class AccessRoleDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param accessRoleId
-     * @return deleted entity
+     * @return the deleted {@link AccessRole}
      * @throws KapuaEntityNotFoundException
      *             If {@link AccessRole} is not found.
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.authorization.access.shiro;
 import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -47,7 +48,7 @@ import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizatio
 public class AccessRoleServiceImpl extends AbstractKapuaService implements AccessRoleService {
 
     public AccessRoleServiceImpl() {
-        super(AuthorizationEntityManagerFactory.getInstance());
+        super(AuthorizationEntityManagerFactory.getInstance(), AccessRoleCacheFactory.getInstance());
     }
 
     @Override
@@ -66,7 +67,7 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
 
         //
         // If role is not in the scope of the access info or does not exists throw an exception.
-        return entityManagerSession.doTransactedAction(em -> {
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessRole>create().onResultHandler(em -> {
 
             //
             // Check that accessInfo exists
@@ -102,7 +103,7 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
             }
 
             return AccessRoleDAO.create(em, accessRoleCreator);
-        });
+        }).onAfterHandler((entity) -> entityCache.removeList(entity.getScopeId(), entity.getAccessInfoId())));
     }
 
     @Override
@@ -116,13 +117,20 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.doTransactedAction(em -> {
-            if (AccessRoleDAO.find(em, scopeId, accessRoleId) == null) {
-                throw new KapuaEntityNotFoundException(AccessRole.TYPE, accessRoleId);
-            }
+        entityManagerSession.doTransactedAction(EntityManagerContainer.<AccessRole>create().onResultHandler(em -> {
+                    // TODO: check if it is correct to remove this statement (already thrown by the delete method, but
+                    //  without TYPE)
+                    AccessRole accessRole = AccessRoleDAO.find(em, scopeId, accessRoleId);
+                    if (accessRole == null) {
+                        throw new KapuaEntityNotFoundException(AccessRole.TYPE, accessRoleId);
+                    }
 
-            return AccessRoleDAO.delete(em, scopeId, accessRoleId);
-        });
+                    return AccessRoleDAO.delete(em, scopeId, accessRoleId);
+                }
+        ).onAfterHandler((entity) -> {
+            entityCache.remove(scopeId, accessRoleId);
+            entityCache.removeList(scopeId, entity.getAccessInfoId());
+        }));
     }
 
     @Override
@@ -138,7 +146,9 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, scopeId));
 
-        return entityManagerSession.doAction(em -> AccessRoleDAO.find(em, scopeId, accessRoleId));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessRole>create().onResultHandler(em -> AccessRoleDAO.find(em, scopeId, accessRoleId))
+                .onBeforeHandler(() -> (AccessRole) entityCache.get(scopeId, accessRoleId))
+                .onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
@@ -148,11 +158,25 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
         ArgumentValidator.notNull(accessInfoId, "accessInfoId");
 
         //
-        // Build query
-        AccessRoleQuery query = new AccessRoleQueryImpl(scopeId);
-        query.setPredicate(query.attributePredicate(AccessRoleAttributes.ACCESS_INFO_ID, accessInfoId));
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN,
+                Actions.read, scopeId));
 
-        return query(query);
+        AccessRoleListResult listResult = (AccessRoleListResult) entityCache.getList(scopeId, accessInfoId);
+        if (listResult == null) {
+
+            //
+            // Build query
+            AccessRoleQuery query = new AccessRoleQueryImpl(scopeId);
+            query.setPredicate(query.attributePredicate(AccessRoleAttributes.ACCESS_INFO_ID, accessInfoId));
+
+            listResult = query(query);
+            entityCache.putList(scopeId, accessInfoId, listResult);
+        }
+        return listResult;
     }
 
     @Override
@@ -167,7 +191,7 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessRoleDAO.query(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<AccessRoleListResult>create().onResultHandler(em -> AccessRoleDAO.query(em, query)));
     }
 
     @Override
@@ -182,6 +206,6 @@ public class AccessRoleServiceImpl extends AbstractKapuaService implements Acces
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ACCESS_INFO_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> AccessRoleDAO.count(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<Long>create().onResultHandler(em -> AccessRoleDAO.count(em, query)));
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,23 +9,20 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.authorization.role.shiro;
 
-import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 
 /**
- * Entity manager factory definition
- *
- * @since 1.0
+ * Cache factory for the {@link RoleServiceImpl}
  */
-public interface EntityManagerFactory {
+public class RoleCacheFactory extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates an instance of {@link EntityManager}
-     *
-     * @return
-     * @throws KapuaException
-     */
-    public EntityManager createEntityManager() throws KapuaException;
+    private RoleCacheFactory() {
+        super("RoleId");
+    }
 
+    protected static RoleCacheFactory getInstance() {
+        return new RoleCacheFactory();
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
@@ -105,7 +105,7 @@ public class RoleDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param roleId
-     * @return deleted entity
+     * @return the deleted {@link Role}
      * @throws KapuaEntityNotFoundException
      *             If {@link Role} is not found.
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactory.java
@@ -9,19 +9,20 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.authorization.role.shiro;
 
-import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.commons.jpa.AbstractEntityCacheFactory;
 
 /**
- * Cache factory definition
+ * Cache factory for the {@link RolePermissionServiceImpl}
  */
-public interface CacheFactory {
+public class RolePermissionCacheFactory extends AbstractEntityCacheFactory {
 
-    /**
-     * Creates the cache for the given service.
-     *
-     * @return an {@link EntityCache} instance.
-     */
-    EntityCache createCache();
+    private RolePermissionCacheFactory() {
+        super("RolePermissionId");
+    }
+
+    protected static RolePermissionCacheFactory getInstance() {
+        return new RolePermissionCacheFactory();
+    }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
@@ -91,7 +91,7 @@ public class RolePermissionDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param rolePermissionId
-     * @return deleted entity
+     * @return the deleted {@link RolePermission}
      * @throws KapuaEntityNotFoundException
      *             If {@link RolePermission} is not found.
      */

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -15,6 +15,7 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -53,7 +54,7 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
     private static final RoleService ROLE_SERVICE = KapuaLocator.getInstance().getService(RoleService.class);
 
     public RolePermissionServiceImpl() {
-        super(AuthorizationEntityManagerFactory.getInstance());
+        super(AuthorizationEntityManagerFactory.getInstance(), RolePermissionCacheFactory.getInstance());
     }
 
     @Override
@@ -115,7 +116,8 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
             throw new KapuaEntityUniquenessException(RolePermission.TYPE, uniquesFieldValues);
         }
 
-        return entityManagerSession.doTransactedAction(em -> RolePermissionDAO.create(em, rolePermissionCreator));
+        return entityManagerSession.doTransactedAction(EntityManagerContainer.<RolePermission>create().onResultHandler(em -> RolePermissionDAO.create(em, rolePermissionCreator))
+                .onAfterHandler((entity) -> entityCache.removeList(entity.getScopeId(), entity.getRoleId())));
     }
 
     @Override
@@ -129,15 +131,21 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.delete, scopeId));
 
-        entityManagerSession.doTransactedAction(em -> {
-            if (RolePermissionDAO.find(em, scopeId, rolePermissionId) == null) {
+        entityManagerSession.doTransactedAction(EntityManagerContainer.<RolePermission>create().onResultHandler(em -> {
+            // TODO: check if it is correct to remove this statement (already thrown by the delete method, but
+            //  without TYPE)
+            RolePermission rolePermission = RolePermissionDAO.find(em, scopeId, rolePermissionId);
+            if (rolePermission == null) {
                 throw new KapuaEntityNotFoundException(RolePermission.TYPE, rolePermissionId);
             } else if (KapuaId.ONE.equals(rolePermissionId)) {
                 throw new KapuaException(KapuaErrorCodes.PERMISSION_DELETE_NOT_ALLOWED);
             }
 
             return RolePermissionDAO.delete(em, scopeId, rolePermissionId);
-        });
+        }).onAfterHandler((entity) -> {
+            entityCache.remove(scopeId, rolePermissionId);
+            entityCache.removeList(scopeId, entity.getRoleId());
+        }));
     }
 
     @Override
@@ -153,7 +161,9 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.read, scopeId));
 
-        return entityManagerSession.doAction(em -> RolePermissionDAO.find(em, scopeId, rolePermissionId));
+        return entityManagerSession.doAction(EntityManagerContainer.<RolePermission>create().onResultHandler(em -> RolePermissionDAO.find(em, scopeId, rolePermissionId))
+                .onBeforeHandler(() -> (RolePermission) entityCache.get(scopeId, rolePermissionId))
+                .onAfterHandler((entity) -> entityCache.put(entity)));
     }
 
     @Override
@@ -163,11 +173,24 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         ArgumentValidator.notNull(roleId, "roleId");
 
         //
-        // Build query
-        RolePermissionQuery query = new RolePermissionQueryImpl(scopeId);
-        query.setPredicate(query.attributePredicate(RolePermissionAttributes.ROLE_ID, roleId));
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.read, scopeId));
 
-        return query(query);
+        RolePermissionListResult listResult = (RolePermissionListResult) entityCache.getList(scopeId, roleId);
+        if (listResult == null) {
+
+            //
+            // Build query
+            RolePermissionQuery query = new RolePermissionQueryImpl(scopeId);
+            query.setPredicate(query.attributePredicate(RolePermissionAttributes.ROLE_ID, roleId));
+
+            listResult = query(query);
+            entityCache.putList(scopeId, roleId, listResult);
+        }
+        return listResult;
     }
 
     @Override
@@ -182,7 +205,7 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> RolePermissionDAO.query(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<RolePermissionListResult>create().onResultHandler(em -> RolePermissionDAO.query(em, query)));
     }
 
     @Override
@@ -197,6 +220,6 @@ public class RolePermissionServiceImpl extends AbstractKapuaService implements R
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthorizationDomains.ROLE_DOMAIN, Actions.read, query.getScopeId()));
 
-        return entityManagerSession.doAction(em -> RolePermissionDAO.count(em, query));
+        return entityManagerSession.doAction(EntityManagerContainer.<Long>create().onResultHandler(em -> RolePermissionDAO.count(em, query)));
     }
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCacheFactory.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCacheFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -9,23 +9,21 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.commons.jpa;
+package org.eclipse.kapua.service.user.internal;
 
-import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.AbstractNamedEntityCacheFactory;
 
 /**
- * Entity manager factory definition
- *
- * @since 1.0
+ * Cache factory for the {@link UserServiceImpl}
  */
-public interface EntityManagerFactory {
+public class UserCacheFactory extends AbstractNamedEntityCacheFactory {
 
-    /**
-     * Creates an instance of {@link EntityManager}
-     *
-     * @return
-     * @throws KapuaException
-     */
-    public EntityManager createEntityManager() throws KapuaException;
+    private UserCacheFactory() {
+        super("UserId", "UserName");
+    }
+
+    protected static UserCacheFactory getInstance() {
+        return new UserCacheFactory();
+    }
 
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
@@ -137,7 +137,7 @@ public class UserDAO extends ServiceDAO {
      * @param em
      * @param scopeId
      * @param userId
-     * @return deleted entity
+     * @return the deleted {@link User}
      * @throws KapuaEntityNotFoundException If {@link User} is not found.
      */
     public static User delete(EntityManager em, KapuaId scopeId, KapuaId userId)

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -236,17 +236,9 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Do the find
-        User user = entityManagerSession.doAction(EntityManagerContainer.<User>create().onResultHandler(em -> checkReadAccess(UserDAO.findByName(em, name)))
+        return entityManagerSession.doAction(EntityManagerContainer.<User>create().onResultHandler(em -> checkReadAccess(UserDAO.findByName(em, name)))
                 .onBeforeHandler(() -> checkReadAccess((User) ((NamedEntityCache) entityCache).get(null, name)))
                 .onAfterHandler((entity) -> entityCache.put(entity)));
-
-        //
-        // Check Access
-        if (user != null) {
-            authorizationService.checkPermission(permissionFactory.newPermission(UserDomains.USER_DOMAIN, Actions.read, user.getScopeId()));
-        }
-
-        return user;
     }
 
     @Override
@@ -257,16 +249,8 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
 
         //
         // Do the find
-        User user = entityManagerSession.doAction(EntityManagerContainer.<User>create().onResultHandler(em -> checkReadAccess(UserDAO.findByExternalId(em, externalId)))
+        return entityManagerSession.doAction(EntityManagerContainer.<User>create().onResultHandler(em -> checkReadAccess(UserDAO.findByExternalId(em, externalId)))
                 .onAfterHandler((entity) -> entityCache.put(entity)));
-
-        //
-        // Check Access
-        if (user != null) {
-            authorizationService.checkPermission(permissionFactory.newPermission(UserDomains.USER_DOMAIN, Actions.read, user.getScopeId()));
-        }
-
-        return user;
     }
 
     @Override


### PR DESCRIPTION
This PR improves the caching feature introduced with PR #2892. In particular, it implements the cache in a given set of services, in order to improve performances.

**Related Issue**

_N/A_

**Description of the solution adopted**

The cache allows avoiding repeated queries to the database, in particular when checking permissions to perform an action on a given method. As an example, the `checkPermission` method of the `AuthorizationService` (responsible for checking if an user is allowed to perform a given operation), performs a chain of calls to the `UserService`, `AccessInfoService`, `AccessPermissionService`, `AccessRoleService`, `RoleService` and `RolePermissionService` services, each of which performs a query to the db. Caching all these services allows considerably reducing the time spent on querying the db. 

Also, note that the message processing by the broker requires methods from the `AccountService` and `DeviceRegistryService`, which both perform transactions to the database. Such transactions are performed for each message received by the broker, thus using a cache on those services allows reducing queries when the same data is required.

**Screenshots**

_N/A_

**Any side note on the changes made**

Services that have been cached:
- `AccessInfoService`
- `AccessPermissionService`
- `AccessRoleService`
- `AccountService`
- `DeviceConnectionService`
- `DeviceRegistryService`
- `RoleService`
- `RolePermissionService`
- `UserService`

Each service is able to instantiate is own cache through a dedicated cache factory. However, note that `DeviceConnectionService` is not using a dedicated cache factory, but it relies on the `DeviceRegistryCacheFactory`. Moreover, also the `AbstractKapuaConfigurableService` has been provided with a cache instance, in order to cache the configuration values for each services. A `LocalCache` instance (which must not be confused with a JCache cache instance) has also been added in order to store the config metadata, which do not change after the first time the object is loaded. 

