### PR TITLE
Rename kapua-guice module to kapua-locator-guice

### DIFF
--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -47,7 +47,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>aopalliance</groupId>

--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -256,7 +256,7 @@
                 <include>${pom.groupId}:kapua-device-registry-api</include>
                 <include>${pom.groupId}:kapua-device-registry-internal</include>
                 <include>${pom.groupId}:kapua-foreignkeys</include>
-                <include>${pom.groupId}:kapua-guice</include>
+                <include>${pom.groupId}:kapua-locator-guice</include>
                 <include>${pom.groupId}:kapua-job-api</include>
                 <include>${pom.groupId}:kapua-job-internal</include>
                 <include>${pom.groupId}:kapua-job-engine-api</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -33,7 +33,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -40,7 +40,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>aopalliance</groupId>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -231,7 +231,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -107,7 +107,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -76,7 +76,7 @@
         <!-- Test dependencies-->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -19,7 +19,7 @@
         <version>1.2.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>kapua-guice</artifactId>
+    <artifactId>kapua-locator-guice</artifactId>
 
     <dependencies>
         <!-- Internal dependencies -->

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -51,7 +51,7 @@
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -796,7 +796,7 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
-                <artifactId>kapua-guice</artifactId>
+                <artifactId>kapua-locator-guice</artifactId>
                 <version>${project.version}</version>
             </dependency>
             <dependency>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -66,7 +66,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -165,7 +165,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -49,7 +49,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -31,7 +31,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>runtime</scope>
         </dependency>
 

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -41,7 +41,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -53,7 +53,7 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -38,7 +38,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
 

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -50,7 +50,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -35,7 +35,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -42,7 +42,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-guice</artifactId>
+            <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR renames `kapua-guice` Maven module to `kapua-locator-guice` to better reflect its purpose

**Related Issue**
This PR fixes #1244

