### PR TITLE
Fixed missing OpenID Provider session invalidation

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -61,6 +61,16 @@ public class KapuaSession implements Serializable {
      * If true every rights check will be skipped, in other word <b>the user is trusted so he is allowed to execute every operation</b> defined in the system.
      */
     private boolean trustedMode;
+
+    /**
+     * OpenID Connect idToken obtained with an OpenID Connect login, contains user information, used for the OpenID Connect logout
+     */
+    private String openIDidToken;
+
+    /**
+     * Set to true when the logout from the current session is triggered by the user
+     */
+    private boolean userInitiatedLogout;
 
     /**
      * Default constructor
@@ -146,6 +156,22 @@ public class KapuaSession implements Serializable {
     }
 
     /**
+     * Constructs a {@link KapuaSession} with given parameters
+     *
+     * @param accessToken
+     * @param scopeId
+     * @param userId
+     * @param openIDidToken the idToken obtained with an OpenID Connect login, contains user information, used for the logout
+     */
+    public KapuaSession(AccessToken accessToken, KapuaId scopeId, KapuaId userId, String openIDidToken) {
+        this();
+        this.accessToken = accessToken;
+        this.scopeId = scopeId;
+        this.userId = userId;
+        this.openIDidToken = openIDidToken;
+    }
+
+    /**
      * Constructs a {@link KapuaSession} with given parameter
      *
      * @param principal
@@ -183,6 +209,15 @@ public class KapuaSession implements Serializable {
     }
 
     /**
+     * Get the OpenID Connect idToken
+     *
+     * @return
+     */
+    public String getOpenIDidToken() {
+        return openIDidToken;
+    }
+
+    /**
      * Set the trusted mode status.<br>
      * If true every rights check will be skipped, in other word <b>the user is trusted so he is allowed to execute every operation</b> defined in the system.
      */
@@ -198,5 +233,23 @@ public class KapuaSession implements Serializable {
      */
     public final boolean isTrustedMode() {
         return trustedMode;
+    }
+
+    /**
+     * Get the `userInitiatedLogout` value.
+     *
+     * @return 'true' if user initiated logout, 'false' otherwise
+     */
+    public boolean isUserInitiatedLogout() {
+        return userInitiatedLogout;
+    }
+
+    /**
+     * Set the logout as 'user initiated'. This will allow to avoid logging out from an OpenID session by using the OpenIDLogoutListener.
+     *
+     * @param userInitiatedLogout 'true' if user initiated logout, 'false' otherwise
+     */
+    public void setUserInitiatedLogout(boolean userInitiatedLogout) {
+        this.userInitiatedLogout = userInitiatedLogout;
     }
 }

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
@@ -435,7 +435,9 @@ public class KapuaCloudConsole implements EntryPoint {
                 logger.info("Sso login failed.");
                 ConsoleInfo.display(CORE_MSGS.loginSsoLoginError(), caught.getLocalizedMessage());
 
-                // Invalidating the sso token
+                // Invalidating the sso token. We must use the OpenID logout here, since we don't have the KapuSession set yet, so we don't have the
+                // openIDidToken set inside. This means we cannot realy on the OpenIDLogoutListener to invalidate the OpenID session, instead we must do that
+                // as a 'real' user initiated logout.
                 gwtSettingService.getSsoLogoutUri(gwtIdToken.getIdToken(), new AsyncCallback<String>() {
 
                     @Override
@@ -472,7 +474,7 @@ public class KapuaCloudConsole implements EntryPoint {
                 logger.info("Sso login success, now rendering screen.");
                 logger.fine("User: " + gwtSession.getUserId());
 
-                // This is needed to remove the access_token from the URL, however it forces the page reload
+                // This is needed to remove tokens from the URL, however it forces the page reload
                 TokenCleaner.cleanToken();
 
                 dlg.hide();

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -194,8 +194,7 @@ public class NorthView extends LayoutContainer {
                             @Override
                             public void onSuccess(Void arg0) {
                                 if (currentSession.isSsoEnabled() && currentSession.getSsoIdToken() != null) {
-                                    gwtSettingService.getSsoLogoutUri(currentSession.getSsoIdToken(),
-                                            new AsyncCallback<String>() {
+                                    gwtSettingService.getSsoLogoutUri(currentSession.getSsoIdToken(), new AsyncCallback<String>() {
 
                                                 @Override
                                                 public void onFailure(Throwable caught) {

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -135,7 +135,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             KapuaLocator locator = KapuaLocator.getInstance();
             AuthenticationService authenticationService = locator.getService(AuthenticationService.class);
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
-            JwtCredentials credentials = credentialsFactory.newJwtCredentials(gwtAccessTokenCredentials.getAccessToken());
+            JwtCredentials credentials = credentialsFactory.newJwtCredentials(gwtAccessTokenCredentials.getAccessToken(), gwtJwtIdToken.getIdToken());
 
             // Get the session infos
             if (gwtJwtIdToken == null || gwtJwtIdToken.getIdToken().isEmpty()) {
@@ -144,7 +144,7 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             }
 
             // Login
-            handleLogin(authenticationService, credentials, gwtJwtIdToken.getIdToken());
+            handleLogin(authenticationService, credentials);
             return establishSession();
         } catch (Throwable t) {
             internalLogout();
@@ -153,9 +153,9 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         return null;
     }
 
-    private void handleLogin(AuthenticationService authenticationService, JwtCredentials credentials, String openIDidToken) throws KapuaException {
+    private void handleLogin(AuthenticationService authenticationService, JwtCredentials credentials) throws KapuaException {
         try {
-            authenticationService.login(credentials, openIDidToken);
+            authenticationService.login(credentials);
         } catch (KapuaAuthenticationException e) {
             logger.debug("First level login attempt failed", e);
             handleLoginError(authenticationService, credentials, e);

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -16,6 +16,7 @@ import org.apache.shiro.session.Session;
 import org.apache.shiro.subject.Subject;
 
 import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtCredential;
 import org.eclipse.kapua.app.console.core.shared.model.authentication.GwtJwtIdToken;
@@ -140,6 +141,10 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             handleLogin(authenticationService, credentials);
 
             // Get the session infos
+            if (gwtJwtIdToken == null || gwtJwtIdToken.getIdToken().isEmpty()) {
+                // in this specific case the gwtJwtIdToken cannot be empty
+                throw new KapuaIllegalNullArgumentException("gwtJwtIdToken");
+            }
             return establishSession(gwtJwtIdToken);
         } catch (Throwable t) {
             logout();
@@ -287,11 +292,13 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
         gwtSession.setAccountPath(gwtAccount.getParentAccountPath());
         gwtSession.setSelectedAccountPath(gwtAccount.getParentAccountPath());
 
-        // Access token
+        // Setting Id token
         if (gwtJwtIdToken!=null) {
             gwtSession.setSsoIdToken(gwtJwtIdToken.getIdToken());
         }
 
+        //TODO: As Alberto said, I can remove this.
+        //  However, I have to check that this is actually possible, since the establishSession method uses the token id
         //
         // Saving session data in session
         Subject currentUser = SecurityUtils.getSubject();

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
@@ -53,7 +53,7 @@ public class GwtSettingsServiceImpl extends RemoteServiceServlet implements GwtS
     @Override
     public String getSsoLogoutUri(String ssoIdToken) throws GwtKapuaException {
         try {
-            if (SETTINGS.getBoolean(ConsoleSettingKeys.SSO_OPENID_LOGOUT_ENABLED, true)) {
+            if (SETTINGS.getBoolean(ConsoleSettingKeys.SSO_OPENID_USER_LOGOUT_ENABLED, true)) {
                 if (ssoIdToken.isEmpty()) {
                     throw new KapuaIllegalArgumentException("ssoIdToken", ssoIdToken);
                 }

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
@@ -12,6 +12,7 @@
 package org.eclipse.kapua.app.console.core.server;
 
 import com.google.gwt.user.server.rpc.RemoteServiceServlet;
+import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.app.console.core.server.util.SsoHelper;
 import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.app.console.core.shared.model.GwtProductInformation;
@@ -53,8 +54,11 @@ public class GwtSettingsServiceImpl extends RemoteServiceServlet implements GwtS
     public String getSsoLogoutUri(String ssoIdToken) throws GwtKapuaException {
         try {
             if (SETTINGS.getBoolean(ConsoleSettingKeys.SSO_OPENID_LOGOUT_ENABLED, true)) {
-                return SsoLocator.getLocator(this).getService().getLogoutUri(ssoIdToken,
-                        URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
+                if (ssoIdToken.isEmpty()) {
+                    throw new KapuaIllegalArgumentException("ssoIdToken", ssoIdToken);
+                }
+                return SsoLocator.getLocator(this).getService().getLogoutUri(
+                        ssoIdToken, URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
             }
             return "";  // return empty string instead of using a dedicated callback just to check if the logout is enabled
         } catch (Throwable t) {

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/OpenIDLogoutListener.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/OpenIDLogoutListener.java
@@ -1,0 +1,84 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.core.server.util;
+
+import org.eclipse.kapua.app.console.core.server.GwtAuthorizationServiceImpl;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSettingKeys;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.servlet.http.HttpSession;
+import javax.servlet.http.HttpSessionEvent;
+import javax.servlet.http.HttpSessionListener;
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.net.HttpURLConnection;
+import java.net.URI;
+import java.net.URL;
+import java.util.UUID;
+
+/**
+ * Listens to the session invalidation, in order to logout also from the sso when the session is invalidated.
+ */
+public class OpenIDLogoutListener implements HttpSessionListener {
+
+    private static final Logger logger = LoggerFactory.getLogger(OpenIDLogoutListener.class);
+
+    @Override
+    public void sessionCreated(HttpSessionEvent httpSessionEvent) {
+        // do nothing
+    }
+
+    /**
+     * Handles the session invalidation by triggering the invalidation on the OpenID Connect Provider for the current user.
+     * Only used when the session on the Kapua Console is unexpectedly invalidated or the session timeout is expired (the normal logout follows a different
+     * path).
+     *
+     * @param httpSessionEvent
+     */
+    @Override
+    public void sessionDestroyed(HttpSessionEvent httpSessionEvent) {
+        HttpSession session = httpSessionEvent.getSession();
+        GwtSession gwtSession = (GwtSession) session.getAttribute(GwtAuthorizationServiceImpl.SESSION_CURRENT);
+
+        // TODO: are you sure that you don't need the shiro session? Is the Gwt one sufficient?
+        //Subject shiroSubject = SecurityUtils.getSubject();
+        //KapuaSession kapuaSession = (KapuaSession) shiroSubject.getSession().getAttribute(KapuaSession.KAPUA_SESSION_KEY);
+
+        // perform the OpenID Logout only if it is enabled
+        if (ConsoleSetting.getInstance().getBoolean(ConsoleSettingKeys.SSO_OPENID_LOGOUT_ENABLED, true)) {
+            if (gwtSession != null && gwtSession.getSsoIdToken() != null) {
+                try {
+                    String logoutUri = SsoLocator.getLocator(httpSessionEvent.getSession().getServletContext()).getService().getLogoutUri(
+                            gwtSession.getSsoIdToken(), URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
+                    if (!logoutUri.isEmpty()) {
+                        URL url = new URL(logoutUri);
+                        HttpURLConnection conn = (HttpURLConnection) url.openConnection();
+                        conn.setRequestMethod("GET");
+                        conn.setRequestProperty("Content-Type", "application/json");
+                        conn.setDoOutput(true);
+
+                        int httpRespCode = conn.getResponseCode();
+                        if (httpRespCode == 200) {
+                            BufferedReader br = new BufferedReader(new InputStreamReader((conn.getInputStream())));
+                        }
+                    }
+                } catch (Exception e) {
+                    // It is not possible to throw exceptions in the HttpSessionListener, so I log them
+                    logger.warn("Remote session has not been invalidated", e);
+                }
+            }
+        }
+    }
+}

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtAuthorizationService.java
@@ -36,9 +36,11 @@ public interface GwtAuthorizationService extends RemoteService {
     public GwtSession login(GwtLoginCredential gwtLoginCredentials) throws GwtKapuaException;
 
     /**
-     * Logins a session based on the given access token. If the access token is correct a session is established and returned
+     * Logins a session based on the given access token. If the access token is correct a session is established and returned.
+     * An id token is also passed for identity information about the user.
      *
-     * @param gwtAccessTokenCredentials The access token to authenticate
+     * @param gwtAccessTokenCredentials The access token to authenticate.
+     * @param gwtJwtIdToken The id token which identifies the user.
      * @return The session info established.
      * @throws GwtKapuaException If the access token is not valid.
      * @since 1.0.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
@@ -39,7 +39,8 @@ public enum ConsoleSettingKeys implements SettingKey {
 
     SSO_REDIRECT_URI("console.sso.redirect.uri"), //
     SSO_CONSOLE_HOME_URI("console.sso.home.uri"), //
-    SSO_OPENID_LOGOUT_ENABLED("console.sso.openid.logout.enabled"), //
+    SSO_OPENID_USER_LOGOUT_ENABLED("console.sso.openid.user.logout.enabled"), //
+    SSO_OPENID_SESSION_LISTENER_LOGOUT_ENABLED("console.sso.openid.session_listener.logout.enabled"),  //
 
     EXPORT_MAX_PAGES("console.export.max.pages"),
     EXPORT_MAX_PAGE_SIZE("console.export.max.pagesize");

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSession.java
@@ -44,7 +44,6 @@ public class GwtSession extends KapuaBaseModel implements Serializable {
     private String userId;
     private String userName;
     private String userDisplayName;
-    private String ssoAccessToken;
     private String ssoIdToken;
 
     private String tokenId;

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -28,6 +28,10 @@
         <listener-class>org.eclipse.kapua.app.console.core.server.util.SsoLocatorListener</listener-class>
     </listener>
 
+    <listener>
+        <listener-class>org.eclipse.kapua.app.console.core.server.util.OpenIDLogoutListener</listener-class>
+    </listener>
+
     <filter>
         <filter-name>ShiroFilter</filter-name>
         <filter-class>org.eclipse.kapua.app.console.core.filter.KapuaWebFilter</filter-class>

--- a/docs/developer-guide/en/sso.md
+++ b/docs/developer-guide/en/sso.md
@@ -122,9 +122,10 @@ This is implemented following the OpenID Connect specification for the
 Note that logging out from the OpenID provider is also possible through the provider OpenID logout endpoint, 
 but the user will remain logged into Kapua until also the logout from Kapua is performed.
 
-The OpenID Connect logout can be disabled by setting the `console.sso.openid.logout.enabled` property to `false` (this property is always set 
-to `true` by default). Be careful if you choose to disable the OpenID logout, since this will allow the user to login again into the Kapua Console without 
-the need to provide any credentials.
+The OpenID Connect logout can be disabled by setting the `console.sso.openid.user.logout.enabled` and `console.sso.openid.session_listener.logout.enabled` 
+properties to `false` (these properties are always set to `true` by default). The first property allows disabling the user-initiated logout, while the 
+second one allows disabling the `HttpSessionListener` managed logout (see class `OpenIDLogoutListener`), which is triggered at session invalidation. Be careful 
+if you choose to disable the OpenID logout, since this will allow the user to login again into the Kapua Console without the need to provide any credentials.
 
 ## Keycloak Example (Docker based)
 

--- a/docs/developer-guide/en/sso.md
+++ b/docs/developer-guide/en/sso.md
@@ -1,13 +1,11 @@
 # Single sign-on (SSO)
 
-This section describes the single sign-on integration of Eclipse Kapua.
-Our single sign-on solution is based on the [OpenID Connect](https://openid.net/connect/) identity layer, 
-on top of the [OAuth 2.0](https://oauth.net/2/) authorization framework. 
-In this document we first describe how to enable SSO on Kapua. 
-In a second step, we present two examples based on the Keycloak Authentication Server, using Docker and OpenShift.
+This section describes the single sign-on integration of Eclipse Kapua. Our single sign-on solution is based on the 
+[OpenID Connect](https://openid.net/connect/) identity layer, on top of the [OAuth 2.0](https://oauth.net/2/) authorization framework. 
+Please note that the OpenID Connect provider is unique for the same Kapua instance, thus it is common to all the accounts in the instance.
 
-**WARNING**: The current SSO implementation is intended as a _Proof-of-Concept_ and should not be used in a production 
-environment.
+In this document we first describe how to enable SSO on Kapua. In a second step we present two examples based on the Keycloak Authentication Server, 
+using Docker and OpenShift.
 
 ## Enabling single sign-on
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -35,16 +35,6 @@ public interface AuthenticationService extends KapuaService {
     AccessToken login(LoginCredentials loginCredentials) throws KapuaException;
 
     /**
-     * Login the provided user login credentials on the system (if the credentials are valid)
-     *
-     * @param loginCredentials
-     * @param openIDidToken the idToken obtained with an OpenID Connect login, contains user information, used for the logout
-     * @return
-     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
-     */
-    AccessToken login(LoginCredentials loginCredentials, String openIDidToken) throws KapuaException;
-
-    /**
      * FIXME: add javadoc
      *
      * @param sessionCredentials

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -33,6 +33,16 @@ public interface AuthenticationService extends KapuaService {
      * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
      */
     AccessToken login(LoginCredentials loginCredentials) throws KapuaException;
+
+    /**
+     * Login the provided user login credentials on the system (if the credentials are valid)
+     *
+     * @param loginCredentials
+     * @param openIDidToken the idToken obtained with an OpenID Connect login, contains user information, used for the logout
+     * @return
+     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     */
+    AccessToken login(LoginCredentials loginCredentials, String openIDidToken) throws KapuaException;
 
     /**
      * FIXME: add javadoc

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -43,7 +43,7 @@ public class AuthenticationXmlRegistry {
      * @return
      */
     public JwtCredentials newJwtCredentials() {
-        return CREDENTIALS_FACTORY.newJwtCredentials(null);
+        return CREDENTIALS_FACTORY.newJwtCredentials(null, null);
     }
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -49,9 +49,10 @@ public interface CredentialsFactory extends KapuaObjectFactory {
      * Creates a new {@link JwtCredentials} instance based on provided Json Web Token
      *
      * @param jwt
+     * @param idToken the OpenID Connect idToken, used for the logout
      * @return
      */
-    JwtCredentials newJwtCredentials(String jwt);
+    JwtCredentials newJwtCredentials(String jwt, String idToken);
 
     /**
      * Creates a new {@link AccessTokenCredentials} instance based on provided tokenId

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "jwtCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "jwt" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
+@XmlType(propOrder = { "jwt", "idToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
 public interface JwtCredentials extends LoginCredentials {
 
     /**
@@ -41,4 +41,19 @@ public interface JwtCredentials extends LoginCredentials {
      * @param jwt
      */
     void setJwt(String jwt);
+
+    /**
+     * Gets the OpenID Connect idToken
+     *
+     * @return
+     */
+    @XmlElement(name = "idToken")
+    String getIdToken();
+
+    /**
+     * Set the OpenID Connect idToken
+     *
+     * @param idToken
+     */
+    void setIdToken(String idToken);
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -113,6 +113,11 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
     @Override
     public AccessToken login(LoginCredentials loginCredentials) throws KapuaException {
+        return login(loginCredentials, null);
+    }
+
+    @Override
+    public AccessToken login(LoginCredentials loginCredentials, String openIDidToken) throws KapuaException {
 
         checkCurrentSubjectNotAuthenticated();
 
@@ -147,7 +152,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             accessToken = createAccessToken(shiroSession);
 
             // Establish session
-            establishSession(shiroSubject, accessToken);
+            establishSession(shiroSubject, accessToken, openIDidToken);
 
             // Set some logging
             MDC.put(KapuaSecurityUtils.MDC_USER_ID, accessToken.getUserId().toCompactId());
@@ -185,7 +190,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             AccessToken accessToken = findAccessToken((String) shiroAuthenticationToken.getCredentials());
 
             // Enstablish session
-            establishSession(currentUser, accessToken);
+            establishSession(currentUser, accessToken, null);
 
             // Set some logging
             Subject shiroSubject = SecurityUtils.getSubject();
@@ -458,8 +463,8 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         return accessToken;
     }
 
-    private void establishSession(Subject subject, AccessToken accessToken) {
-        KapuaSession kapuaSession = new KapuaSession(accessToken, accessToken.getScopeId(), accessToken.getUserId());
+    private void establishSession(Subject subject, AccessToken accessToken, String openIDidToken) {
+        KapuaSession kapuaSession = new KapuaSession(accessToken, accessToken.getScopeId(), accessToken.getUserId(), openIDidToken);
         KapuaSecurityUtils.setSession(kapuaSession);
         subject.getSession().setAttribute(KapuaSession.KAPUA_SESSION_KEY, kapuaSession);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -113,17 +113,13 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
     @Override
     public AccessToken login(LoginCredentials loginCredentials) throws KapuaException {
-        return login(loginCredentials, null);
-    }
-
-    @Override
-    public AccessToken login(LoginCredentials loginCredentials, String openIDidToken) throws KapuaException {
 
         checkCurrentSubjectNotAuthenticated();
 
         //
         // Parse login credentials
         AuthenticationToken shiroAuthenticationToken;
+        String openIDidToken = null;
         if (loginCredentials instanceof UsernamePasswordCredentialsImpl) {
             UsernamePasswordCredentialsImpl usernamePasswordCredentials = (UsernamePasswordCredentialsImpl) loginCredentials;
 
@@ -131,7 +127,9 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         } else if (loginCredentials instanceof ApiKeyCredentialsImpl) {
             shiroAuthenticationToken = new ApiKeyCredentialsImpl(((ApiKeyCredentialsImpl) loginCredentials).getApiKey());
         } else if (loginCredentials instanceof JwtCredentialsImpl) {
-            shiroAuthenticationToken = new JwtCredentialsImpl(((JwtCredentialsImpl) loginCredentials).getJwt());
+            shiroAuthenticationToken = new JwtCredentialsImpl(((JwtCredentialsImpl) loginCredentials).getJwt(),
+                    ((JwtCredentialsImpl) loginCredentials).getIdToken());
+            openIDidToken = ((JwtCredentialsImpl) loginCredentials).getIdToken();
         } else {
             throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED);
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -39,8 +39,8 @@ public class CredentialsFactoryImpl implements CredentialsFactory {
     }
 
     @Override
-    public JwtCredentials newJwtCredentials(String jwt) {
-        return new JwtCredentialsImpl(jwt);
+    public JwtCredentials newJwtCredentials(String jwt, String idToken) {
+        return new JwtCredentialsImpl(jwt, idToken);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -19,9 +19,11 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
     private static final long serialVersionUID = -5920944517814926028L;
 
     private String jwt;
+    private String idToken;
 
-    public JwtCredentialsImpl(String jwt) {
+    public JwtCredentialsImpl(String jwt, String idToken) {
         setJwt(jwt);
+        setIdToken(idToken);
     }
 
     @Override
@@ -32,6 +34,16 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
     @Override
     public void setJwt(String jwt) {
         this.jwt = jwt;
+    }
+
+    @Override
+    public String getIdToken() {
+        return idToken;
+    }
+
+    @Override
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
     }
 
     @Override


### PR DESCRIPTION
Logout from the OpenID Connect Provider in case the Kapua Console session is expired.

**Related Issue**
This PR fixes #2971 

**Description of the solution adopted**
Added an HttpSessionListener that listens to the Kapua Console session invalidation. When the session is invalidated, it performs an HTTP request to the OpenID Provider logout endpoint.

Note that this does not follow the same flow as the normal OpenID logout. Moreover, this feature can be disabled with a dedicated property called `console.sso.openid.session_listener.logout.enabled`.

**Screenshots**
_N/A_

**Any side note on the changes made**
Also updated comments and removed unused variables that are part of the SSO code.

This PR requires PR #2996 to be merged!
