### PR TITLE
Restore Path annotation in DeviceManagementOperations REST APIs

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -40,7 +40,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-//@Path("{scopeId}/devices/{deviceId}/operations/{operationId}/notifications")
+@Path("{scopeId}/devices/{deviceId}/operations/{operationId}/notifications")
 public class DeviceManagementOperationNotifications extends AbstractKapuaResource {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -41,7 +41,7 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
-//@Path("{scopeId}/devices/{deviceId}/operations")
+@Path("{scopeId}/devices/{deviceId}/operations")
 public class DeviceManagementOperations extends AbstractKapuaResource {
 
     private final KapuaLocator locator = KapuaLocator.getInstance();


### PR DESCRIPTION
In #2795 `{scopeId}/devices/{deviceId}/operations` and `{scopeId}/devices/{deviceId}/operations/{operationId}/notifications` were inadvertently removed. This is to restore them. 

**Related Issue**
No related issues
