### PR TITLE
Update Copyright Years

### DIFF
--- a/assembly/api/descriptors/kapua-api-jetty.xml
+++ b/assembly/api/descriptors/kapua-api-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/activemq.xml
+++ b/assembly/broker/configurations/activemq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/activemq.xml
+++ b/assembly/broker/configurations/activemq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/camel-experimental.xml
+++ b/assembly/broker/configurations/camel-experimental.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/camel-experimental.xml
+++ b/assembly/broker/configurations/camel-experimental.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/camel-routes.xml
+++ b/assembly/broker/configurations/camel-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/camel.xml
+++ b/assembly/broker/configurations/camel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/camel.xml
+++ b/assembly/broker/configurations/camel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/configurations/logback.xml
+++ b/assembly/broker/configurations/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/docker/Dockerfile
+++ b/assembly/broker/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/entrypoint/run-broker
+++ b/assembly/broker/entrypoint/run-broker
@@ -1,6 +1,6 @@
 #!/bin/bash
 ################################################################################
-#    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+#    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/broker/entrypoint/run-broker
+++ b/assembly/broker/entrypoint/run-broker
@@ -1,6 +1,6 @@
 #!/bin/bash
 ################################################################################
-#    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/console/descriptors/kapua-console-jetty.xml
+++ b/assembly/console/descriptors/kapua-console-jetty.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#    Copyright (c) 2017, 2019 Red Hat Inc and others
+#    Copyright (c) 2017, 2020 Red Hat Inc and others
 #   
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/artemis-roles.properties
+++ b/assembly/events-broker/configurations/artemis-roles.properties
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2016, 2018 Red Hat Inc and others
+#   Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 #   All rights reserved. This program and the accompanying materials
 #   are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/artemis-users.properties
+++ b/assembly/events-broker/configurations/artemis-users.properties
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2016, 2018 Red Hat Inc and others
+#   Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 #   All rights reserved. This program and the accompanying materials
 #   are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/artemis.profile
+++ b/assembly/events-broker/configurations/artemis.profile
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2016, 2017 Red Hat Inc and others
+#   Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 #   All rights reserved. This program and the accompanying materials
 #   are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/bootstrap.xml
+++ b/assembly/events-broker/configurations/bootstrap.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/broker.xml
+++ b/assembly/events-broker/configurations/broker.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0'?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/logging.properties
+++ b/assembly/events-broker/configurations/logging.properties
@@ -1,5 +1,5 @@
 #
-#   Copyright (c) 2016, 2018 Red Hat Inc and others
+#   Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 #   All rights reserved. This program and the accompanying materials
 #   are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/configurations/login.config
+++ b/assembly/events-broker/configurations/login.config
@@ -1,5 +1,5 @@
 /*
- *   Copyright (c) 2016, 2018 Red Hat Inc and others
+ *   Copyright (c) 2016, 2020 Red Hat Inc and others
  *
  *   All rights reserved. This program and the accompanying materials
  *   are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/descriptors/events-broker.xml
+++ b/assembly/events-broker/descriptors/events-broker.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/entrypoint/run-artemis
+++ b/assembly/events-broker/entrypoint/run-artemis
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 ################################################################################
-#    Copyright (c) 2017, 2018 Eurotech
+#    Copyright (c) 2017, 2020 Eurotech
 #
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/jetty-base/descriptors/jetty-base.xml
+++ b/assembly/jetty-base/descriptors/jetty-base.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/jetty-base/docker/Dockerfile
+++ b/assembly/jetty-base/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/jetty-base/entrypoint/run-jetty
+++ b/assembly/jetty-base/entrypoint/run-jetty
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 ################################################################################
-#    Copyright (c) 2017 Red Hat Inc
+#    Copyright (c) 2017, 2020 Red Hat Inc
 #   
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/sql/descriptors/kapua-sql.xml
+++ b/assembly/sql/descriptors/kapua-sql.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/sql/docker/Dockerfile
+++ b/assembly/sql/docker/Dockerfile
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/sql/entrypoint/run-h2
+++ b/assembly/sql/entrypoint/run-h2
@@ -1,6 +1,6 @@
 #!/bin/sh
 ################################################################################
-#    Copyright (c) 2017, 2018 Red Hat Inc
+#    Copyright (c) 2017, 2020 Red Hat Inc
 #   
 #    All rights reserved. This program and the accompanying materials
 #    are made available under the terms of the Eclipse Public License v1.0

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/api/pom.xml
+++ b/broker/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/api/src/main/java/org/eclipse/kapua/broker/BrokerDomain.java
+++ b/broker/api/src/main/java/org/eclipse/kapua/broker/BrokerDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/api/src/main/java/org/eclipse/kapua/broker/BrokerDomains.java
+++ b/broker/api/src/main/java/org/eclipse/kapua/broker/BrokerDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/BrokerJAXBContextProvider.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/BrokerJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/BrokerJAXBContextProvider.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/BrokerJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerApplicationPlugin.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerApplicationPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerApplicationPlugin.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerApplicationPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerJAXBContextLoader.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerJAXBContextLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and others.
+ * Copyright (c) 2016, 2020 Eurotech and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaCamelFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and others.
+ * Copyright (c) 2011, 2020 Eurotech and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaDataConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/converter/KapuaLifeCycleConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractProcessor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractProcessor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/AbstractProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/CamelConstants.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/CamelConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/CamelConstants.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/CamelConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceManagementNotificationMessageProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/DeviceMessageListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelUtil.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelUtil.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/CamelUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/JmsUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/MessageConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/system/SystemMessageCreator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/message/system/SystemMessageCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/Acl.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/Acl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIdResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIdResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIpResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/BrokerIpResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/CachingConnectorDescriptorProvider.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/CachingConnectorDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvider.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProviders.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProviders.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIdResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIdResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolver.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProvider.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaBrokerErrorCodes.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaBrokerErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdException.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImpl.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImpl.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AdminAuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AdminAuthenticationLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/Authenticator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/Authenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthorizationEntry.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthorizationEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetric.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetric.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetric.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPool.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPool.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPool.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapper.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapper.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactory.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactory.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactory.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactory.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConsumerWrapper.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsConsumerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapper.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapper.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/CamelKapuaDefaultRouter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndChainEndPoint.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndChainEndPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPoint.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointAdapter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/ParentEndPoint.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/ParentEndPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacer.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/SimpleEndPoint.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/SimpleEndPoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSetting.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKey.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/resources/liquibase/0.2.0/broker-domain.xml
+++ b/broker/core/src/main/resources/liquibase/0.2.0/broker-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/resources/liquibase/0.2.0/changelog-broker-0.2.0.xml
+++ b/broker/core/src/main/resources/liquibase/0.2.0/changelog-broker-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/resources/liquibase/1.0.0/broker-domain.xml
+++ b/broker/core/src/main/resources/liquibase/1.0.0/broker-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/resources/liquibase/1.0.0/changelog-broker-1.0.0.xml
+++ b/broker/core/src/main/resources/liquibase/1.0.0/changelog-broker-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/main/resources/liquibase/changelog-broker-master.xml
+++ b/broker/core/src/main/resources/liquibase/changelog-broker-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/CamelRoutesLoaderTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/CamelRoutesLoaderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/TestFragment.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/TestFragment.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/Tests.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/Tests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/resources/camel-routes.xml
+++ b/broker/core/src/test/resources/camel-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/resources/camel-routes.xml
+++ b/broker/core/src/test/resources/camel-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/core/src/test/resources/logback.xml
+++ b/broker/core/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/build-tools/src/main/resources/checkstyle/kapua.suppressions.xml
+++ b/build-tools/src/main/resources/checkstyle/kapua.suppressions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/build-tools/src/main/resources/checkstyle/kapua.xml
+++ b/build-tools/src/main/resources/checkstyle/kapua.xml
@@ -88,7 +88,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^/\*{79}$\n^ \* Copyright \(c\) \d{4}(|, \d{4}) (.*) and others\.?$\n^ \*$\n^ \* All rights reserved. This program and the accompanying materials$\n^ \* are made available under the terms of the Eclipse Public License v1.0$\n^ \* which accompanies this distribution, and is available at$\n^ \* http://www.eclipse.org/legal/epl-v10.html$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
+            value="^/\*{79}$\n^ \* Copyright \(c\) (|\d{4}, )2020 (.*) and others\.?$\n^ \*$\n^ \* All rights reserved. This program and the accompanying materials$\n^ \* are made available under the terms of the Eclipse Public License v1.0$\n^ \* which accompanies this distribution, and is available at$\n^ \* http://www.eclipse.org/legal/epl-v10.html$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="10" />
         <property name="fileExtensions" value="java" />
@@ -96,7 +96,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) \d{4}(|, \d{4}) (.*) and others\.?$\n^$\n^    All rights reserved\. This program and the accompanying materials$\n^    are made available under the terms of the Eclipse Public License v1\.0$\n^    which accompanies this distribution, and is available at$\n^    http\:\/\/www.eclipse.org/legal/epl-v10\.html$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
+            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) (|\d{4}, )2020 (.*) and others\.?$\n^$\n^    All rights reserved\. This program and the accompanying materials$\n^    are made available under the terms of the Eclipse Public License v1\.0$\n^    which accompanies this distribution, and is available at$\n^    http\:\/\/www.eclipse.org/legal/epl-v10\.html$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="11" />
         <property name="fileExtensions" value="xml" />

--- a/build-tools/src/main/resources/checkstyle/kapua.xml
+++ b/build-tools/src/main/resources/checkstyle/kapua.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/build-tools/src/main/toolchains/fedora-rhel-centos.xml
+++ b/build-tools/src/main/toolchains/fedora-rhel-centos.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/build-tools/src/main/toolchains/travis-ci.xml
+++ b/build-tools/src/main/toolchains/travis-ci.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/cloud/generate-client-java.sh
+++ b/client/cloud/generate-client-java.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright (c) 2016, 2017 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/pom.xml
+++ b/client/gateway/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Application.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/BinaryPayloadCodec.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/BinaryPayloadCodec.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Client.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Client.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Credentials.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Credentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Data.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Data.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/ErrorHandler.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/ErrorHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/MessageErrorHandler.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/MessageErrorHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/MessageHandler.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/MessageHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Payload.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Payload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Sender.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Sender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Topic.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Topic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/TransmissionException.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/TransmissionException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Transport.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/Transport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/util/Errors.java
+++ b/client/gateway/api/src/main/java/org/eclipse/kapua/client/gateway/util/Errors.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/util/ErrorsTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/util/ErrorsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/features/karaf/pom.xml
+++ b/client/gateway/features/karaf/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/features/karaf/src/main/feature/feature.xml
+++ b/client/gateway/features/karaf/src/main/feature/feature.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/features/pom.xml
+++ b/client/gateway/features/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/pom.xml
+++ b/client/gateway/profile/kura/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraBinaryPayloadCodec.java
+++ b/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraBinaryPayloadCodec.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraBirthCertificateModule.java
+++ b/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraBirthCertificateModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraNamespace.java
+++ b/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/KuraNamespace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/internal/Metrics.java
+++ b/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/kura/internal/Metrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/profile/kura/KuraMqttProfile.java
+++ b/client/gateway/profile/kura/src/main/java/org/eclipse/kapua/client/gateway/profile/kura/KuraMqttProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/KuraProfileExample.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/KuraProfileExample.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/NamespaceTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/NamespaceTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/PayloadCodecTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/PayloadCodecTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/fuse/src/main/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannel.java
+++ b/client/gateway/provider/fuse/src/main/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/fuse/src/main/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/Callbacks.java
+++ b/client/gateway/provider/fuse/src/main/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/Callbacks.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/mqtt/pom.xml
+++ b/client/gateway/provider/mqtt/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannel.java
+++ b/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttMessageHandler.java
+++ b/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttMessageHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttModuleContext.java
+++ b/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttModuleContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttNamespace.java
+++ b/client/gateway/provider/mqtt/src/main/java/org/eclipse/kapua/client/gateway/mqtt/MqttNamespace.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/paho/src/main/java/org/eclipse/kapua/client/gateway/mqtt/paho/PahoChannel.java
+++ b/client/gateway/provider/paho/src/main/java/org/eclipse/kapua/client/gateway/mqtt/paho/PahoChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/paho/src/main/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/Listeners.java
+++ b/client/gateway/provider/paho/src/main/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/Listeners.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/provider/pom.xml
+++ b/client/gateway/provider/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/pom.xml
+++ b/client/gateway/spi/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/AbstractClient.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/AbstractClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/Channel.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/Channel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultApplication.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultClient.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultData.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/DefaultData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/Module.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/Module.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/ModuleContext.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/ModuleContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Buffers.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Buffers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Futures.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Futures.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/MoreExecutors.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/MoreExecutors.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Strings.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/Strings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsync.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsync.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxy.java
+++ b/client/gateway/spi/src/main/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/AboutScanner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/about/package-info.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/about/package-info.java
@@ -1,5 +1,5 @@
 /**
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  * <p>
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/Cache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/cache/LocalCache.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtilsWithResources.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurableServiceSchemaUtilsWithResources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/KapuaConfigurationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceComponentConfigurationImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceComponentConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigAttributes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreatorImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreatorImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResult.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResult.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQueryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ValueTokenizer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2005, 2016 IBM Corporation and others.
+ * Copyright (c) 2005, 2020 IBM Corporation and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/EmptyTocd.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/EmptyTocd.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/Password.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TadImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TadImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TattributeImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TdesignateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TdesignateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TdesignateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TdesignateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TiconImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TiconImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TiconImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TiconImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TmetadataImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TmetadataImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TmetadataImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TmetadataImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TobjectImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TobjectImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TobjectImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TobjectImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TocdImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TocdImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TocdImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TocdImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ToptionImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ToptionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ToptionImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/ToptionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/TscalarImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/InterceptorBind.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/InterceptorBind.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProviderImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProviderImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/HousekeeperRun.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/HousekeeperRun.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/JsonServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/JsonServiceEventMarshaler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEntry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusDriver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusDriver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventBusManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventClientConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventClientConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHousekeeper.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventHousekeeper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventMarshaler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventModuleConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventModuleConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventScope.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceEventScope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceInspector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/ServiceMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/XmlServiceEventMarshaler.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/XmlServiceEventMarshaler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/jms/JMSServiceEventBus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/CommonsEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/CommonsEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/CommonsEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/CommonsEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/DefaultConfigurableJdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerCallback.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/EntityManagerSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/H2JdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/H2JdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Red Hat and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/JdbcConnectionUrlResolvers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Red Hat and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/SimpleSqlScriptExecutor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerNotTransacted.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerNotTransacted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerNotTransacted.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerNotTransacted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerTransacted.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerTransacted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerTransacted.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/TransactionManagerTransacted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricServiceFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricServiceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/metric/MetricsServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaNamedEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntityCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/AbstractKapuaUpdatableEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEid.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEid.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEidConverter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEidConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEidConverter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaEidConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaIdFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaIdFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaIdFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/KapuaIdFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/FieldSortCriteriaImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AndPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AttributePredicateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/AttributePredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/OrPredicateImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/predicate/OrPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSecurityUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSecurityUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSecurityUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSecurityUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/security/KapuaSession.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreDomain.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreDomains.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecord.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecord.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordAttributes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordAttributes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordCreator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordListResult.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordListResult.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/ServiceEventUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/ServiceEventUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordCreatorImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordCreatorImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreRecordListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/AbstractKapuaService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractBaseKapuaSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/AbstractKapuaSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/EnvFriendlyConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/EnvFriendlyConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/EnvFriendlyConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/EnvFriendlyConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/KapuaSettingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/SettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/SettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/SettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/SettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/SimpleSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/SimpleSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/SimpleSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/SimpleSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ClassUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/CommonsValidationRegex.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/CommonsValidationRegex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/CryptoUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/CryptoUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/CryptoUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/CryptoUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaCommonsErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaCommonsErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaCommonsErrorCodes.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaCommonsErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDelayUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDelayUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaExceptionUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaFileUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaFileUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/Payloads.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/Payloads.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/PropertiesUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/PropertiesUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ResourceUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ResourceUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ResourceUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/StringUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/SystemUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ThrowingRunnable.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ThrowingRunnable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ValidationRegex.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ValidationRegex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/JAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/META-INF/persistence.xml
+++ b/commons/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/META-INF/persistence.xml
+++ b/commons/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/kapua-configuration-service-error-messages.properties
+++ b/commons/src/main/resources/kapua-configuration-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/kapua-configuration-service-error-messages.properties
+++ b/commons/src/main/resources/kapua-configuration-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/0.2.0/changelog-system-configuration-0.2.0.xml
+++ b/commons/src/main/resources/liquibase/0.2.0/changelog-system-configuration-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/0.3.0/changelog-system-configuration-0.3.0.xml
+++ b/commons/src/main/resources/liquibase/0.3.0/changelog-system-configuration-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/0.3.0/system_configuration-id_check_positive.xml
+++ b/commons/src/main/resources/liquibase/0.3.0/system_configuration-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/0.3.0/system_configuration-scope_id_index.xml
+++ b/commons/src/main/resources/liquibase/0.3.0/system_configuration-scope_id_index.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.0.0/changelog-event-store.xml
+++ b/commons/src/main/resources/liquibase/1.0.0/changelog-event-store.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.0.0/sys-event-store.xml
+++ b/commons/src/main/resources/liquibase/1.0.0/sys-event-store.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.0.0/sys-housekeeper-run.xml
+++ b/commons/src/main/resources/liquibase/1.0.0/sys-housekeeper-run.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.2.0/changelog-event-store-1.2.0.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/changelog-event-store-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.2.0/changelog-system-configuration-1.2.0.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/changelog-system-configuration-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-event-store-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/sys-housekeeper-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
+++ b/commons/src/main/resources/liquibase/1.2.0/system_configuration-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/changelog-event-store-master.pre.xml
+++ b/commons/src/main/resources/liquibase/changelog-event-store-master.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/main/resources/liquibase/changelog-system-configurations-master.pre.xml
+++ b/commons/src/main/resources/liquibase/changelog-system-configurations-master.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/about/AboutTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/about/AboutTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/StringUtilTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/ObjectFactoryImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/PasswordTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/configuration/metatype/PasswordTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/metric/MetricServiceFactoryTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/metric/MetricServiceFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/KapuaIdGeneratorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/id/KapuaEidTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/id/KapuaEidTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityCreator.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDAO.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDAO.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomain.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomains.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityManagerFactory.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityManagerFactory.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionIdGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/security/KapuaDoPrivilegeTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/AbstractKapuaSettingTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/setting/SimpleSettingKeyTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/setting/SimpleSettingKeyTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaDateUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/KapuaDateUtilsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/PayloadsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/PayloadsTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
@@ -57,7 +57,7 @@ public class ResourceUtilsTest extends Assert {
         Charset[] validCharsetList = new Charset[]{StandardCharsets.UTF_8, StandardCharsets.US_ASCII, StandardCharsets.ISO_8859_1};
         Charset[] invalidCharsetList = new Charset[]{StandardCharsets.UTF_16, StandardCharsets.UTF_16BE, StandardCharsets.UTF_16LE,};
         String expectedString = "###############################################################################\n" +
-                "# Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others\n" +
+                "# Copyright (c) 2016, 2020 Red Hat and/or its affiliates and others\n" +
                 "#\n" +
                 "# All rights reserved. This program and the accompanying materials\n" +
                 "# are made available under the terms of the Eclipse Public License v1.0\n" +

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ResourceUtilsTest.java
@@ -57,14 +57,14 @@ public class ResourceUtilsTest extends Assert {
         Charset[] validCharsetList = new Charset[]{StandardCharsets.UTF_8, StandardCharsets.US_ASCII, StandardCharsets.ISO_8859_1};
         Charset[] invalidCharsetList = new Charset[]{StandardCharsets.UTF_16, StandardCharsets.UTF_16BE, StandardCharsets.UTF_16LE,};
         String expectedString = "###############################################################################\n" +
-                "# Copyright (c) 2011, 2016 Red Hat and/or its affiliates and others\n" +
+                "# Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others\n" +
                 "#\n" +
                 "# All rights reserved. This program and the accompanying materials\n" +
                 "# are made available under the terms of the Eclipse Public License v1.0\n" +
                 "# which accompanies this distribution, and is available at\n" +
                 "# http://www.eclipse.org/legal/epl-v10.html\n" +
                 "#\n" +
-                "###############################################################################";
+                "###############################################################################\n";
         NullPointerException expectedException = new NullPointerException();
 
         //Positive tests

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilterTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlNamespaceFilterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/META-INF/persistence.xml
+++ b/commons/src/test/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/META-INF/persistence.xml
+++ b/commons/src/test/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/liquibase/changelog-liquibase-master.xml
+++ b/commons/src/test/resources/liquibase/changelog-liquibase-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/liquibase/liquibase.sql
+++ b/commons/src/test/resources/liquibase/liquibase.sql
@@ -1,5 +1,5 @@
 -- *******************************************************************************
--- Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+-- Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 --
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/liquibase/liquibase.sql
+++ b/commons/src/test/resources/liquibase/liquibase.sql
@@ -1,5 +1,5 @@
 -- *******************************************************************************
--- Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+-- Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 --
 -- All rights reserved. This program and the accompanying materials
 -- are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/logback.xml
+++ b/commons/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/test.properties
+++ b/commons/src/test/resources/test.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Red Hat and/or its affiliates and others
+# Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/resources/test.properties
+++ b/commons/src/test/resources/test.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Red Hat and/or its affiliates and others
+# Copyright (c) 2016, 2020 Red Hat and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/sql/H2/test_collision_entity_test_create.sql
+++ b/commons/src/test/sql/H2/test_collision_entity_test_create.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/commons/src/test/sql/H2/test_collision_entity_test_create.sql
+++ b/commons/src/test/sql/H2/test_collision_entity_test_create.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *  
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/ChangePasswordDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/ChangePasswordDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/InfoPopup.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/InfoPopup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/KapuaViewport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/LoginDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/WestNavigationView.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/WestNavigationView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/resources/Resources.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/resources/Resources.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/ImageUtils.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/ImageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/ScaledAbstractImagePrototype.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/ScaledAbstractImagePrototype.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/TokenCleaner.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/client/util/TokenCleaner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/SsoLocator.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/SsoLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/SsoLocatorListener.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/util/SsoLocatorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/FileServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/FileServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/KapuaErrorHandlerServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/KapuaErrorHandlerServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/KapuaHttpServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/KapuaHttpServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SkinServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/UploadRequest.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/UploadRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/FieldVerifier.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/FieldVerifier.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/GwtProductInformation.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/GwtProductInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaFormFields.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaFormFields.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoadConfig.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoadConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoadResult.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoadResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoader.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/KapuaPagingLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtCredential.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtIdToken.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtJwtIdToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtLoginCredential.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtLoginCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtSettingsService.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/service/GwtSettingsService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
+++ b/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
+++ b/console/core/src/main/resources/org/eclipse/kapua/app/console/core/adminCore.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutViewDescriptor.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/client/about/AboutViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/server/GwtAboutServiceImpl.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/server/GwtAboutServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/model/GwtAboutDependency.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/model/GwtAboutDependency.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/model/GwtAboutInformation.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/model/GwtAboutInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/service/GwtAboutService.java
+++ b/console/module/about/src/main/java/org/eclipse/kapua/app/console/module/about/shared/service/GwtAboutService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/about/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/adminModuleAbout.gwt.xml
+++ b/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/adminModuleAbout.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/client/messages/ConsoleAboutMessages.properties
+++ b/console/module/about/src/main/resources/org/eclipse/kapua/app/console/module/about/client/messages/ConsoleAboutMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc and others
+# Copyright (c) 2017, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTab.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTabDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDescriptionTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabDescription.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsViewDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountFilterPanel.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfiguration.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfigurationDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfigurationDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountView.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountViewDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTabDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/childuser/AccountChildUserToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/toolbar/AccountGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccount.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountCreator.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountQuery.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountStringListItem.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtAccountStringListItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtOrganization.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/GwtOrganization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/permission/AccountSessionPermission.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/model/permission/AccountSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/service/GwtAccountService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/GwtKapuaAccountModelConverter.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/GwtKapuaAccountModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/shared/util/KapuaGwtAccountModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/account/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/client/messages/ConsoleAccountMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaErrorCode.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaErrorCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/GwtKapuaException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/resources/icons/IconSet.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/resources/icons/IconSet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/resources/icons/KapuaIcon.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/resources/icons/KapuaIcon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/AddButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/AddButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/Button.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/Button.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/DeleteButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/DeleteButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/DiscardButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/DiscardButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/EditButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/EditButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/ExportButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/RefreshButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/RefreshButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/SaveButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/SaveButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/SplitButton.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/button/SplitButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/color/Color.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/color/Color.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/FileUploadDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/InfoDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/InfoDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/KapuaDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/KapuaDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/KapuaMessageBox.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/KapuaMessageBox.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/SimpleDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/SimpleDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/TabbedDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/TabbedDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityAddEditDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityAddEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityDeleteDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityLogDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/entity/EntityLogDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/CreatedByNameCellRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridCheckBoxSelectionModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGridLoadListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaEditableGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaEditableGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/KapuaGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/ModifiedByNameCellRenderer.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/ModifiedByNameCellRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/label/Label.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/label/Label.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/ContentPanel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/ContentPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/EntityFilterPanel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/EntityFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/FormPanel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/FormPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/KapuaBorderLayoutData.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/KapuaBorderLayoutData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/KapuaTabPanel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/panel/KapuaTabPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/EntityDescriptionTabItem.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/EntityDescriptionTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/KapuaTabItem.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/KapuaTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/TabItem.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/tab/TabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/GwtValidationRegex.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/GwtValidationRegex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/RegexFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/RegexFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractEntityView.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractEntityView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractView.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/EntityView.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/EntityView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/View.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/View.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractEntityTabDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractEntityTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractEntityViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractEntityViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractMainViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractMainViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractTabDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/AbstractViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/EntityTabDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/EntityTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/EntityViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/EntityViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/MainViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/MainViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/TabDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/TabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/ViewDescriptor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/descriptor/ViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/ComboEnumCellEditor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/ComboEnumCellEditor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelectorListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/DateRangeSelectorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityCRUDToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityGridField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityGridField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityGridFieldToolbar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EntityGridFieldToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EnumComboBox.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/EnumComboBox.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaDateField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaMenuItem.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaMenuItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaNumberField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaNumberField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolBar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolbarMessages.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaPagingToolbarMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextArea.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextArea.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextField.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/KapuaTextField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageDateRangeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageDateRangeSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageDateRangeSelectorListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageDateRangeSelectorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageQueryTypeSelector.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageQueryTypeSelector.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageQueryTypeSelectorListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/widget/UsageQueryTypeSelectorListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/ConsoleInfo.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/ConsoleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/Constants.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/Constants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/DateUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/DateUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/DialogUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/DialogUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FailureHandler.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FailureHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FormUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/FormUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaLoadListener.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaLoadListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaSafeHtmlUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/KapuaSafeHtmlUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/MessageUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/MessageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SplitTooltipStringUtil.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SplitTooltipStringUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SwappableListStore.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/SwappableListStore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/UserAgentUtils.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/UserAgentUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/Years.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/Years.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/AfterDateValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/BeforeDateValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/BeforeDateValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/ConfirmPasswordFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/ConfirmPasswordFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/ConfirmPasswordUpdateFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/ConfirmPasswordUpdateFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/DateRangeValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/DateRangeValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/DeviceDisplayNameValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/DeviceDisplayNameValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/EditableComboValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/EditableComboValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/NumberFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/NumberFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/PasswordFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/PasswordFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/PasswordUpdateFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/PasswordUpdateFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/util/validator/TextFieldValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtConsoleServiceImpl.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtConsoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtSecurityTokenServiceImpl.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtSecurityTokenServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/KapuaRemoteServiceServlet.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/KapuaRemoteServiceServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/util/KapuaExceptionHandler.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/util/KapuaExceptionHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSetting.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/setting/ConsoleSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/Enum.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/Enum.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtConfigComponent.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtConfigComponent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtConfigParameter.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtConfigParameter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtEntityCreator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtEntityModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtEntityModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtGroupedNVPair.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtGroupedNVPair.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtStringListItem.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtStringListItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtUpdatableEntityModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtUpdatableEntityModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtXSRFToken.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/GwtXSRFToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBaseModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBaseModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBasePagingCursor.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBasePagingCursor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBaseTreeModel.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/KapuaBaseTreeModel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/query/GwtQuery.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/query/GwtQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermission.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermissionAction.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermissionAction.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermissionScope.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/model/session/GwtSessionPermissionScope.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/service/GwtConsoleService.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/service/GwtConsoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/service/GwtSecurityTokenService.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/service/GwtSecurityTokenService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/GwtKapuaCommonsModelConverter.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/GwtKapuaCommonsModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/KapuaGwtCommonsModelConverter.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/shared/util/KapuaGwtCommonsModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/adminModuleApi.gwt.xml
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/adminModuleApi.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/api/src/test/java/org/eclipse/kapua/app/console/module/api/test/SplitTooltipStringTest.java
+++ b/console/module/api/src/test/java/org/eclipse/kapua/app/console/module/api/test/SplitTooltipStringTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/ApiKeyConfirmationDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/ApiKeyConfirmationDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/CredentialUnlockDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredential.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialCreator.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialQuery.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialStatus.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialType.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtSubjectType.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtSubjectType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/permission/CredentialSessionPermission.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/permission/CredentialSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/service/GwtCredentialService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/GwtKapuaAuthenticationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/util/KapuaGwtAuthenticationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/adminModuleAuthentication.gwt.xml
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/adminModuleAuthentication.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupTabDescription.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupTabDescriptionDescriptor.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupView.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupViewDescriptor.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/group/GroupViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RolePermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescription.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescription.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescriptionDescriptor.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGridDescriptor.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleTabPermissionGridDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleView.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleView.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleViewDescriptor.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/RoleViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RoleEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionGridFieldToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionGridFieldToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionGridFieldToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionGridFieldToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/AccessRoleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleToolbar.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/role/UserTabAccessRoleToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessInfoServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessInfoServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessPermissionServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessPermissionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtAccessRoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtDomainRegistryServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtDomainRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtGroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/server/GwtRoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessInfo.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessInfoCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessPermissionCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessPermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRole.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRoleCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRoleQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessRoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessTagQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtAccessTagQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtDomain.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtGroupQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRole.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermissionCreator.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRolePermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleQuery.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/GwtRoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/AccessInfoSessionPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/AccessInfoSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/DomainSessionPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/DomainSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/GroupSessionPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/GroupSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/RoleSessionPermission.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/model/permission/RoleSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessInfoService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessInfoService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessPermissionService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessPermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessRoleService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtAccessRoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtDomainRegistryService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtDomainRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtGroupService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtGroupService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtRoleService.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/service/GwtRoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/GwtKapuaAuthorizationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/shared/util/KapuaGwtAuthorizationModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/authorization/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/adminModuleAuthorization.gwt.xml
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/adminModuleAuthorization.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleGroupMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsolePermissionMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
+++ b/console/module/authorization/src/main/resources/org/eclipse/kapua/app/console/module/authorization/client/messages/ConsoleRoleMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/AssetTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ChannelTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ChannelTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ChannelTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ChannelTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ConsoleResizeHandler.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ConsoleResizeHandler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataViewDescriptor.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DataViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/DeviceTimestampCellRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GridSelectionChangedListener.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GridSelectionChangedListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GwtTopic.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/GwtTopic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/MetricsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/ResultsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicTimestampCellRenderer.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicTimestampCellRenderer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/TopicsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/util/GwtMessage.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/util/GwtMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/util/HeaderTypeUtils.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/client/util/HeaderTypeUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/server/GwtDataServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterCsv.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterCsv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/servlet/DataExporterServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDataChannelInfoQuery.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDataChannelInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreAsset.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreChannel.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreDevice.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtDatastoreDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtHeader.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/GwtHeader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/permission/DatastoreSessionPermission.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/permission/DatastoreSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/permission/DeviceSessionPermission.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/model/permission/DeviceSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/service/GwtDataService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/GwtKapuaDataModelConverter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/GwtKapuaDataModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
+++ b/console/module/data/src/main/java/org/eclipse/kapua/app/console/module/data/shared/util/KapuaGwtDataModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/data/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/adminModuleData.gwt.xml
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/adminModuleData.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
+++ b/console/module/data/src/main/resources/org/eclipse/kapua/app/console/module/data/client/messages/ConsoleDataMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTab.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTab.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTab.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTabDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionDescriptionTabDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionView.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionView.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionViewDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/ConnectionViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/connection/toolbar/ConnectionGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceMap.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceMap.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceView.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceViewDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/DeviceViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/AssetDetailsTable.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/AssetDetailsTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssetsDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssetsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/BundleStartButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/BundleStartButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/BundleStopButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/BundleStopButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundlesDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundlesDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommandDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommandDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/ConfigurationPanelTable.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/ConfigurationPanelTable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigComponents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceConfigSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotDownloadButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotDownloadButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotRollbackButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotRollbackButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotUploadButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/SnapshotUploadButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItem.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItemDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/DevicesGroupTabItemDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/group/GroupSubjectGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistoryDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistoryDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/EventMessageDetailsDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/EventMessageDetailsDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesHistory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInProgress.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInProgress.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInProgress.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInProgress.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesInstalled.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/DeviceManagementOperationLogButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/DeviceManagementOperationLogButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageInstallButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageInstallButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageInstallButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageInstallButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageUninstallButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageUninstallButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageUninstallButton.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/button/PackageUninstallButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/DeviceManagementOperationLog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/DeviceManagementOperationLog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageUninstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageUninstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageUninstallDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/dialog/PackageUninstallDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfile.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfile.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfileDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfileDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTags.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTags.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTagsDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTagsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTagToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagTabItem.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagsTabItemDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DevicesTagsTabItemDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/TagSubjectGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceAssetServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceAssetServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionOptionServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionOptionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceConnectionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementOperationServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementOperationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterCsv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterServlet.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceEventExporterServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterCsv.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterCsv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterServlet.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceExporterServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceSnapshotsServlet.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/servlet/DeviceSnapshotsServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtBundleInfo.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtBundleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtChannel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeploymentPackage.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeploymentPackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDevice.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCommandInput.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCommandInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCommandOutput.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCommandOutput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnection.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionOption.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionOption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionQuery.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionQueryPredicates.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionQueryPredicates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionStatus.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceConnectionStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCreator.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceEvent.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQuery.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQueryPredicates.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtDeviceQueryPredicates.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtSnapshot.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/GwtSnapshot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAsset.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAssetChannel.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAssets.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/assets/GwtDeviceAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/bundles/GwtBundle.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/bundles/GwtBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/bundles/GwtBundle.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/bundles/GwtBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtFileType.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtFileType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageDownloadOperation.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageDownloadOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageDownloadOperation.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageDownloadOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageOperation.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageOperation.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageUninstallRequest.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageUninstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageUninstallRequest.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/packages/GwtPackageUninstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtDeviceManagementOperation.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtDeviceManagementOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtDeviceManagementOperationQuery.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtDeviceManagementOperationQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtOperationStatus.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/device/management/registry/GwtOperationStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceConnectionSessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceConnectionSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceEventSessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceEventSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementRegistrySessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementRegistrySessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementSessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceManagementSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceSessionPermission.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/permission/DeviceSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceAssetService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceAssetService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionOptionService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionOptionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceConnectionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementOperationService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementOperationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceService.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/service/GwtDeviceService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/GwtKapuaDeviceModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/KapuaGwtDeviceModelConverter.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/util/KapuaGwtDeviceModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/device/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/adminModuleDevice.gwt.xml
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/adminModuleDevice.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleConnectionMessages.properties
+++ b/console/module/device/src/main/resources/org/eclipse/kapua/app/console/module/device/client/messages/ConsoleConnectionMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointFilterPanel.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescription.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescriptionDescriptor.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointView.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointViewDescriptor.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/server/GwtEndpointServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpoint.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpoint.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointCreator.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointQuery.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/permission/EndpointSessionPermission.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/permission/EndpointSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/validation/GwtEndpointValidationRegex.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/validation/GwtEndpointValidationRegex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/GwtKapuaEndpointModelConverter.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/GwtKapuaEndpointModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/KapuaGwtEndpointModelConverter.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/KapuaGwtEndpointModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/endpoint/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/adminModuleEndpoint.gwt.xml
+++ b/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/adminModuleEndpoint.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/client/messages/ConsoleEndpointMessages.properties
+++ b/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/client/messages/ConsoleEndpointMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteForcedDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobDeleteForcedDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobRestartDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobRestartDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStartDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobStopDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobTabDescription.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobTabDescriptionDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobView.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobViewDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/JobViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogButton.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogButton.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionLogDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionStopDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobExecutionStopDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutions.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/execution/JobTabExecutionsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobScheduleDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedules.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedules.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/schedule/JobTabSchedulesToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabSteps.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobTabStepsToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargets.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsDescriptor.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTabTargetsGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDeviceGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDeviceGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddTagGrid.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetAddTagGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetStartTargetDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/targets/JobTargetStartTargetDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobExecutionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobTargetServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerDefinitionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerDefinitionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtTriggerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterServlet.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterServlet.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJob.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobCreator.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecutionQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobExecutionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStartOptions.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStartOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStep.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepCreator.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepDefinition.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepDefinitionQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepDefinitionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTarget.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTargetCreator.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTargetCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTargetQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobTargetQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/JobSessionPermission.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/JobSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/SchedulerSessionPermission.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/permission/SchedulerSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTrigger.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTrigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerCreator.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/GwtTriggerQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinition.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinitionQuery.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/scheduler/definition/GwtTriggerDefinitionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobExecutionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepDefinitionService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepDefinitionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobStepService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobTargetService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtJobTargetService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtTriggerDefinitionService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtTriggerDefinitionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtTriggerService.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/service/GwtTriggerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/job/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/adminModuleJob.gwt.xml
+++ b/console/module/job/src/main/resources/org/eclipse/kapua/app/console/module/job/adminModuleJob.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/pom.xml
+++ b/console/module/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagTabDescription.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagTabDescriptionDescriptor.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagToolbarGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagView.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagViewDescriptor.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/client/TagViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/server/GwtTagServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagCreator.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagQuery.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/GwtTagQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/permission/TagSessionPermission.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/model/permission/TagSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/service/GwtTagService.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/service/GwtTagService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/GwtKapuaTagModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/KapuaGwtTagModelConverter.java
+++ b/console/module/tag/src/main/java/org/eclipse/kapua/app/console/module/tag/shared/util/KapuaGwtTagModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/tag/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/adminModuleTag.gwt.xml
+++ b/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/adminModuleTag.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/client/messages/ConsoleTagMessages.properties
+++ b/console/module/tag/src/main/resources/org/eclipse/kapua/app/console/module/tag/client/messages/ConsoleTagMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserFilterPanel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGridToolbar.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserGridToolbar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserView.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserViewDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/UserViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserAddDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserDeleteDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/dialog/UserEditDialog.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/credentials/UserTabItemCredentials.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/credentials/UserTabItemCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/credentials/UserTabItemCredentialsDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/credentials/UserTabItemCredentialsDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescription.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescription.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescription.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescriptionDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/description/UserTabDescriptionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermission.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/permission/UserTabItemPermissionDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/RoleSubjectGrid.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/RoleSubjectGrid.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UserTabItemAccessRole.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UserTabItemAccessRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UserTabItemAccessRoleDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UserTabItemAccessRoleDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItem.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItem.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItemDescriptor.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/client/tabs/roles/UsersRoleTabItemDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUser.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserCreator.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserPermission.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserQuery.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/GwtUserQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/permission/UserSessionPermission.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/model/permission/UserSessionPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/service/GwtUserService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/GwtKapuaUserModelConverter.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/GwtKapuaUserModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/KapuaGwtUserModelConverter.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/shared/util/KapuaGwtUserModelConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/user/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/adminModuleUser.gwt.xml
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/adminModuleUser.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/java/org/eclipse/kapua/app/console/module/welcome/client/WelcomeView.java
+++ b/console/module/welcome/src/main/java/org/eclipse/kapua/app/console/module/welcome/client/WelcomeView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/java/org/eclipse/kapua/app/console/module/welcome/client/WelcomeViewDescriptor.java
+++ b/console/module/welcome/src/main/java/org/eclipse/kapua/app/console/module/welcome/client/WelcomeViewDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
+++ b/console/module/welcome/src/main/resources/META-INF/services/org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.MainViewDescriptor
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/adminModuleWelcome.gwt.xml
+++ b/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/adminModuleWelcome.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/client/messages/ConsoleWelcomeMessages.properties
+++ b/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/client/messages/ConsoleWelcomeMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/client/messages/ConsoleWelcomeMessages.properties
+++ b/console/module/welcome/src/main/resources/org/eclipse/kapua/app/console/module/welcome/client/messages/ConsoleWelcomeMessages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/java/org/eclipse/kapua/app/console/ConsoleJAXBContextProvider.java
+++ b/console/web/src/main/java/org/eclipse/kapua/app/console/ConsoleJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/resources/console-setting.properties
+++ b/console/web/src/main/resources/console-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/resources/console-setting.properties
+++ b/console/web/src/main/resources/console-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/resources/logback.xml
+++ b/console/web/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/admin.gwt.xml
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/admin.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/adminDev.gwt.xml
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/adminDev.gwt.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/webapp/META-INF/context.xml
+++ b/console/web/src/main/webapp/META-INF/context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/webapp/META-INF/context.xml
+++ b/console/web/src/main/webapp/META-INF/context.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/webapp/console.jsp
+++ b/console/web/src/main/webapp/console.jsp
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others All rights reserved.
+	Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others All rights reserved.
 	
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 

--- a/console/web/src/main/webapp/console.jsp
+++ b/console/web/src/main/webapp/console.jsp
@@ -1,5 +1,5 @@
 <!-- 
-	Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others All rights reserved. 
+	Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others All rights reserved.
 	
     This program and the accompanying materials are made available under the 
     terms of the Eclipse Public License v1.0 which accompanies this distribution, 

--- a/console/web/src/main/webapp/js/kapuaconsole/console.js
+++ b/console/web/src/main/webapp/js/kapuaconsole/console.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/main/webapp/js/kapuaconsole/console.js
+++ b/console/web/src/main/webapp/js/kapuaconsole/console.js
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/console/web/src/test/resources/logback.xml
+++ b/console/web/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/docker/pom.xml
+++ b/deployment/docker/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-deploy.sh
+++ b/deployment/minishift/minishift-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-destroy.sh
+++ b/deployment/minishift/minishift-destroy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-importer.sh
+++ b/deployment/minishift/minishift-importer.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-initialize.sh
+++ b/deployment/minishift/minishift-initialize.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-pull-images.sh
+++ b/deployment/minishift/minishift-pull-images.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/minishift-undeploy.sh
+++ b/deployment/minishift/minishift-undeploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/minishift/pom.xml
+++ b/deployment/minishift/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/openshift-common.sh
+++ b/deployment/openshift/openshift-common.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/openshift-deploy.sh
+++ b/deployment/openshift/openshift-deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/openshift-destroy.sh
+++ b/deployment/openshift/openshift-destroy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/openshift-initialize.sh
+++ b/deployment/openshift/openshift-initialize.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/openshift-start.sh
+++ b/deployment/openshift/openshift-start.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 ###############################################################################
-# Copyright (c) 2016, 2018 Red Hat Inc and others
+# Copyright (c) 2016, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/pom.xml
+++ b/deployment/openshift/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/sso/activate
+++ b/deployment/openshift/sso/activate
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc and others
+# Copyright (c) 2017, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/openshift/sso/env
+++ b/deployment/openshift/sso/env
@@ -1,7 +1,7 @@
 # -*-Shell-script-*-
 
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc and others
+# Copyright (c) 2017, 2020 Red Hat Inc and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
+++ b/dev-tools/cucumber-reports/src/main/descriptors/kapua-cucumber-report.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/cucumber-reports/src/main/resources/html/cucumber/eclipse.css
+++ b/dev-tools/cucumber-reports/src/main/resources/html/cucumber/eclipse.css
@@ -1,5 +1,5 @@
 <!--
-    Copyright (c) 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/src/main/eclipse/codeStyle/KapuaCleanup_v_1.0.xml
+++ b/dev-tools/src/main/eclipse/codeStyle/KapuaCleanup_v_1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/src/main/eclipse/codeStyle/KapuaCleanup_v_1.0.xml
+++ b/dev-tools/src/main/eclipse/codeStyle/KapuaCleanup_v_1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/src/main/eclipse/codeStyle/KapuaFormatter_v_2.1.xml
+++ b/dev-tools/src/main/eclipse/codeStyle/KapuaFormatter_v_2.1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/src/main/eclipse/codeStyle/KapuaFormatter_v_2.1.xml
+++ b/dev-tools/src/main/eclipse/codeStyle/KapuaFormatter_v_2.1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="no"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -1,5 +1,5 @@
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/baseBox/create.sh
+++ b/dev-tools/vagrant/baseBox/create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/baseBox/create.sh
+++ b/dev-tools/vagrant/baseBox/create.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/start-broker-service.sh
+++ b/dev-tools/vagrant/develop/broker/start-broker-service.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/start-broker-service.sh
+++ b/dev-tools/vagrant/develop/broker/start-broker-service.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/start-broker.sh
+++ b/dev-tools/vagrant/develop/broker/start-broker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/start-broker.sh
+++ b/dev-tools/vagrant/develop/broker/start-broker.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
+++ b/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
+++ b/dev-tools/vagrant/develop/broker/update-kapua-jars-cfg.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/envs/kapua_env.sh
+++ b/dev-tools/vagrant/develop/envs/kapua_env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/envs/kapua_env.sh
+++ b/dev-tools/vagrant/develop/envs/kapua_env.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/jetty/start-jetty.sh
+++ b/dev-tools/vagrant/develop/jetty/start-jetty.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/jetty/update-kapua-war.sh
+++ b/dev-tools/vagrant/develop/jetty/update-kapua-war.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/develop/jetty/update-kapua-war.sh
+++ b/dev-tools/vagrant/develop/jetty/update-kapua-war.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #*******************************************************************************
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/dev-tools/vagrant/pom.xml
+++ b/dev-tools/vagrant/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/pom.xml
+++ b/extras/foreignkeys/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/account-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_access_token-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/atht_credential-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_access_info-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_group-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/athz_role-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/changelog-foreignkeys-0.3.0.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/changelog-foreignkeys-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-connection-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/device-tag-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/job_step_definition-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/tag-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/trigger-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/0.3.0/user-foreignkey.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/pom.xml
+++ b/job-engine/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineFactory.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2098 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineXmlRegistry.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobEngineXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptionsAttributes.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/JobStartOptionsAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecution.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionAttributes.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionCreator.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionFactory.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionListResult.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionQuery.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionXmlRegistry.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/pom.xml
+++ b/job-engine/commons/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/JobCommonsErrorCodes.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/JobCommonsErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/JobCommonsRuntimeException.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/JobCommonsRuntimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/ReadJobPropertyException.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/exception/ReadJobPropertyException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/logger/JobLogger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTargetSublist.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/model/JobTransientUserData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/AbstractTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetReader.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractGenericJobStepDefinition.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractGenericJobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractTargetJobStepDefinition.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/step/definition/AbstractTargetJobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextPropertyNames.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextPropertyNames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobTargetWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/JobTargetWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextPropertyNames.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextPropertyNames.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextWrapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/extra/pom.xml
+++ b/job-engine/extra/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/extra/remote/pom.xml
+++ b/job-engine/extra/remote/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobEngineFactoryRemote.java
+++ b/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobEngineFactoryRemote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobEngineServiceRemote.java
+++ b/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobEngineServiceRemote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobStartOptionsRemote.java
+++ b/job-engine/extra/remote/src/main/java/org/eclipse/kapua/job/engine/remote/JobStartOptionsRemote.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineEntityManagerFactory.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineFactoryJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineFactoryJbatch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobStartOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchJobRunningStatuses.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchJobRunningStatuses.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotBuildJobDefDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotBuildJobDefDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotCleanJobDefFileDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotCleanJobDefFileDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotCreateTmpDirDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotCreateTmpDirDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotWriteJobDefFileDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CannotWriteJobDefFileDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CleanJobDataDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/CleanJobDataDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/ExecutionNotFoundDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/ExecutionNotFoundDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/ExecutionNotRunningDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/ExecutionNotRunningDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JbatchDriverErrorCodes.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JbatchDriverErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JbatchDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JbatchDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JobExecutionIsRunningDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JobExecutionIsRunningDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JobStartingDriverException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/exception/JobStartingDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JbatchUtil.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JbatchUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JobDefinitionBuildUtils.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JobDefinitionBuildUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/WaitForJobExecutionStopTask.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/WaitForJobExecutionStopTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/CheckRunningJobEngineException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/CheckRunningJobEngineException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/CleanJobDataException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/CleanJobDataException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobAlreadyRunningException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobCheckRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobCheckRunningException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobEngineException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobEngineException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobExecutionEnqueuedException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobExecutionEnqueuedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobInvalidTargetException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobMissingStepException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobMissingStepException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobMissingTargetException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobMissingTargetException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobNotRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobNotRunningException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobResumingException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobResumingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobRunningException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobRunningException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStartingException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStartingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/JobStopppingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/KapuaJobEngineErrorCodes.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/KapuaJobEngineErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/KapuaJobEngineException.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/exception/KapuaJobEngineException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/KapuaJobListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/QueuedJobExecutionCheckTask.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/listener/QueuedJobExecutionCheckTask.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSetting.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSettingKeys.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/setting/JobEngineSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/step/definition/LogPropertyKeys.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/step/definition/LogPropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionDAO.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionFactoryImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionListResultImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionQueryImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/META-INF/persistence.xml
+++ b/job-engine/jbatch/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/kapua-job-engine-service-error-messages.properties
+++ b/job-engine/jbatch/src/main/resources/kapua-job-engine-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/kapua-job-engine-setting.properties
+++ b/job-engine/jbatch/src/main/resources/kapua-job-engine-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/0.3.0/changelog-job-engine-0.3.0.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/0.3.0/changelog-job-engine-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/0.3.0/job-engine-jbatch.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/0.3.0/job-engine-jbatch.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/1.1.0/changelog-job-engine-1.1.0.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.1.0/changelog-job-engine-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/1.1.0/queued_job_execution.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.1.0/queued_job_execution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/job-engine-jbatch-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.2.0/queued_job-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/jbatch/src/main/resources/locator.xml
+++ b/job-engine/jbatch/src/main/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/job-engine/pom.xml
+++ b/job-engine/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ComponentResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ComponentResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ComponentResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ComponentResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/FactoryResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/ServiceResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/SyntheticMethodMatcher.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/SyntheticMethodMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/SyntheticMethodMatcher.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/SyntheticMethodMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/TestService.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/TestService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/TestService.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/TestService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/resources/META-INF/services/org.eclipse.kapua.locator.KapuaLocator
+++ b/locator/guice/src/main/resources/META-INF/services/org.eclipse.kapua.locator.KapuaLocator
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/resources/META-INF/services/org.eclipse.kapua.locator.KapuaLocator
+++ b/locator/guice/src/main/resources/META-INF/services/org.eclipse.kapua.locator.KapuaLocator
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/resources/locator.services
+++ b/locator/guice/src/main/resources/locator.services
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/main/resources/locator.services
+++ b/locator/guice/src/main/resources/locator.services
@@ -1,5 +1,5 @@
 #
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/ResolverTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryA.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryAImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryAImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryB.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryC.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceA.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceA.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceAImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceAImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceB.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceB.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceC.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceC.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceCImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceCImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/resources/META-INF/services/org.eclipse.kapua.locator.internal.GuiceLocatorImplTest$MyTestableService
+++ b/locator/guice/src/test/resources/META-INF/services/org.eclipse.kapua.locator.internal.GuiceLocatorImplTest$MyTestableService
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/resources/META-INF/services/org.eclipse.kapua.locator.internal.GuiceLocatorImplTest$MyTestableService
+++ b/locator/guice/src/test/resources/META-INF/services/org.eclipse.kapua.locator.internal.GuiceLocatorImplTest$MyTestableService
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/resources/locator-1.xml
+++ b/locator/guice/src/test/resources/locator-1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/resources/locator.xml
+++ b/locator/guice/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/guice/src/test/resources/logback.xml
+++ b/locator/guice/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/pom.xml
+++ b/locator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/locator/pom.xml
+++ b/locator/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/pom.xml
+++ b/message/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/pom.xml
+++ b/message/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Channel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaMessageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/KapuaPosition.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/KapuaPosition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/Message.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Message.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Payload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/Position.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/Position.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessageFactory.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataMessageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/KapuaDataPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/data/xml/DataMessageXmlRegistry.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/data/xml/DataMessageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaAppsPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019  Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020  Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayloadAttibutes.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaBirthPayloadAttibutes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectPayloadAttibutes.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaDisconnectPayloadAttibutes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleMessageFactory.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecycleMessageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecyclePayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaLifecyclePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingChannel.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingMessage.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingPayload.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/device/lifecycle/KapuaMissingPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/MessageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/MetricsXmlAdapter.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/MetricsXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetrics.java
+++ b/message/api/src/main/java/org/eclipse/kapua/message/xml/XmlAdaptedMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPositionImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaPositionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageErrorCodes.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageException.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecycleChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecycleChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecycleMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecycleMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecyclePayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/AbstractLifecyclePayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaLifecycleMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaLifecycleMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingChannelImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingPayloadImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/BasicMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/FullMessageTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaChannelTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaDataMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaDataMessageFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaMessageUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPayloadTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/KapuaPositionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/MessageJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/data/KapuaDeviceDataTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaAppsMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaBirthMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaDisconnectMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaMissingMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/device/lifecycle/LifecycleTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/KapuaMetricsMapAdapterTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
+++ b/message/internal/src/test/java/org/eclipse/kapua/message/internal/xml/MetricTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/logback.xml
+++ b/message/internal/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/message-error-messages.properties
+++ b/message/internal/src/test/resources/message-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/message/internal/src/test/resources/message-error-messages.properties
+++ b/message/internal/src/test/resources/message-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/HookPriorities.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/HookPriorities.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/MockedLocator.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/MockedLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/Ports.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/Ports.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/Session.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/Session.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDevice.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDeviceApplication.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDeviceApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDeviceSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/SimulatedDeviceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/Starting.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/Starting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/StepData.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/StepData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/Suppressed.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/Suppressed.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/TestDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/ThrowingConsumer.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/ThrowingConsumer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/Wait.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/Wait.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/WaitTimeoutException.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/WaitTimeoutException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/With.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/With.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucAccount.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucAccount.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucConfig.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucConfig.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucConnection.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucCredentials.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDevice.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucGroup.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucGroup.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucGroup.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucJobStepProperty.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucJobStepProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMessageRange.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMessageRange.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucPermission.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRole.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRole.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRolePermission.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRolePermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRolePermission.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucRolePermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucTopic.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucTopic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucTriggerProperty.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucTriggerProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUser.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucUser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberProperty.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberSystemProperties.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberSystemProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberWithProperties.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/cucumber/CucumberWithProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedBroker.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedBroker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedDatastore.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedDatastore.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedEventBroker.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedEventBroker.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedJetty.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/EmbeddedJetty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerClient.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerClient.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerConfigData.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/BrokerConfigData.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestJAXBContextProvider.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/docker/RunDockerBrokerTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MqttClientTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MqttClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/rest/RunRestUserTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/rest/RunRestUserTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/account/RunAccountServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/connection/RunConnectionI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/connection/RunConnectionI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexCustomPrefixTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreRestI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreRestI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastoreJunit/MessageStoreServiceSslTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpConfigFileI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpConfigFileI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpSysEnvI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpSysEnvI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpUndefinedI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpUndefinedI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerStealingLinkI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerStealingLinkI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceDataI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceDataI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceLifecycleI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceLifecycleI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/job/RunJobServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/job/RunJobServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunExecuteOnDeviceConnectI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunExecuteOnDeviceConnectI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunTriggerServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/jobScheduling/RunTriggerServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunLockoutExpirationI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunLockoutExpirationI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunTenantSEI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunTenantSEI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserPermissionI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserPermissionI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserRoleI9nTests.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserRoleI9nTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/protobuf/kurapayload.proto
+++ b/qa/integration/src/test/protobuf/kurapayload.proto
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/activemq.xml
+++ b/qa/integration/src/test/resources/activemq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/activemq.xml
+++ b/qa/integration/src/test/resources/activemq.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/camel-experimental.xml
+++ b/qa/integration/src/test/resources/camel-experimental.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/camel-experimental.xml
+++ b/qa/integration/src/test/resources/camel-experimental.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/camel-routes.xml
+++ b/qa/integration/src/test/resources/camel-routes.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/camel.xml
+++ b/qa/integration/src/test/resources/camel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/camel.xml
+++ b/qa/integration/src/test/resources/camel.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/credentials.properties
+++ b/qa/integration/src/test/resources/credentials.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
+++ b/qa/integration/src/test/resources/features/account/FindSelfAccount.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
+++ b/qa/integration/src/test/resources/features/authorization/AccessInfoService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/authorization/DomainService.feature
+++ b/qa/integration/src/test/resources/features/authorization/DomainService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/authorization/MiscAuthorization.feature
+++ b/qa/integration/src/test/resources/features/authorization/MiscAuthorization.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/authorization/RoleService.feature
+++ b/qa/integration/src/test/resources/features/authorization/RoleService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpConfigFileI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpSysEnvI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerIpUndefinedI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceBrokerStealingLinkI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceData.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceData.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/DeviceLifecycle.feature
+++ b/qa/integration/src/test/resources/features/broker/DeviceLifecycle.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/acl/BrokerACLDeviceManageI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
+++ b/qa/integration/src/test/resources/features/broker/acl/BrokerACLI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
+++ b/qa/integration/src/test/resources/features/connection/UserCouplingI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreNewIndex.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
+++ b/qa/integration/src/test/resources/features/datastore/DatastoreNewIndexCustomPrefix.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/docker/broker.feature
+++ b/qa/integration/src/test/resources/features/docker/broker.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/integration/src/test/resources/features/rest/user/RestUser.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/tag/TagService.feature
+++ b/qa/integration/src/test/resources/features/tag/TagService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
+++ b/qa/integration/src/test/resources/features/user/TenantSEI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-certificate-setting.properties
+++ b/qa/integration/src/test/resources/kapua-certificate-setting.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-datastore-embedded-client-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-embedded-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-datastore-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-datastore-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/qa/integration/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/integration/src/test/resources/logback.xml
+++ b/qa/integration/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/qa/markers/src/main/java/org/eclipse/kapua/qa/markers/junit/JUnitTests.java
+++ b/qa/markers/src/main/java/org/eclipse/kapua/qa/markers/junit/JUnitTests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/ListBodyWriter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/ListBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/ListBodyWriter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/ListBodyWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolver.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaAuthenticationExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaAuthenticationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaAuthorizationExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaAuthorizationExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaEntityNotFoundExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaEntityNotFoundExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaIllegalArgumentExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaIllegalArgumentExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaIllegalNullArgumentExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaIllegalNullArgumentExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaServiceDisabledExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/KapuaServiceDisabledExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/SubjectUnathorizedExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/SubjectUnathorizedExceptionMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/ThrowableMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/ThrowableMapper.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/filter/KapuaSessionCleanupFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/filter/KapuaSessionCleanupFilter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSetting.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSetting.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AbstractKapuaResource.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AbstractKapuaResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AbstractKapuaResource.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AbstractKapuaResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessInfos.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessRoles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessRoles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Authentication.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Authentication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Credentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataChannels.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataClients.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMessagesJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DataMetrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnectionOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceConnections.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementCommands.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementCommands.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementCommands.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementCommands.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementConfigurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperationNotifications.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementOperations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementPackages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementPackages.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequests.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequests.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementRequestsJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementSnapshots.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementSnapshots.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Domains.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Domains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Groups.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Groups.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobExecutions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobSteps.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTriggers.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/ServiceConfigurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Streams.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Streams.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/StreamsJson.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Tags.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiErrorCodes.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiRuntimeException.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/RestApiRuntimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/SessionNotPopulatedException.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/exception/SessionNotPopulatedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/marker/JsonSerializationFixed.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/marker/JsonSerializationFixed.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ByteArrayParam.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ByteArrayParam.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/CountResult.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/CountResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/CountResult.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/CountResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/DateParam.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/DateParam.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/DateParam.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/DateParam.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/EntityId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/EntityId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/EntityId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/EntityId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/MetricType.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/MetricType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/MetricType.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/MetricType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/ScopeId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/StorableEntityId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/StorableEntityId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/StorableEntityId.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/StorableEntityId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonDatastoreMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonDatastoreMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonKapuaDataMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonKapuaDataMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonMessageListResult.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonMessageListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonMessageQuery.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/data/JsonMessageQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericRequestMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericResponseMessage.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/device/management/JsonGenericResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/model/message/JsonKapuaPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/JaxbContextResolver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProvider.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProvider.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/resources/kapua-api-settings.properties
+++ b/rest-api/web/src/main/resources/kapua-api-settings.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/resources/kapua-api-settings.properties
+++ b/rest-api/web/src/main/resources/kapua-api-settings.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/resources/logback.xml
+++ b/rest-api/web/src/main/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/rest-api/web/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/web/src/main/webapp/WEB-INF/web.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/pom.xml
+++ b/service/account/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/pom.xml
+++ b/service/account/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Account.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountAttributes.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountDomain.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountDomains.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountFactory.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountListResult.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountListResult.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountXmlRegistry.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountXmlRegistry.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/Organization.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/Organization.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountEntityManagerFactory.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountEntityManagerFactory.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountFactoryImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountListResultImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountListResultImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountQueryImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016 , 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 , 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountErrorCodes.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountErrorCodes.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountException.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountException.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/KapuaAccountException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/OrganizationImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/OrganizationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/OrganizationImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/OrganizationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSetting.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSetting.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSettingKeys.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSettingKeys.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/setting/KapuaAccountSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
+++ b/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
+++ b/service/account/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.account.AccountService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/account/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/account/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/kapua-account-service-error-messages.properties
+++ b/service/account/internal/src/main/resources/kapua-account-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/kapua-account-service-error-messages.properties
+++ b/service/account/internal/src/main/resources/kapua-account-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/kapua-account-setting.properties
+++ b/service/account/internal/src/main/resources/kapua-account-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/kapua-account-setting.properties
+++ b/service/account/internal/src/main/resources/kapua-account-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/account-configuration.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/account-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/account-domain.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/account-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/account.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/account.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/changelog-account-0.2.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/changelog-account-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.3.0/account-id_check_positive.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.3.0/account-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.3.0/account-parent_account_path_length.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.3.0/account-parent_account_path_length.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/0.3.0/changelog-account-0.3.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.3.0/changelog-account-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.0.0/account-domain.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.0.0/account-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.0.0/account-expiration-date.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.0.0/account-expiration-date.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.0.0/account-sys-housekeeper-run-seed.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.0.0/account-sys-housekeeper-run-seed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.0.0/changelog-account-1.0.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.0.0/changelog-account-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.1.0/account-description.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.1.0/account-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.1.0/changelog-account-1.1.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.1.0/changelog-account-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.2.0/account-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/1.2.0/changelog-account-1.2.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.2.0/changelog-account-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
+++ b/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/pom.xml
+++ b/service/account/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/pom.xml
+++ b/service/account/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test-steps/pom.xml
+++ b/service/account/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/pom.xml
+++ b/service/account/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/CucumberWithPropertiesForAccount.java
+++ b/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/CucumberWithPropertiesForAccount.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/RunAccountUnitTest.java
+++ b/service/account/test/src/test/java/org/eclipse/kapua/service/account/test/RunAccountUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/account/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/account/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/features/AccountService.feature
+++ b/service/account/test/src/test/resources/features/AccountService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/account/test/src/test/resources/logback.xml
+++ b/service/account/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/DeviceMenagementErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/DeviceMenagementErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/DeviceMenagementException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/DeviceMenagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/ExceptionMessageUtils.java
+++ b/service/api/src/main/java/org/eclipse/kapua/ExceptionMessageUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountError.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountError.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountError.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountError.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountError.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountError.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountError.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountError.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEndBeforeStartTimeException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEndBeforeStartTimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityCloneException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityCloneException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityExistsException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityExistsException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityExistsException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityExistsException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityNotFoundException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityUniquenessException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityUniquenessException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaEntityUniquenessException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaEntityUniquenessException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCode.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalAccessException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalAccessException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalAccessException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalAccessException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalNullArgumentException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalNullArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalNullArgumentException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalNullArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalStateException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalStateException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalStateException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaIllegalStateException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaMaxNumberOfItemsReachedException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaMaxNumberOfItemsReachedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaOptimisticLockingException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaOptimisticLockingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaOptimisticLockingException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaOptimisticLockingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaRuntimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaSerializable.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaSerializable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaSerializable.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaSerializable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaUnauthenticatedException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaUnauthenticatedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/KapuaUnauthenticatedException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/KapuaUnauthenticatedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/MissingKapuaErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/MissingKapuaErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/entity/EntityPropertiesReadException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/entity/EntityPropertiesReadException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/entity/EntityPropertiesWriteException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/entity/EntityPropertiesWriteException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ListenServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ListenServiceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/RaiseServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/RaiseServiceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBus.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusListener.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventBusListener.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventListeners.java
+++ b/service/api/src/main/java/org/eclipse/kapua/event/ServiceEventListeners.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorException.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaLocatorException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaServiceLoader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaEntityFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaNamedEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaObjectFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaObjectFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntity.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/KapuaUpdatableEntityCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaMetatypeFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTad.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTattribute.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTdesignate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTicon.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTmetadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTobject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTocd.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaToption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalar.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/KapuaTscalarAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/config/metatype/MetatypeXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/AbstractDomain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/AbstractDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Actions.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Actions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Actions.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Actions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/id/KapuaIdStatic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/FieldSortCriteria.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/FieldSortCriteria.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaSortCriteria.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaSortCriteria.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaSortCriteria.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaSortCriteria.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/SortOrder.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/SortOrder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/AndPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/OrPredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/OrPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/QueryPredicate.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/predicate/QueryPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ByteArrayConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectTypeConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/type/ObjectValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/BinaryXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/DateXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObject.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaNamedEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/KapuaUpdatableEntityService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/KapuaConfigurableService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationXmlRegistry.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceConfigurationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapter.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
+++ b/service/api/src/main/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/kapua-locator-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-locator-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/kapua-locator-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-locator-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/kapua-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/kapua-service-error-messages.properties
+++ b/service/api/src/main/resources/kapua-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/log4j.properties
+++ b/service/api/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/main/resources/log4j.properties
+++ b/service/api/src/main/resources/log4j.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundle.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ChannelInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/ClientInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomain.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomains.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/DatastoreObjectFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MessageStoreService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/MetricInfoRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ChannelInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/ClientInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/DatastoreMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MessageListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Metric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/MetricInfoTypeAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/Storable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableId.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableIdFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/StorableListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/AndPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ChannelMatchPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ClientInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ClientInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ClientInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ClientInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/ExistsPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/IdsPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MessageQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MessageQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MessageQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MessageQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricExistsPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricExistsPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricInfoQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/MetricPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/OrPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/OrPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/RangePredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortDirection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortFieldXmlAdapter.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/SortFieldXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableFetchStyle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorablePredicateFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/StorableQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/TermPredicate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortField.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortFields.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/query/XmlAdaptedSortFields.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ChannelInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/ClientInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/DatastoreMessageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
+++ b/service/datastore/api/src/main/java/org/eclipse/kapua/service/datastore/model/xml/MetricInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/pom.xml
+++ b/service/datastore/client-api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientCommunicationException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientCommunicationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorCodes.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientErrorMessages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientProvider.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientUnavailableException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientUnavailableException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientUndefinedException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ClientUndefinedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatamodelMappingException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DatamodelMappingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DocumentNotFoundException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/DocumentNotFoundException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ModelContext.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/ModelContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryConverter.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryMappingException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/QueryMappingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaMappingException.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/SchemaMappingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/BulkUpdateRequest.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/BulkUpdateRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/BulkUpdateResponse.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/BulkUpdateResponse.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/IndexRequest.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/IndexRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/IndexResponse.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/IndexResponse.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertRequest.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertResponse.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/InsertResponse.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Request.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Request.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Response.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/Response.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/ResultList.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/ResultList.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/TypeDescriptor.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/TypeDescriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateRequest.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateResponse.java
+++ b/service/datastore/client-api/src/main/java/org/eclipse/kapua/service/datastore/client/model/UpdateResponse.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-embedded/pom.xml
+++ b/service/datastore/client-embedded/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EmbeddedNodeSettings.java
+++ b/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EmbeddedNodeSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EmbeddedNodeSettingsKey.java
+++ b/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EmbeddedNodeSettingsKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EsEmbeddedEngine.java
+++ b/service/datastore/client-embedded/src/main/java/org/eclipse/kapua/service/datastore/client/embedded/EsEmbeddedEngine.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-rest/pom.xml
+++ b/service/datastore/client-rest/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettings.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ClientSettingsKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ssl/SkipCertificateCheckTrustStrategy.java
+++ b/service/datastore/client-rest/src/main/java/org/eclipse/kapua/service/datastore/client/rest/ssl/SkipCertificateCheckTrustStrategy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/client-rest/src/main/resources/kapua-datastore-rest-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-transport/pom.xml
+++ b/service/datastore/client-transport/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/ClientSettings.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/ClientSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/ClientSettingsKey.java
+++ b/service/datastore/client-transport/src/main/java/org/eclipse/kapua/service/datastore/client/transport/ClientSettingsKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/client-transport/src/main/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/client-transport/src/main/resources/kapua-datastore-transport-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractStorableQuery.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractStorableQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractStorableQuery.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractStorableQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProviderImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProviderImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ConfigurationProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreCacheManager.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreEntityManagerFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreEntityManagerFactory.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreObjectFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreObjectFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreObjectFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreObjectFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/AbstractStorableQueryConverter.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/AbstractStorableQueryConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/ModelContextImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/QueryConverterImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/converter/QueryConverterImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ChannelInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ClientInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ConfigurationException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ConfigurationException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/ConfigurationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreCommunicationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/InvalidChannelException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/InvalidChannelException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/InvalidChannelException.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/InvalidChannelException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MessageStoreMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/Metric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoField.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/MetricInfoRegistryMediator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BinaryMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BinaryMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BinaryMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BinaryMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BooleanMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BooleanMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BooleanMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/BooleanMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ChannelInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/ClientInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DataIndexBy.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DataIndexBy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DataIndexBy.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DataIndexBy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DatastoreMessageImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DatastoreMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DatastoreMessageImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DatastoreMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DateMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DateMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DateMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DateMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DoubleMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DoubleMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DoubleMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/DoubleMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/FloatMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/FloatMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/FloatMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/FloatMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/IntMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/IntMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/IntMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/IntMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/LongMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/LongMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/LongMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/LongMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MessageListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoCreatorImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoListResultImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricsIndexBy.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricsIndexBy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricsIndexBy.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/MetricsIndexBy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StorableIdImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StringMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StringMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StringMetric.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/StringMetric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AbstractStorableListResult.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AbstractStorableListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AbstractStorableListResult.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AbstractStorableListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AndPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AndPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AndPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/AndPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelMatchPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelMatchPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelMatchPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ChannelMatchPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ClientInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/ExistsPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/IdsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/IdsPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/IdsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/IdsPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MessageQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricExistsPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricExistsPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/MetricPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/OrPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/OrPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/PredicateConstants.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/RangePredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/RangePredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/RangePredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/RangePredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorableFieldImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorableFieldImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorableFieldImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorableFieldImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/StorablePredicateFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/TermPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/TermPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/TermPredicateImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/TermPredicateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/KeyValueEntry.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/KeyValueEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/KeyValueEntry.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/KeyValueEntry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/setting/DatastoreSettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.datastore.MessageStoreService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/datastore/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/kapua-datastore-service-error-messages.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/kapua-datastore-service-error-messages.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
+++ b/service/datastore/internal/src/main/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/liquibase/0.2.0/changelog-datastore-0.2.0.xml
+++ b/service/datastore/internal/src/main/resources/liquibase/0.2.0/changelog-datastore-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/liquibase/0.2.0/datastore-domain.xml
+++ b/service/datastore/internal/src/main/resources/liquibase/0.2.0/datastore-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/liquibase/1.0.0/changelog-datastore-1.0.0.xml
+++ b/service/datastore/internal/src/main/resources/liquibase/1.0.0/changelog-datastore-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/liquibase/1.0.0/datastore-domain.xml
+++ b/service/datastore/internal/src/main/resources/liquibase/1.0.0/datastore-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/internal/src/main/resources/liquibase/changelog-datastore-master.xml
+++ b/service/datastore/internal/src/main/resources/liquibase/changelog-datastore-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/pom.xml
+++ b/service/datastore/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/pom.xml
+++ b/service/datastore/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderProxy.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/client/transport/EsTransportClientProviderProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceProxy.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/pom.xml
+++ b/service/datastore/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreJAXBContextProvider.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreJAXBContextProvider.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreJAXBContextProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/IndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/IndexCalculatorTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/ClientUtilsConvertDateTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/ClientUtilsConvertDateTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/ClientUtilsIndexNameTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/ClientUtilsIndexNameTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/MessageStoreConfigurationTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/client/MessageStoreConfigurationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/clientTransport/EsClientTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/clientTransport/EsClientTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/clientTransport/EsTransportClientProviderTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/clientTransport/EsTransportClientProviderTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/datastore/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/datastore/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/bck_kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/bck_kapua-datastore-rest-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-embedded-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-rest-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-datastore-transport-client-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/locator.xml
+++ b/service/datastore/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/locator.xml
+++ b/service/datastore/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/datastore/test/src/test/resources/logback.xml
+++ b/service/datastore/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaControlChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaControlChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaControlChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/KapuaControlChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyPayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/KapuaNotifyPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/OperationStatus.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/notification/OperationStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessageFactory.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestMessageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestPayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestPayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/KapuaRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/xml/RequestMessageXmlRegistry.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/request/xml/RequestMessageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseChannel.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseCode.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseCode.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseCode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/ResponseProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/ResponseProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/ResponseProperties.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/ResponseProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/xml/KapuaAppPropertiesXmlAdapter.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/xml/KapuaAppPropertiesXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/notification/DeviceNotifyMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/notification/DeviceNotifyMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/notification/DeviceNotifyMessage.java
+++ b/service/device/call/api/src/main/java/org/eclipse/kapua/service/device/call/message/app/notification/DeviceNotifyMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAsset.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAsset.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannel.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannelMode.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannelMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannelMode.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssetChannelMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/KuraAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/asset/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/KuraBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/bundle/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraDeviceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/KuraPassword.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/KuraXmlConfigPropertiesAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/XmlConfigPropertyAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/configuration/xml/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraBundleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/KuraDeploymentPackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/deploy/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/KuraSnapshotIds.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/package-info.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/snapshot/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectTypeConverter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectTypeConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectTypeConverter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectTypeConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectValueConverter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectValueConverter.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/type/KuraObjectValueConverter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/app/notification/KuraNotifyPayload.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/message/kura/app/notification/KuraNotifyPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/pom.xml
+++ b/service/device/call/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/call/pom.xml
+++ b/service/device/call/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/AbstractDeviceManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/KapuaAppPropertiesImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/KapuaAppPropertiesImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementException.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementResponseErrorCodes.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementResponseException.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/exception/DeviceManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaAppChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaAppChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyPayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestMessageImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestPayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/request/KapuaRequestPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseChannelImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseMessageImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponseMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/device-management-setting.properties
+++ b/service/device/commons/src/main/resources/device-management-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/device-management-setting.properties
+++ b/service/device/commons/src/main/resources/device-management-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/liquibase/0.2.0/changelog-device-management-0.2.0.xml
+++ b/service/device/commons/src/main/resources/liquibase/0.2.0/changelog-device-management-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/liquibase/0.2.0/device_management-domain.xml
+++ b/service/device/commons/src/main/resources/liquibase/0.2.0/device_management-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/liquibase/1.0.0/changelog-device-management-1.0.0.xml
+++ b/service/device/commons/src/main/resources/liquibase/1.0.0/changelog-device-management-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/liquibase/1.0.0/device_management-domain.xml
+++ b/service/device/commons/src/main/resources/liquibase/1.0.0/device_management-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/main/resources/liquibase/changelog-device-management-master.xml
+++ b/service/device/commons/src/main/resources/liquibase/changelog-device-management-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageTest.java
+++ b/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageTest.java
+++ b/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/KapuaNotifyMessageTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/NotifyTestSuite.java
+++ b/service/device/commons/src/test/java/org/eclipse/kapua/service/device/management/commons/message/notification/NotifyTestSuite.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/all/api/pom.xml
+++ b/service/device/management/all/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/all/internal/pom.xml
+++ b/service/device/management/all/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/all/job/pom.xml
+++ b/service/device/management/all/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/all/pom.xml
+++ b/service/device/management/all/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/pom.xml
+++ b/service/device/management/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementDomain.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementDomains.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/DeviceManagementDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceNotConnectedException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceNotConnectedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/api/src/main/resources/device-management-error-messages.properties
+++ b/service/device/management/api/src/main/resources/device-management-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/pom.xml
+++ b/service/device/management/asset/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAsset.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannel.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannelMode.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannelMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannelMode.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetChannelMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetManagementService.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetXmlRegistry.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssetXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssets.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/DeviceAssets.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/DeviceAssetChannelXmlAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
+++ b/service/device/management/asset/api/src/main/java/org/eclipse/kapua/service/device/management/asset/xml/XmlAdaptedDeviceAssetChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/pom.xml
+++ b/service/device/management/asset/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/pom.xml
+++ b/service/device/management/asset/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetAppProperties.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetAppProperties.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetChannelImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetChannelImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetsImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetsImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetGetManagementException.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetGetManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetManagementResponseErrorCodes.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetManagementResponseException.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetReadManagementException.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetReadManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetWriteManagementException.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/exception/AssetWriteManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseMessage.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponsePayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponsePayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/channel/message/internal/ChannelResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/pom.xml
+++ b/service/device/management/asset/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/DeviceAssetWriteTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWritePropertyKeys.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWritePropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteStepDefinition.java
+++ b/service/device/management/asset/job/src/main/java/org/eclipse/kapua/service/device/management/asset/job/definition/DeviceAssetWriteStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/0.3.0/asset_write_job_step_definition.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/0.3.0/asset_write_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/0.3.0/changelog-asset-job-0.3.0.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/0.3.0/changelog-asset-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.0/asset_job_step_definition-scopeId.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.0/asset_job_step_definition-scopeId.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.0/changelog-asset-job-1.0.0.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.0/changelog-asset-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/asset_job_step_definition_name_update.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/asset_job_step_definition_name_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/changelog-asset-job-1.0.4.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.0.4/changelog-asset-job-1.0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.1.0/asset_job_step_definition_property_update.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.1.0/asset_job_step_definition_property_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/1.1.0/changelog-asset-job-1.1.0.post.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/1.1.0/changelog-asset-job-1.1.0.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.post.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.xml
+++ b/service/device/management/asset/job/src/main/resources/liquibase/changelog-asset-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/asset/pom.xml
+++ b/service/device/management/asset/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/pom.xml
+++ b/service/device/management/bundle/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundle.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
+++ b/service/device/management/bundle/api/src/main/java/org/eclipse/kapua/service/device/management/bundle/DeviceBundles.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/pom.xml
+++ b/service/device/management/bundle/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundlesImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleGetManagementException.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleGetManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleManagementResponseErrorCodes.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleManagementResponseException.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/exception/BundleManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/pom.xml
+++ b/service/device/management/bundle/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStartTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/DeviceBundleStopTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundlePropertyKeys.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundlePropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStartStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
+++ b/service/device/management/bundle/job/src/main/java/org/eclipse/kapua/service/device/management/bundle/job/definition/DeviceBundleStopStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/bundle_start_job_step_definition.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/bundle_start_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/bundle_stop_job_step_definition.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/bundle_stop_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/changelog-bundle-job-0.3.0.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/0.3.0/changelog-bundle-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.0/bundle_job_step_definition-scopeId.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.0/bundle_job_step_definition-scopeId.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.0/changelog-bundle-job-1.0.0.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.0/changelog-bundle-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/bundle_job_step_definition_name_update.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/bundle_job_step_definition_name_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/changelog-bundle-job-1.0.4.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/1.0.4/changelog-bundle-job-1.0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/job/src/main/resources/liquibase/changelog-bundle-job-master.xml
+++ b/service/device/management/bundle/job/src/main/resources/liquibase/changelog-bundle-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/bundle/pom.xml
+++ b/service/device/management/bundle/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/pom.xml
+++ b/service/device/management/command/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandInput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandOutput.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
+++ b/service/device/management/command/api/src/main/java/org/eclipse/kapua/service/device/management/command/DeviceCommandXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/pom.xml
+++ b/service/device/management/command/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/CommandAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandInputImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandOutputImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandExecuteManagementException.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandExecuteManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandManagementResponseErrorCodes.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandManagementResponseException.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/exception/CommandManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/pom.xml
+++ b/service/device/management/command/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/DeviceCommandExecTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecPropertyKeys.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecPropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecStepDefinition.java
+++ b/service/device/management/command/job/src/main/java/org/eclipse/kapua/service/device/management/command/job/definition/DeviceCommandExecStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/0.3.0/changelog-command-job-0.3.0.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/0.3.0/changelog-command-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/0.3.0/command_job_step_definition.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/0.3.0/command_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.0/changelog-command-job-1.0.0.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.0/changelog-command-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.0/command_job_step_definition-scopeId.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.0/command_job_step_definition-scopeId.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.4/changelog-command-job-1.0.4.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.4/changelog-command-job-1.0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.0.4/command_job_step_definition_name_update.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.0.4/command_job_step_definition_name_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.1.0/changelog-command-job-1.1.0.post.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.1.0/changelog-command-job-1.1.0.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/1.1.0/command_job_step_definition_property_update.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/1.1.0/command_job_step_definition_property_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.post.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.xml
+++ b/service/device/management/command/job/src/main/resources/liquibase/changelog-command-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/command/pom.xml
+++ b/service/device/management/command/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/pom.xml
+++ b/service/device/management/configuration/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceComponentConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceConfigurationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapter.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertiesAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/configuration/DeviceXmlConfigPropertyAdapted.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshot.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshotXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
+++ b/service/device/management/configuration/api/src/main/java/org/eclipse/kapua/service/device/management/snapshot/DeviceSnapshots.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/pom.xml
+++ b/service/device/management/configuration/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceComponentConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationGetManagementException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationGetManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationManagementResponseErrorCodes.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationManagementResponseException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationPutManagementException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/exception/ConfigurationPutManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotGetManagementException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotGetManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotManagementResponseErrorCodes.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotManagementResponseException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotRollbackManagementException.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/exception/SnapshotRollbackManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestPayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestPayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseMessage.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponsePayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponsePayload.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/pom.xml
+++ b/service/device/management/configuration/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/DeviceConfigurationPutTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutPropertyKeys.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutPropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutStepDefinition.java
+++ b/service/device/management/configuration/job/src/main/java/org/eclipse/kapua/service/device/management/configuration/job/definition/DeviceConfigurationPutStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/0.3.0/changelog-configuration-job-0.3.0.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/0.3.0/changelog-configuration-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/0.3.0/configuration_put_job_step_definition.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/0.3.0/configuration_put_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.0/changelog-configuration-job-1.0.0.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.0/changelog-configuration-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.0/configuration_job_step_definition-scopeId.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.0/configuration_job_step_definition-scopeId.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/changelog-configuration-job-1.0.4.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/changelog-configuration-job-1.0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/configuration_job_step_definition_name_update.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.0.4/configuration_job_step_definition_name_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.1.0/changelog-configuration-job-1.1.0.post.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.1.0/changelog-configuration-job-1.1.0.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/1.1.0/configuration_job_step_definition_property_update.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/1.1.0/configuration_job_step_definition_property_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.post.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.xml
+++ b/service/device/management/configuration/job/src/main/resources/liquibase/changelog-configuration-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/pom.xml
+++ b/service/device/management/configuration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/configuration/pom.xml
+++ b/service/device/management/configuration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/pom.xml
+++ b/service/device/management/job/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperation.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationAttributes.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationCreator.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationFactory.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationListResult.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationQuery.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationService.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationXmlRegistry.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/manager/JobDeviceManagementOperationManagerService.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/manager/JobDeviceManagementOperationManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/JobDeviceManagementTriggerManagerService.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/JobDeviceManagementTriggerManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/JobDeviceManagementTriggerErrorCodes.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/JobDeviceManagementTriggerErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/JobDeviceManagementTriggerException.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/JobDeviceManagementTriggerException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/ProcessOnConnectException.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/manager/exception/ProcessOnConnectException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/api/src/main/resources/job-device-management-trigger-service-error-messages.properties
+++ b/service/device/management/job/api/src/main/resources/job-device-management-trigger-service-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/pom.xml
+++ b/service/device/management/job/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationCreatorImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationDAO.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationEntityManagerFactory.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationFactoryImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationListResultImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationQueryImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/management/job/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-device-management-operation-1.1.0.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-device-management-operation-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.1.0/job_device_management_operation.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.1.0/job_device_management_operation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-device-management-operation-1.2.0.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-device-management-operation-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/1.2.0/job_device_management_operation-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/internal/src/main/resources/liquibase/changelog-job-device-management-operation-master.xml
+++ b/service/device/management/job/internal/src/main/resources/liquibase/changelog-job-device-management-operation-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/job/pom.xml
+++ b/service/device/management/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/pom.xml
+++ b/service/device/management/packages/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/DevicePackageManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageBundleInfos.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackageXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/DevicePackages.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/FileType.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/FileType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/DevicePackageDownloadStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/DevicePackageInstallStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
+++ b/service/device/management/packages/api/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/DevicePackageUninstallStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/pom.xml
+++ b/service/device/management/packages/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadExecuteManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadExecuteManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadStatusManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadStatusManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadStopManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageDownloadStopManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageGetManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageGetManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageInstallExecuteManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageInstallExecuteManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageInstallStatusManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageInstallStatusManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageManagementResponseErrorCodes.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageManagementResponseErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageManagementResponseException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageManagementResponseException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageUninstallExecuteManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageUninstallExecuteManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageUninstallStatusManagementException.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/exception/PackageUninstallStatusManagementException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/setting/PackageManagementServiceSetting.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/setting/PackageManagementServiceSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/setting/PackageManagementServiceSettingKeys.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/setting/PackageManagementServiceSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadRequestImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/download/internal/DevicePackageDownloadRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/install/internal/DevicePackageInstallRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageBundleInfosImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackageOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/internal/DevicePackagesImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallOptionsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/model/uninstall/internal/DevicePackageUninstallRequestImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/internal/src/main/resources/service-device-management-package-setting.properties
+++ b/service/device/management/packages/internal/src/main/resources/service-device-management-package-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/pom.xml
+++ b/service/device/management/packages/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/AbstractDevicePackageTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/AbstractDevicePackageTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageDownloadTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/DevicePackageUninstallTargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageDownloadPropertyKeys.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageDownloadPropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageUninstallPropertyKeys.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackageUninstallPropertyKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesDownloadStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesDownloadStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesUninstallStepDefinition.java
+++ b/service/device/management/packages/job/src/main/java/org/eclipse/kapua/service/device/management/packages/job/definition/DevicePackagesUninstallStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/changelog-packages-job-0.3.0.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/changelog-packages-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/package_download_job_step_definition.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/package_download_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/package_uninstall_job_step_definition.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/0.3.0/package_uninstall_job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.0/changelog-packages-job-1.0.0.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.0/changelog-packages-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.0/packages_job_step_definition-scopeId.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.0/packages_job_step_definition-scopeId.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/changelog-packages-job-1.0.4.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/changelog-packages-job-1.0.4.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/packages_job_step_definition_name_update.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.0.4/packages_job_step_definition_name_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.1.0/changelog-packages-job-1.1.0.post.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.1.0/changelog-packages-job-1.1.0.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/1.1.0/packages_job_step_definition_property_update.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/1.1.0/packages_job_step_definition_property_update.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.post.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
+++ b/service/device/management/packages/job/src/main/resources/liquibase/changelog-packages-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/packages/pom.xml
+++ b/service/device/management/packages/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/pom.xml
+++ b/service/device/management/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/pom.xml
+++ b/service/device/management/registry/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/DeviceManagementRegistryManagerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationManagerErrorCodes.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationManagerErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationNotificationInvalidStatusException.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationNotificationInvalidStatusException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationNotificationProcessingException.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/exception/ManagementOperationNotificationProcessingException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperation.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationAttributes.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationCreator.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationFactory.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationListResult.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationProperty.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationQuery.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationXmlRegistry.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementRegistryDomain.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementRegistryDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementRegistryDomains.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementRegistryDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotification.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotification.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationAttributes.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationCreator.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationFactory.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationListResult.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationQuery.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationService.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationXmlRegistry.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/pom.xml
+++ b/service/device/management/registry/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceManagementRegistryManagerServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceManagementRegistryManagerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationCreatorImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationDAO.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationEntityManagerFactory.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationFactoryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationListResultImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationPropertyImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationPropertyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationQueryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationCreatorImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationDAO.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationFactoryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationListResultImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationQueryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/management/registry/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/changelog-device_management_registry-1.0.0.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/changelog-device_management_registry-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation_input_properties.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation_input_properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation_notification.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_operation_notification.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_registry-domain.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.0.0/device_management_registry-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device_management_registry-1.2.0.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device_management_registry-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-add_log.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-add_log.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-add_message.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-add_message.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/1.2.0/device_management_operation_notification-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/internal/src/main/resources/liquibase/changelog-device_management_registry-master.xml
+++ b/service/device/management/registry/internal/src/main/resources/liquibase/changelog-device_management_registry-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/registry/pom.xml
+++ b/service/device/management/registry/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/pom.xml
+++ b/service/device/management/request/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/DeviceRequestManagementService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestFactory.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestXmlRegistry.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/GenericRequestXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestPayload.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/request/GenericRequestPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseChannel.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponseMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponsePayload.java
+++ b/service/device/management/request/api/src/main/java/org/eclipse/kapua/service/device/management/request/message/response/GenericResponsePayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/pom.xml
+++ b/service/device/management/request/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericAppProperties.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericAppProperties.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestChannelImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestMessageImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestPayloadImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/request/GenericRequestPayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseChannelImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseChannelImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseMessageImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponseMessageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponsePayloadImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/message/response/GenericResponsePayloadImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/management/request/pom.xml
+++ b/service/device/management/request/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/pom.xml
+++ b/service/device/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2016, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/pom.xml
+++ b/service/device/registry/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/pom.xml
+++ b/service/device/registry/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/ConnectionUserCouplingMode.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/ConnectionUserCouplingMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/ConnectionUserCouplingMode.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/ConnectionUserCouplingMode.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/Device.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceDomains.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceEventType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettingKeys.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnection.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceErrorCodes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceErrorCodes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceException.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceException.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/ConnectionServiceException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOption.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/UserAlreadyReservedException.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/UserAlreadyReservedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/UserAlreadyReservedException.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/UserAlreadyReservedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEvent.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventFactory.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifeCycleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/DeviceLifecycleDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettings.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/KapuaDeviceRegistrySettings.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationRegex.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/common/DeviceValidationRegex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.DeviceRegistryService.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.DeviceRegistryService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/device/registry/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/kapua-device-registry-setting.properties
+++ b/service/device/registry/internal/src/main/resources/kapua-device-registry-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/kapua-device-registry-setting.properties
+++ b/service/device/registry/internal/src/main/resources/kapua-device-registry-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/changelog-device-0.2.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/changelog-device-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device-configuration.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_connection-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_connection-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_connection.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_connection.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_event-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_event-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_event.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_event.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_lifecycle-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.2.0/device_lifecycle-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/changelog-device-0.3.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/changelog-device-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-id_check_positive.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-network_interface.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-network_interface.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-remove_credential_options.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-remove_credential_options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-tag.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device-tag.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-add_connection_options.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-add_connection_options.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-configuration.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-id_check_positive.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_connection-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_event-id_check_positive.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.0/device_event-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.1/changelog-device-0.3.1.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.1/changelog-device-0.3.1.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/0.3.1/device-domain_set_groupable.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/0.3.1/device-domain_set_groupable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/changelog-device-1.0.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/changelog-device-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device-sys-housekeeper-run-seed.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device-sys-housekeeper-run-seed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_connection-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_connection-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_event-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_event-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_lifecycle-domain.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.0.0/device_lifecycle-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/changelog-device-1.1.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/changelog-device-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-add-model-name.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-add-model-name.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-remove-modem-constraint.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device-remove-modem-constraint.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device_event-modify_gps_column.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.1.0/device_event-modify_gps_column.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device-1.2.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/changelog-device-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_connection-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.2.0/device_event-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/pom.xml
+++ b/service/device/registry/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/pom.xml
+++ b/service/device/registry/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/pom.xml
+++ b/service/device/registry/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclCreator.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclPermission.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclSteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/AclSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/KuraDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/MqttDevice.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/MqttDevice.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/pom.xml
+++ b/service/device/registry/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/device/registry/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/device/registry/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/device/registry/test/src/test/resources/logback.xml
+++ b/service/device/registry/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/pom.xml
+++ b/service/endpoint/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoDomain.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoDomains.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoListResult.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointUsage.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointUsage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointEntityManagerFactory.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoListResultImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointUsageImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointUsageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/changelog-endpoint-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info_usage.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/endpoint_info_usage.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.0.0/update-endpoint_info-domain.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.0.0/update-endpoint_info-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.2.0/changelog-endpoint-1.2.0.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.2.0/changelog-endpoint-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.2.0/endpoint_info-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.post.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.post.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/pom.xml
+++ b/service/endpoint/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/test-steps/pom.xml
+++ b/service/endpoint/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
+++ b/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/pom.xml
+++ b/service/job/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomain.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomains.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobListResult.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecution.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionListResult.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/GenericOperation.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/GenericOperation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetProcessor.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetReader.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetWriter.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/operation/TargetWriter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStep.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepIndex.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepIndex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepListResult.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobPropertyKey.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobPropertyKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionListResult.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepType.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTarget.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetFactory.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetListResult.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetStatus.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionFactoryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionListResultImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobEntityManagerFactory.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobFactoryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobListResultImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionFactoryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionListResultImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepFactoryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepListResultImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetCreatorImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetDAO.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetFactoryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetListResultImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.job.JobService.xml
+++ b/service/job/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.job.JobService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/job/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/changelog-job-0.3.0.pre.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/changelog-job-0.3.0.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/changelog-job-0.3.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/changelog-job-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job-configuration.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job-domain.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_execution.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_execution.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_step.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_step.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_definition.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_definition_properties.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_definition_properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_properties.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_step_properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/0.3.0/job_target.xml
+++ b/service/job/internal/src/main/resources/liquibase/0.3.0/job_target.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.0.0/changelog-job-1.0.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.0.0/changelog-job-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.0.0/job-domain.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.0.0/job-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/changelog-job-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution-log.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_execution_target.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_job_step_definition_properties-example_value.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_job_step_definition_properties-example_value.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_job_step_properties-example_value.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_job_step_properties-example_value.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.1.0/job_target-status_message.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.1.0/job_target-status_message.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-1.2.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/changelog-job-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_execution-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_step_definition-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.2.0/job_target-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.pre.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/pom.xml
+++ b/service/job/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/TestProcessor.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/TestProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/RunJobUnitTest.java
+++ b/service/job/test/src/test/java/org/eclipse/kapua/service/job/test/RunJobUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/job/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/job/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
+++ b/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/job/test/src/test/resources/logback.xml
+++ b/service/job/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/pom.xml
+++ b/service/scheduler/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerDomain.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerDomains.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/SchedulerDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/Trigger.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerAttributes.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerFactory.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerListResult.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerQuery.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerXmlRegistry.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinition.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinition.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionAttributes.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionCreator.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionFactory.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionListResult.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionQuery.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionService.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionXmlRegistry.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerProperty.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerProperty.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerPropertyKey.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerPropertyKey.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerType.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerEntityManagerFactory.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerServiceInit.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/SchedulerServiceInit.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/QuartzTriggerDriver.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/QuartzTriggerDriver.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/CannotAddQuartzJobException.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/CannotAddQuartzJobException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/CannotScheduleJobException.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/CannotScheduleJobException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/QuartzTriggerDriverErrorCodes.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/QuartzTriggerDriverErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/QuartzTriggerDriverException.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/QuartzTriggerDriverException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/SchedulerNotAvailableException.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/SchedulerNotAvailableException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/TriggerNeverFiresException.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/driver/exception/TriggerNeverFiresException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/job/KapuaJobLauncher.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/job/KapuaJobLauncher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/persistence/KapuaQuartzConnectionProvider.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/persistence/KapuaQuartzConnectionProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/setting/KapuaSchedulerSetting.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/setting/KapuaSchedulerSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/setting/KapuaSchedulerSettingKeys.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/quartz/setting/KapuaSchedulerSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionCreatorImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionDAO.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionFactoryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionListResultImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionQueryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerPropertyImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerCreatorImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerDAO.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerFactoryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerListResultImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerQueryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
+++ b/service/scheduler/quartz/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.schedule.trigger.TriggerService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/META-INF/persistence.xml
+++ b/service/scheduler/quartz/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/kapua-scheduler-setting.properties
+++ b/service/scheduler/quartz/src/main/resources/kapua-scheduler-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/changelog-scheduler-0.3.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/changelog-scheduler-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-domain.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-engine-quartz.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/scheduler-engine-quartz.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger-configuration.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger_properties.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/0.3.0/trigger_properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/changelog-scheduler-1.0.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/changelog-scheduler-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/scheduler-domain.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.0.0/scheduler-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.pre.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/changelog-scheduler-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/cron_job_trigger_definition.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/cron_job_trigger_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/device_connect_trigger_definition.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/device_connect_trigger_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/interval_job_trigger_definition.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/interval_job_trigger_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/scheduler-engine-quartz-update_job_launcher.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/scheduler-engine-quartz-update_job_launcher.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-description.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-trigger_definition_id.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger-trigger_definition_id.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger_definition.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger_definition.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger_definition_properties.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.1.0/trigger_definition_properties.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/changelog-scheduler-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.2.0/trigger_definition-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.pre.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/changelog-scheduler-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/quartz/src/main/resources/quartz-trigger-driver-error-messages.properties
+++ b/service/scheduler/quartz/src/main/resources/quartz-trigger-driver-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/scheduler/test-steps/pom.xml
+++ b/service/scheduler/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/pom.xml
+++ b/service/security/authentication/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/pom.xml
+++ b/service/security/authentication/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AccessTokenCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/ApiKeyCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationDomains.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/CredentialsFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/KapuaPrincipal.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/LoginCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/LoginCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/LoginCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/LoginCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/RefreshTokenCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SessionCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SessionCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SessionCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/SessionCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/StringToCharArrayAdapter.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/StringToCharArrayAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/StringToCharArrayAdapter.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/StringToCharArrayAdapter.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/Credential.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialDomain.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialStatus.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/KapuaExistingCredentialException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/registration/RegistrationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/registration/RegistrationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessToken.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenDomain.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/LoginInfo.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/LoginInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/pom.xml
+++ b/service/security/authentication/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authentication/pom.xml
+++ b/service/security/authentication/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/pom.xml
+++ b/service/security/authorization/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/pom.xml
+++ b/service/security/authorization/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationDomains.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoDomain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRole.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/Domain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainDomain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainRegistryService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Group.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupDomain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/Groupable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/Permission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/permission/PermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/Role.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleDomain.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermission.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionAttributes.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionFactory.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionListResult.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/pom.xml
+++ b/service/security/authorization/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/authorization/pom.xml
+++ b/service/security/authorization/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/Certificate.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateAttributes.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateDomain.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateDomains.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateFactory.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateGenerator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateListResult.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateStatus.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateUsage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsage.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsageSetting.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/KeyUsageSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/exception/KapuaCertificateErrorCodes.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/exception/KapuaCertificateErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/exception/KapuaCertificateException.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/exception/KapuaCertificateException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfo.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoAttributes.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoCreator.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoFactory.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoListResult.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/xml/CertificateInfoXmlRegistry.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/xml/CertificateInfoXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/util/CertificateUtils.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/util/CertificateUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/xml/CertificateXmlRegistry.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/xml/CertificateXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/pom.xml
+++ b/service/security/certificate/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoFactoryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoListResultImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateFactoryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateListResultImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateUsageImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateUsageImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/KeyUsageSettingImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/KeyUsageSettingImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSetting.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSettingKeys.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/setting/KapuaCertificateSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/internal/src/main/resources/kapua-certificate-setting.properties
+++ b/service/security/certificate/internal/src/main/resources/kapua-certificate-setting.properties
@@ -1,5 +1,5 @@
 ################################################################################
-# Copyright (c) 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/certificate/pom.xml
+++ b/service/security/certificate/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/pom.xml
+++ b/service/security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/pom.xml
+++ b/service/security/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/api/pom.xml
+++ b/service/security/registration/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessor.java
+++ b/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessorProvider.java
+++ b/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/RegistrationProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2018 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/package-info.java
+++ b/service/security/registration/api/src/main/java/org/eclipse/kapua/security/registration/package-info.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/pom.xml
+++ b/service/security/registration/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/pom.xml
+++ b/service/security/registration/simple/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessorProvider.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/SimpleRegistrationProcessorProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSetting.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSetting.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSettingKeys.java
+++ b/service/security/registration/simple/src/main/java/org/eclipse/kapua/security/registration/simple/setting/SimpleSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/registration/simple/src/main/resources/kapua-security-registration-simple-setting.properties
+++ b/service/security/registration/simple/src/main/resources/kapua-security-registration-simple-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc
+# Copyright (c) 2017, 2020 Red Hat Inc
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationErrorCodes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationErrorCodes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/RefreshTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/RefreshTokenCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/RefreshTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/RefreshTokenCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationErrorCodes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationRuntimeException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationRuntimeException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/JwtCertificateNotFoundException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/JwtCertificateNotFoundException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/AccessTokenCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfo.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtils.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtils.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/CryptAlgorithm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/CryptAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/CryptAlgorithm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/CryptAlgorithm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/JwtProcessors.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/utils/JwtProcessors.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/LoginInfoImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/LoginInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionValidator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionValidator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealm.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationErrorCodes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationErrorCodes.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedException.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authentication.credential.CredentialService.xml
+++ b/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authentication.credential.CredentialService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authorization.group.GroupService.xml
+++ b/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authorization.group.GroupService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authorization.role.RoleService.xml
+++ b/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authorization.role.RoleService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/META-INF/persistence.xml
+++ b/service/security/shiro/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/META-INF/persistence.xml
+++ b/service/security/shiro/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-authorization-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authorization-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-authorization-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authorization-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_access_token-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_access_token-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_access_token.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_access_token.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_credential-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_credential-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_credential.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/atht_credential.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_info-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_info-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_info.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_info.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_permission.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_permission.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_role.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_access_role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain_actions.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_domain_actions.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group-configuration.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_group.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role-configuration.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role_permission.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/athz_role_permission.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authentication-0.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authentication-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authorization-0.2.0.pre.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authorization-0.2.0.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authorization-0.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.2.0/changelog-authorization-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_access_token-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_access_token-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-expiration.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-expiration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-lockout_policy.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/atht_credential-lockout_policy.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_info-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_info-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_permission-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_permission-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_role-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_access_role-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_domain-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_domain-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_domain_actions-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_domain_actions-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_group-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_group-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_role-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_role-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_role_permission-id_check_positive.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/athz_role_permission-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/changelog-authentication-0.3.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/changelog-authentication-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.0/changelog-authorization-0.3.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.0/changelog-authorization-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.1/athz_domain-add_groupable.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.1/athz_domain-add_groupable.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/0.3.1/changelog-authorization-0.3.1.pre.xml
+++ b/service/security/shiro/src/main/resources/liquibase/0.3.1/changelog-authorization-0.3.1.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-access_token-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-access_token-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-credential-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-credential-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-sys-housekeeper-run-seed.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/atht-sys-housekeeper-run-seed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-access_info-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-access_info-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-domain-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-domain-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-group-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-group-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-role-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-role-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-run-seed.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-run-seed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-update-domain-service.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/athz-sys-housekeeper-update-domain-service.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authentication-1.0.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authentication-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authorization-1.0.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.0.0/changelog-authorization-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/changelog-authorization-1.1.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/changelog-authorization-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/group-description.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/group-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.1.0/role-description.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.1.0/role-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-access_token-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/atht-credential-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_info-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_permission-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-access_role-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-domain-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-group-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/athz-role_permission-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authentication-1.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authentication-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authorization-1.2.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.2.0/changelog-authorization-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.pre.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.pre.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
+++ b/service/security/shiro/src/main/resources/liquibase/changelog-authorization-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/security/test-steps/pom.xml
+++ b/service/security/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/api/pom.xml
+++ b/service/stream/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamDomain.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamDomains.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
+++ b/service/stream/api/src/main/java/org/eclipse/kapua/service/stream/StreamService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/internal/pom.xml
+++ b/service/stream/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/internal/src/main/resources/liquibase/1.0.0/changelog-stream-1.0.0.xml
+++ b/service/stream/internal/src/main/resources/liquibase/1.0.0/changelog-stream-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/internal/src/main/resources/liquibase/1.0.0/stream-domain.xml
+++ b/service/stream/internal/src/main/resources/liquibase/1.0.0/stream-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/internal/src/main/resources/liquibase/changelog-stream-master.xml
+++ b/service/stream/internal/src/main/resources/liquibase/changelog-stream-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/stream/pom.xml
+++ b/service/stream/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/pom.xml
+++ b/service/tag/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Tag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagAttributes.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagDomain.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagDomains.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagFactory.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagListResult.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagQuery.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagService.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/Taggable.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagCreatorImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDAO.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagEntityManagerFactory.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagFactoryImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagListResultImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagQueryImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.tag.TagService.xml
+++ b/service/tag/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.tag.TagService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/tag/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/0.3.0/changelog-tag-0.3.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/0.3.0/changelog-tag-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/0.3.0/tag-configuration.xml
+++ b/service/tag/internal/src/main/resources/liquibase/0.3.0/tag-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/0.3.0/tag-domain.xml
+++ b/service/tag/internal/src/main/resources/liquibase/0.3.0/tag-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/0.3.0/tag.xml
+++ b/service/tag/internal/src/main/resources/liquibase/0.3.0/tag.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.0.0/changelog-tag-1.0.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.0.0/changelog-tag-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.0.0/tag-domain.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.0.0/tag-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.1.0/changelog-tag-1.1.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.1.0/changelog-tag-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.1.0/tag-description.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.1.0/tag-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.2.0/changelog-tag-1.2.0.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.2.0/changelog-tag-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
+++ b/service/tag/internal/src/main/resources/liquibase/1.2.0/tag-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
+++ b/service/tag/internal/src/main/resources/liquibase/changelog-tag-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/pom.xml
+++ b/service/tag/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test-steps/pom.xml
+++ b/service/tag/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
+++ b/service/tag/test-steps/src/main/java/org/eclipse/kapua/service/tag/steps/TagServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/CucumberWithPropertiesForTag.java
+++ b/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/CucumberWithPropertiesForTag.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/RunTagUnitTest.java
+++ b/service/tag/test/src/test/java/org/eclipse/kapua/service/tag/test/RunTagUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/tag/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/tag/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2017, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/tag/test/src/test/resources/logback.xml
+++ b/service/tag/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/pom.xml
+++ b/service/user/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/pom.xml
+++ b/service/user/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/User.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserAttributes.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserAttributes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserDomain.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserDomain.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserDomains.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserDomains.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserFactory.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserListResult.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserListResult.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserListResult.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserStatus.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserStatus.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserStatus.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserType.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserType.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserType.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserXmlRegistry.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserEntityManagerFactory.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserEntityManagerFactory.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserEntityManagerFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserFactoryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserListResultImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserListResultImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserListResultImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSetting.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSetting.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingKeys.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingKeys.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/setting/KapuaUserSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.user.UserService.xml
+++ b/service/user/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.user.UserService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.user.UserService.xml
+++ b/service/user/internal/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.user.UserService.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/user/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/user/internal/src/main/resources/META-INF/persistence.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/kapua-user-setting.properties
+++ b/service/user/internal/src/main/resources/kapua-user-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/kapua-user-setting.properties
+++ b/service/user/internal/src/main/resources/kapua-user-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.2.0/changelog-user-0.2.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.2.0/changelog-user-0.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.2.0/user-configuration.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.2.0/user-configuration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.2.0/user-domain.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.2.0/user-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.2.0/user.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.2.0/user.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.3.0/changelog-user-0.3.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.3.0/changelog-user-0.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.3.0/user-expiration.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.3.0/user-expiration.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/0.3.0/user-id_check_positive.xml
+++ b/service/user/internal/src/main/resources/liquibase/0.3.0/user-id_check_positive.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.0.0/changelog-user-1.0.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.0.0/changelog-user-1.0.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.0.0/user-domain.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.0.0/user-domain.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.0.0/user-sys-housekeeper-run-seed.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.0.0/user-sys-housekeeper-run-seed.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.1.0/changelog-user-1.1.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.1.0/changelog-user-1.1.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.1.0/user-description.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.1.0/user-description.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.2.0/changelog-user-1.2.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.2.0/changelog-user-1.2.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.2.0/user-timestamp.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
+++ b/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/pom.xml
+++ b/service/user/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/pom.xml
+++ b/service/user/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test-steps/pom.xml
+++ b/service/user/test-steps/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/ComparableUser.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/ComparableUser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserRoleServiceSteps.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/CucumberWithPropertiesForUser.java
+++ b/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/CucumberWithPropertiesForUser.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/RunUserUnitTest.java
+++ b/service/user/test/src/test/java/org/eclipse/kapua/service/user/test/RunUserUnitTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2018, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/user/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
+++ b/service/user/test/src/test/resources/META-INF/services/org.eclipse.kapua.service.authentication.CredentialsFactory
@@ -1,5 +1,5 @@
 #################################################################################
-#  Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+#  Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 # 
 #  All rights reserved. This program and the accompanying materials
 #  are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2011, 2019 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/service/user/test/src/test/resources/logback.xml
+++ b/service/user/test/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/openshift/setup-external.sh
+++ b/simulator-kura/openshift/setup-external.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc
+# Copyright (c) 2017, 2020 Red Hat Inc
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/openshift/setup.sh
+++ b/simulator-kura/openshift/setup.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
 ###############################################################################
-# Copyright (c) 2017 Red Hat Inc
+# Copyright (c) 2017, 2020 Red Hat Inc
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2018 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/docker/kura-simulator.xml
+++ b/simulator-kura/src/main/docker/kura-simulator.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/docker/logback.xml
+++ b/simulator-kura/src/main/docker/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/AbstractMqttTransport.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/AbstractMqttTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/GatewayConfiguration.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/GatewayConfiguration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Module.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Module.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/MqttAsyncTransport.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/MqttAsyncTransport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Simulator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Simulator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Transport.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/Transport.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/AbstractDefaultApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/AbstractDefaultApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Application.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/ApplicationContext.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/ApplicationContext.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/ApplicationController.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/ApplicationController.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Descriptor.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Descriptor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Handler.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Handler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Request.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Request.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Sender.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/Sender.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/AnnotatedApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/AnnotatedApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/Application.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/Application.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/DELETE.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/DELETE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/EXECUTE.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/EXECUTE.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/GET.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/GET.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/POST.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/POST.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/PUT.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/PUT.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/Resource.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/annotated/Resource.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/command/AbstractCommandApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/command/AbstractCommandApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/command/SimpleCommandApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/command/SimpleCommandApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/AbstractSingleTopicPeriodicGenerator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/AbstractSingleTopicPeriodicGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/PeriodicGenerator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/PeriodicGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/SimplePeriodicGenerator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/data/SimplePeriodicGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/AbstractDeployApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/AbstractDeployApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/BundleInformation.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/BundleInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentDownloadPackageRequest.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentDownloadPackageRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentInstallPackageRequest.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentInstallPackageRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentPackageInformation.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentPackageInformation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentUninstallPackageRequest.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DeploymentUninstallPackageRequest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DownloadSimulator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DownloadSimulator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DownloadState.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/DownloadState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/InstallState.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/InstallState.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/SimpleDeployApplication.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/app/deploy/SimpleDeployApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/birth/BirthCertificateBuilder.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/birth/BirthCertificateBuilder.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/birth/BirthCertificateModule.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/birth/BirthCertificateModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Generator.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Generator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorFactories.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorFactories.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorFactory.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorScheduler.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/GeneratorScheduler.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Generators.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Generators.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Payload.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Payload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Position.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/Position.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/AbstractGeneratorFactory.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/AbstractGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/SineGeneratorFactory.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/SineGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/StraightPositionGeneratorFactory.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/generator/basic/StraightPositionGeneratorFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/NameFactories.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/NameFactories.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/NameFactory.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/NameFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/SimulatorRunner.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/main/SimulatorRunner.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Message.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Message.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Metric.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Metric.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Metrics.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Metrics.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Optional.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/payload/Optional.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Configuration.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Configuration.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Configurations.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Configurations.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/ConfiguredSimulation.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/ConfiguredSimulation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/JsonReader.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/JsonReader.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Simulation.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/simulation/Simulation.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/topic/Topic.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/topic/Topic.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Documents.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Documents.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Get.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Get.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Hex.java
+++ b/simulator-kura/src/main/java/org/eclipse/kapua/kura/simulator/util/Hex.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/SingleTestApplication.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/SingleTestApplication.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/TestDownloadSimulator.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/TestDownloadSimulator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/AppTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/AppTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ConfigurationTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ConfigurationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/JsonTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/JsonTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ValidationTest.java
+++ b/simulator-kura/src/test/java/org/eclipse/kapua/kura/simulator/main/simulation/ValidationTest.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/simulator-kura/src/test/resources/logback.xml
+++ b/simulator-kura/src/test/resources/logback.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/src/main/dependency-checker/suppress.xml
+++ b/src/main/dependency-checker/suppress.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/pom.xml
+++ b/sso/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/JwtProcessor.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/JwtProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnLocator.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnService.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoAccessTokenException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoAccessTokenException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoErrorCodes.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoIllegalArgumentException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/SsoIllegalArgumentException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtExtractionException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtExtractionException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtProcessException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/jwt/SsoJwtProcessException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoIllegalUriException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoIllegalUriException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoJwtUriException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoJwtUriException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoLoginUriException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoLoginUriException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoLogoutUriException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoLogoutUriException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoUriException.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/exception/uri/SsoUriException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/api/src/main/resources/sso-error-messages.properties
+++ b/sso/api/src/main/resources/sso-error-messages.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2019 Eurotech and/or its affiliates and others
+# Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/sso/pom.xml
+++ b/sso/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/pom.xml
+++ b/sso/provider-generic/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/GenericSingleSignOnLocator.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/GenericSingleSignOnLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/GenericSingleSignOnService.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/GenericSingleSignOnService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/ProviderImpl.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/ProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/jwt/GenericJwtProcessor.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/jwt/GenericJwtProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others.
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSetting.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSettingKeys.java
+++ b/sso/provider-generic/src/main/java/org/eclipse/kapua/sso/provider/generic/setting/GenericSsoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/pom.xml
+++ b/sso/provider-keycloak/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnLocator.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnService.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnUtils.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/KeycloakSingleSignOnUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others.
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/ProviderImpl.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/ProviderImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/jwt/KeycloakJwtProcessor.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/jwt/KeycloakJwtProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others.
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/setting/KeycloakSsoSetting.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/setting/KeycloakSsoSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/setting/KeycloakSsoSettingKeys.java
+++ b/sso/provider-keycloak/src/main/java/org/eclipse/kapua/sso/provider/keycloak/setting/KeycloakSsoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/pom.xml
+++ b/sso/provider/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2017 Red Hat Inc and others
+    Copyright (c) 2017, 2020 Red Hat Inc and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/AbstractSingleSignOnService.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/AbstractSingleSignOnService.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/ProviderSingleSignOnLocator.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/ProviderSingleSignOnLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/SingleSignOnProvider.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/SingleSignOnProvider.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/internal/DisabledLocator.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/internal/DisabledLocator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/jwt/AbstractJwtProcessor.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/jwt/AbstractJwtProcessor.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others.
+ * Copyright (c) 2017, 2020 Red Hat Inc and others.
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/jwt/JsonUtils.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/jwt/JsonUtils.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/setting/SsoSetting.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/setting/SsoSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/setting/SsoSettingKeys.java
+++ b/sso/provider/src/main/java/org/eclipse/kapua/sso/provider/setting/SsoSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2019 Red Hat Inc and others
+ * Copyright (c) 2017, 2020 Red Hat Inc and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/pom.xml
+++ b/transport/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/pom.xml
+++ b/transport/api/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/TransportClientConnectOptions.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/TransportClientConnectOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/TransportFacade.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/TransportFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportException.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportSendException.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportSendException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportTimeoutException.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/exception/TransportTimeoutException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportChannel.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportChannel.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportChannel.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportMessage.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2017 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportMessage.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportPayload.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportPayload.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/TransportPayload.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/message/pubsub/PubSubTransportMessage.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/message/pubsub/PubSubTransportMessage.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/utils/ClientIdGenerator.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/utils/ClientIdGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/api/src/main/java/org/eclipse/kapua/transport/utils/ClientIdGenerator.java
+++ b/transport/api/src/main/java/org/eclipse/kapua/transport/utils/ClientIdGenerator.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientConnectionOptions.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientConnectionOptions.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttFacade.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttFacade.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttResponseTimeoutTimer.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttResponseTimeoutTimer.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/PooledMqttClientFactory.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/PooledMqttClientFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/PooledMqttClientFactory.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/PooledMqttClientFactory.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSetting.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSetting.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSettingKeys.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSettingKeys.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/pooling/setting/MqttClientPoolSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSetting.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSetting.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSetting.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+ * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/setting/MqttClientSettingKeys.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/resources/mqtt-client-pool-setting.properties
+++ b/transport/mqtt/src/main/resources/mqtt-client-pool-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2016 Eurotech and/or its affiliates and others
+# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/transport/mqtt/src/main/resources/mqtt-client-pool-setting.properties
+++ b/transport/mqtt/src/main/resources/mqtt-client-pool-setting.properties
@@ -1,5 +1,5 @@
 ###############################################################################
-# Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+# Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 #
 # All rights reserved. This program and the accompanying materials
 # are made available under the terms of the Eclipse Public License v1.0

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2018 Eurotech and/or its affiliates and others
+    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0"?>
 <!--
-    Copyright (c) 2011, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2016, 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0


### PR DESCRIPTION
Updates to all copyright headers:

- Last update year changed to 2020
- First update moved to 2016 where it was 2011

**Related Issue**
No related issues

