### PR TITLE
Users Match Predicate

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
@@ -51,11 +51,13 @@ public class Users extends AbstractKapuaResource {
     /**
      * Gets the {@link User} list in the scope.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param name    The {@link User} name in which to search results.
+     * @param scopeId       The {@link ScopeId} in which to search results.
+     * @param name          The {@link User} name in which to search results.
+     * @param matchTerm     A term to be matched in at least one of the configured fields of this entity
      * @param askTotalCount    Ask for the total count of the matched entities in the result
-     * @param offset  The result set offset.
-     * @param limit   The result set limit.
+     * @param offset        The result set offset.
+     * @param limit         The result set limit.
+     *
      * @return The {@link UserListResult} of all the users associated to the current selected scope.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -65,6 +67,7 @@ public class Users extends AbstractKapuaResource {
     public UserListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("name") String name,
+            @QueryParam("matchTerm") String matchTerm,
             @QueryParam("askTotalCount") boolean askTotalCount,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
@@ -74,6 +77,10 @@ public class Users extends AbstractKapuaResource {
         if (!Strings.isNullOrEmpty(name)) {
             andPredicate.and(query.attributePredicate(KapuaNamedEntityAttributes.NAME, name));
         }
+        if (matchTerm != null && !matchTerm.isEmpty()) {
+            andPredicate.and(query.matchPredicate(matchTerm));
+        }
+
         query.setPredicate(andPredicate);
 
         query.setAskTotalCount(askTotalCount);

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
@@ -25,6 +25,18 @@ paths:
           description: The user name to filter results
           schema:
             type: string
+        - name: matchTerm
+          in: query
+          description: |
+            A term to match on different fields. Every entity whose at least one of the specified fields starts with this value will be matched.
+            Matches on the following fields:
+
+            - NAME
+            - EMAIL
+            - PHONE_NUMBER
+            - DISPLAY_NAME
+            - EXTERNAL_ID
+            - DESCRIPTION
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceMatchPredicate.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceMatchPredicate.java
@@ -11,35 +11,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
-import java.util.Arrays;
+import org.eclipse.kapua.model.query.predicate.MatchPredicate;
 
-import org.eclipse.kapua.commons.model.query.predicate.AbstractMatchPredicate;
-
-public class DeviceMatchPredicate<T> extends AbstractMatchPredicate<T> {
-
-    /**
-     * Constructor.
-     *
-     * @param matchTerm
-     * @since 1.3.0
-     */
-    public DeviceMatchPredicate(T matchTerm) {
-        this.attributeNames = Arrays.asList(
-                DeviceAttributes.CLIENT_ID,
-                DeviceAttributes.DISPLAY_NAME,
-                DeviceAttributes.SERIAL_NUMBER,
-                DeviceAttributes.MODEL_ID,
-                DeviceAttributes.MODEL_NAME,
-                DeviceAttributes.BIOS_VERSION,
-                DeviceAttributes.FIRMWARE_VERSION,
-                DeviceAttributes.OS_VERSION,
-                DeviceAttributes.JVM_VERSION,
-                DeviceAttributes.OSGI_FRAMEWORK_VERSION,
-                DeviceAttributes.APPLICATION_FRAMEWORK_VERSION,
-                DeviceAttributes.CONNECTION_INTERFACE,
-                DeviceAttributes.CONNECTION_IP
-        );
-        this.matchTerm = matchTerm;
-    }
+public interface DeviceMatchPredicate<T> extends MatchPredicate<T> {
 
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceMatchPredicateImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceMatchPredicateImpl.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry.internal;
+
+import java.util.Arrays;
+
+import org.eclipse.kapua.commons.model.query.predicate.AbstractMatchPredicate;
+import org.eclipse.kapua.service.device.registry.DeviceAttributes;
+import org.eclipse.kapua.service.device.registry.DeviceMatchPredicate;
+
+public class DeviceMatchPredicateImpl<T> extends AbstractMatchPredicate<T> implements DeviceMatchPredicate<T> {
+
+    /**
+     * Constructor.
+     *
+     * @param matchTerm
+     * @since 1.3.0
+     */
+    public DeviceMatchPredicateImpl(T matchTerm) {
+        this.attributeNames = Arrays.asList(
+                DeviceAttributes.CLIENT_ID,
+                DeviceAttributes.DISPLAY_NAME,
+                DeviceAttributes.SERIAL_NUMBER,
+                DeviceAttributes.MODEL_ID,
+                DeviceAttributes.MODEL_NAME,
+                DeviceAttributes.BIOS_VERSION,
+                DeviceAttributes.FIRMWARE_VERSION,
+                DeviceAttributes.OS_VERSION,
+                DeviceAttributes.JVM_VERSION,
+                DeviceAttributes.OSGI_FRAMEWORK_VERSION,
+                DeviceAttributes.APPLICATION_FRAMEWORK_VERSION,
+                DeviceAttributes.CONNECTION_INTERFACE,
+                DeviceAttributes.CONNECTION_IP
+        );
+        this.matchTerm = matchTerm;
+    }
+
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceAttributes;
-import org.eclipse.kapua.service.device.registry.DeviceMatchPredicate;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
 /**
@@ -47,8 +46,8 @@ public class DeviceQueryImpl extends AbstractKapuaQuery<Device> implements Devic
     }
 
     @Override
-    public <T> DeviceMatchPredicate<T> matchPredicate(T matchTerm) {
-        return new DeviceMatchPredicate<>(matchTerm);
+    public <T> DeviceMatchPredicateImpl<T> matchPredicate(T matchTerm) {
+        return new DeviceMatchPredicateImpl<>(matchTerm);
     }
 
 }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserMatchPredicate.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserMatchPredicate.java
@@ -1,0 +1,18 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user;
+
+import org.eclipse.kapua.model.query.predicate.MatchPredicate;
+
+public interface UserMatchPredicate<T> extends MatchPredicate<T> {
+
+}

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
@@ -28,4 +28,6 @@ import org.eclipse.kapua.model.query.KapuaQuery;
 @XmlType(factoryClass = UserXmlRegistry.class, factoryMethod = "newQuery")
 public interface UserQuery extends KapuaQuery<User> {
 
+    <T> UserMatchPredicate<T> matchPredicate(T matchTerm);
+
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserMatchPredicateImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserMatchPredicateImpl.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal;
+
+import java.util.Arrays;
+
+import org.eclipse.kapua.commons.model.query.predicate.AbstractMatchPredicate;
+import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.service.user.UserAttributes;
+import org.eclipse.kapua.service.user.UserMatchPredicate;
+
+public class UserMatchPredicateImpl<T> extends AbstractMatchPredicate<T> implements UserMatchPredicate<T> {
+
+    /**
+     * Constructor.
+     *
+     * @param matchTerm
+     * @since 1.3.0
+     */
+    public UserMatchPredicateImpl(T matchTerm) {
+        this.attributeNames = Arrays.asList(
+                KapuaNamedEntityAttributes.NAME,
+                UserAttributes.EMAIL,
+                UserAttributes.PHONE_NUMBER,
+                UserAttributes.DISPLAY_NAME,
+                UserAttributes.EXTERNAL_ID,
+                KapuaNamedEntityAttributes.DESCRIPTION
+        );
+        this.matchTerm = matchTerm;
+    }
+
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
@@ -39,4 +39,10 @@ public class UserQueryImpl extends AbstractKapuaQuery<User> implements UserQuery
         this();
         setScopeId(scopeId);
     }
+
+    @Override
+    public <T> UserMatchPredicateImpl<T> matchPredicate(T matchTerm) {
+        return new UserMatchPredicateImpl<>(matchTerm);
+    }
+
 }


### PR DESCRIPTION
Following the Devices Match Predicates in #2875, this PR introduces a `UserMatchPredicates`. Evaluated properties are:

- NAME
- EMAIL
- PHONE_NUMBER
- DISPLAY_NAME
- EXTERNAL_ID
- DESCRIPTION

**Related Issue**
No related issues

**Any side note on the changes made**
The PR also refactors the `DeviceMatchPredicate` to have a public interface and an internal implementation, to better isolate the one from the other