### PR TITLE
HashMap-based JCache implementation for QAs

### DIFF
--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/DBHelper.java
@@ -18,6 +18,7 @@ import cucumber.runtime.java.guice.ScenarioScoped;
 import org.eclipse.kapua.commons.configuration.KapuaConfigurableServiceSchemaUtilsWithResources;
 import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
 import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.commons.service.internal.cache.KapuaCacheManager;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.h2.tools.Server;
@@ -157,6 +158,7 @@ public class DBHelper {
     public void deleteAll() {
 
         KapuaConfigurableServiceSchemaUtilsWithResources.scriptSession(FULL_SCHEMA_PATH, DELETE_SCRIPT);
+        KapuaCacheManager.invalidateAll();
     }
 
     public void dropAll() throws SQLException {
@@ -170,5 +172,6 @@ public class DBHelper {
         }
 
         this.close();
+        KapuaCacheManager.invalidateAll();
     }
 }

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCache.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCache.java
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.cache;
+
+import org.eclipse.kapua.model.KapuaEntity;
+import org.eclipse.kapua.model.query.KapuaListResult;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.CacheEntryListenerConfiguration;
+import javax.cache.configuration.Configuration;
+import javax.cache.integration.CompletionListener;
+import javax.cache.processor.EntryProcessor;
+import javax.cache.processor.EntryProcessorException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Dummy implementation of JCache using an hashmap, to be used only for tests!
+ */
+public class MapCache<K, V> implements Cache<K, V> {
+
+    private static final Logger logger = LoggerFactory.getLogger(MapCacheManager.class);
+    private ConcurrentHashMap<K, V> hashMap;
+
+    MapCache() {
+        hashMap = new ConcurrentHashMap<>();
+    }
+
+    @Override
+    public Object get(Object key) {
+        try {
+            Object returnedValue = clone(hashMap.get(key));
+            if (returnedValue instanceof KapuaListResult) {
+                for (Object element: ((KapuaListResult) hashMap.get(key)).getItems()) {
+                    ((KapuaListResult) returnedValue).addItem((KapuaEntity) clone(element));
+                }
+            }
+            return returnedValue;
+        } catch (Exception e) {
+            logger.error("Error while getting value from cache", e);
+        }
+        return null;
+    }
+
+
+    @Override
+    public Map getAll(Set keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void loadAll(Set keys, boolean replaceExistingValues, CompletionListener completionListener) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void put(Object key, Object value) {
+        try {
+            V newValue = (V) clone(value);
+            if (value instanceof KapuaListResult) {
+                for (Object element: ((KapuaListResult) value).getItems()) {
+                    ((KapuaListResult) newValue).addItem((KapuaEntity) clone(element));
+                }
+            }
+            hashMap.put((K) key, newValue);
+        } catch (Exception e) {
+            logger.error("Error while putting value in cache", e);
+        }
+    }
+
+    @Override
+    public Object getAndPut(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void putAll(Map map) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean putIfAbsent(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean remove(Object key) {
+        return hashMap.remove(key) != null;
+    }
+
+    @Override
+    public boolean remove(Object key, Object oldValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndRemove(Object key) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(Object key, Object oldValue, Object newValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean replace(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object getAndReplace(Object key, Object value) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAll(Set keys) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void removeAll() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void clear() {
+        hashMap.clear();
+    }
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CacheManager getCacheManager() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isClosed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void registerCacheEntryListener(CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void deregisterCacheEntryListener(CacheEntryListenerConfiguration cacheEntryListenerConfiguration) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterator<Entry<K, V>> iterator() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object unwrap(Class clazz) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Map invokeAll(Set keys, EntryProcessor entryProcessor, Object... arguments) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Object invoke(Object key, EntryProcessor entryProcessor, Object... arguments) throws EntryProcessorException {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Configuration getConfiguration(Class clazz) {
+        throw new UnsupportedOperationException();
+    }
+
+    private Object clone(Object object) throws InvocationTargetException, IllegalAccessException,
+            InstantiationException {
+        if (object != null) {
+            try {
+                Class<?> objectClass = object.getClass();
+                Constructor<?> objectConstructor = objectClass.getDeclaredConstructor();
+                objectConstructor.setAccessible(true);  // change the constructor accessibility for protected fields
+                Object newObject = objectConstructor.newInstance();
+
+                Method[] methods = object.getClass().getMethods();
+                Map<String, Method> getterMethods = new ConcurrentHashMap<>();
+                Map<String, Method> setterMethods = new ConcurrentHashMap<>();
+
+                for (Method method : methods) {
+                    if (isGetter(method)) {
+                        getterMethods.put(method.getName(), method);
+                    } else if (isSetter(method)) {
+                        setterMethods.put(method.getName(), method);
+                    }
+                }
+
+                if (setterMethods.size() == 0) {
+                    return object;
+                }
+
+                getterMethods.forEach((getterName, getter) -> {
+                    Object fieldValue;
+                    try {
+                        fieldValue = getter.invoke(object, null);
+                        Method setter = setterMethods.get("s" + getterName.substring(1));
+                        if (setter != null) {
+                            if (fieldValue != null && !fieldValue.getClass().isPrimitive()) {
+                                fieldValue = clone(fieldValue);
+                            }
+                            setter.invoke(newObject, fieldValue);
+                        }
+                    } catch (Exception e) {
+                        logger.error("Error while invoking methods.", e);
+                    }
+                });
+                return newObject;
+            } catch (NoSuchMethodException noe) {
+                return object;
+            }
+        }
+        return null;
+    }
+
+    public boolean isGetter(Method method) {
+        if (!method.getName().startsWith("get")) { //&& !method.getName().startsWith("is")) {
+            return false;
+        }
+        if (method.getParameterTypes().length != 0) {
+            return false;
+        }
+        return !void.class.equals(method.getReturnType());
+    }
+
+    public boolean isSetter(Method method) {
+        if (!method.getName().startsWith("set")) {
+            return false;
+        }
+        return method.getParameterTypes().length == 1;
+    }
+}

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCacheManager.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCacheManager.java
@@ -1,0 +1,111 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.cache;
+
+import javax.cache.Cache;
+import javax.cache.CacheManager;
+import javax.cache.configuration.Configuration;
+import javax.cache.spi.CachingProvider;
+import java.net.URI;
+import java.util.Properties;
+
+public class MapCacheManager implements CacheManager {
+
+    private static MapCacheManager instance;
+
+    private MapCacheManager() {
+
+    }
+
+    public static MapCacheManager getInstance() {
+        if (instance == null) {
+            synchronized (MapCacheManager.class) {
+                if (instance == null) {
+                    instance = new MapCacheManager();
+                }
+            }
+        }
+        return instance;
+    }
+
+    @Override
+    public CachingProvider getCachingProvider() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public ClassLoader getClassLoader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Properties getProperties() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V, C extends Configuration<K, V>> Cache<K, V> createCache(String cacheName, C configuration) throws IllegalArgumentException {
+        //Class<K> kClass = configuration.getKeyType();
+        //Class<V> vClass = configuration.getValueType();
+        return new MapCache<>();
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName, Class<K> keyType, Class<V> valueType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <K, V> Cache<K, V> getCache(String cacheName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Iterable<String> getCacheNames() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void destroyCache(String cacheName) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enableManagement(String cacheName, boolean enabled) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void enableStatistics(String cacheName, boolean enabled) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isClosed() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public <T> T unwrap(Class<T> clazz) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCachingProvider.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cache/MapCachingProvider.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.qa.common.cache;
+
+import javax.cache.CacheManager;
+import javax.cache.configuration.OptionalFeature;
+import javax.cache.spi.CachingProvider;
+import java.net.URI;
+import java.util.Properties;
+
+public class MapCachingProvider implements CachingProvider {
+
+    private static MapCachingProvider instance;
+
+    public static MapCachingProvider getInstance() {
+        if (instance == null) {
+            synchronized (MapCachingProvider.class) {
+                if (instance == null) {
+                    instance = new MapCachingProvider();
+                }
+            }
+        }
+        return instance;
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader, Properties properties) {
+        return getCacheManager();
+    }
+
+    @Override
+    public ClassLoader getDefaultClassLoader() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public URI getDefaultURI() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Properties getDefaultProperties() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public CacheManager getCacheManager(URI uri, ClassLoader classLoader) {
+        return getCacheManager();
+    }
+
+    @Override
+    public CacheManager getCacheManager() {
+        return MapCacheManager.getInstance();
+    }
+
+    @Override
+    public void close() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close(ClassLoader classLoader) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void close(URI uri, ClassLoader classLoader) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public boolean isSupported(OptionalFeature optionalFeature) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -94,7 +94,9 @@ commons.eventbus.transport.useEpoll=true
 # Cache settings (please provide consistent values for these parameters)
 #
 # Provided dummy JCache implementation cache (no cache)
-commons.cache.provider.classname=org.eclipse.kapua.commons.service.internal.cache.dummy.CachingProvider
+#commons.cache.provider.classname=org.eclipse.kapua.commons.service.internal.cache.dummy.CachingProvider
+# In memory Map cache (to be used only for testing purpose)
+commons.cache.provider.classname=org.eclipse.kapua.qa.common.cache.MapCachingProvider
 # Additional cache configuration file (if any)
 #commons.cache.config.url=yourconfig.yaml
 #commons.cache.config.ttl=15


### PR DESCRIPTION
This PR provides a simple JCache implementation based on HashMaps, in order to test the caching feature with the QAs.
See PRs #2892 and #2945  for further information about the caching feature.  

**Related Issue**

_N/A_

**Description of the solution adopted**

The QAs will make use of an in-memory HashMaps-based implementation of JCache in order to mimic the behaviour of a real cache instance. In order to mimic the serialisation, this cache is also provided with a clone method which performs a deep clone of the given entity in `put` and `get` operations.

**Screenshots**

_N/A_

**Any side note on the changes made**

This cache is enabled trough the following property  `commons.cache.provider.classname=org.eclipse.kapua.qa.common.cache.MapCachingProvider`