### PR TITLE
Added Integration Tests For SSO Using Keycloak Provider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -925,6 +925,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-sso-test-steps</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-sso-provider</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUser.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUser.java
@@ -45,6 +45,8 @@ public class CucUser {
 
     private String expirationDate;
 
+    private String externalId;
+
     public String getName() {
         return name;
     }
@@ -107,6 +109,14 @@ public class CucUser {
 
     public void setScopeId(BigInteger scopeId) {
         this.scopeId = scopeId;
+    }
+
+    public String getExternalId() {
+        return externalId;
+    }
+
+    public void setExternalId(String externalId) {
+        this.externalId = externalId;
     }
 
     public Date getExpirationDate() {

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -233,7 +233,14 @@
             <artifactId>kapua-translator-kura-jms</artifactId>
             <scope>provided</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-sso-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-sso-test-steps</artifactId>
+        </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-transport-api</artifactId>

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/sso/RunSsoLoginUsingKeycloakProvider.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/sso/RunSsoLoginUsingKeycloakProvider.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.sso;
+import cucumber.api.CucumberOptions;
+import org.eclipse.kapua.qa.common.cucumber.CucumberWithProperties;
+import org.junit.runner.RunWith;
+
+@RunWith(CucumberWithProperties.class)
+@CucumberOptions(
+        features = {
+                "classpath:features/sso/SsoLoginUsingKeycloakProvider.feature"
+        },
+        glue = {
+                "org.eclipse.kapua.qa.common",
+                "org.eclipse.kapua.service.sso.steps",
+                "org.eclipse.kapua.qa.integration.steps",
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.user.steps"
+        },
+        plugin = {
+                "pretty",
+                "html:target/SsoUnitTests",
+                "json:target/SsoUnitTests_cucumber.json"
+        },
+        strict = true,
+        monochrome = true)
+public class RunSsoLoginUsingKeycloakProvider {
+}

--- a/qa/integration/src/test/resources/features/sso/SsoLoginUsingGenericProvider.feature
+++ b/qa/integration/src/test/resources/features/sso/SsoLoginUsingGenericProvider.feature
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@sso
+@integration
+
+Feature: Sso Login using Generic Provider
+
+  Scenario: Configure environment for SSO with the Generic provider
+    Given Set environment variables for generic provider

--- a/qa/integration/src/test/resources/features/sso/SsoLoginUsingKeycloakProvider.feature
+++ b/qa/integration/src/test/resources/features/sso/SsoLoginUsingKeycloakProvider.feature
@@ -27,7 +27,7 @@ Feature: Sso Login using Keycloak Provider
 
   Scenario: Create external user using the the SimpleRegistrationProcessor
   Create a user using keycloak
-  Login using jwt credentials
+  Login using jwt credentials with SimpleRegistrationProcessor
   Check if user exists
 
     Then Get access token for user with username "test-user" and password "TestPassword123#"
@@ -71,7 +71,7 @@ Feature: Sso Login using Keycloak Provider
       | test-user | test-user@co.co | EXTERNAL | 5698d2ff-d26e-45bf-92df-c3e88da58dad |
 
   Scenario: Using normal login using Keycloak credentials
-  Create user using keycloak
+  Create user using keycloak and login using SimpleRegistrationProcessor
   Login as external user using normal login method
   Exception should be thrown
 
@@ -105,10 +105,8 @@ Feature: Sso Login using Keycloak Provider
       | name      | password          | enabled |
       | test-user | ToManySecrets123# | true    |
     Then I logout
-    Then Get access token for user with username "test-user" and password "TestPassword123#"
-    And Create a jwt credential using the access token
-    Given I expect the exception "KapuaException" with the text "*"
-    When Configure the SSO service
+    Given I expect the exception "NullPointerException" with the text "*"
+    Then Get access token for user with username "test-user" and password "ToManySecrets123#"
     Then An exception was thrown
 
   Scenario: Add user with fake externalId
@@ -136,7 +134,7 @@ Feature: Sso Login using Keycloak Provider
     Then An exception was thrown
 
   Scenario: Logging out and logging back in with SSO
-  Login as external user, logout
+  Login as external user using SimpleRegistrationProcessor, logout
   Login again, no exception should be thrown
 
     Then Get access token for user with username "test-user" and password "TestPassword123#"
@@ -148,7 +146,7 @@ Feature: Sso Login using Keycloak Provider
     Then No exception was thrown
 
   Scenario: Login using normal login after logging out with SSO
-  Login as external user, logout
+  Login as external user using SimpleRegistrationProcessor, logout
   Login again, this time with normal login method, exception should be thrown
 
     Then Get access token for user with username "test-user" and password "TestPassword123#"

--- a/qa/integration/src/test/resources/features/sso/SsoLoginUsingKeycloakProvider.feature
+++ b/qa/integration/src/test/resources/features/sso/SsoLoginUsingKeycloakProvider.feature
@@ -1,0 +1,167 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+###############################################################################
+@sso
+@integration
+
+Feature: Sso Login using Keycloak Provider
+
+  Scenario: Configure environment for SSO with the Keycloak provider
+    Given Set environment variables for keycloak provider
+
+  Scenario: Start Keycloak
+
+    Given Pull image "jboss/keycloak:8.0.1"
+    When Create network
+    Then Start Keycloak container with name "keycloak"
+    Then I wait 45 seconds
+    And Initialize shiro ini file
+
+  Scenario: Create external user using the the SimpleRegistrationProcessor
+  Create a user using keycloak
+  Login using jwt credentials
+  Check if user exists
+
+    Then Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given Configure the SSO service
+    And Login using a jwt credential
+    Then I logout
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I search for user with name "test-user"
+    Then I find user
+      | name      | email           | status  | userType | externalId                           |
+      | test-user | test-user@co.co | ENABLED | EXTERNAL | 5698d2ff-d26e-45bf-92df-c3e88da58dad |
+    And I logout
+
+  Scenario: Create external user using the the UserService
+  Login as kapua-sys, create user with externalId
+  Login as external user using jwt credentials
+  Check if user exists
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    Then Account
+      | name      |
+      | test-user |
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And A generic user
+      | name      | email           | userType | externalId                           |
+      | test-user | test-user@co.co | EXTERNAL | 5698d2ff-d26e-45bf-92df-c3e88da58dad |
+    And I logout
+    And Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    And Login using a jwt credential
+    Then I logout
+    And I login as user with name "kapua-sys" and password "kapua-password"
+    Then I search for user with name "test-user"
+    And I find user
+      | name      | email           | userType | externalId                           |
+      | test-user | test-user@co.co | EXTERNAL | 5698d2ff-d26e-45bf-92df-c3e88da58dad |
+
+  Scenario: Using normal login using Keycloak credentials
+  Create user using keycloak
+  Login as external user using normal login method
+  Exception should be thrown
+
+    Then Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given Configure the SSO service
+    And Login using a jwt credential
+    Then I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "test-user" and password "TestPassword123#"
+    Then An exception was thrown
+
+  Scenario: Login with an existing internal user using the SSO login
+  Login as kapua-sys, create a regular user without externalId
+  Try to login as a keycloak user with same username as previously created user
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    Then Account
+      | name      |
+      | test-user |
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    When A generic user
+      | name      | displayName | email           | phoneNumber     | status  | userType |
+      | test-user | Test User   | test-user@co.co | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name      | password          | enabled |
+      | test-user | ToManySecrets123# | true    |
+    Then I logout
+    Then Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given I expect the exception "KapuaException" with the text "*"
+    When Configure the SSO service
+    Then An exception was thrown
+
+  Scenario: Add user with fake externalId
+  Login as kapua-sys, create an external user with made up externalId
+  Try to login as created user using sso
+  Exception should be thrown
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    Then Account
+      | name      |
+      | test-user |
+    And I configure user service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And A generic user
+      | name      | email           | userType | externalId                           |
+      | test-user | test-user@co.co | EXTERNAL | 1118d3dd-f11w-11bf-11de-c3e88da58abc |
+    And I logout
+    And Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When Login using a jwt credential
+    Then An exception was thrown
+
+  Scenario: Logging out and logging back in with SSO
+  Login as external user, logout
+  Login again, no exception should be thrown
+
+    Then Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given Configure the SSO service
+    And Login using a jwt credential
+    Then I logout
+    And Login using a jwt credential
+    Then No exception was thrown
+
+  Scenario: Login using normal login after logging out with SSO
+  Login as external user, logout
+  Login again, this time with normal login method, exception should be thrown
+
+    Then Get access token for user with username "test-user" and password "TestPassword123#"
+    And Create a jwt credential using the access token
+    Given Configure the SSO service
+    And Login using a jwt credential
+    Then I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "*"
+    When I login as user with name "test-user" and password "TestPassword123#"
+    Then An exception was thrown
+
+  Scenario: Stop Keycloak
+
+    Then Stop container with name "keycloak"
+    And Remove container with name "keycloak"
+    Then Remove network

--- a/qa/integration/src/test/resources/keycloak/kapua-realm.json
+++ b/qa/integration/src/test/resources/keycloak/kapua-realm.json
@@ -1,0 +1,1638 @@
+{
+  "id" : "kapua",
+  "realm" : "kapua",
+  "notBefore" : 0,
+  "revokeRefreshToken" : false,
+  "refreshTokenMaxReuse" : 0,
+  "accessTokenLifespan" : 900,
+  "accessTokenLifespanForImplicitFlow" : 900,
+  "ssoSessionIdleTimeout" : 1800,
+  "ssoSessionMaxLifespan" : 36000,
+  "ssoSessionIdleTimeoutRememberMe" : 0,
+  "ssoSessionMaxLifespanRememberMe" : 0,
+  "offlineSessionIdleTimeout" : 2592000,
+  "offlineSessionMaxLifespanEnabled" : false,
+  "offlineSessionMaxLifespan" : 5184000,
+  "accessCodeLifespan" : 60,
+  "accessCodeLifespanUserAction" : 300,
+  "accessCodeLifespanLogin" : 1800,
+  "actionTokenGeneratedByAdminLifespan" : 43200,
+  "actionTokenGeneratedByUserLifespan" : 300,
+  "enabled" : true,
+  "sslRequired" : "external",
+  "registrationAllowed" : false,
+  "registrationEmailAsUsername" : false,
+  "rememberMe" : false,
+  "verifyEmail" : false,
+  "loginWithEmailAllowed" : true,
+  "duplicateEmailsAllowed" : false,
+  "resetPasswordAllowed" : false,
+  "editUsernameAllowed" : false,
+  "bruteForceProtected" : false,
+  "permanentLockout" : false,
+  "maxFailureWaitSeconds" : 900,
+  "minimumQuickLoginWaitSeconds" : 60,
+  "waitIncrementSeconds" : 60,
+  "quickLoginCheckMilliSeconds" : 1000,
+  "maxDeltaTimeSeconds" : 43200,
+  "failureFactor" : 30,
+  "roles" : {
+    "realm" : [ {
+      "id" : "788bbe30-7288-4bbe-9ef0-b602ae58eb4f",
+      "name" : "offline_access",
+      "description" : "${role_offline-access}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "kapua",
+      "attributes" : { }
+    }, {
+      "id" : "32c74fc9-ada0-44fe-a3f7-67c3b2c680f5",
+      "name" : "uma_authorization",
+      "description" : "${role_uma_authorization}",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "kapua",
+      "attributes" : { }
+    }, {
+      "id" : "b760b547-fe65-446b-9281-9697131235ed",
+      "name" : "console",
+      "composite" : false,
+      "clientRole" : false,
+      "containerId" : "kapua",
+      "attributes" : { }
+    } ],
+    "client" : {
+      "console" : [ ],
+      "realm-management" : [ {
+        "id" : "d35cf07a-dafd-4d90-8fa8-82d74cbb39fe",
+        "name" : "impersonation",
+        "description" : "${role_impersonation}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "16aa58d7-4b29-4384-9b9b-93ece05796b5",
+        "name" : "view-users",
+        "description" : "${role_view-users}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-groups", "query-users" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "8138c527-f200-4197-9d2a-6458969b6e23",
+        "name" : "realm-admin",
+        "description" : "${role_realm-admin}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "impersonation", "view-users", "view-events", "query-realms", "view-authorization", "manage-clients", "manage-authorization", "view-realm", "create-client", "manage-users", "query-users", "view-identity-providers", "view-clients", "query-groups", "manage-realm", "query-clients", "manage-events", "manage-identity-providers" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "9a798320-ba88-4f2d-8795-1f59feffb4f3",
+        "name" : "view-events",
+        "description" : "${role_view-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "f0fb70fa-75e0-4b24-a758-0ad617fbdeef",
+        "name" : "query-realms",
+        "description" : "${role_query-realms}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "b7d771ab-7ad1-4ea0-9329-7593bdce7451",
+        "name" : "view-authorization",
+        "description" : "${role_view-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "86ad59cb-882d-4ae7-a0ed-95c6b2c4139e",
+        "name" : "manage-clients",
+        "description" : "${role_manage-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "8774e43b-5142-4c2d-9522-ed08099732b8",
+        "name" : "manage-authorization",
+        "description" : "${role_manage-authorization}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "6a204886-884e-4bc9-8ebd-a22243b45503",
+        "name" : "view-realm",
+        "description" : "${role_view-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "5bd26e25-5649-4b6e-aa2a-e61df4cb5680",
+        "name" : "create-client",
+        "description" : "${role_create-client}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "7ff58430-38a6-4476-ae9d-b1d5e89fe635",
+        "name" : "manage-users",
+        "description" : "${role_manage-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "f5bac544-72f9-484c-97bf-265a8924cfdf",
+        "name" : "query-users",
+        "description" : "${role_query-users}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "1813fa21-2418-4984-93f2-a3cd949798f9",
+        "name" : "view-identity-providers",
+        "description" : "${role_view-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "875421eb-a414-43fb-8c4e-dde165980739",
+        "name" : "view-clients",
+        "description" : "${role_view-clients}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "realm-management" : [ "query-clients" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "2b9a07df-3a40-485c-be8b-52a113b0dcd9",
+        "name" : "manage-realm",
+        "description" : "${role_manage-realm}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "29815f08-7b5e-4f14-a0c4-64ff68a32a92",
+        "name" : "query-groups",
+        "description" : "${role_query-groups}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "d0d21a7e-421e-4de1-a0e7-8ab19a8b3c51",
+        "name" : "query-clients",
+        "description" : "${role_query-clients}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "d702197a-2e14-4a18-a270-c7d6ca5afafc",
+        "name" : "manage-events",
+        "description" : "${role_manage-events}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      }, {
+        "id" : "351cc4e2-f772-40ea-9b30-03c3ab9bc1da",
+        "name" : "manage-identity-providers",
+        "description" : "${role_manage-identity-providers}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+        "attributes" : { }
+      } ],
+      "security-admin-console" : [ ],
+      "admin-cli" : [ ],
+      "broker" : [ {
+        "id" : "047eb381-4eab-402a-b435-f3daa75f8e78",
+        "name" : "read-token",
+        "description" : "${role_read-token}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "13570cc2-880f-404d-9d5c-d6b23ee959c3",
+        "attributes" : { }
+      } ],
+      "account" : [ {
+        "id" : "23175e8b-9ada-427a-a35f-ebc95771b254",
+        "name" : "manage-account",
+        "description" : "${role_manage-account}",
+        "composite" : true,
+        "composites" : {
+          "client" : {
+            "account" : [ "manage-account-links" ]
+          }
+        },
+        "clientRole" : true,
+        "containerId" : "773ca2f5-9a28-4d8d-9665-365cd1209330",
+        "attributes" : { }
+      }, {
+        "id" : "a25200a8-7d84-44b8-b4a0-2726465b1be4",
+        "name" : "view-profile",
+        "description" : "${role_view-profile}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "773ca2f5-9a28-4d8d-9665-365cd1209330",
+        "attributes" : { }
+      }, {
+        "id" : "b7cf58ec-f311-445c-9135-b81eda698b2b",
+        "name" : "manage-account-links",
+        "description" : "${role_manage-account-links}",
+        "composite" : false,
+        "clientRole" : true,
+        "containerId" : "773ca2f5-9a28-4d8d-9665-365cd1209330",
+        "attributes" : { }
+      } ]
+    }
+  },
+  "groups" : [ ],
+  "defaultRoles" : [ "uma_authorization", "offline_access" ],
+  "requiredCredentials" : [ "password" ],
+  "otpPolicyType" : "totp",
+  "otpPolicyAlgorithm" : "HmacSHA1",
+  "otpPolicyInitialCounter" : 0,
+  "otpPolicyDigits" : 6,
+  "otpPolicyLookAheadWindow" : 1,
+  "otpPolicyPeriod" : 30,
+  "otpSupportedApplications" : [ "FreeOTP", "Google Authenticator" ],
+  "webAuthnPolicyRpEntityName" : "keycloak",
+  "webAuthnPolicySignatureAlgorithms" : [ "ES256" ],
+  "webAuthnPolicyRpId" : "",
+  "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+  "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+  "webAuthnPolicyRequireResidentKey" : "not specified",
+  "webAuthnPolicyUserVerificationRequirement" : "not specified",
+  "webAuthnPolicyCreateTimeout" : 0,
+  "webAuthnPolicyAvoidSameAuthenticatorRegister" : false,
+  "webAuthnPolicyAcceptableAaguids" : [ ],
+  "users" : [ {
+    "id" : "5698d2ff-d26e-45bf-92df-c3e88da58dad",
+    "createdTimestamp" : 1579003113425,
+    "username" : "test-user",
+    "enabled" : true,
+    "totp" : false,
+    "emailVerified" : false,
+    "email" : "test-user@co.co",
+    "credentials" : [ {
+      "id" : "4749a0b2-6186-4aeb-adb3-4943ccdba07f",
+      "type" : "password",
+      "createdDate" : 1579003139550,
+      "secretData" : "{\"value\":\"n4A/1co7refjNk+TSsmAS6ySf8p7vo4wDeTLfVB1i62m7sF+yCnB8KDSuHJu7xY+LFsHalnu1pSwDG+NqDH8qQ==\",\"salt\":\"Kc8H7IIO1VCVYaLyc7EMQA==\"}",
+      "credentialData" : "{\"hashIterations\":27500,\"algorithm\":\"pbkdf2-sha256\"}"
+    } ],
+    "disableableCredentialTypes" : [ ],
+    "requiredActions" : [ ],
+    "realmRoles" : [ "offline_access", "uma_authorization" ],
+    "clientRoles" : {
+      "account" : [ "manage-account", "view-profile" ]
+    },
+    "notBefore" : 0,
+    "groups" : [ ]
+  } ],
+  "scopeMappings" : [ {
+    "clientScope" : "offline_access",
+    "roles" : [ "offline_access" ]
+  } ],
+  "clients" : [ {
+    "id" : "773ca2f5-9a28-4d8d-9665-365cd1209330",
+    "clientId" : "account",
+    "name" : "${client_account}",
+    "rootUrl" : "${authBaseUrl}",
+    "baseUrl" : "/realms/kapua/account/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "24c93246-a91e-49c9-bbc6-6f95cd041ec2",
+    "defaultRoles" : [ "manage-account", "view-profile" ],
+    "redirectUris" : [ "/realms/kapua/account/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "4f9b5197-d188-4d59-937f-fa1a42425e63",
+    "clientId" : "admin-cli",
+    "name" : "${client_admin-cli}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "00a2dfbf-6464-4423-a652-5b508ad9baa7",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : false,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "13570cc2-880f-404d-9d5c-d6b23ee959c3",
+    "clientId" : "broker",
+    "name" : "${client_broker}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "5abab99c-9cf1-456a-9152-f193dd35925d",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "4beb45d6-ae67-466e-873e-5642b86962ae",
+    "clientId" : "console",
+    "baseUrl" : "http://localhost:8080/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "1efab341-0bc9-4fcc-a487-6b90b6ce763b",
+    "redirectUris" : [ "http://localhost:8080/*" ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : true,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "saml.assertion.signature" : "false",
+      "saml.force.post.binding" : "false",
+      "saml.multivalued.roles" : "false",
+      "saml.encrypt" : "false",
+      "saml.server.signature" : "false",
+      "saml.server.signature.keyinfo.ext" : "false",
+      "exclude.session.state.from.auth.response" : "false",
+      "saml_force_name_id_format" : "false",
+      "saml.client.signature" : "false",
+      "tls.client.certificate.bound.access.tokens" : "false",
+      "saml.authnstatement" : "false",
+      "display.on.consent.screen" : "false",
+      "saml.onetimeuse.condition" : "false"
+    },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : true,
+    "nodeReRegistrationTimeout" : -1,
+    "protocolMappers" : [ {
+      "id" : "e2c29e37-ca62-4c32-9ace-d6ed194528c6",
+      "name" : "console",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "included.client.audience" : "console",
+        "id.token.claim" : "false",
+        "access.token.claim" : "true"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "185350bf-2112-45b1-9f31-a06b2044a51e",
+    "clientId" : "realm-management",
+    "name" : "${client_realm-management}",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "8b27e4dc-890e-4099-98db-324697492172",
+    "redirectUris" : [ ],
+    "webOrigins" : [ ],
+    "notBefore" : 0,
+    "bearerOnly" : true,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : false,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  }, {
+    "id" : "cb596175-3a81-470c-bf9d-56e44c929b40",
+    "clientId" : "security-admin-console",
+    "name" : "${client_security-admin-console}",
+    "rootUrl" : "${authAdminUrl}",
+    "baseUrl" : "/admin/kapua/console/",
+    "surrogateAuthRequired" : false,
+    "enabled" : true,
+    "clientAuthenticatorType" : "client-secret",
+    "secret" : "b9a494ee-4fc8-4d39-b8f2-4ea64bf99d62",
+    "redirectUris" : [ "/admin/kapua/console/*" ],
+    "webOrigins" : [ "+" ],
+    "notBefore" : 0,
+    "bearerOnly" : false,
+    "consentRequired" : false,
+    "standardFlowEnabled" : true,
+    "implicitFlowEnabled" : false,
+    "directAccessGrantsEnabled" : false,
+    "serviceAccountsEnabled" : false,
+    "publicClient" : true,
+    "frontchannelLogout" : false,
+    "protocol" : "openid-connect",
+    "attributes" : { },
+    "authenticationFlowBindingOverrides" : { },
+    "fullScopeAllowed" : false,
+    "nodeReRegistrationTimeout" : 0,
+    "protocolMappers" : [ {
+      "id" : "ffb2a680-3f05-43e5-8488-71b514d8b14f",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    } ],
+    "defaultClientScopes" : [ "web-origins", "role_list", "profile", "roles", "email" ],
+    "optionalClientScopes" : [ "address", "phone", "offline_access", "microprofile-jwt" ]
+  } ],
+  "clientScopes" : [ {
+    "id" : "9486d65b-c4a1-4598-8592-04126c3a7d00",
+    "name" : "address",
+    "description" : "OpenID Connect built-in scope: address",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${addressScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "394a5374-6148-4f3a-a944-099fa5c59b36",
+      "name" : "address",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-address-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute.formatted" : "formatted",
+        "user.attribute.country" : "country",
+        "user.attribute.postal_code" : "postal_code",
+        "userinfo.token.claim" : "true",
+        "user.attribute.street" : "street",
+        "id.token.claim" : "true",
+        "user.attribute.region" : "region",
+        "access.token.claim" : "true",
+        "user.attribute.locality" : "locality"
+      }
+    } ]
+  }, {
+    "id" : "389a3bc0-ef95-4919-912b-d9df08759484",
+    "name" : "console",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "85785867-982e-4bdb-8054-2771c35b0e18",
+    "name" : "email",
+    "description" : "OpenID Connect built-in scope: email",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${emailScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "dd408588-3273-4b3a-9765-03ab8c1e415d",
+      "name" : "email",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "email",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "78ae103b-9c65-4acb-a881-8cfb6be64301",
+      "name" : "email verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "emailVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "email_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "6ac48782-1e5d-4598-bd69-ae9d08f7b8c5",
+    "name" : "microprofile-jwt",
+    "description" : "Microprofile - JWT built-in scope",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "false"
+    },
+    "protocolMappers" : [ {
+      "id" : "a6a6f812-3623-48ca-8254-a6754c2ea674",
+      "name" : "groups",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "multivalued" : "true",
+        "user.attribute" : "foo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "groups",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "de9d664f-fa10-4b99-9f64-98b1e52f557a",
+      "name" : "upn",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "upn",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "b7a63db4-7583-4539-956a-810c5c35ace4",
+    "name" : "offline_access",
+    "description" : "OpenID Connect built-in scope: offline_access",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "consent.screen.text" : "${offlineAccessScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    }
+  }, {
+    "id" : "c9d08baf-cecb-42ed-8026-0fa5ff12f0b4",
+    "name" : "phone",
+    "description" : "OpenID Connect built-in scope: phone",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${phoneScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "6c141d39-80b4-4e44-ae7d-56350c686ea7",
+      "name" : "phone number",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumber",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "771cc444-223f-4146-8f2a-185477f0e13a",
+      "name" : "phone number verified",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "phoneNumberVerified",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "phone_number_verified",
+        "jsonType.label" : "boolean"
+      }
+    } ]
+  }, {
+    "id" : "2045e4b2-d066-405b-9d14-6fea75dc2f25",
+    "name" : "profile",
+    "description" : "OpenID Connect built-in scope: profile",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "true",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${profileScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "231a8ecb-629e-490a-af97-61cef8601c68",
+      "name" : "gender",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "gender",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "gender",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "61e18ae1-c34f-4cf7-9721-645c90a628a2",
+      "name" : "full name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-full-name-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "userinfo.token.claim" : "true"
+      }
+    }, {
+      "id" : "9beb8f62-3954-4224-8dcb-c7e1eb0c41ae",
+      "name" : "profile",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "profile",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "profile",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "06084701-3242-4082-a5b3-be1afbaa42dc",
+      "name" : "picture",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "picture",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "picture",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "d608418f-d113-499a-84be-5781ac148ecf",
+      "name" : "zoneinfo",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "zoneinfo",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "zoneinfo",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "07f64a25-02cf-4b63-84fb-580ced9dc06f",
+      "name" : "username",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "username",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "preferred_username",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4049cf7f-59fa-4018-aa7b-8839d88a13c9",
+      "name" : "website",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "website",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "website",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "37c6360c-4bc4-49b6-8769-5ac495ad6881",
+      "name" : "family name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "lastName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "family_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "0a14d43a-8eaa-4355-ac8c-20884192601f",
+      "name" : "given name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-property-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "firstName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "given_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "4e773d59-6929-4128-8f39-989addf6bbb8",
+      "name" : "birthdate",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "birthdate",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "birthdate",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "51a666ea-c895-4c42-af9e-5f1830e08de6",
+      "name" : "locale",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "locale",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "locale",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "ebb40e5a-4ad7-4c4b-8543-a8d3565d53af",
+      "name" : "updated at",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "updatedAt",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "updated_at",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "27d9baa7-8b10-4990-9bc4-00737f456063",
+      "name" : "middle name",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "middleName",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "middle_name",
+        "jsonType.label" : "String"
+      }
+    }, {
+      "id" : "e24ca402-e87b-43a2-ac9e-1ea6515bae1b",
+      "name" : "nickname",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-attribute-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "userinfo.token.claim" : "true",
+        "user.attribute" : "nickname",
+        "id.token.claim" : "true",
+        "access.token.claim" : "true",
+        "claim.name" : "nickname",
+        "jsonType.label" : "String"
+      }
+    } ]
+  }, {
+    "id" : "a1fb590c-e4b9-4146-8409-5f1ed7fcaec4",
+    "name" : "role_list",
+    "description" : "SAML role list",
+    "protocol" : "saml",
+    "attributes" : {
+      "consent.screen.text" : "${samlRoleListScopeConsentText}",
+      "display.on.consent.screen" : "true"
+    },
+    "protocolMappers" : [ {
+      "id" : "e429835f-bbd3-4a67-9eaf-fc4bf2be8953",
+      "name" : "role list",
+      "protocol" : "saml",
+      "protocolMapper" : "saml-role-list-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "single" : "false",
+        "attribute.nameformat" : "Basic",
+        "attribute.name" : "Role"
+      }
+    } ]
+  }, {
+    "id" : "b886305b-3e02-408f-811f-2c97b462ddf0",
+    "name" : "roles",
+    "description" : "OpenID Connect scope for add user roles to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "true",
+      "consent.screen.text" : "${rolesScopeConsentText}"
+    },
+    "protocolMappers" : [ {
+      "id" : "6d208fe0-921f-4e58-bcf2-37bdcefe34f0",
+      "name" : "realm roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-realm-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "realm_access.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "e8252c9e-2d6d-4c9e-a396-1c6c36a5ddcf",
+      "name" : "client roles",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-usermodel-client-role-mapper",
+      "consentRequired" : false,
+      "config" : {
+        "user.attribute" : "foo",
+        "access.token.claim" : "true",
+        "claim.name" : "resource_access.${client_id}.roles",
+        "jsonType.label" : "String",
+        "multivalued" : "true"
+      }
+    }, {
+      "id" : "083a893f-3355-4138-9d01-ae149c804b8a",
+      "name" : "audience resolve",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-audience-resolve-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  }, {
+    "id" : "5e0ca845-4cc8-4d80-a921-0dc4f7501a3f",
+    "name" : "web-origins",
+    "description" : "OpenID Connect scope for add allowed web origins to the access token",
+    "protocol" : "openid-connect",
+    "attributes" : {
+      "include.in.token.scope" : "false",
+      "display.on.consent.screen" : "false",
+      "consent.screen.text" : ""
+    },
+    "protocolMappers" : [ {
+      "id" : "a7f8b444-41a8-49b1-a7fe-06e178cf0370",
+      "name" : "allowed web origins",
+      "protocol" : "openid-connect",
+      "protocolMapper" : "oidc-allowed-origins-mapper",
+      "consentRequired" : false,
+      "config" : { }
+    } ]
+  } ],
+  "defaultDefaultClientScopes" : [ "profile", "web-origins", "email", "role_list", "roles" ],
+  "defaultOptionalClientScopes" : [ "microprofile-jwt", "address", "offline_access", "phone" ],
+  "browserSecurityHeaders" : {
+    "contentSecurityPolicyReportOnly" : "",
+    "xContentTypeOptions" : "nosniff",
+    "xRobotsTag" : "none",
+    "xFrameOptions" : "SAMEORIGIN",
+    "contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "xXSSProtection" : "1; mode=block",
+    "strictTransportSecurity" : "max-age=31536000; includeSubDomains"
+  },
+  "smtpServer" : { },
+  "eventsEnabled" : false,
+  "eventsListeners" : [ "jboss-logging" ],
+  "enabledEventTypes" : [ ],
+  "adminEventsEnabled" : false,
+  "adminEventsDetailsEnabled" : false,
+  "components" : {
+    "org.keycloak.services.clientregistration.policy.ClientRegistrationPolicy" : [ {
+      "id" : "8671a196-97b4-4ff6-9a4a-9394aec6bfcd",
+      "name" : "Full Scope Disabled",
+      "providerId" : "scope",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "9067f1b7-bfef-48f1-9d71-7607cb56f25d",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "1556bab7-fb3a-4269-b1f3-45dcac11b863",
+      "name" : "Trusted Hosts",
+      "providerId" : "trusted-hosts",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "host-sending-registration-request-must-match" : [ "true" ],
+        "client-uris-must-match" : [ "true" ]
+      }
+    }, {
+      "id" : "40304054-f682-41e7-bf5d-1b8c7ae832ee",
+      "name" : "Max Clients Limit",
+      "providerId" : "max-clients",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "max-clients" : [ "200" ]
+      }
+    }, {
+      "id" : "96aaf411-90fd-44fd-888f-47ed01217737",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "saml-user-attribute-mapper", "oidc-address-mapper", "saml-user-property-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-sha256-pairwise-sub-mapper", "oidc-usermodel-property-mapper" ]
+      }
+    }, {
+      "id" : "4ffe4d57-3b40-4624-b13e-bf8f0901a100",
+      "name" : "Allowed Client Scopes",
+      "providerId" : "allowed-client-templates",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : {
+        "allow-default-scopes" : [ "true" ]
+      }
+    }, {
+      "id" : "fc91c82c-e94e-433f-ab55-f8483612df3c",
+      "name" : "Consent Required",
+      "providerId" : "consent-required",
+      "subType" : "anonymous",
+      "subComponents" : { },
+      "config" : { }
+    }, {
+      "id" : "bcc078fa-3580-4c0e-b423-0fac2830ee26",
+      "name" : "Allowed Protocol Mapper Types",
+      "providerId" : "allowed-protocol-mappers",
+      "subType" : "authenticated",
+      "subComponents" : { },
+      "config" : {
+        "allowed-protocol-mapper-types" : [ "saml-role-list-mapper", "oidc-usermodel-attribute-mapper", "oidc-full-name-mapper", "oidc-usermodel-property-mapper", "oidc-sha256-pairwise-sub-mapper", "saml-user-attribute-mapper", "saml-user-property-mapper", "oidc-address-mapper" ]
+      }
+    } ],
+    "org.keycloak.keys.KeyProvider" : [ {
+      "id" : "8b0a96d7-1cf2-4a05-8ea6-cf0def9d44df",
+      "name" : "hmac-generated",
+      "providerId" : "hmac-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "6bb79a72-f21b-4780-90af-bc4b39110f9e" ],
+        "secret" : [ "yfDEjni8Qxq6UQGqiG90tXeOdpbFZbxKRLMJ4-gFF3CSIwLF3zKcwsw3jnSbDIVTkOx4L6-ek_MueyXrXJwl4w" ],
+        "priority" : [ "100" ],
+        "algorithm" : [ "HS256" ]
+      }
+    }, {
+      "id" : "506db3ae-0dfa-4de5-9594-491ac3d8fa40",
+      "name" : "rsa-generated",
+      "providerId" : "rsa-generated",
+      "subComponents" : { },
+      "config" : {
+        "privateKey" : [ "MIIEowIBAAKCAQEAvnPCYvOJAKYstF1QLvRJujzCKfICuxEO4JHF5hAkHUMxCaZmgechVDLBVHJVigIKMI2HcWnwhrcGJapRLUHoI/oCgO1Z1jdC/DVK+AoDGGkzEFTIGJj5QxfbqJCr8+UUU5TrLzV4hv+ObwIbY/yNKR2BzykUoUCboBF1i47luVOPrLBkamFOjo0GlE2parEInEtKyT49W5fAKD5jf1QmwPiZTilHb3wl2C2zkbvKmQusgUYoCRno+gTsJZrgZHbvC4EyEQHC96CEyzhrvT3zzVC9huYN6RMK7FFOs0wjk6sS0CqN+EDGoaZsDIczaRm7YTsGFfVtx1Suix+XafyJlwIDAQABAoIBAGeyGZ3M4cRzthWCVR0rr1TyrfkupuP5trL5S9om4bL5GaMacee607/HXtI+6moZEDk9ZgiPWQHQd01cvZQ5tU6ZWnGeSfLD5fnyfl4s/WB2LvJuZwBVkipAvD28f5NtIDMd+yuaHoTKcl/osscvBCDlyv7jbDMcPV/bAbg51sSfVTbYed8Mu34rwE5B/LMNjlg/cgSpNdAQSHzFfstkjjNo0i2uJhPJs6/4arTiBUzoZ7QWY1L5whRrK4BSgsZgqhPgvFwy6twDGX4s/nPAdiP75VgeNIN1Wp+uT/vIQg9YSDZhr56wBmLq38FgoMGE+nzSH+1cRoLLBqLKAqWQTzkCgYEA4NLwVD/oPXo9awTCtOnuPhK2YjZeR061JsuoszqTXOWU8O7fwfXfMc++wtHyL4oPKioyoI9EW8VuI/QDYb7T9JlVbJHOXFMyAqhCO7lBuADOAlxSUybzigfxow1JnP3zuZQOhkGBABLAJmQotZ5/ofcQ+8/7pbPxJrN8NqQbPiUCgYEA2NymoArb0vNi7LHTnAAueW0myAQcs9C8Oh9lNwukrObeNGHIECs0+RJXHfAWNh3rDLqC3wOQxXUtYpoxWLel6p9vVHsYWKcof4Bq5shEZLBoosm6OrijvUNwzETu0bAmp1J3HWYn37uxoSn0mRTSY39wUjwwQ5SfXHByIW8sBgsCgYEAggzDBJkrKFTLrlpEnw4qyDFe2xUEGE+JLnXkkjiyAay0KWKkgLhPcarweBWl+KXt+8AJJSN6sXNVMOr4AdS3GuiPp4v4SSO+7BaUqaOSRnQAtxDcdkkz24aY2m7XRD8KezEP7c16Z6ZxDEQn4FddET2vz1oSAVpDhtWQZrMrJxkCgYBvii35qxwdiCmdbGlWl5FPyyBjSBorMnVdv8Aja82rUKOBdbmc91wrr483SsFh3EmFJnkhk4fmx7osOPqgkvS3lIGChj2je3aM/dP+F4t17nYjJHawtT8inYlqxxm+qEd5UCUL7fscTEG0jwvLoLYFjwqKgYKhf9Pni75oC/IsuQKBgAfJTakGobDLc4zaJ0I/nAfPq3FAXdFRhLct7A1+1QZs5ERBDHOu18XmUVUDG7luECJ9k18lAlDsBYzfEsgPD+DwErfSnpVPayC7iCBPHOsFUNIuWZRRcn7FnLqj0yDl99CYVDNpgtpKdHTGJtY6HsN1UBdrBtJl31pvwjS1P7jf" ],
+        "certificate" : [ "MIICmTCCAYECBgFvo9xhETANBgkqhkiG9w0BAQsFADAQMQ4wDAYDVQQDDAVrYXB1YTAeFw0yMDAxMTQxMTQwMjZaFw0zMDAxMTQxMTQyMDZaMBAxDjAMBgNVBAMMBWthcHVhMIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAvnPCYvOJAKYstF1QLvRJujzCKfICuxEO4JHF5hAkHUMxCaZmgechVDLBVHJVigIKMI2HcWnwhrcGJapRLUHoI/oCgO1Z1jdC/DVK+AoDGGkzEFTIGJj5QxfbqJCr8+UUU5TrLzV4hv+ObwIbY/yNKR2BzykUoUCboBF1i47luVOPrLBkamFOjo0GlE2parEInEtKyT49W5fAKD5jf1QmwPiZTilHb3wl2C2zkbvKmQusgUYoCRno+gTsJZrgZHbvC4EyEQHC96CEyzhrvT3zzVC9huYN6RMK7FFOs0wjk6sS0CqN+EDGoaZsDIczaRm7YTsGFfVtx1Suix+XafyJlwIDAQABMA0GCSqGSIb3DQEBCwUAA4IBAQBlcRaHifhSZoVMS1qFKkJsWtKn4jk8aEyxdNoilq8uX5pSa/VproPg4656ig7t03GBx/MQPsHQ8EBgCyACOBIVfjZMbBhDqJgQfFdUasnUMvD+4euOclVZkdlULjEaeh9ixh4vl6g9X5UUL3pkUmopYmH3NBcUmhtfdC7UEPF2s/8TfZS6ISP/euq6nQSXGGZxte7eILAb5oKzpcSUKZYD/G9hRcSZVmkj9inKF3vnGaXsg2gKCvbDtRFaGZvq9y+AdEU8mnnLVtUAjKs4GsyOJ3RUJe2Lq8Tnt0vaov2lQOvG+nY5N/NMQKCscsBVlCNHdDivmBf++kv4QQy+kvQL" ],
+        "priority" : [ "100" ]
+      }
+    }, {
+      "id" : "980be81f-e05d-4199-bac5-72fa3a06800c",
+      "name" : "aes-generated",
+      "providerId" : "aes-generated",
+      "subComponents" : { },
+      "config" : {
+        "kid" : [ "51efde5c-bf88-4035-abf9-931b679f5a93" ],
+        "secret" : [ "vOZAPr-tW06tlh-wlWYbhA" ],
+        "priority" : [ "100" ]
+      }
+    } ]
+  },
+  "internationalizationEnabled" : false,
+  "supportedLocales" : [ ],
+  "authenticationFlows" : [ {
+    "id" : "1b6642bd-8352-4375-ba37-fb402a52a30e",
+    "alias" : "Account verification options",
+    "description" : "Method with which to verity the existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-email-verification",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Verify Existing Account by Re-authentication",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "e787a5dd-28c9-481a-834e-be743d1e538d",
+    "alias" : "Authentication Options",
+    "description" : "Authentication options.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "basic-auth",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "basic-auth-otp",
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "4be27f90-f07d-4d13-b59f-e0c668b79211",
+    "alias" : "Browser - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "c0a44a76-47a3-49e8-ae3e-59ce76309df3",
+    "alias" : "Direct Grant - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-otp",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "1adfe4b8-f27b-4d09-aa82-69d38fa2e01b",
+    "alias" : "First broker login - Conditional OTP",
+    "description" : "Flow to determine if the OTP is required for the authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-otp-form",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "fe4d3aa4-ca60-4468-b4b6-96f0e6b56c98",
+    "alias" : "Handle Existing Account",
+    "description" : "Handle what to do if there is existing account with same email/username like authenticated identity provider",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-confirm-link",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Account verification options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "fa3fbe97-4663-4cf9-8694-79760dca481d",
+    "alias" : "Reset - Conditional OTP",
+    "description" : "Flow to determine if the OTP should be reset or not. Set to REQUIRED to force.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "conditional-user-configured",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-otp",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "a97ce730-23cb-49c1-ab72-895becedc734",
+    "alias" : "User creation or linking",
+    "description" : "Flow for the existing/non-existing user alternatives",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "create unique user config",
+      "authenticator" : "idp-create-user-if-unique",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "flowAlias" : "Handle Existing Account",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "32408232-5ea5-456c-b92f-49567e5627f0",
+    "alias" : "Verify Existing Account by Re-authentication",
+    "description" : "Reauthentication of existing account",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "idp-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "First broker login - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "f9bca502-17d1-4cd3-a251-a9cb62e6b62a",
+    "alias" : "browser",
+    "description" : "browser based authentication",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-cookie",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "auth-spnego",
+      "requirement" : "DISABLED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "identity-provider-redirector",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 25,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "flowAlias" : "forms",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "77f07c91-bddc-4f9a-a1d9-9f8fa175611c",
+    "alias" : "clients",
+    "description" : "Base authentication for clients",
+    "providerId" : "client-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "client-secret",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-secret-jwt",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "client-x509",
+      "requirement" : "ALTERNATIVE",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "11621629-e836-400e-9cb0-b943718616e7",
+    "alias" : "direct grant",
+    "description" : "OpenID Connect Resource Owner Grant",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "direct-grant-validate-username",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "direct-grant-validate-password",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 30,
+      "flowAlias" : "Direct Grant - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "3b6b650b-2b21-4bfa-b539-f7df3cde0b7a",
+    "alias" : "docker auth",
+    "description" : "Used by Docker clients to authenticate against the IDP",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "docker-http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "54007644-ceec-4af7-ab89-1fa2cd4220b4",
+    "alias" : "first broker login",
+    "description" : "Actions taken after first broker login with identity provider account, which is not yet linked to any Keycloak account",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticatorConfig" : "review profile config",
+      "authenticator" : "idp-review-profile",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "User creation or linking",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2657b515-030a-4c4a-a08f-7f49bb973f48",
+    "alias" : "forms",
+    "description" : "Username, password, otp and other auth forms.",
+    "providerId" : "basic-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "auth-username-password-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 20,
+      "flowAlias" : "Browser - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "6d42f349-73e8-4a38-9248-66725336f9ed",
+    "alias" : "http challenge",
+    "description" : "An authentication flow based on challenge-response HTTP Authentication Schemes",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "no-cookie-redirect",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "flowAlias" : "Authentication Options",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "19b09870-a3b2-403f-b9b5-cccd9d2023c4",
+    "alias" : "registration",
+    "description" : "registration flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-page-form",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "flowAlias" : "registration form",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "65aea758-6a80-44ca-83d6-ad2c02bc2838",
+    "alias" : "registration form",
+    "description" : "registration form",
+    "providerId" : "form-flow",
+    "topLevel" : false,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "registration-user-creation",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-profile-action",
+      "requirement" : "REQUIRED",
+      "priority" : 40,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-password-action",
+      "requirement" : "REQUIRED",
+      "priority" : 50,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "registration-recaptcha-action",
+      "requirement" : "DISABLED",
+      "priority" : 60,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  }, {
+    "id" : "0447bef9-4812-45db-8a54-adbea325a961",
+    "alias" : "reset credentials",
+    "description" : "Reset credentials for a user if they forgot their password or something",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "reset-credentials-choose-user",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-credential-email",
+      "requirement" : "REQUIRED",
+      "priority" : 20,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "authenticator" : "reset-password",
+      "requirement" : "REQUIRED",
+      "priority" : 30,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    }, {
+      "requirement" : "CONDITIONAL",
+      "priority" : 40,
+      "flowAlias" : "Reset - Conditional OTP",
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : true
+    } ]
+  }, {
+    "id" : "2db1f236-0618-495c-84ee-6776edc6bfc3",
+    "alias" : "saml ecp",
+    "description" : "SAML ECP Profile Authentication Flow",
+    "providerId" : "basic-flow",
+    "topLevel" : true,
+    "builtIn" : true,
+    "authenticationExecutions" : [ {
+      "authenticator" : "http-basic-authenticator",
+      "requirement" : "REQUIRED",
+      "priority" : 10,
+      "userSetupAllowed" : false,
+      "autheticatorFlow" : false
+    } ]
+  } ],
+  "authenticatorConfig" : [ {
+    "id" : "dc8a2422-7920-4ff4-aa28-31c35a2cd0e0",
+    "alias" : "create unique user config",
+    "config" : {
+      "require.password.update.after.registration" : "false"
+    }
+  }, {
+    "id" : "ce2f9d3e-45d7-4a9e-a434-968696ff01c3",
+    "alias" : "review profile config",
+    "config" : {
+      "update.profile.on.first.login" : "missing"
+    }
+  } ],
+  "requiredActions" : [ {
+    "alias" : "CONFIGURE_TOTP",
+    "name" : "Configure OTP",
+    "providerId" : "CONFIGURE_TOTP",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 10,
+    "config" : { }
+  }, {
+    "alias" : "terms_and_conditions",
+    "name" : "Terms and Conditions",
+    "providerId" : "terms_and_conditions",
+    "enabled" : false,
+    "defaultAction" : false,
+    "priority" : 20,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PASSWORD",
+    "name" : "Update Password",
+    "providerId" : "UPDATE_PASSWORD",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 30,
+    "config" : { }
+  }, {
+    "alias" : "UPDATE_PROFILE",
+    "name" : "Update Profile",
+    "providerId" : "UPDATE_PROFILE",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 40,
+    "config" : { }
+  }, {
+    "alias" : "VERIFY_EMAIL",
+    "name" : "Verify Email",
+    "providerId" : "VERIFY_EMAIL",
+    "enabled" : true,
+    "defaultAction" : false,
+    "priority" : 50,
+    "config" : { }
+  } ],
+  "browserFlow" : "browser",
+  "registrationFlow" : "registration",
+  "directGrantFlow" : "direct grant",
+  "resetCredentialsFlow" : "reset credentials",
+  "clientAuthenticationFlow" : "clients",
+  "dockerAuthenticationFlow" : "docker auth",
+  "attributes" : {
+    "webAuthnPolicyAuthenticatorAttachment" : "not specified",
+    "_browser_header.xRobotsTag" : "none",
+    "webAuthnPolicyRpEntityName" : "keycloak",
+    "failureFactor" : "30",
+    "actionTokenGeneratedByUserLifespan" : "300",
+    "maxDeltaTimeSeconds" : "43200",
+    "webAuthnPolicySignatureAlgorithms" : "ES256",
+    "offlineSessionMaxLifespan" : "5184000",
+    "_browser_header.contentSecurityPolicyReportOnly" : "",
+    "bruteForceProtected" : "false",
+    "_browser_header.contentSecurityPolicy" : "frame-src 'self'; frame-ancestors 'self'; object-src 'none';",
+    "_browser_header.xXSSProtection" : "1; mode=block",
+    "_browser_header.xFrameOptions" : "SAMEORIGIN",
+    "_browser_header.strictTransportSecurity" : "max-age=31536000; includeSubDomains",
+    "webAuthnPolicyUserVerificationRequirement" : "not specified",
+    "permanentLockout" : "false",
+    "quickLoginCheckMilliSeconds" : "1000",
+    "webAuthnPolicyCreateTimeout" : "0",
+    "webAuthnPolicyRequireResidentKey" : "not specified",
+    "webAuthnPolicyRpId" : "",
+    "webAuthnPolicyAttestationConveyancePreference" : "not specified",
+    "maxFailureWaitSeconds" : "900",
+    "minimumQuickLoginWaitSeconds" : "60",
+    "webAuthnPolicyAvoidSameAuthenticatorRegister" : "false",
+    "_browser_header.xContentTypeOptions" : "nosniff",
+    "actionTokenGeneratedByAdminLifespan" : "43200",
+    "waitIncrementSeconds" : "60",
+    "offlineSessionMaxLifespanEnabled" : "false"
+  },
+  "keycloakVersion" : "8.0.1",
+  "userManagedAccessAllowed" : false
+}

--- a/qa/integration/src/test/resources/shiro.ini
+++ b/qa/integration/src/test/resources/shiro.ini
@@ -36,9 +36,6 @@ jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.Jw
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 
-# Jwt
-jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
-
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $jwtAuthenticatingRealm
 

--- a/qa/integration/src/test/resources/shiro.ini
+++ b/qa/integration/src/test/resources/shiro.ini
@@ -27,13 +27,16 @@ kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shir
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
 
+# Jwt
+jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+
 ########################
 #Authorization section #
 ########################
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
-securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
+securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $jwtAuthenticatingRealm
 
 authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.

--- a/qa/integration/src/test/resources/shiro.ini
+++ b/qa/integration/src/test/resources/shiro.ini
@@ -35,6 +35,10 @@ jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.Jw
 ########################
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+
+# Jwt
+jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm, $jwtAuthenticatingRealm
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -190,9 +190,6 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
     private String extractExternalId(String jwt) {
         final String id;
         try {
-            if (jwtProcessor == null) {
-                init();
-            }
             final JwtContext ctx = jwtProcessor.process(jwt);
             id = ctx.getJwtClaims().getSubject();
         } catch (final Exception e) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -190,6 +190,9 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
     private String extractExternalId(String jwt) {
         final String id;
         try {
+            if (jwtProcessor == null) {
+                init();
+            }
             final JwtContext ctx = jwtProcessor.process(jwt);
             id = ctx.getJwtClaims().getSubject();
         } catch (final Exception e) {

--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -8,7 +8,7 @@
     http://www.eclipse.org/legal/epl-v10.html
 
     Contributors:
-        Red Hat Inc - initial API and implementation
+        Eurotech - initial API and implementation
  -->
 
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -30,6 +30,7 @@
         <module>provider</module>
         <module>provider-generic</module>
         <module>provider-keycloak</module>
+        <module>test-steps</module>
     </modules>
 
 </project>

--- a/sso/test-steps/about.html
+++ b/sso/test-steps/about.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml"><head><meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
+
+<title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+ 
+<p>June 5, 2006</p>	
+<h3>License</h3>
+
+<p>The Eclipse Foundation makes available all content in this plug-in ("Content").  Unless otherwise 
+indicated below, the Content is provided to you under the terms and conditions of the
+Eclipse Public License Version 1.0 ("EPL").  A copy of the EPL is available 
+at <a href="http://www.eclipse.org/legal/epl-v10.html">http://www.eclipse.org/legal/epl-v10.html</a>.
+For purposes of the EPL, "Program" will mean the Content.</p>
+
+<p>If you did not receive this Content directly from the Eclipse Foundation, the Content is 
+being redistributed by another party ("Redistributor") and different terms and conditions may
+apply to your use of any object code in the Content.  Check the Redistributor's license that was 
+provided with the Content.  If no such license exists, contact the Redistributor.  Unless otherwise
+indicated below, the terms and conditions of the EPL still apply to any source code in the Content
+and such source code may be obtained at <a href="http://www.eclipse.org/">http://www.eclipse.org</a>.</p>
+
+
+</body></html>

--- a/sso/test-steps/pom.xml
+++ b/sso/test-steps/pom.xml
@@ -13,12 +13,14 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
     <parent>
-        <artifactId>kapua-sso</artifactId>
         <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-sso</artifactId>
         <version>1.3.0-SNAPSHOT</version>
     </parent>
-    <modelVersion>4.0.0</modelVersion>
 
     <artifactId>kapua-sso-test-steps</artifactId>
 

--- a/sso/test-steps/pom.xml
+++ b/sso/test-steps/pom.xml
@@ -1,0 +1,115 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-sso</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-sso-test-steps</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-account-test-steps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-internal</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-user-test-steps</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-authentication-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-authorization-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-registration-simple</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-sso-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-sso-provider-generic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-sso-provider-keycloak</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-integration-steps</artifactId>
+        </dependency>
+        <!-- Internal dependencies -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-common</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+        </dependency>
+
+        <!-- Test dependencies -->
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-core</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-java</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>info.cukes</groupId>
+            <artifactId>cucumber-guice</artifactId>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/sso/test-steps/src/main/java/org/eclipse/kapua/service/sso/steps/SsoServiceSteps.java
+++ b/sso/test-steps/src/main/java/org/eclipse/kapua/service/sso/steps/SsoServiceSteps.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.sso.steps;
+
+import cucumber.api.Scenario;
+import cucumber.api.java.After;
+import cucumber.api.java.Before;
+import cucumber.api.java.en.And;
+import cucumber.api.java.en.Given;
+import cucumber.api.java.en.Then;
+import cucumber.runtime.java.guice.ScenarioScoped;
+import org.apache.http.HttpResponse;
+import org.apache.http.NameValuePair;
+import org.apache.http.client.HttpClient;
+import org.apache.http.client.entity.UrlEncodedFormEntity;
+import org.apache.http.client.methods.HttpPost;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.apache.http.message.BasicNameValuePair;
+import org.apache.http.util.EntityUtils;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.mgt.SecurityManager;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.common.DBHelper;
+import org.eclipse.kapua.qa.common.StepData;
+import org.eclipse.kapua.qa.common.TestBase;
+import org.eclipse.kapua.qa.common.TestJAXBContextProvider;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
+import org.eclipse.kapua.service.authentication.CredentialsFactory;
+import org.eclipse.kapua.service.authentication.JwtCredentials;
+import org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm;
+import org.eclipse.kapua.service.authentication.shiro.registration.RegistrationServiceImpl;
+import org.eclipse.kapua.sso.provider.ProviderSingleSignOnLocator;
+import org.jose4j.json.internal.json_simple.JSONObject;
+import org.jose4j.json.internal.json_simple.parser.JSONParser;
+import org.jose4j.json.internal.json_simple.parser.ParseException;
+import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import javax.inject.Inject;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+import java.util.List;
+
+@ScenarioScoped
+public class SsoServiceSteps extends TestBase {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SsoServiceSteps.class);
+    private static final String KEYCLOAK_TOKEN_REST_URI = "http://localhost:9090/auth/realms/kapua/protocol/openid-connect/token";
+    private static JwtAuthenticatingRealm jwtAuthenticatingRealm;
+    public static SecurityManager securityManager;
+    private CredentialsFactory credentialsFactory;
+    private AuthenticationService authenticationService;
+
+    // Default constructor
+    @Inject
+    public SsoServiceSteps(StepData stepData, DBHelper dbHelper) {
+
+        this.stepData = stepData;
+        this.database = dbHelper;
+    }
+
+    // ************************************************************************************
+    // * Setup and tear-down steps                                                        *
+    // ************************************************************************************
+
+    @Before
+    public void beforeScenario(Scenario scenario) throws Exception {
+
+        this.scenario = scenario;
+        database.setup();
+        stepData.clear();
+
+        locator = KapuaLocator.getInstance();
+        credentialsFactory = locator.getFactory(CredentialsFactory.class);
+        authenticationService = locator.getService(AuthenticationService.class);
+
+        // Setup JAXB context
+        XmlUtil.setContextProvider(new TestJAXBContextProvider());
+    }
+
+    @After
+    public void afterScenario() {
+
+        // Clean up the database
+        try {
+            LOGGER.info("Logging out in cleanup");
+            if (isIntegrationTest()) {
+                database.deleteAll();
+                SecurityUtils.getSubject().logout();
+            } else {
+                database.dropAll();
+                database.close();
+            }
+            KapuaSecurityUtils.clearSession();
+        } catch (Exception e) {
+            LOGGER.error("Failed to log out in @After", e);
+        }
+    }
+
+    // ************************************************************************************
+    // * Definition of Cucumber scenario steps                                            *
+    // ************************************************************************************
+
+    @And("^Set environment variables for keycloak provider$")
+    public void setEnvVariablesForKeycloakProvider() throws UnknownHostException {
+        InetAddress address = InetAddress.getLocalHost();
+//        System.setProperty("sso.keycloak.uri", address.getHostAddress() + ":9090");
+        System.setProperty("sso.keycloak.uri", "http://localhost:9090");
+        System.setProperty("site.home.uri", "http://localhost:8080");
+        System.setProperty("sso.keycloak.realm", "kapua");
+        System.setProperty("sso.openid.client.id", "console");
+        System.setProperty("sso.provider", "keycloak");
+        System.setProperty("authentication.registration.service.enabled", "true");
+    }
+
+    @And("^Set environment variables for generic provider$")
+    public void setEnvVariablesForGenericProvider() {
+        System.setProperty("sso.generic.openid.server.endpoint.auth", "http://localhost:9090/auth/realms/master/protocol/openid-connect/auth");
+        System.setProperty("sso.generic.openid.server.endpoint.token", "http://localhost:9090/auth/realms/master/protocol/openid-connect/token");
+        System.setProperty("sso.openid.client.id", "console");
+        System.setProperty("site.home.uri", "http://localhost:8080");
+        System.setProperty("sso.provider", "generic");
+    }
+
+    @Given("^Configure the SSO service$")
+    public void configureTheSso() throws Exception {
+        primeException();
+        try {
+            JwtCredentials credentials = (JwtCredentials) stepData.get("jwtCredentials");
+            RegistrationServiceImpl registrationService = new RegistrationServiceImpl();
+            registrationService.createAccount(credentials);
+        } catch (Exception e) {
+            verifyException(e);
+        }
+    }
+
+    @Given("^Configure JWT authenticating realm$")
+    public void configureJwtAuthenticatingRealm() throws Exception {
+        primeException();
+    }
+
+    @Given("^Check is SSO enabled$")
+    public void checkIsSsoEnabled() {
+        primeException();
+        try {
+            ProviderSingleSignOnLocator providerSingleSignOnLocator = new ProviderSingleSignOnLocator();
+            boolean isEnabled = providerSingleSignOnLocator.getService().isEnabled();
+            Assert.assertTrue(isEnabled);
+        } catch (AssertionError ae) {
+            verifyAssertionError(ae);
+        }
+    }
+
+    @Given("^Get access token for user with username \"(.*)\" and password \"(.*)\"$")
+    public void getSsoLoginURL(String username, String password) throws Exception {
+        primeException();
+        try {
+            JSONObject response = getKeycloakResponse(username, password);
+            String accessToken = getKeycloakAccessToken(response);
+            stepData.put("accessToken", accessToken);
+        } catch (Exception ex) {
+            verifyException(ex);
+        }
+    }
+
+    @Then("^Create a jwt credential using the access token$")
+    public void createJwtCredential() throws KapuaException {
+        String accessToken = (String) stepData.get("accessToken");
+        JwtCredentials jwtCredentials = credentialsFactory.newJwtCredentials(accessToken, KapuaId.ONE.toStringId());
+        stepData.put("jwtCredentials", jwtCredentials);
+    }
+
+
+
+    private JSONObject getKeycloakResponse(String username, String password) throws IOException, ParseException {
+        HttpClient httpClient = HttpClientBuilder.create().build();
+        HttpPost httpPost = new HttpPost(KEYCLOAK_TOKEN_REST_URI);
+        List<NameValuePair> nameValuePairs = new ArrayList<>();
+        nameValuePairs.add(new BasicNameValuePair("client_id", "console"));
+        nameValuePairs.add(new BasicNameValuePair("grant_type", "password"));
+        nameValuePairs.add(new BasicNameValuePair("username", username));
+        nameValuePairs.add(new BasicNameValuePair("password", password));
+        UrlEncodedFormEntity formEntity;
+        formEntity = new UrlEncodedFormEntity(nameValuePairs, "UTF-8");
+        httpPost.setEntity(formEntity);
+        HttpResponse response = httpClient.execute(httpPost);
+        String content = EntityUtils.toString(response.getEntity());
+        JSONParser parser = new JSONParser();
+        JSONObject jsonResponse = (JSONObject) parser.parse(content);
+        return jsonResponse;
+    }
+
+    private String getKeycloakAccessToken(JSONObject response) {
+        return response.get("access_token").toString();
+    }
+}

--- a/sso/test-steps/src/main/java/org/eclipse/kapua/service/sso/steps/SsoServiceSteps.java
+++ b/sso/test-steps/src/main/java/org/eclipse/kapua/service/sso/steps/SsoServiceSteps.java
@@ -125,7 +125,6 @@ public class SsoServiceSteps extends TestBase {
         System.setProperty("sso.keycloak.realm", "kapua");
         System.setProperty("sso.openid.client.id", "console");
         System.setProperty("sso.provider", "keycloak");
-        System.setProperty("authentication.registration.service.enabled", "true");
     }
 
     @And("^Set environment variables for generic provider$")
@@ -141,6 +140,7 @@ public class SsoServiceSteps extends TestBase {
     public void configureTheSso() throws Exception {
         primeException();
         try {
+            System.setProperty("authentication.registration.service.enabled", "true");
             JwtCredentials credentials = (JwtCredentials) stepData.get("jwtCredentials");
             RegistrationServiceImpl registrationService = new RegistrationServiceImpl();
             registrationService.createAccount(credentials);


### PR DESCRIPTION
Tests are added for SSO login using Keycloak provider.

Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

In this PR are added integration tests for SSO using Keycloak provider.

**Related Issue**
None

**Description of the solution adopted**
There are a few changes in this PR: 
- New testing methods for Docker are added to configure keycloak containers,
- Keycloak configuration is added to `kapua-realm.json` file,
- Added test scenarios and methods that are testing SSO login using Keycloak provider,
- Modified tests for creating user.

**Any side note on the changes made**
/
