### PR TITLE
Force EclipseLink JaxbContextFactory

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -37,7 +37,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Dcommons.eventbus.url=\${SERVICE_BROKER_ADDR} \
                -Dcertificate.jwt.private.key=file:///var/opt/jetty/key.pk8 \
                -Dcertificate.jwt.certificate=file:///var/opt/jetty/cert.pem \
-               -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false}"
+               -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
+               -Djavax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory"
 
 USER 0
 


### PR DESCRIPTION
EclipseLink `JaxbContextFactory` is currently not forced on the REST APIs. This can cause troubles with CORS and in general every time a non-application error is thrown by the REST APIs.

**Related Issue**
No related issues
