### PR TITLE
Fix ssoException in broker docker container

### DIFF
--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -156,11 +156,6 @@
 
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-sso-provider</artifactId>
-            <scope>runtime</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-translator-kapua-kura</artifactId>
             <scope>runtime</scope>
         </dependency>

--- a/broker/core/src/main/resources/shiro.ini
+++ b/broker/core/src/main/resources/shiro.ini
@@ -23,8 +23,6 @@ securityManager.authenticator = $authenticator
 ##########
 # Login
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
-kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
-kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
 
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
@@ -35,7 +33,7 @@ kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.s
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
-securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaApiKeyAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
+securityManager.realms = $kapuaUserPassAuthenticatingRealm
 
 authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.


### PR DESCRIPTION
The broker image is not able to start since there is a missing dependency on SsoException.
Exception: `java.lang.ClassNotFoundException: org.eclipse.kapua.sso.exception.SsoException`.

**Related Issue**
_N/A_

**Description of the solution adopted**
Unused realms, like `ApiKeyAuthenticatingRealm` and `JwtAuthenticatingRealm`, have been removed from `broker/core/src/main/resources/shiro.ini`.
Also, `kapua-sso-provider` has been removed `assembly/broker/pom.xml`.

**Screenshots**
_N/A_

**Any side note on the changes made**
_N/A_