### PR TITLE
Correctly populate Child Accounts Menu

### DIFF
--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -79,6 +79,7 @@ accountSelectorItemYourAccount={0} - <i>Your account</i>
 accountSelectorItemNoChild=<i>No child accounts</i>
 accountSelectorMenuMaskLoading=Switching to {0} account...
 accountSelectorTooltipYourAccount=Click to return to your main account
+accountSelectorLoadingChildAccounts=Loading child accounts...
 
 changePassword=Change Password
 oldPassword=Old Password


### PR DESCRIPTION
This PR adds a "Loading Child Accounts“ fake menu item in the Menu when loading child accounts, and forces a refresh after the list is loaded.

**Related Issue**
Fixes #3049 

**Description of the solution adopted**
The proposed solution isn't 100% clean, since in theory the menu should refresh itself when adding new items but for some reasons it doesn't. Through tests and reviews (@pintify feel free to test and report) are more than welcome.