### PR TITLE
Disable datastore for REST API

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -36,7 +36,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Ddatastore.client.class=\${DATASTORE_CLIENT} \
                -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
                -Dcertificate.jwt.private.key=file:///var/opt/jetty/key.pk8 \
-               -Dcertificate.jwt.certificate=file:///var/opt/jetty/cert.pem"
+               -Dcertificate.jwt.certificate=file:///var/opt/jetty/cert.pem \
+               -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false}"
 
 USER 0
 


### PR DESCRIPTION
After merging #2963 REST API container was not correctly injecting the `KAPUA_DISABLE_DATASTORE` environment value. This PR fixes this issue.

**Related Issue**
No related issues
