### PR TITLE
Refactor CORS Filter as Servlet Filter and disable WADL

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -13,19 +13,30 @@ package org.eclipse.kapua.app.api.core;
 
 import java.io.IOException;
 
+import javax.servlet.Filter;
 import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.shiro.web.servlet.OncePerRequestFilter;
 import org.apache.shiro.web.util.WebUtils;
 
-public class CORSResponseFilter extends OncePerRequestFilter {
+public class CORSResponseFilter implements Filter {
 
     @Override
-    protected void doFilterInternal(ServletRequest request, ServletResponse response, FilterChain chain) throws ServletException, IOException {
+    public void init(FilterConfig filterConfig) {
+        // No init required
+    }
+
+    @Override
+    public void destroy() {
+        // No destroy required
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletResponse httpResponse = WebUtils.toHttp(response);
         httpResponse.addHeader("Access-Control-Allow-Origin", "*");
         httpResponse.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");

--- a/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
+++ b/rest-api/web/src/main/java/org/eclipse/kapua/app/api/web/RestApisApplication.java
@@ -40,6 +40,7 @@ public class RestApisApplication extends ResourceConfig {
         mappedMediaTypes.put("json", MediaType.APPLICATION_JSON_TYPE);
 
         property(ServerProperties.MEDIA_TYPE_MAPPINGS, mappedMediaTypes);
+        property(ServerProperties.WADL_FEATURE_DISABLE, true);
         register(UriConnegFilter.class);
         register(JaxbContextResolver.class);
         register(RestApiJAXBContextProvider.class);

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -14,7 +14,6 @@ securityManager.authenticator = $authenticator
 #
 # Auth filters
 kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthenticationFilter
-corsFilter = org.eclipse.kapua.app.api.core.CORSResponseFilter
 
 ##########
 # Realms #
@@ -52,79 +51,77 @@ securityManager.rememberMeManager.cookie.maxAge = 0
 # Web documentation
 
 # Authentication
-/v1/authentication/info         = corsFilter, kapuaAuthcAccessToken
-/v1/authentication/logout       = corsFilter, kapuaAuthcAccessToken
-/v1/*/credentials.json          = corsFilter, kapuaAuthcAccessToken
-/v1/*/credentials.xml           = corsFilter, kapuaAuthcAccessToken
-/v1/*/credentials/**            = corsFilter, kapuaAuthcAccessToken
+/v1/authentication/info         = kapuaAuthcAccessToken
+
+/v1/authentication/logout       = kapuaAuthcAccessToken
+/v1/*/credentials.json          = kapuaAuthcAccessToken
+/v1/*/credentials.xml           = kapuaAuthcAccessToken
+/v1/*/credentials/**            = kapuaAuthcAccessToken
 
 # Authorization
-/v1/*/accessinfos.xml           = corsFilter, kapuaAuthcAccessToken
-/v1/*/accessinfos.json          = corsFilter, kapuaAuthcAccessToken
-/v1/*/accessinfos/**            = corsFilter, kapuaAuthcAccessToken
-/v1/*/domains.xml               = corsFilter, kapuaAuthcAccessToken
-/v1/*/domains.json              = corsFilter, kapuaAuthcAccessToken
-/v1/*/domains/**                = corsFilter, kapuaAuthcAccessToken
-/v1/*/groups.xml                = corsFilter, kapuaAuthcAccessToken
-/v1/*/groups.json               = corsFilter, kapuaAuthcAccessToken
-/v1/*/groups/**                 = corsFilter, kapuaAuthcAccessToken
-/v1/*/roles.xml                 = corsFilter, kapuaAuthcAccessToken
-/v1/*/roles.json                = corsFilter, kapuaAuthcAccessToken
-/v1/*/roles/**                  = corsFilter, kapuaAuthcAccessToken
+/v1/*/accessinfos.xml           = kapuaAuthcAccessToken
+/v1/*/accessinfos.json          = kapuaAuthcAccessToken
+/v1/*/accessinfos/**            = kapuaAuthcAccessToken
+/v1/*/domains.xml               = kapuaAuthcAccessToken
+/v1/*/domains.json              = kapuaAuthcAccessToken
+/v1/*/domains/**                = kapuaAuthcAccessToken
+/v1/*/groups.xml                = kapuaAuthcAccessToken
+/v1/*/groups.json               = kapuaAuthcAccessToken
+/v1/*/groups/**                 = kapuaAuthcAccessToken
+/v1/*/roles.xml                 = kapuaAuthcAccessToken
+/v1/*/roles.json                = kapuaAuthcAccessToken
+/v1/*/roles/**                  = kapuaAuthcAccessToken
 
 # Account
-/v1/*/accounts.xml              = corsFilter, kapuaAuthcAccessToken
-/v1/*/accounts.json             = corsFilter, kapuaAuthcAccessToken
-/v1/*/accounts/**               = corsFilter, kapuaAuthcAccessToken
+/v1/*/accounts.xml              = kapuaAuthcAccessToken
+/v1/*/accounts.json             = kapuaAuthcAccessToken
+/v1/*/accounts/**               = kapuaAuthcAccessToken
 
 # Datastore
-/v1/*/data/clients.xml          = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/clients.json         = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/clients/**           = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/channels.xml         = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/channels.json        = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/channels/**          = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/messages.xml         = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/messages.json        = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/messages/**          = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/metrics.xml          = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/metrics.json         = corsFilter, kapuaAuthcAccessToken
-/v1/*/data/metrics/**           = corsFilter, kapuaAuthcAccessToken
+/v1/*/data/clients.xml          = kapuaAuthcAccessToken
+/v1/*/data/clients.json         = kapuaAuthcAccessToken
+/v1/*/data/clients/**           = kapuaAuthcAccessToken
+/v1/*/data/channels.xml         = kapuaAuthcAccessToken
+/v1/*/data/channels.json        = kapuaAuthcAccessToken
+/v1/*/data/channels/**          = kapuaAuthcAccessToken
+/v1/*/data/messages.xml         = kapuaAuthcAccessToken
+/v1/*/data/messages.json        = kapuaAuthcAccessToken
+/v1/*/data/messages/**          = kapuaAuthcAccessToken
+/v1/*/data/metrics.xml          = kapuaAuthcAccessToken
+/v1/*/data/metrics.json         = kapuaAuthcAccessToken
+/v1/*/data/metrics/**           = kapuaAuthcAccessToken
 
 # Device and Device Management
-/v1/*/devices.json              = corsFilter, kapuaAuthcAccessToken
-/v1/*/devices.xml               = corsFilter, kapuaAuthcAccessToken
-/v1/*/devices/**                = corsFilter, kapuaAuthcAccessToken
-/v1/*/deviceconnections.json    = corsFilter, kapuaAuthcAccessToken
-/v1/*/deviceconnections.xml     = corsFilter, kapuaAuthcAccessToken
-/v1/*/deviceconnections/**      = corsFilter, kapuaAuthcAccessToken
+/v1/*/devices.json              = kapuaAuthcAccessToken
+/v1/*/devices.xml               = kapuaAuthcAccessToken
+/v1/*/devices/**                = kapuaAuthcAccessToken
+/v1/*/deviceconnections.json    = kapuaAuthcAccessToken
+/v1/*/deviceconnections.xml     = kapuaAuthcAccessToken
+/v1/*/deviceconnections/**      = kapuaAuthcAccessToken
 
 # Endpoint
-/v1/*/endpointInfos.json        = corsFilter, kapuaAuthcAccessToken
-/v1/*/endpointInfos.xml         = corsFilter, kapuaAuthcAccessToken
-/v1/*/endpointInfos/**          = corsFilter, kapuaAuthcAccessToken
+/v1/*/endpointInfos.json        = kapuaAuthcAccessToken
+/v1/*/endpointInfos.xml         = kapuaAuthcAccessToken
+/v1/*/endpointInfos/**          = kapuaAuthcAccessToken
 
 # Jobs
-/v1/*/jobs.json                 = corsFilter, kapuaAuthcAccessToken
-/v1/*/jobs.xml                  = corsFilter, kapuaAuthcAccessToken
-/v1/*/jobs/**                   = corsFilter, kapuaAuthcAccessToken
+/v1/*/jobs.json                 = kapuaAuthcAccessToken
+/v1/*/jobs.xml                  = kapuaAuthcAccessToken
+/v1/*/jobs/**                   = kapuaAuthcAccessToken
 
 # Service Configurations
-/v1/*/serviceConfigurations     = corsFilter, kapuaAuthcAccessToken
-/v1/*/serviceConfigurations/**  = corsFilter, kapuaAuthcAccessToken
+/v1/*/serviceConfigurations     = kapuaAuthcAccessToken
+/v1/*/serviceConfigurations/**  = kapuaAuthcAccessToken
 
 # Streams
-/v1/*/streams/**                = corsFilter, kapuaAuthcAccessToken
+/v1/*/streams/**                = kapuaAuthcAccessToken
 
 # Tag
-/v1/*/tags.json                 = corsFilter, kapuaAuthcAccessToken
-/v1/*/tags.xml                  = corsFilter, kapuaAuthcAccessToken
-/v1/*/tags/**                   = corsFilter, kapuaAuthcAccessToken
+/v1/*/tags.json                 = kapuaAuthcAccessToken
+/v1/*/tags.xml                  = kapuaAuthcAccessToken
+/v1/*/tags/**                   = kapuaAuthcAccessToken
 
 # User
-/v1/*/users.json                = corsFilter, kapuaAuthcAccessToken
-/v1/*/users.xml                 = corsFilter, kapuaAuthcAccessToken
-/v1/*/users/**                  = corsFilter, kapuaAuthcAccessToken
-
-# All other paths
-/v1/**                          = corsFilter
+/v1/*/users.json                = kapuaAuthcAccessToken
+/v1/*/users.xml                 = kapuaAuthcAccessToken
+/v1/*/users/**                  = kapuaAuthcAccessToken

--- a/rest-api/web/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/web/src/main/webapp/WEB-INF/web.xml
@@ -32,6 +32,16 @@
 
     <!-- -->
     <!-- Filters -->
+
+    <filter>
+        <filter-name>CORSResponseFilter</filter-name>
+        <filter-class>org.eclipse.kapua.app.api.core.CORSResponseFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>CORSResponseFilter</filter-name>
+        <url-pattern>/v1/*</url-pattern>
+    </filter-mapping>
+
     <filter>
         <filter-name>ShiroFilter</filter-name>
         <filter-class>org.apache.shiro.web.servlet.ShiroFilter</filter-class>


### PR DESCRIPTION
Two changes about REST APIs in this PR:

- WADL generation when issuing an `OPTIONS` HTTP request has been disabled
- `CORSResponseFilter`, that was moved in Shiro with #2855, has been refactored to be a standalone Filter, since it's more logical. It will still be executed before the Shiro filter anyway, so the logic of that change is preserved.

**Related Issue**
No related issues
