### PR TITLE
datastore driver - adding reconnect to datastore capabilities

### DIFF
--- a/qa/integration/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -26,3 +26,5 @@ datastore.elasticsearch.port=9200
 # A comma separated list of nodes in the form: "host1,host2" or "host1:port,host2:port"
 # **Note:** Using the "nodes" version overrides the "node" property.
 #datastore.elasticsearch.nodes=host1:port1,host2:port2
+
+datastore.elasticsearch.client.reconnection_wait_between_exec=15000

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/AbstractDatastoreClient.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/AbstractDatastoreClient.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.client;
+
+import java.io.Closeable;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Datastore client definition. It defines the methods (crud and utilities) to be exposed to the caller.<br>
+ * The datastore client implementation should provide a static init method and a static getInstance method that return the already initialized client instance.
+ *
+ * @since 1.0
+ */
+public abstract class AbstractDatastoreClient<C extends Closeable> implements DatastoreClient<C> {
+
+    private static final Logger logger = LoggerFactory.getLogger(AbstractDatastoreClient.class);
+
+    private static final String CLIENT_UNDEFINED_MSG = "Elasticsearch client must be not null";
+    private static final String CLIENT_CLEANUP_ERROR_MSG = "Cannot cleanup rest datastore driver. Cannot close Elasticsearch client instance";
+
+    protected String clientType;
+    protected ClientProvider<C> esClientProvider;
+    protected ModelContext modelContext;
+    protected QueryConverter queryConverter;
+
+    protected AbstractDatastoreClient(String clientType) {
+        this.clientType = clientType;
+        init();
+    }
+
+    protected abstract ClientProvider<C> getNewInstance();
+
+    @Override
+    public void init() {
+        synchronized (AbstractDatastoreClient.class) {
+            logger.info("Starting Elasticsearch {} client...", clientType);
+            esClientProvider = getNewInstance();
+            logger.info("Starting Elasticsearch {} client... DONE", clientType);
+        }
+    }
+
+    @Override
+    public void close() throws ClientUnavailableException {
+        synchronized (AbstractDatastoreClient.class) {
+            if (esClientProvider != null) {
+                logger.info("Stopping Elasticsearch {} client...", clientType);
+                // all fine... try to cleanup the client
+                try {
+                    getClient().close();
+                    esClientProvider = null;
+                } catch (Throwable e) {
+                    logger.error(CLIENT_CLEANUP_ERROR_MSG, e);
+                }
+                logger.info("Stopping Elasticsearch {} client... DONE", clientType);
+            } else {
+                logger.warn("Close method called for a not initialized client!");
+            }
+        }
+    }
+
+    protected C getClient() throws ClientUndefinedException {
+        if (esClientProvider != null) {
+            return esClientProvider.getClient();
+        }
+        throw new ClientUndefinedException(CLIENT_UNDEFINED_MSG);
+    }
+
+    /**
+     * Set the model context
+     *
+     * @param modelContext
+     */
+    @Override
+    public void setModelContext(ModelContext modelContext) {
+        this.modelContext = modelContext;
+    }
+
+    /**
+     * Set the query converter
+     *
+     * @param queryConverter
+     */
+    @Override
+    public void setQueryConverter(QueryConverter queryConverter) {
+        this.queryConverter = queryConverter;
+    }
+
+}

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatastoreClient.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatastoreClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -13,6 +13,9 @@ package org.eclipse.kapua.service.datastore.client;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
+import java.io.Closeable;
+
 import org.eclipse.kapua.service.datastore.client.model.BulkUpdateRequest;
 import org.eclipse.kapua.service.datastore.client.model.BulkUpdateResponse;
 import org.eclipse.kapua.service.datastore.client.model.IndexRequest;
@@ -30,14 +33,18 @@ import org.eclipse.kapua.service.datastore.client.model.UpdateResponse;
  *
  * @since 1.0
  */
-public interface DatastoreClient {
+public interface DatastoreClient<C extends Closeable> {
 
     /**
-     * Close the underlying client resources (such as datastore client connection)
-     *
-     * @throws ClientException
+     * Initialize the underlying data-store connection
      */
-    void close() throws ClientException;
+    void init();
+
+    /**
+     * Close the underlying data-store connection
+     * @throws ClientUnavailableException
+     */
+    void close() throws ClientUnavailableException;
 
     /**
      * Insert
@@ -191,8 +198,6 @@ public interface DatastoreClient {
      */
     IndexResponse findIndexes(IndexRequest indexRequest) throws ClientException;
 
-    // ModelContext
-
     /**
      * Set the model context
      *
@@ -206,5 +211,4 @@ public interface DatastoreClient {
      * @param queryConverter
      */
     void setQueryConverter(QueryConverter queryConverter);
-
 }

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
@@ -89,7 +89,11 @@ public enum ClientSettingsKey implements SettingKey {
     /**
      * Elastichsearch client trust store password (at the present only the rest client supports it)
      */
-    ELASTICSEARCH_SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore_password");
+    ELASTICSEARCH_SSL_TRUSTSTORE_PASSWORD("datastore.elasticsearch.ssl.truststore_password"),
+    /**
+     * Wait between client reconnection task executions
+     */
+    RECONNECTION_TASK_WAIT_BETWEEN_EXECUTIONS("datastore.elasticsearch.client.reconnection_wait_between_exec");
 
     private String key;
 

--- a/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
@@ -54,3 +54,5 @@ datastore.elasticsearch.ssl.keystore_password=
 datastore.elasticsearch.ssl.truststore_path=
 datastore.elasticsearch.ssl.truststore_password=
 datastore.elasticsearch.ssl.keystore_type=jks
+
+datastore.elasticsearch.client.reconnection_wait_between_exec=15000

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProvider.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -35,8 +35,11 @@ import org.slf4j.LoggerFactory;
  * Elasticsearch transport client implementation.<br>
  * Instantiate the Elasticsearch transport client.
  *
+ * @deprecated Elasticsearch transport client will be removed in the next releases. Please use the Rest client instead.
+ *
  * @since 1.0
  */
+@Deprecated
 public class EsTransportClientProvider implements ClientProvider<Client> {
 
     private static final Logger logger = LoggerFactory.getLogger(EsTransportClientProvider.class);
@@ -78,13 +81,16 @@ public class EsTransportClientProvider implements ClientProvider<Client> {
      * before initializing the new one.</b>
      * 
      * @return
-     * @throws ClientUnavailableException
      */
-    public static EsTransportClientProvider init() throws ClientUnavailableException {
+    public static EsTransportClientProvider init() {
         synchronized (EsTransportClientProvider.class) {
             logger.info(">>> Initializing ES transport client...");
             closeIfInstanceInitialized();
-            instance = new EsTransportClientProvider();
+            try {
+                instance = new EsTransportClientProvider();
+            } catch (ClientUnavailableException e) {
+                logger.error(">>> Initializing ES transport client... ERROR: {}", e.getMessage(), e);
+            }
             logger.info(">>> Initializing ES transport client... DONE");
         }
         return instance;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -89,7 +89,7 @@ public final class MessageStoreFacade {
 
     private final MessageStoreMediator mediator;
     private final ConfigurationProvider configProvider;
-    private DatastoreClient client;
+    private DatastoreClient<?> client;
 
     /**
      * Constructs the message store facade

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/client/DatastoreClientFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -28,6 +28,7 @@ import java.lang.reflect.Method;
  *
  * @since 1.0
  */
+@SuppressWarnings("rawtypes")
 public class DatastoreClientFactory {
 
     private static final String CANNOT_LOAD_CLIENT_ERROR_MSG = "Cannot load the provided client class name [%s]. Check the configuration.";


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>
There is no way to start the broker if ElasticSearch is down at startup. The broker is expected to start even if ES is down. The connection with the data-store should be tried periodically, until it has been established

**Related Issue**
none

**Description of the solution adopted**
No exception is thrown if an error occurred when establishing the data-store connection. A connection task is then executed periodically until the connection is established.

**Screenshots**
none

**Any side note on the changes made**
none