### PR TITLE
Added unit tests for broker/core converter and listener module

### DIFF
--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -231,6 +231,11 @@
             <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverterTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/converter/AbstractKapuaConverterTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.converter;
+
+import org.eclipse.kapua.commons.metric.MetricsService;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AbstractKapuaConverterTest extends Assert {
+
+    AbstractKapuaConverter converter;
+
+    @Before
+    public void start() {
+        converter = Mockito.mock(AbstractKapuaConverter.class, Mockito.CALLS_REAL_METHODS);
+    }
+
+    @Test
+    public void convertToJmsMessageNullTest() {
+        try {
+            converter.convertToJmsMessage(null, null);
+            fail("Exception should be thrown");
+        } catch (Exception e) {
+            // pass
+        }
+    }
+
+    @Test
+    public void metricServiceTest() {
+        Object metricService = AbstractKapuaConverter.METRICS_SERVICE;
+        assertTrue(metricService instanceof MetricsService);
+    }
+
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverterTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/converter/DeviceManagementNotificationConverterTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.converter;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DeviceManagementNotificationConverterTest extends Assert {
+
+    DeviceManagementNotificationConverter converter;
+
+    @Before
+    public void start() {
+        converter = new DeviceManagementNotificationConverter();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void convertToManagementNotificationNullTest() throws KapuaException {
+        converter.convertToManagementNotification(null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void convertToManagementNotificationOnExceptionNullTest() throws KapuaException {
+        converter.convertToManagementNotificationOnException(null, null);
+    }
+
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DataStorageMessageProcessorTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import com.google.inject.ProvisionException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DataStorageMessageProcessorTest extends Assert {
+
+    @Test(expected = ProvisionException.class)
+    public void constructorTest() {
+        DataStorageMessageProcessor processor = new DataStorageMessageProcessor();
+    }
+
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessageTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessageTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message;
+
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProvider;
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptorProviders;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.message.KapuaMessageFactory;
+import org.eclipse.kapua.message.internal.KapuaMessageFactoryImpl;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class CamelKapuaMessageTest extends Assert {
+
+    CamelKapuaMessage message;
+
+    @Before
+    public void start() {
+        message = new CamelKapuaMessage(null, null, null);
+    }
+
+    @Test
+    public void setAndGetMessageTest() {
+        KapuaMessageFactory messageFactory = new KapuaMessageFactoryImpl();
+        KapuaMessage message1 = messageFactory.newMessage();
+        message.setMessage(message1);
+        assertEquals(message1, message.getMessage());
+    }
+
+    @Test
+    public void setAndGetConnectionIdTest() {
+        KapuaId id = KapuaId.ONE;
+        message.setConnectionId(id);
+        assertEquals(id, message.getConnectionId());
+    }
+
+    @Test
+    public void setAndGetDatastoreIdTest() {
+        String[] ids = {"1", "awsd", "123123123", "-123", "ASDa12$%~", "~ˇ#$%&/()=?*\\", "DSUrCucsvb2qUwbdD5yyiCC5v1wwF5FmBIcWa2oXafNw5bqV2RAcyyN0gCHQTdL2JedME5A4PXsXt7iHekhys52GZVmiCNcA065RxFEsDasCcaH1dzeRioRvA14NoJPGmScHdHf8Mfzv03vWrs7n2W59f1In9NdUtnaxY1Wp5TjknB6X8U5ZRczLntQZNX3MSu5f4OzF29oTtuDcuPIUal6OBTKnm8qLVhsiu3oMK3YnFhoHuiATBk3Pl0q9LaL"};
+        for (String id : ids) {
+            message.setDatastoreId(id);
+            assertEquals(id, message.getDatastoreId());
+        }
+    }
+
+    @Test
+    public void setAndGetConnectorDescriptorTest() {
+        ConnectorDescriptorProvider descriptorProvider = ConnectorDescriptorProviders.getInstance();
+        ConnectorDescriptor descriptor = descriptorProvider.getDescriptor("test");
+        message.setConnectorDescriptor(descriptor);
+        assertEquals(descriptor, message.getConnectorDescriptor());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelUtilTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelUtilTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message;
+
+import org.apache.activemq.command.ActiveMQTopic;
+import org.apache.camel.impl.DefaultMessage;
+import org.eclipse.kapua.broker.core.listener.CamelConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.jms.JMSException;
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class CamelUtilTest extends Assert {
+
+    @Test(expected = NullPointerException.class)
+    public void getTopicNullTest() throws JMSException {
+        String topic = CamelUtil.getTopic(null);
+    }
+
+    @Test
+    public void getTopicTest() throws JMSException {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put("originalTopic", "testTopic");
+        message.setHeaders(map);
+        String topic = CamelUtil.getTopic(message);
+        assertEquals("testTopic", topic);
+    }
+
+    @Test(expected = JMSException.class)
+    public void getTopicWithOrigTopicTest() throws JMSException {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put(MessageConstants.PROPERTY_ORIGINAL_TOPIC, null);
+        message.setHeaders(map);
+        String topic = CamelUtil.getTopic(message);
+    }
+
+    @Test
+    public void getTopicWithJmsHeaderDestinationTest() throws JMSException {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put(CamelConstants.JMS_HEADER_DESTINATION, new ActiveMQTopic("VirtualTopic.topic1"));
+        message.setHeaders(map);
+        String topic = CamelUtil.getTopic(message);
+        assertEquals("topic1", topic);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreatorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreatorTest.java
@@ -1,0 +1,81 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message.system;
+
+import org.eclipse.kapua.broker.core.plugin.KapuaConnectionContext;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class DefaultSystemMessageCreatorTest extends Assert {
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        String result = messageCreator.createMessage(null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullMessageTypeTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        KapuaConnectionContext kcc = new KapuaConnectionContext(new Long("1"), "1", "client1");
+        String result = messageCreator.createMessage(null, kcc);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullKbcTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        String result = messageCreator.createMessage(SystemMessageCreator.SystemMessageType.CONNECT, null);
+    }
+
+    @Test
+    public void createMessageConnectTypeTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        KapuaConnectionContext kcc = new KapuaConnectionContext(new Long("1"), "1", "client1");
+        String result = messageCreator.createMessage(SystemMessageCreator.SystemMessageType.CONNECT, kcc);
+        assertEquals("Event,CONNECT,,DeviceId,1,,Username,null", result);
+    }
+
+    @Test
+    public void createMessageDisconnectTypeTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        KapuaConnectionContext kcc = new KapuaConnectionContext(new Long("1"), "1", "client1");
+        String result = messageCreator.createMessage(SystemMessageCreator.SystemMessageType.DISCONNECT, kcc);
+        assertEquals("Event,DISCONNECT,,DeviceId,1,,Username,null", result);
+    }
+
+    @Test
+    public void convertFromTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        Map<String, String> map = messageCreator.convertFrom("DeviceId,device1,,Username,user1");
+        assertEquals("device1", messageCreator.getDeviceId(map));
+        assertEquals("user1", messageCreator.getUsername(map));
+    }
+
+    @Test
+    public void convertFromWrongArgumentsTest() {
+        DefaultSystemMessageCreator messageCreator = new DefaultSystemMessageCreator();
+        String[] values = {"a", "test,test,test,test", "::::", "test,test,,test,test,,test,test", ",,,,", "test, test, test, test, test"};
+        for (String value : values) {
+            try {
+                Map<String, String> map = messageCreator.convertFrom("Dasdasdsdasd");
+                fail("Exception should be thrown");
+            } catch (IllegalArgumentException e) {
+                // pass
+            }
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/AclTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/AclTest.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AclTest extends Assert {
+
+    @Test
+    public void aclAllTrueTest() {
+        Acl acl = new Acl(true, true, true);
+        assertTrue(acl.isAdmin());
+        assertTrue(acl.isRead());
+        assertTrue(acl.isWrite());
+    }
+
+    @Test
+    public void aclAllFalseTest() {
+        Acl acl = new Acl(false, false, false);
+        assertFalse(acl.isAdmin());
+        assertFalse(acl.isRead());
+        assertFalse(acl.isWrite());
+    }
+
+    @Test
+    public void aclMixedTest() {
+        Acl acl = new Acl(true, false, true);
+        assertTrue(acl.isAdmin());
+        assertTrue(acl.isRead());
+        assertFalse(acl.isWrite());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvidersTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvidersTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ConnectorDescriptorProvidersTest extends Assert {
+
+    @Test
+    public void getInstanceProviderTest() {
+        try {
+            ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
+            assertTrue(provider.toString().startsWith("org.eclipse.kapua.broker.core.plugin.DefaultConnectorDescriptionProvider"));
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+
+    @Test
+    public void getDescriptorNullTest() {
+        ConnectorDescriptor descriptor = ConnectorDescriptorProviders.getDescriptor(null);
+        assertTrue(descriptor.toString().startsWith("org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor"));
+    }
+
+    @Test
+    public void getDescriptorMultipleValuesTest() {
+        String[] values = {"1", "", "123123", "asdaf", "asdsad2123", "a", "#$$#žčš", "@{123213#$%&/(/\\/)\"", "iclMIJRMCu6i1GrZlsM5ZKbcltMpM7sASCbPFl0MEfE689RIs9jjnw2i7GLrgQ7hDlW0d3LosPlfgkMepUqBgLVdmuGXT3RiITICjmcA0TrxkPAjVKaOWkFBY1LiTDcQSF6BcxCCPPxqNbsx2xGnzWL0d8vILXr3mvM2MBGhVSqT4g5CpMcMEiqkJP9YRKWky7Zp41neccWoFjQwFp9jSCZySOiY6J5VB6c1mXdHGxsiuGK8vE3tA029P6jL8Zma", ""};
+        for (String value : values) {
+            ConnectorDescriptor descriptor = ConnectorDescriptorProviders.getDescriptor(value);
+            assertTrue(descriptor.toString().startsWith("org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor"));
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -29,7 +29,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Category(JUnitTests.class)
-public class ConnectorDescriptorTest {
+public class ConnectorDescriptorTest extends Assert {
 
     private static final String BROKER_IP_RESOLVER_CLASS_NAME;
 
@@ -56,27 +56,37 @@ public class ConnectorDescriptorTest {
      * A simple test to get a default descriptor
      */
     @Test
-    public void testNonNull() {
+    public void nonNullProviderTest() {
         ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
-        Assert.assertNotNull(provider);
+        assertNotNull(provider);
     }
 
     /**
      * A simple test to get a descriptor
      */
     @Test
-    public void testDefault1a() {
+    public void defaultDescriptorFromProviderTest() {
         ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
         ConnectorDescriptor descriptor = provider.getDescriptor("foo");
-        Assert.assertNotNull(descriptor);
+        assertNotNull(descriptor);
     }
 
     /**
      * A simple test to get a descriptor
      */
     @Test
-    public void testDefault1b() {
-        Assert.assertNotNull(ConnectorDescriptorProviders.getDescriptor("foo"));
+    public void getDescriptorFromProvidersClassTest() {
+        assertNotNull(ConnectorDescriptorProviders.getDescriptor("foo"));
+    }
+
+    /**
+     * Test for getTransportProtocol
+     */
+    @Test
+    public void getTransportProtocolTest() {
+        ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
+        ConnectorDescriptor descriptor = provider.getDescriptor("foo");
+        assertEquals("MQTT", descriptor.getTransportProtocol());
     }
 
     /**
@@ -86,7 +96,7 @@ public class ConnectorDescriptorTest {
      * </p>
      */
     @Test
-    public void testDefault2() {
+    public void defaultProviderWithDisabledDefaultDescriptorTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
 
@@ -101,7 +111,7 @@ public class ConnectorDescriptorTest {
      * Use a default provider, configuring a file which does not exist
      */
     @Test(expected = Exception.class)
-    public void testDefault3() {
+    public void defaultProviderWithNonExistingFileTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/does-not-exist.properties");
 
@@ -112,7 +122,7 @@ public class ConnectorDescriptorTest {
      * Use a default provider, configuring a file which does exist, but allow default fallback
      */
     @Test
-    public void testDefault4() {
+    public void defaultProviderAllowingDefaultFallbackTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/1.properties");
 
@@ -127,7 +137,7 @@ public class ConnectorDescriptorTest {
      * Use a default provider, configuring an empty file, disabling default
      */
     @Test
-    public void testDefault5() {
+    public void defaultProviderWithEmptyFileTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/1.properties");
@@ -143,7 +153,7 @@ public class ConnectorDescriptorTest {
      * Use a default provider, configuring a non-empty configuration
      */
     @Test
-    public void testDefault6() throws Exception {
+    public void defaultProviderUsingNonEmptyConfigurationTest() throws Exception {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/2.properties");
@@ -167,7 +177,7 @@ public class ConnectorDescriptorTest {
      * Use a default provider, configuring a non-empty, invalid configuration
      */
     @Test(expected = Exception.class)
-    public void testDefault7() {
+    public void defaultProviderWithInvalidConfigurationTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/3.properties");
@@ -179,7 +189,7 @@ public class ConnectorDescriptorTest {
      * Empty configuration URL
      */
     @Test
-    public void testConfig1() {
+    public void emptyConfigurationUrlTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "");
 

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilterTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaApplicationBrokerFilterTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.event.ServiceEventBusException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaApplicationBrokerFilterTest extends Assert {
+
+    @Test(expected = ServiceEventBusException.class)
+    public void startNullTest() throws Exception {
+        KapuaApplicationBrokerFilter filter = new KapuaApplicationBrokerFilter(null);
+        filter.start();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void stopNullTest() throws Exception {
+        KapuaApplicationBrokerFilter filter = new KapuaApplicationBrokerFilter(null);
+        filter.stop();
+    }
+
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContextTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaConnectionContextTest.java
@@ -1,0 +1,141 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.apache.activemq.command.ConnectionId;
+import org.apache.activemq.command.ConnectionInfo;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaPrincipal;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaConnectionContextTest extends Assert {
+
+    @Test
+    public void firstConstructorTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        assertEquals("client1", connectionContext.getFullClientId());
+        assertEquals("1", connectionContext.getClientId());
+        assertEquals(Long.parseLong("0"), connectionContext.getScopeIdAsLong());
+        assertEquals("1", connectionContext.getClientId());
+    }
+
+    @Test
+    public void secondConstructorTest() {
+        ConnectionInfo connectionInfo = new ConnectionInfo();
+        connectionInfo.setUserName("testuser");
+        connectionInfo.setClientId("1");
+        connectionInfo.setClientIp("192.168.1.2");
+        connectionInfo.setConnectionId(new ConnectionId("1"));
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext("broker1", connectionInfo);
+        assertEquals("broker1" ,connectionContext.getBrokerId());
+        assertEquals("1" ,connectionContext.getClientId());
+        assertEquals("testuser" ,connectionContext.getUserName());
+        assertEquals("192.168.1.2" ,connectionContext.getClientIp());
+        assertEquals("1" ,connectionContext.getConnectionId());
+    }
+
+    @Test
+    public void thirdConstructorTest() {
+        ConnectionInfo connectionInfo = new ConnectionInfo();
+        connectionInfo.setUserName("testuser");
+        connectionInfo.setClientId("1");
+        connectionInfo.setClientIp("192.168.1.2");
+        connectionInfo.setConnectionId(new ConnectionId("1"));
+        AccessToken accessToken = new AccessTokenImpl();
+        accessToken.setScopeId(KapuaId.ONE);
+        KapuaPrincipal kapuaPrincipal = new KapuaPrincipalImpl(accessToken, "user1", "client1", "192.168.2.2");
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext("broker1", "192.168.1.2", kapuaPrincipal, "account1", connectionInfo, "{0}:{1}", true);
+        assertEquals("broker1" ,connectionContext.getBrokerId());
+        assertEquals("client1" ,connectionContext.getClientId());
+        assertEquals("testuser" ,connectionContext.getUserName());
+        assertEquals("192.168.1.2" ,connectionContext.getClientIp());
+        assertEquals("1" ,connectionContext.getConnectionId());
+        assertTrue(connectionContext.isMissing());
+    }
+
+    @Test
+    public void updateTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        AccessToken accessToken = new AccessTokenImpl();
+        accessToken.setScopeId(KapuaId.ONE);
+        connectionContext.update(accessToken, "account1", KapuaId.ONE, KapuaId.ONE, "connector1", "192.168.1.2", "{0}:{1}");
+        assertEquals(KapuaId.ONE, connectionContext.getScopeId());
+        assertEquals(KapuaId.ONE, connectionContext.getUserId());
+        assertEquals("192.168.1.2", connectionContext.getBrokerIpOrHostName());
+    }
+
+    @Test
+    public void updatePermissionsTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        connectionContext.updatePermissions(new boolean[]{true, false, true});
+        assertEquals(true, connectionContext.getHasPermissions()[0]);
+        assertEquals(false, connectionContext.getHasPermissions()[1]);
+        assertEquals(true, connectionContext.getHasPermissions()[2]);
+        assertEquals(3, connectionContext.getHasPermissions().length);
+    }
+
+    @Test
+    public void updateKapuaConnectionIdNullTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        connectionContext.updateKapuaConnectionId(null);
+        assertNull(connectionContext.getKapuaConnectionId());
+    }
+
+    @Test
+    public void updateOldConnectionIdTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        connectionContext.updateOldConnectionId("con1");
+        assertEquals("con1", connectionContext.getOldConnectionId());
+    }
+
+    @Test
+    public void gettersTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        assertEquals("client1", connectionContext.getFullClientId());
+        assertNull(connectionContext.getAccountName());
+        assertNull(connectionContext.getBrokerId());
+        assertNull(connectionContext.getClientCertificates());
+        assertNull(connectionContext.getUserName());
+        assertNull(connectionContext.getScopeId());
+        assertEquals("1", connectionContext.getClientId());
+        assertNull(connectionContext.getScopeId());
+        assertEquals(Long.parseLong("0"), connectionContext.getScopeIdAsLong());
+        assertEquals("1", connectionContext.getClientId());
+        assertNull(connectionContext.getClientIp());
+        assertNull(connectionContext.getPrincipal());
+        assertNull(connectionContext.getConnectionId());
+        assertNull(connectionContext.getOldConnectionId());
+        assertNull(connectionContext.getConnectorDescriptor());
+        assertNull(connectionContext.getKapuaConnectionId());
+        assertNull(connectionContext.getUserId());
+        assertNull(connectionContext.getHasPermissions());
+        assertNull(connectionContext.getBrokerIpOrHostName());
+        assertFalse(connectionContext.isMissing());
+    }
+
+    @Test
+    public void logAuthDestinationTest() {
+        KapuaConnectionContext connectionContext = new KapuaConnectionContext(Long.parseLong("1"), "1", "client1");
+        try {
+            connectionContext.logAuthDestinationToLog();
+            connectionContext.addAuthDestinationToLog("test");
+        } catch (Exception e) {
+            fail("No exception should be thrown");
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdExceptionTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdExceptionTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaDuplicateClientIdExceptionTest extends Assert {
+
+    @Test(expected = KapuaDuplicateClientIdException.class)
+    public void kapuaDuplicateClientIdExceptionNotNullTest() throws KapuaDuplicateClientIdException {
+        throw new KapuaDuplicateClientIdException("someId");
+    }
+
+    @Test(expected = KapuaDuplicateClientIdException.class)
+    public void kapuaDuplicateClientIdExceptionNullTest() throws KapuaDuplicateClientIdException {
+        throw new KapuaDuplicateClientIdException(null);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImplTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImplTest.java
@@ -1,0 +1,136 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaPrincipalImplTest extends Assert {
+
+    KapuaPrincipalImpl kapuaPrincipal;
+
+    @Before
+    public void start() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        kapuaPrincipal = new KapuaPrincipalImpl(token, "user1", "client1", "192.168.1.2");
+    }
+
+    @Test
+    public void gettersTest() {
+        assertEquals("user1", kapuaPrincipal.getName());
+        assertEquals("192.168.1.2", kapuaPrincipal.getClientIp());
+        assertEquals("client1", kapuaPrincipal.getClientId());
+        assertEquals("1", kapuaPrincipal.getTokenId());
+        assertEquals(KapuaId.ONE, kapuaPrincipal.getUserId());
+        assertEquals(KapuaId.ONE, kapuaPrincipal.getAccountId());
+    }
+
+    @Test
+    public void hashCodeTest() {
+        assertEquals(111580519, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hashCodeWithNullAccountTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(null);
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(token, "user1", "client1", "192.168.1.2");
+        assertEquals(111579527, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hashCodeWithNullUsernameTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(token, null, "client1", "192.168.1.2");
+        assertEquals(1953, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hashCodeWithNullUsernameAndScopeIdTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(null);
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(token, null, "client1", "192.168.1.2");
+        assertEquals(961, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void equalsDifferentValuesTest() {
+        assertTrue(kapuaPrincipal.equals(kapuaPrincipal));
+        assertFalse(kapuaPrincipal.equals(null));
+        assertFalse(kapuaPrincipal.equals("test"));
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        KapuaPrincipalImpl nullPrincipal = new KapuaPrincipalImpl(token, null, null, null);
+        assertFalse(kapuaPrincipal.equals(nullPrincipal));
+        assertFalse(nullPrincipal.equals(kapuaPrincipal));
+
+    }
+
+    @Test
+    public void equalsWithSameAccountTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl nullPrincipal = new KapuaPrincipalImpl(token, null, null, null);
+        assertFalse(kapuaPrincipal.equals(nullPrincipal));
+        assertFalse(nullPrincipal.equals(kapuaPrincipal));
+    }
+
+    @Test
+    public void equalsWithDifferentNameTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl nullPrincipal = new KapuaPrincipalImpl(token, "differentName", "client1", "192.168.1.2");
+        assertFalse(nullPrincipal.equals(kapuaPrincipal));
+    }
+
+    @Test
+    public void equalsWithNullNameTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl nullPrincipal = new KapuaPrincipalImpl(token, null, "client1", "192.168.1.2");
+        assertFalse(nullPrincipal.equals(kapuaPrincipal));
+    }
+
+    @Test
+    public void equalsWithIdenticalPrincipalsTest() {
+        AccessToken token = new AccessTokenImpl();
+        token.setTokenId("1");
+        token.setUserId(KapuaId.ONE);
+        token.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl nullPrincipal = new KapuaPrincipalImpl(token, "user1", "client1", "192.168.1.2");
+        assertTrue(nullPrincipal.equals(kapuaPrincipal));
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetricTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ClientMetricTest extends Assert {
+
+    ClientMetric clientMetric;
+
+    @Before
+    public void start() {
+        clientMetric = ClientMetric.getInstance();
+    }
+
+    @Test
+    public void getConnectedClientTest() {
+        assertEquals(Long.parseLong("0"), clientMetric.getConnectedClient().getCount());
+    }
+
+    @Test
+    public void getConnectedKapuaSysTest() {
+        assertEquals(Long.parseLong("0"), clientMetric.getConnectedKapuasys().getCount());
+    }
+
+    @Test
+    public void getDisconnectionClientTest() {
+        assertEquals(Long.parseLong("0"), clientMetric.getDisconnectionClient().getCount());
+    }
+
+    @Test
+    public void getDisconnectionKapuasysTest() {
+        assertEquals(Long.parseLong("0"), clientMetric.getDisconnectionKapuasys().getCount());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetricTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import com.codahale.metrics.Counter;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class LoginMetricTest extends Assert {
+
+    LoginMetric loginMetric;
+
+    @Before
+    public void start() {
+        loginMetric = LoginMetric.getInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertNotNull(loginMetric.getSuccess());
+        assertNotNull(loginMetric.getFailure());
+        assertNotNull(loginMetric.getInvalidUserPassword());
+        assertNotNull(loginMetric.getInvalidClientId());
+        assertNotNull(loginMetric.getKapuasysTokenAttempt());
+        assertNotNull(loginMetric.getNormalUserAttempt());
+        assertNotNull(loginMetric.getStealingLinkConnect());
+        assertNotNull(loginMetric.getStealingLinkDisconnect());
+        assertNotNull(loginMetric.getRemoteStealingLinkDisconnect());
+        assertNotNull(loginMetric.getAdminStealingLinkDisconnect());
+        assertNotNull(loginMetric.getAddConnectionTime());
+        assertNotNull(loginMetric.getNormalUserTime());
+        assertNotNull(loginMetric.getShiroLoginTime());
+        assertNotNull(loginMetric.getCheckAccessTime());
+        assertNotNull(loginMetric.getFindDeviceConnectionTime());
+        assertNotNull(loginMetric.getUpdateDeviceConnectionTime());
+        assertNotNull(loginMetric.getShiroLogoutTime());
+        assertNotNull(loginMetric.getSendLoginUpdateMsgTime());
+        assertNotNull(loginMetric.getRemoveConnectionTime());
+    }
+
+    @Test
+    public void settersTest() {
+        Counter counter = new Counter();
+        loginMetric.setAdminStealingLinkDisconnect(counter);
+        assertEquals(counter, loginMetric.getAdminStealingLinkDisconnect());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetricTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class PublishMetricTest extends Assert {
+
+    PublishMetric publishMetric;
+
+    @Before
+    public void start() {
+        publishMetric = PublishMetric.getInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertNotNull(publishMetric.getAllowedMessages());
+        assertNotNull(publishMetric.getNotAllowedMessages());
+        assertNotNull(publishMetric.getTime());
+        assertNotNull(publishMetric.getMessageSizeAllowed());
+        assertNotNull(publishMetric.getMessageSizeNotAllowed());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetricTest.java
@@ -1,0 +1,36 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class SubscribeMetricTest extends Assert {
+
+    SubscribeMetric subscribeMetric;
+
+    @Before
+    public void start() {
+        subscribeMetric = SubscribeMetric.getInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertEquals(Long.parseLong("0"), subscribeMetric.getAllowedMessages().getCount());
+        assertEquals(Long.parseLong("0"), subscribeMetric.getNotAllowedMessages().getCount());
+        assertEquals(Long.parseLong("0"), subscribeMetric.getTime().getCount());
+    }
+}


### PR DESCRIPTION
Signed-off-by: zanpizmoht <zan.pizmoht@comtrade.com>

First part of locator module unit tests were added.

**Related Issue**
/

**Description of the solution adopted**
Unit tests for broker module were added. This is the first part of tests. Second part is waiting for this one to merge because of the 1k LOC limit.

**Screenshots**
/
