### PR TITLE
Fixed input parameters definition for device/packages/_download

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -34,23 +34,57 @@ paths:
                   type: string
                 version:
                   type: string
+                username:
+                  type: string
+                password:
+                  type: string
+                fileHash:
+                  type: string
+                fileType:
+                  type: string
                 install:
                   type: boolean
                 reboot:
                   type: boolean
                 rebootDelay:
                   type: integer
+                advancedOptions:
+                  type: object
+                  properties:
+                    restart:
+                      type: boolean
+                    blockSize:
+                      type: integer
+                    blockDelay:
+                      type: integer
+                    blockTimeout:
+                      type: integer
+                    notifyBlockSize:
+                      type: integer
+                    installVerifyURI:
+                      type: string
               required:
                 - uri
                 - name
                 - version
             example:
-              uri: http://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
+              uri: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
               name: heater
               version: 1.0.500
+              username: username
+              password: password
+              fileHash: MD5:0d04154164145cd6b2167fdd457ed28f
+              fileType: DEPLOYMENT_PACKAGE
               install: true
               reboot: false
               rebootDelay: 0
+              advancedOptions:
+                restart: false
+                blockSize: 128
+                blockDelay: 0
+                blockTimeout: 5000
+                notifyBlockSize: 256
+                installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh
         required: true
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -26,65 +26,38 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                uri:
-                  type: string
-                name:
-                  type: string
-                version:
-                  type: string
-                username:
-                  type: string
-                password:
-                  type: string
-                fileHash:
-                  type: string
-                fileType:
-                  type: string
-                install:
-                  type: boolean
-                reboot:
-                  type: boolean
-                rebootDelay:
-                  type: integer
-                advancedOptions:
-                  type: object
-                  properties:
-                    restart:
-                      type: boolean
-                    blockSize:
-                      type: integer
-                    blockDelay:
-                      type: integer
-                    blockTimeout:
-                      type: integer
-                    notifyBlockSize:
-                      type: integer
-                    installVerifyURI:
-                      type: string
-              required:
-                - uri
-                - name
-                - version
-            example:
-              uri: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
-              name: heater
-              version: 1.0.500
-              username: username
-              password: password
-              fileHash: MD5:0d04154164145cd6b2167fdd457ed28f
-              fileType: DEPLOYMENT_PACKAGE
-              install: true
-              reboot: false
-              rebootDelay: 0
-              advancedOptions:
-                restart: false
-                blockSize: 128
-                blockDelay: 0
-                blockTimeout: 5000
-                notifyBlockSize: 256
-                installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh
+              $ref: './devicePackage.yaml#/components/schemas/devicePackageDownloadRequest'
+            examples:
+              basic:
+                summary: Basic
+                description: A request with basic options
+                value:
+                  uri: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
+                  name: heater
+                  version: 1.0.500
+                  install: true
+                  reboot: false
+              complete:
+                summary: Complete
+                description: A request with all available options used
+                value:
+                  uri: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
+                  name: heater
+                  version: 1.0.500
+                  username: username
+                  password: password
+                  fileHash: MD5:0d04154164145cd6b2167fdd457ed28f
+                  fileType: DEPLOYMENT_PACKAGE
+                  install: true
+                  reboot: false
+                  rebootDelay: 0
+                  advancedOptions:
+                    restart: false
+                    blockSize: 128
+                    blockDelay: 0
+                    blockTimeout: 5000
+                    notifyBlockSize: 256
+                    installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh
         required: true
       responses:
         204:

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
@@ -19,25 +19,25 @@ components:
       type: object
       description: A Device Package
       properties:
-          name:
-            type: string
-          version:
-            type: string
-          bundleInfos:
-            type: object
-            properties:
-              bundleInfo:
-                type: array
-                items:
-                  type: object
-                  properties:
-                    name:
-                      type: string
-                    version:
-                      type: string
-          installDate:
-            type: string
-            format: 'date-time'
+        name:
+          type: string
+        version:
+          type: string
+        bundleInfos:
+          type: object
+          properties:
+            bundleInfo:
+              type: array
+              items:
+                type: object
+                properties:
+                  name:
+                    type: string
+                  version:
+                    type: string
+        installDate:
+          type: string
+          format: 'date-time'
       example:
         name: org.eclipse.kura.demo.heater
         version: 1.0.300
@@ -61,3 +61,59 @@ components:
               bundleInfo:
                 - name: org.eclipse.kura.demo.heater
                   version: 1.0.300
+    devicePackageDownloadRequest:
+      type: object
+      properties:
+        uri:
+          type: string
+        name:
+          type: string
+        version:
+          type: string
+        username:
+          type: string
+        password:
+          type: string
+        fileHash:
+          type: string
+        fileType:
+          type: string
+        install:
+          type: boolean
+        reboot:
+          type: boolean
+        rebootDelay:
+          type: integer
+        advancedOptions:
+          type: object
+          properties:
+            restart:
+              type: boolean
+            blockSize:
+              type: integer
+            blockDelay:
+              type: integer
+            blockTimeout:
+              type: integer
+            notifyBlockSize:
+              type: integer
+            installVerifyURI:
+              type: string
+      example:
+        uri: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.dp
+        name: heater
+        version: 1.0.500
+        username: username
+        password: password
+        fileHash: MD5:0d04154164145cd6b2167fdd457ed28f
+        fileType: DEPLOYMENT_PACKAGE
+        install: true
+        reboot: false
+        rebootDelay: 0
+        advancedOptions:
+          restart: false
+          blockSize: 128
+          blockDelay: 0
+          blockTimeout: 5000
+          notifyBlockSize: 256
+          installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh


### PR DESCRIPTION
This PR fix the definition of input parameters for REST resource `device/{deviceId}/packages/_download` which was missing some properties.

**Related Issue**
_None_

**Description of the solution adopted**
Added the definitions of missing properties.

**Screenshots**
_None_

**Any side note on the changes made**
_None_