### PR TITLE
Disable auto scroll in timestamp refresh

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaTreeGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaTreeGrid.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.ui.grid;
+
+import com.extjs.gxt.ui.client.data.ModelData;
+import com.extjs.gxt.ui.client.store.TreeStore;
+import com.extjs.gxt.ui.client.widget.grid.ColumnModel;
+import com.extjs.gxt.ui.client.widget.treegrid.TreeGrid;
+
+public class KapuaTreeGrid<M extends ModelData> extends TreeGrid<M> {
+
+    public KapuaTreeGrid(TreeStore store, ColumnModel cm) {
+        super(store, cm);
+        setView(new KapuaTreeGridView());
+    }
+
+}

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaTreeGridView.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaTreeGridView.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.api.client.ui.grid;
+
+import com.extjs.gxt.ui.client.widget.treegrid.TreeGridView;
+
+public class KapuaTreeGridView extends TreeGridView {
+
+    public KapuaTreeGridView() {
+        super();
+        preventScrollToTopOnRefresh = true;
+    }
+
+}

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
@@ -43,6 +43,7 @@ import com.google.gwt.user.client.rpc.AsyncCallback;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
 import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.Button;
+import org.eclipse.kapua.app.console.module.api.client.ui.grid.KapuaTreeGrid;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.data.client.messages.ConsoleDataMessages;
@@ -76,6 +77,7 @@ public class TopicsTable extends LayoutContainer {
                 store.sort("topicName", Style.SortDir.ASC);
                 updateTimestamps(new ArrayList<ModelData>(topics));
                 topicInfoGrid.unmask();
+                topicInfoGrid.getView().scrollToTop();
                 refreshButton.enable();
             }
 
@@ -159,7 +161,7 @@ public class TopicsTable extends LayoutContainer {
         store = new TreeStore<GwtTopic>();
         store.setSortInfo(new SortInfo("topicName", Style.SortDir.ASC));
         dataService.findTopicsTree(currentSession.getSelectedAccountId(), topicsCallback);
-        topicInfoGrid = new TreeGrid<GwtTopic>(store, new ColumnModel(configs));
+        topicInfoGrid = new KapuaTreeGrid<GwtTopic>(store, new ColumnModel(configs));
         topicInfoGrid.getView().setViewConfig(new GridViewConfig() {
             @Override
             public String getRowStyle(ModelData model, int rowIndex, ListStore<ModelData> ds) {


### PR DESCRIPTION
This PR fixes the view scrolling to the top when expanding a node.

**Related Issue**
Fixes #2948, Fixes #2949 
