### PR TITLE
Fix swagger-cli version

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -27,6 +27,7 @@
     <properties>
         <nodejs.version>10.16.3</nodejs.version>
         <swagger-cli.executable>${project.build.directory}/bin/swagger-cli</swagger-cli.executable>
+        <swagger-cli.version>4.0.2</swagger-cli.version>
     </properties>
 
     <dependencies>
@@ -243,7 +244,7 @@
                             <goal>npm</goal>
                         </goals>
                         <configuration>
-                            <arguments>install -g @apidevtools/swagger-cli</arguments>
+                            <arguments>install -g @apidevtools/swagger-cli@${swagger-cli.version}</arguments>
                         </configuration>
                     </execution>
                 </executions>


### PR DESCRIPTION
This PR fixes `swagger-cli` version to 4.0.2 (latest publicly available in this moment)

**Related Issue**
Related to #2952 

