### PR TITLE
Added options to keep staging repository in case of error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1750,7 +1750,10 @@
                         <configuration>
                             <serverId>ossrh</serverId>
                             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+
                             <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                            <keepStagingRepositoryOnFailure>true</keepStagingRepositoryOnFailure>
+                            <keepStagingRepositoryOnCloseRuleFailure>true</keepStagingRepositoryOnCloseRuleFailure>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This PR enables two options on the `nexus-staging-maven-plugin` that enables the keeping of the staging repository when a failure occurs. 

**Related Issue**
_None_

**Description of the solution adopted**
Enabled `keepStagingRepositoryOnFailure` and `keepStagingRepositoryOnCloseRuleFailure` which change the default behaviour of the plugin which is to delete the staging repo in case of failure. 
This is beneficial for two reasons:
- in case of error the staging repository can be inspected and info will be available, otherwise they will be lost
- for Kapua 1.2.0 there was an issue on Sonatype due to degraded performances which made the checking of the rule exceed the timeout that the plugin expect for the task to complete. This was making the build fail even if it was fine and only slow to complete. See also BugZilla issue [564077](https://bugs.eclipse.org/bugs/show_bug.cgi?id=564077)

**Screenshots**
_None_

**Any side note on the changes made**
This has been committed on `release-1.2.x` so there is no need to backport