### PR TITLE
Remove duplicated dependencies on kapua-qa-integration

### DIFF
--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -93,10 +93,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-management-job-api</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-management-api</artifactId>
         </dependency>
         <dependency>
@@ -109,10 +105,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-management-job-internal</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-management-packages-job</artifactId>
         </dependency>
         <dependency>
@@ -122,10 +114,6 @@
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-management-configuration-job</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-device-registry-internal</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>


### PR DESCRIPTION
This PR just removes three duplicated dependencies in `kapua-qa-integration` in order to avoid the following Maven warning message:

```
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.eclipse.kapua:kapua-qa-integration:jar:1.2.0-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.eclipse.kapua:kapua-device-management-job-api:jar -> duplicate declaration of version (?) @ line 94, column 21
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.eclipse.kapua:kapua-device-management-job-internal:jar -> duplicate declaration of version (?) @ line 110, column 21
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.eclipse.kapua:kapua-device-registry-internal:jar -> duplicate declaration of version (?) @ line 126, column 21
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```