### PR TITLE
Added index on DeviceEvent table to optimize query for receivedOn DESC

### DIFF
--- a/service/device/registry/internal/src/main/resources/liquibase/1.3.0/changelog-device-1.3.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.3.0/changelog-device-1.3.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-1.3.0.xml">
+
+    <include relativeToChangelogFile="true" file="./device_event-index_received_on.xml"/>
+
+</databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.3.0/device_event-index_received_on.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.3.0/device_event-index_received_on.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-1.3.0.xml">
+
+    <changeSet id="changelog-device_event-1.3.0_index_received_on" author="eurotech">
+        <createIndex tableName="dvc_device_event" indexName="idx_device_event_scope_device_received_on">
+            <column name="scope_id"/>
+            <column name="device_id"/>
+            <column name="received_on"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -21,5 +21,6 @@
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-device-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-device-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-device-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.3.0/changelog-device-1.3.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds an index to the `dvc_device_event` table to improve performance of the table with a large number of rows.

**Related Issue**
This PR fixes #2851 

**Description of the solution adopted**
Added a new index with the following fields:

- scopeId
- deviceId
- receivedOn

This is the default query on the Device Event tab in the Device View and adding the index simplifies the sort of the results which is always performed with `received_on DESC` Device Event tab.

**Screenshots**
_None_

**Any side note on the changes made**
I've also considered that this index is potentially very big. 
So we might add another issue to add a task that clean up the device events.
Another solution would be to create another column with the same content as `received_on` but with less precision and use the index and filtering on that column. But it would add much more complexity on the code.