### PR TITLE
Enabling property to disable the OpenID Connect logout

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaCloudConsole.java
@@ -370,7 +370,7 @@ public class KapuaCloudConsole implements EntryPoint {
             String error = Window.Location.getParameter("error");
 
             // Check if coming from failed SSO login (the user exists but she does not have the authorizations)
-            if (error !=null && !error.isEmpty() && error.equals("access_denied")) {
+            if (error != null && !error.isEmpty() && error.equals("access_denied")) {
                 logger.info("Access denied, SSO login failed");
                 ConsoleInfo.display(CORE_MSGS.loginSsoLoginError(), CORE_MSGS.ssoClientAuthenticationFailed());
             }
@@ -446,18 +446,23 @@ public class KapuaCloudConsole implements EntryPoint {
 
                     @Override
                     public void onSuccess(final String result) {
-                        logger.info("Waiting for logout.");
+                        if (!result.isEmpty()) {
+                            logger.info("Waiting for logout.");
 
-                        // this timer is needed to give time to the ConsoleInfo.display method (called above) to show
-                        // the message to the user (otherwise the Window.location.assign would reload the page,
-                        // giving no time to the user to read the message).
-                        Timer timer = new Timer() {
-                            @Override
-                            public void run() {
-                                Window.Location.assign(result);
-                            }
-                        };
-                        timer.schedule(SSO_FAILURE_WAIT_TIME);
+                            // this timer is needed to give time to the ConsoleInfo.display method (called above) to show
+                            // the message to the user (otherwise the Window.location.assign would reload the page,
+                            // giving no time to the user to read the message).
+                            Timer timer = new Timer() {
+                                @Override
+                                public void run() {
+                                    Window.Location.assign(result);
+                                }
+                            };
+                            timer.schedule(SSO_FAILURE_WAIT_TIME);
+                        } else {
+                            // result is empty, thus the OpenID logout is disabled
+                            TokenCleaner.cleanToken();  // removes the access_token from the URL, however it forces the page reload
+                        }
                     }
                 });
             }

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/NorthView.java
@@ -197,16 +197,21 @@ public class NorthView extends LayoutContainer {
                                     gwtSettingService.getSsoLogoutUri(currentSession.getSsoIdToken(),
                                             new AsyncCallback<String>() {
 
-                                        @Override
-                                        public void onFailure(Throwable caught) {
-                                            FailureHandler.handle(caught);
-                                        }
+                                                @Override
+                                                public void onFailure(Throwable caught) {
+                                                    FailureHandler.handle(caught);
+                                                }
 
-                                        @Override
-                                        public void onSuccess(String result) {
-                                            Window.Location.assign(result);
-                                        }
-                                    });
+                                                @Override
+                                                public void onSuccess(String result) {
+                                                    if (!result.isEmpty()) {
+                                                        Window.Location.assign(result);
+                                                    } else {
+                                                        // result is empty, thus the OpenID logout is disabled
+                                                        TokenCleaner.cleanToken();
+                                                    }
+                                                }
+                                            });
                                 } else {
                                     TokenCleaner.cleanToken();
                                 }

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtSettingsServiceImpl.java
@@ -52,8 +52,11 @@ public class GwtSettingsServiceImpl extends RemoteServiceServlet implements GwtS
     @Override
     public String getSsoLogoutUri(String ssoIdToken) throws GwtKapuaException {
         try {
-            return SsoLocator.getLocator(this).getService().getLogoutUri(ssoIdToken,
-                    URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
+            if (SETTINGS.getBoolean(ConsoleSettingKeys.SSO_OPENID_LOGOUT_ENABLED, true)) {
+                return SsoLocator.getLocator(this).getService().getLogoutUri(ssoIdToken,
+                        URI.create(SsoHelper.getHomeUri()), UUID.randomUUID().toString());
+            }
+            return "";  // return empty string instead of using a dedicated callback just to check if the logout is enabled
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
             return null;

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSettingKeys.java
@@ -39,6 +39,7 @@ public enum ConsoleSettingKeys implements SettingKey {
 
     SSO_REDIRECT_URI("console.sso.redirect.uri"), //
     SSO_CONSOLE_HOME_URI("console.sso.home.uri"), //
+    SSO_OPENID_LOGOUT_ENABLED("console.sso.openid.logout.enabled"), //
 
     EXPORT_MAX_PAGES("console.export.max.pages"),
     EXPORT_MAX_PAGE_SIZE("console.export.max.pagesize");

--- a/docs/developer-guide/en/sso.md
+++ b/docs/developer-guide/en/sso.md
@@ -122,6 +122,10 @@ This is implemented following the OpenID Connect specification for the
 Note that logging out from the OpenID provider is also possible through the provider OpenID logout endpoint, 
 but the user will remain logged into Kapua until also the logout from Kapua is performed.
 
+The OpenID Connect logout can be disabled by setting the `console.sso.openid.logout.enabled` property to `false` (this property is always set 
+to `true` by default). Be careful if you choose to disable the OpenID logout, since this will allow the user to login again into the Kapua Console without 
+the need to provide any credentials.
+
 ## Keycloak Example (Docker based)
 
 We detail here the steps to run an SSO Keycloak provider.


### PR DESCRIPTION
Added a property to disable the OpenID Connect logout. 

**Related Issue**
_N/A_

**Description of the solution adopted**
The OpenID Connect logout can be disabled by setting the `console.sso.openid.logout.enabled` property to `false`. This property is always `true` by default. 
If the OpenID logout is disabled, the user is allowed to login again into the Kapua Console without the need to provide any credentials.

**Screenshots**
_N/A_

**Any side note on the changes made**
This feature is implemented directly inside the `getSsoLogoutUri` method of the `GwtSettingsServiceImpl` class. If the property is `false`, an empty string (URL) will be returned to the console on the browser side, and the call to the logout endpoint won't be performed. This simple approach has been preferred to the use of a dedicated callback, in order to avoid having too many nested callbacks.