### PR TITLE
Rename JSESSIONID Cookie Name

### DIFF
--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -94,6 +94,9 @@
     <!-- Session Timeout -->
     <session-config>
         <session-timeout>30</session-timeout>
+        <cookie-config>
+            <name>KAPUA_JSESSIONID</name>
+        </cookie-config>
     </session-config>
 
     <!--  -->


### PR DESCRIPTION
This PR renames the `JSESSIONID` cookie to `KAPUA_JSESSIONID` to avoid name clash with other web applications running in the same host

**Related Issue**
Fixes #2931 
