### PR TITLE
Fixed failed redirect with sso logout

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -157,8 +157,8 @@ public class NorthView extends LayoutContainer {
                 }
 
                 // Change Password menu item
-                //  (only if the current user is an INTERNAL one; note that an INTERNAL user has no ssoAccessToken)
-                if (currentSession.getSsoAccessToken() == null) {
+                //  (only if the current user is an INTERNAL one; note that an INTERNAL user has no ssoIdToken)
+                if (currentSession.getSsoIdToken() == null) {
                     KapuaMenuItem changePassword = new KapuaMenuItem();
                     changePassword.setText(MSGS.changePassword());
                     changePassword.setIcon(IconSet.KEY);
@@ -193,8 +193,8 @@ public class NorthView extends LayoutContainer {
 
                             @Override
                             public void onSuccess(Void arg0) {
-                                if (currentSession.isSsoEnabled() && currentSession.getSsoAccessToken() != null) {
-                                    gwtSettingService.getSsoLogoutUri(currentSession.getSsoAccessToken(),
+                                if (currentSession.isSsoEnabled() && currentSession.getSsoIdToken() != null) {
+                                    gwtSettingService.getSsoLogoutUri(currentSession.getSsoIdToken(),
                                             new AsyncCallback<String>() {
 
                                         @Override

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/TokenCleaner.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/TokenCleaner.java
@@ -20,11 +20,12 @@ public final class TokenCleaner {
     }
 
     /**
-     * Clear GWT state and remove SSO token when set (invalidates URL parameters)
+     * Clear GWT state and remove SSO tokens when set (invalidates URL parameters)
      */
     public static void cleanToken() {
         final String url = Window.Location.createUrlBuilder()
                 .removeParameter(KapuaCloudConsole.PARAMETER_ACCESS_TOKEN)
+                .removeParameter(KapuaCloudConsole.PARAMETER_ID_TOKEN)
                 .removeParameter(KapuaCloudConsole.PARAMETER_ERROR)
                 .removeParameter(KapuaCloudConsole.PARAMETER_ERROR_DESC)
                 .buildString();

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -18,6 +18,7 @@ import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtCredential;
+import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtIdToken;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtLoginCredential;
 import org.eclipse.kapua.app.console.core.shared.service.GwtAuthorizationService;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
@@ -118,7 +119,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
     }
 
     @Override
-    public GwtSession login(GwtJwtCredential gwtAccessTokenCredentials) throws GwtKapuaException {
+    public GwtSession login(GwtJwtCredential gwtAccessTokenCredentials, GwtJwtIdToken gwtJwtIdToken) throws GwtKapuaException {
         // VIP
         // keep this here to make sure we initialize the logger.
         // Without the following, console logger may not log anything when deployed into tomcat.
@@ -137,7 +138,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             handleLogin(authenticationService, credentials);
 
             // Get the session infos
-            return establishSession(gwtAccessTokenCredentials);
+            return establishSession(gwtJwtIdToken);
         } catch (Throwable t) {
             logout();
             KapuaExceptionHandler.handle(t);
@@ -222,7 +223,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         return gwtSession;
     }
 
-    private GwtSession establishSession(GwtJwtCredential gwtAccessTokenCredentials) throws KapuaException {
+    private GwtSession establishSession(GwtJwtIdToken gwtJwtIdToken) throws KapuaException {
         KapuaLocator locator = KapuaLocator.getInstance();
 
         //
@@ -284,8 +285,8 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         gwtSession.setSelectedAccountPath(gwtAccount.getParentAccountPath());
 
         // Access token
-        if (gwtAccessTokenCredentials!=null) {
-            gwtSession.setSsoAccessToken(gwtAccessTokenCredentials.getAccessToken());
+        if (gwtJwtIdToken!=null) {
+            gwtSession.setSsoIdToken(gwtJwtIdToken.getIdToken());
         }
 
         //

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
@@ -50,9 +50,9 @@ public class GwtSettingsServiceImpl extends RemoteServiceServlet implements GwtS
     }
 
     @Override
-    public String getSsoLogoutUri(String ssoAccessToken) throws GwtKapuaException {
+    public String getSsoLogoutUri(String ssoIdToken) throws GwtKapuaException {
         try {
-            return SsoLocator.getLocator(this).getService().getLogoutUri(ssoAccessToken,
+            return SsoLocator.getLocator(this).getService().getLogoutUri(ssoIdToken,
                     URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
@@ -66,9 +66,11 @@ public class SsoCallbackServlet extends HttpServlet {
 
             // Get and clean jwks_uri property
             final String accessToken = jsonObject.getString("access_token");
+            final String idToken = jsonObject.getString("id_token");
             try {
                 final URIBuilder redirect = new URIBuilder(homeUri);
                 redirect.addParameter("access_token", accessToken);
+                redirect.addParameter("id_token", idToken);
                 resp.sendRedirect(redirect.toString());
             } catch (final URISyntaxException e) {
                 throw new ServletException("Failed to parse redirect URL " + homeUri + " : " + e.getMessage(), e);

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtIdToken.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtIdToken.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.core.shared.model.authentication;
+
+import org.eclipse.kapua.app.console.module.api.shared.model.KapuaBaseModel;
+
+public class GwtJwtIdToken extends KapuaBaseModel {
+
+    private static final long serialVersionUID = -7683275209937145099L;
+
+    public GwtJwtIdToken() {
+        super();
+    }
+
+    public GwtJwtIdToken(String idToken) {
+        this();
+        setIdToken(idToken);
+    }
+
+    public String getIdToken() {
+        return get("idToken");
+    }
+
+    public void setIdToken(String idToken) {
+        set("idToken", idToken);
+    }
+}

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.app.console.core.shared.service;
 import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtCredential;
+import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtIdToken;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtLoginCredential;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -42,7 +43,7 @@ public interface GwtAuthorizationService extends RemoteService {
      * @throws GwtKapuaException If the access token is not valid.
      * @since 1.0.0
      */
-    public GwtSession login(GwtJwtCredential gwtAccessTokenCredentials) throws GwtKapuaException;
+    public GwtSession login(GwtJwtCredential gwtAccessTokenCredentials, GwtJwtIdToken gwtJwtIdToken) throws GwtKapuaException;
 
     /**
      * Return the currently authenticated user or null if no session has been established.

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtSettingsService.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtSettingsService.java
@@ -27,7 +27,7 @@ public interface GwtSettingsService extends RemoteService {
 
     public String getSsoLoginUri() throws GwtKapuaException;
 
-    public String getSsoLogoutUri(String ssoAccessToken) throws GwtKapuaException;
+    public String getSsoLogoutUri(String ssoIdToken) throws GwtKapuaException;
 
     public String getHomeUri() throws GwtKapuaException;
 

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
@@ -44,6 +44,7 @@ public class GwtSession extends KapuaBaseModel implements Serializable {
     private String userName;
     private String userDisplayName;
     private String ssoAccessToken;
+    private String ssoIdToken;
 
     private String tokenId;
 
@@ -296,12 +297,12 @@ public class GwtSession extends KapuaBaseModel implements Serializable {
         return false;
     }
 
-    public String getSsoAccessToken() {
-        return ssoAccessToken;
+    public String getSsoIdToken() {
+        return ssoIdToken;
     }
 
-    public void setSsoAccessToken(String ssoAccessToken) {
-        this.ssoAccessToken = ssoAccessToken;
+    public void setSsoIdToken(String ssoIdToken) {
+        this.ssoIdToken = ssoIdToken;
     }
 
 }

--- a/docs/developer-guide/en/sso.md
+++ b/docs/developer-guide/en/sso.md
@@ -213,7 +213,7 @@ will create the "_admin_" user without the need of the SimpleRegistrationProcess
 
 ### Keycloak logout endpoint
 
-Logging out from the Keycloak provider is also possible through the Keycloak logout endpoint: 
+Logging out from the Keycloak provider is possible through the Keycloak OpenID Connect logout endpoint: 
 
 `{sso.keycloak.uri}/auth/realms/{realm_name}/protocol/openid-connect/logout`
 


### PR DESCRIPTION
With some SSO providers, the logout might fail to redirect to the Kapua login page. This is due to the `access_token` being used as `id_token_hint` parameter with the OpenID Connect logout endpoint. The `id_token` must be used instead.

**Related Issue**
_N/A_

**Description of the solution adopted**
The `id_token` is now used as `id_token_hint` parameter.  Changes have been made to the console in order to retrieve and store the `id_token`, and then to use it when building the logout URI.

**Screenshots**
_N/A_

**Any side note on the changes made**
_N/A_
