### PR TITLE
Removed unnecessary dependencies of netty-all

### DIFF
--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -242,8 +242,7 @@
         </dependency>
         <dependency>
             <groupId>io.netty</groupId>
-            <artifactId>netty-transport-native-epoll</artifactId>
-            <!-- used both by qpid and elasticsearch -->
+            <artifactId>netty-all</artifactId>
         </dependency>
 
         <dependency>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -179,10 +179,7 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
         </dependency>
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-        </dependency>
+
         <!-- misc -->
         <dependency>
             <groupId>org.quartz-scheduler</groupId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -71,10 +71,6 @@
             <artifactId>metrics-core</artifactId>
         </dependency>
         <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-all</artifactId>
-        </dependency>
-        <dependency>
             <groupId>joda-time</groupId>
             <artifactId>joda-time</artifactId>
         </dependency>


### PR DESCRIPTION
This PR removes unnecessary imports of `netty-all` dependency.

Each dependency will import its netty-* transient dependencies on their own.
This also cleans up the startup of the Docker Jetty containers.

**Related Issue**
_None_

**Description of the solution adopted**
Just removed dependencies of `netty-all`. 
In `kapua-broker-assembly` they were left for simplicity

`mvn dependency:tree`
Before: [netty-all.txt](https://github.com/eclipse/kapua/files/4865237/netty-all.txt)
After: [netty-all-removed.txt](https://github.com/eclipse/kapua/files/4865239/netty-all-removed.txt)

**Screenshots**
_None_

**Any side note on the changes made**
_None_