### PR TITLE
Fix search for refreshable access tokens

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -50,13 +50,24 @@ public interface AuthenticationService extends KapuaService {
     void logout() throws KapuaException;
 
     /**
-     * Return the {@link AccessToken} identified by the provided token identifier
+     * Return the {@link AccessToken} identified by the provided token identifier. Expired {@link AccessToken}s are
+     * excluded.
      *
-     * @param tokenId
-     * @return
+     * @param tokenId           The ID of the {@link AccessToken}
+     * @return                  The desired {@link AccessToken} object
      * @throws KapuaException if no {@link AccessToken} is found for that token identifier
      */
     AccessToken findAccessToken(String tokenId) throws KapuaException;
+
+    /**
+     * Return a Refreshable {@link AccessToken} identified by the provided token identifier. A Refreshable token may be
+     * already expired or not, but its Refresh Token is still valid
+     *
+     * @param tokenId               The ID of the {@link AccessToken}
+     * @return                      The desired {@link AccessToken} object
+     * @throws KapuaException if no {@link AccessToken} is found for that token identifier
+     */
+    AccessToken findRefreshableAccessToken(String tokenId) throws KapuaException;
 
     AccessToken refreshAccessToken(String tokenId, String refreshToken) throws KapuaException;
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
@@ -24,5 +24,6 @@ public class AccessTokenAttributes extends KapuaUpdatableEntityAttributes {
     public static final String USER_ID = "userId";
     public static final String EXPIRES_ON = "expiresOn";
     public static final String INVALIDATED_ON = "invalidatedOn";
+    public static final String REFRESH_EXPIRES_ON = "refreshExpiresOn";
 
 }

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-refresh-expires_index.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-access_token-refresh-expires_index.xml
@@ -15,9 +15,12 @@
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+        logicalFilePath="KapuaDB/atht-access_token-refresh-expires_index.xml">
 
-    <include relativeToChangelogFile="true" file="./atht-access_token-expires_index.xml"/>
-    <include relativeToChangelogFile="true" file="./atht-access_token-refresh-expires_index.xml"/>
+    <changeSet id="changelog-access_token-1.3.0_refresh-expires_index" author="eurotech">
+        <createIndex tableName="atht_access_token" indexName="idx_atht_access_token_refresh_expires_on">
+            <column name="refresh_expires_on" />
+        </createIndex>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR fixes the Access Token Refresh operation, by including in the results Access Tokens that are expired but whose Refresh Token is not expired yet

**Related Issue**
Fixes #3055 
