### PR TITLE
Use index to search for AccessTokens

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -22,5 +22,7 @@ public class AccessTokenAttributes extends KapuaUpdatableEntityAttributes {
 
     public static final String TOKEN_ID = "tokenId";
     public static final String USER_ID = "userId";
+    public static final String EXPIRES_ON = "expiresOn";
+    public static final String INVALIDATED_ON = "invalidatedOn";
 
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,6 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import java.util.Date;
+
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.ShiroException;
 import org.apache.shiro.authc.AuthenticationException;
@@ -21,22 +23,26 @@ import org.apache.shiro.authc.ExpiredCredentialsException;
 import org.apache.shiro.authc.UnknownAccountException;
 import org.apache.shiro.realm.AuthenticatingRealm;
 import org.apache.shiro.subject.Subject;
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.predicate.AndPredicate;
+import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountService;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
 import org.eclipse.kapua.service.authentication.shiro.exceptions.ExpiredAccountException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.AccessTokenAttributes;
+import org.eclipse.kapua.service.authentication.token.AccessTokenFactory;
+import org.eclipse.kapua.service.authentication.token.AccessTokenQuery;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.UserStatus;
-
-import java.util.Date;
 
 /**
  * {@link AccessTokenCredentials} based {@link AuthenticatingRealm} implementation.
@@ -53,6 +59,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     private static final AccessTokenService ACCESS_TOKEN_SERVICE = LOCATOR.getService(AccessTokenService.class);
+    private static final AccessTokenFactory ACCESS_TOKEN_FACTORY = LOCATOR.getFactory(AccessTokenFactory.class);
     private static final AccountService ACCOUNT_SERVICE = LOCATOR.getService(AccountService.class);
     private static final UserService USER_SERVICE = LOCATOR.getService(UserService.class);
 
@@ -76,11 +83,20 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         AccessTokenCredentialsImpl token = (AccessTokenCredentialsImpl) authenticationToken;
         String tokenTokenId = token.getTokenId();
 
+        Date now = new Date();
         //
         // Find accessToken
         final AccessToken accessToken;
         try {
-            accessToken = KapuaSecurityUtils.doPrivileged(() -> ACCESS_TOKEN_SERVICE.findByTokenId(tokenTokenId));
+            AccessTokenQuery accessTokenQuery = ACCESS_TOKEN_FACTORY.newQuery(null);
+            AndPredicate andPredicate = accessTokenQuery.andPredicate(
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.EXPIRES_ON, new java.sql.Timestamp(now.getTime()), Operator.GREATER_THAN_OR_EQUAL),
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.INVALIDATED_ON, null, Operator.IS_NULL),
+                    accessTokenQuery.attributePredicate(AccessTokenAttributes.TOKEN_ID, tokenTokenId)
+            );
+            accessTokenQuery.setPredicate(andPredicate);
+            accessTokenQuery.setLimit(1);
+            accessToken = KapuaSecurityUtils.doPrivileged(() -> ACCESS_TOKEN_SERVICE.query(accessTokenQuery).getFirstItem());
         } catch (AuthenticationException ae) {
             throw ae;
         } catch (Exception e) {
@@ -93,8 +109,8 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check validity
-        if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(new Date())) ||
-                (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(new Date()))) {
+        if ((accessToken.getExpiresOn() != null && accessToken.getExpiresOn().before(now)) ||
+                (accessToken.getInvalidatedOn() != null && accessToken.getInvalidatedOn().before(now))) {
             throw new ExpiredCredentialsException();
         }
 
@@ -120,7 +136,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check if expired
-        if (user.getExpirationDate() != null && !user.getExpirationDate().after(new Date())) {
+        if (user.getExpirationDate() != null && !user.getExpirationDate().after(now)) {
             throw new ExpiredCredentialsException();
         }
 
@@ -141,7 +157,7 @@ public class AccessTokenAuthenticatingRealm extends AuthenticatingRealm {
         }
 
         // Check account expired
-        if (account.getExpirationDate() != null && !account.getExpirationDate().after(new Date())) {
+        if (account.getExpirationDate() != null && !account.getExpirationDate().after(now)) {
             throw new ExpiredAccountException(account.getExpirationDate());
         }
 

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-expires_index.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-expires_index.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/atht-access_token-expires_index.xml">
+
+    <changeSet id="changelog-access_token-1.3.0_expires_index" author="eurotech">
+        <createIndex tableName="atht_access_token" indexName="idx_atht_access_token_expires_on">
+            <column name="expires_on" />
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <include relativeToChangelogFile="true" file="./atht-access_token-expires_index.xml"/>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authentication-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-authentication-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-authentication-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-authentication-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.3.0/changelog-authentication-1.3.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR introduces an index in the `ATHT_ACCESS_TOKEN` table that is then used when looking for a specific Access Token, specifically during REST API authentication check and token refresh

**Related Issue**
This should really help #1537 but it's not 100% sure that this is the only cause of that issue. We may think to close it after we gather some feedback from the community

**Description of the solution adopted**
Changing the query we do when looking for a specific AccessToken, filtering out already expired and invalidated tokens, will allow the DBMS to use the newly created index to perform the search, cutting down the search time.

**Screenshots**
This from a brief test on my local machine:

Without the index and the optimized query:

```
kapuadb> SELECT * FROM atht_access_token WHERE token_id = '...'
[2020-07-09 11:33:05] 1 row retrieved starting from 1 in 6 s 714 ms (execution: 6 s 676 ms, fetching: 38 ms)
```

With the index and the optimized query:

```
kapuadb> SELECT * FROM atht_access_token WHERE invalidated_on IS NULL AND expires_on > NOW() AND token_id = '...'
[2020-07-09 11:32:29] 1 row retrieved starting from 1 in 60 ms (execution: 13 ms, fetching: 47 ms)
```