### PR TITLE
Fixed Failing Cucumber Unit Tests

### DIFF
--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -44,5 +44,10 @@
             <artifactId>kapua-scheduler-quartz</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/CucumberWithPropertiesForJob.java
+++ b/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/CucumberWithPropertiesForJob.java
@@ -20,6 +20,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.account.internal.AccountFactoryImpl;
+import org.eclipse.kapua.service.account.internal.AccountServiceImpl;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -92,6 +96,10 @@ public class CucumberWithPropertiesForJob extends CucumberWithProperties {
                 bind(PermissionFactory.class).toInstance(Mockito.mock(PermissionFactory.class));
                 // Set KapuaMetatypeFactory for Metatype configuration
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
+
+                // binding Account related services
+                bind(AccountService.class).toInstance(Mockito.spy(new AccountServiceImpl()));
+                bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
 
                 // Inject actual Job service related services
                 JobEntityManagerFactory jobEntityManagerFactory = JobEntityManagerFactory.getInstance();

--- a/service/scheduler/test/pom.xml
+++ b/service/scheduler/test/pom.xml
@@ -49,5 +49,10 @@
             <artifactId>kapua-job-internal</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/CucumberWithPropertiesForScheduler.java
+++ b/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/CucumberWithPropertiesForScheduler.java
@@ -20,6 +20,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.account.internal.AccountFactoryImpl;
+import org.eclipse.kapua.service.account.internal.AccountServiceImpl;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -75,6 +79,10 @@ public class CucumberWithPropertiesForScheduler extends CucumberWithProperties {
                 bind(PermissionFactory.class).toInstance(Mockito.mock(PermissionFactory.class));
                 // Set KapuaMetatypeFactory for Metatype configuration
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
+
+                // binding Account related services
+                bind(AccountService.class).toInstance(Mockito.spy(new AccountServiceImpl()));
+                bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
 
                 // Inject actual Tag service related services
                 SchedulerEntityManagerFactory schedulerEntityManagerFactory = SchedulerEntityManagerFactory.getInstance();

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -39,5 +39,10 @@
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/CucumberWithPropertiesForTag.java
+++ b/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/CucumberWithPropertiesForTag.java
@@ -20,6 +20,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.account.internal.AccountFactoryImpl;
+import org.eclipse.kapua.service.account.internal.AccountServiceImpl;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -67,6 +71,10 @@ public class CucumberWithPropertiesForTag extends CucumberWithProperties {
                 bind(PermissionFactory.class).toInstance(Mockito.mock(PermissionFactory.class));
                 // Set KapuaMetatypeFactory for Metatype configuration
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
+
+                // binding Account related services
+                bind(AccountService.class).toInstance(Mockito.spy(new AccountServiceImpl()));
+                bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
 
                 // Inject actual Tag service related services
                 TagEntityManagerFactory tagEntityManagerFactory = TagEntityManagerFactory.getInstance();

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -39,5 +39,10 @@
             <artifactId>cucumber-junit</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/CucumberWithPropertiesForUser.java
+++ b/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/CucumberWithPropertiesForUser.java
@@ -20,6 +20,10 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
 import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.account.internal.AccountFactoryImpl;
+import org.eclipse.kapua.service.account.internal.AccountServiceImpl;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
@@ -67,6 +71,10 @@ public class CucumberWithPropertiesForUser extends CucumberWithProperties {
                 bind(PermissionFactory.class).toInstance(Mockito.mock(PermissionFactory.class));
                 // Set KapuaMetatypeFactory for Metatype configuration
                 bind(KapuaMetatypeFactory.class).toInstance(new KapuaMetatypeFactoryImpl());
+
+                // binding Account related services
+                bind(AccountService.class).toInstance(Mockito.spy(new AccountServiceImpl()));
+                bind(AccountFactory.class).toInstance(Mockito.spy(new AccountFactoryImpl()));
 
                 // Inject actual User service related services
                 UserEntityManagerFactory userEntityManagerFactory = UserEntityManagerFactory.getInstance();


### PR DESCRIPTION
**Brief description of the PR.**
With a fix for a certain REST API bug (preventing users to change their account settings) in PR #2946 and PR #2954 the unit tests for services (tags, users, jobs, scheduling,...) started to fail. 
I have fixed this by introducing a mocked account that is used as basis for the service creation. 
I have already ran PR on my Travis and everything was fine. CodeCov should report 0% increased/decreased coverage, since all the changes made are in the ignored folders. 

Signed-off-by: Leonardo Gaube <leonardo.gaube@comtrade.com>

**Related Issue**
This PR fixes problems with unit tests in PR #2947 and PR #2954.

**Description of the solution adopted:**
I have added a mocked AccountService and mocked AccountFactory classes to the existing unit tests, so that the check does not fail. This is  achieved with Mockito's "spy" method. The necessary Account methods are injected in the _CucumberWithProeprtiesFor(Service)_ file. 

@lorthirk can you please look at the solution adopted and see if it's ok? After you merge this PR into develop, just rebase your PRs to develop and the tests should be passing normally. 

**Screenshots**
N/A

**Any side note on the changes made**
N/A
