### PR TITLE
Set with the same digits of precision for mysql timestamp default value

### DIFF
--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -9,6 +9,7 @@
 
     Contributors:
         Eurotech - initial API and implementation
+        alva.huang - alva@izhiju.cn
  -->
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017,2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -17,5 +17,5 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
 </databaseChangeLog>


### PR DESCRIPTION
Modify the timestamp default value to current_timestamp(3) in mysql

In the file liquibase/common-properties.xml:
modify:
```
<property name="now" value="current_timestamp()" dbms="mysql,mariadb,h2"/>
```
to
```
<property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
```
to fix #2991 