### PR TITLE
New sorting on Device View Tabs

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundlesDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundlesDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabBundlesDescriptor extends AbstractEntityTabDescriptor<GwtD
 
     @Override
     public Integer getOrder() {
-        return 400;
+        return 500;
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommandDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommandDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabCommandDescriptor extends AbstractEntityTabDescriptor<GwtD
 
     @Override
     public Integer getOrder() {
-        return 600;
+        return 800;
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfigurationDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabConfigurationDescriptor extends AbstractEntityTabDescripto
 
     @Override
     public Integer getOrder() {
-        return 500;
+        return 600;
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistoryDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/history/DeviceTabHistoryDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabHistoryDescriptor extends AbstractEntityTabDescriptor<GwtD
 
     @Override
     public Integer getOrder() {
-        return 200;
+        return 300;
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackagesDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabPackagesDescriptor extends AbstractEntityTabDescriptor<Gwt
 
     @Override
     public Integer getOrder() {
-        return 300;
+        return 400;
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfileDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/profile/DeviceTabProfileDescriptor.java
@@ -26,7 +26,7 @@ public class DeviceTabProfileDescriptor extends AbstractEntityTabDescriptor<GwtD
 
     @Override
     public String getViewId() {
-        return "device.tabs";
+        return "device.profile";
     }
 
     @Override

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTagsDescriptor.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/tag/DeviceTabTagsDescriptor.java
@@ -31,7 +31,7 @@ public class DeviceTabTagsDescriptor extends AbstractEntityTabDescriptor<GwtDevi
 
     @Override
     public Integer getOrder() {
-        return 150;
+        return 200;
     }
 
     @Override


### PR DESCRIPTION
This PR changes the sorting of the tabs on the Device view.

New order is:

- Description
- Tags
- Events
- Packages
- Bundles
- Configuration
- Assets
- Command

**Related Issue**
_None_

**Description of the solution adopted**
Just changed the `order` number in the tabs.

**Screenshots**
_None_

**Any side note on the changes made**
_None_