### PR TITLE
Merged SSO 'audience' and 'client_id' properties into a single one

### DIFF
--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -42,14 +42,12 @@ if [ -n "$KAPUA_CONSOLE_URL" ] && [ -n "$OPENID_JWT_ISSUER" ] && [ -n "$OPENID_A
    echo "  Token Endpoint: $OPENID_TOKEN_ENDPOINT"
 
    : OPENID_CLIENT_ID=${OPENID_CLIENT_ID:=console}
-   : JWT_AUDIENCE=${JWT_AUDIENCE:=console}
 
    JAVA_OPTS="$JAVA_OPTS -Dsso.provider=generic"
    JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.id=${OPENID_CLIENT_ID}"
    test -n "$CLIENT_SECRET" && JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.secret=${CLIENT_SECRET}"
    JAVA_OPTS="$JAVA_OPTS -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
 
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.audience.allowed=${JWT_AUDIENCE}"
    JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.issuer.allowed=${OPENID_JWT_ISSUER}"
    JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.auth=${OPENID_AUTH_ENDPOINT}"
    JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.logout=${OPENID_LOGOUT_ENDPOINT}"

--- a/docs/developer-guide/en/sso.md
+++ b/docs/developer-guide/en/sso.md
@@ -20,8 +20,11 @@ The current default providers are:
 Each provider will require additional configuration options. But there is a set of common configuration
 options:
 
-- **`sso.openid.client.id`** : 
-    the "client id" used when communicating with the OpenID Connect server.
+- **`sso.openid.client.id`** : the "client id" used when communicating with the OpenID Connect server. 
+    According to the official OpenID Connect specification (see [here](https://openid.net/specs/openid-connect-core-1_0.html#IDToken),
+    the token containa a list of audiences (described by the `aud` claim). 
+    When the token is received, we need to validate that the audience contains the `client_id` corresponding to the Kapua Console. 
+    Only one  `client_id` corresponds to the Kapua Console (if multiple client_ids are present in the audience, they correspond to other clients).
 - **`sso.openid.client.secret` (optional)** : 
     the "client secret" used when communicating with the OpenID Connect server.
 - **`sso.openid.jwt-processor-timeout` (optional)** : the JwtProcessor expiration time (the default value is 1 hour).
@@ -41,7 +44,6 @@ documentation to look up the required values:
 - **`sso.generic.openid.server.endpoint.auth`** : the endpoint URL to the authentication API.
 - **`sso.generic.openid.server.endpoint.logout`** : the logout endpoint of the OpenID provider.
 - **`sso.generic.openid.server.endpoint.token`** : the endpoint URL to the token API.
-- **`sso.generic.openid.jwt.audience.allowed`** : the JWT audience.
 - **`sso.generic.openid.jwt.issuer.allowed`** : the base URL to the OpenID server provider.
 
 ### Keycloak provider

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/jwt/GenericJwtProcessor.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/jwt/GenericJwtProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others.
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -16,6 +16,8 @@ import org.eclipse.kapua.sso.exception.SsoIllegalArgumentException;
 import org.eclipse.kapua.sso.provider.jwt.AbstractJwtProcessor;
 import org.eclipse.kapua.sso.provider.generic.setting.GenericSsoSetting;
 import org.eclipse.kapua.sso.provider.generic.setting.GenericSsoSettingKeys;
+import org.eclipse.kapua.sso.provider.setting.SsoSetting;
+import org.eclipse.kapua.sso.provider.setting.SsoSettingKeys;
 
 import java.util.List;
 
@@ -29,24 +31,18 @@ public class GenericJwtProcessor extends AbstractJwtProcessor {
 
     @Override
     protected List<String> getJwtExpectedIssuers() throws SsoIllegalArgumentException {
-        List<String> jwtExpectedIssuers =
-                GenericSsoSetting.getInstance().getList(String.class, GenericSsoSettingKeys.SSO_OPENID_JWT_ISSUER_ALLOWED);
+        List<String> jwtExpectedIssuers = GenericSsoSetting.getInstance().getList(String.class, GenericSsoSettingKeys.SSO_OPENID_JWT_ISSUER_ALLOWED);
         if (jwtExpectedIssuers == null || jwtExpectedIssuers.isEmpty()) {
-            throw new SsoIllegalArgumentException(
-                    GenericSsoSettingKeys.SSO_OPENID_JWT_ISSUER_ALLOWED.key(),
-                    (jwtExpectedIssuers == null ? null : ""));
+            throw new SsoIllegalArgumentException(GenericSsoSettingKeys.SSO_OPENID_JWT_ISSUER_ALLOWED.key(), (jwtExpectedIssuers == null ? null : ""));
         }
         return jwtExpectedIssuers;
     }
 
     @Override
     protected List<String> getJwtAudiences() throws SsoIllegalArgumentException {
-        List<String> jwtAudiences = GenericSsoSetting.getInstance().getList(String.class,
-                GenericSsoSettingKeys.SSO_OPENID_JWT_AUDIENCE_ALLOWED);
+        List<String> jwtAudiences = SsoSetting.getInstance().getList(String.class, SsoSettingKeys.SSO_OPENID_CLIENT_ID);
         if (jwtAudiences == null || jwtAudiences.isEmpty()) {
-            throw new SsoIllegalArgumentException(
-                    GenericSsoSettingKeys.SSO_OPENID_JWT_AUDIENCE_ALLOWED.key(),
-                    (jwtAudiences == null ? null : ""));
+            throw new SsoIllegalArgumentException(SsoSettingKeys.SSO_OPENID_CLIENT_ID.key(), (jwtAudiences == null ? null : ""));
         }
         return jwtAudiences;
     }

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSettingKeys.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -18,7 +18,6 @@ public enum GenericSsoSettingKeys implements SettingKey {
     SSO_OPENID_SERVER_ENDPOINT_AUTH("sso.generic.openid.server.endpoint.auth"), //
     SSO_OPENID_SERVER_ENDPOINT_TOKEN("sso.generic.openid.server.endpoint.token"), //
     SSO_OPENID_SERVER_ENDPOINT_LOGOUT("sso.generic.openid.server.endpoint.logout"),
-    SSO_OPENID_JWT_AUDIENCE_ALLOWED("sso.generic.openid.jwt.audience.allowed"),
     SSO_OPENID_JWT_ISSUER_ALLOWED("sso.generic.openid.jwt.issuer.allowed"),
     ;
 

--- a/sso/provider-generic/src/main/resources/sso-generic-setting.properties
+++ b/sso/provider-generic/src/main/resources/sso-generic-setting.properties
@@ -12,7 +12,6 @@
 ###############################################################################
 
 # properties with example values
-#sso.generic.openid.jwt.audience.allowed=console
 #sso.generic.openid.jwt.issuer.allowed=http://localhost:9090/auth/realms/kapua
 #sso.generic.openid.server.endpoint.auth=http://localhost:9090/auth/realms/kapua/protocol/openid-connect/auth
 #sso.generic.openid.server.endpoint.logout=http://localhost:9090/auth/realms/kapua/protocol/openid-connect/logout


### PR DESCRIPTION
The `sso.openid.client.id` and the `sso.generic.openid.jwt.audience.allowed` are merged into only one, since they basically represent the same value. 

**Related Issue**
This PR fixes/closes _#3038_

**Description of the solution adopted**
`sso.openid.client.id` is the chosen name for the merged property, while `sso.generic.openid.jwt.audience.allowed` has been removed.

**Screenshots**
_N/A_

**Any side note on the changes made**
The `sso.md` documentation file has also been updated accordingly.
