### PR TITLE
Add logging on the SSO

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -120,6 +120,7 @@ public class KapuaLiquibaseClient {
         ConfigurationPrinter
                 .create()
                 .withLogger(LOG)
+                .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                 .withTitle("KapuaLiquibaseClient Configuration")
                 .addParameter("Liquibase Version", currentLiquibaseVersionString)
                 .addHeader("DB connection info")

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
@@ -15,7 +15,7 @@ import org.apache.http.client.utils.URIBuilder;
 import org.eclipse.kapua.app.console.core.server.util.SsoHelper;
 import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.sso.SingleSignOnLocator;
-import org.eclipse.kapua.sso.exception.SsoException;
+import org.eclipse.kapua.sso.exception.SsoAccessTokenException;
 import org.eclipse.kapua.sso.exception.uri.SsoIllegalUriException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -36,6 +36,12 @@ public class SsoCallbackServlet extends HttpServlet {
 
     private static final Logger logger = LoggerFactory.getLogger(SsoCallbackServlet.class);
 
+    private static final String ACCESS_TOKEN_PARAM = "access_token";
+    private static final String ID_TOKEN_PARAM = "id_token";
+    private static final String ERROR_PARAM = "error";
+    private static final String ERROR_DESCRIPTION_PARAM = "error_description";
+    private static final String HIDDEN_SECRET = "****";
+
     private SingleSignOnLocator locator;
 
     @Override
@@ -48,52 +54,59 @@ public class SsoCallbackServlet extends HttpServlet {
     protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws ServletException, IOException {
         final String authCode = req.getParameter("code");
 
-        final String homeUri;
+        String homeUri = "";
+        StringBuilder logStr = new StringBuilder();
+        logStr.append("SSO Servlet Log:");
+        logStr.append("\n\tSSO servlet request:");
+        logStr.append("\n\t\tRequest URL: ").append(req.getRequestURL());
+        logStr.append("\n\t\tAuthCode: ").append(HIDDEN_SECRET);
+        logStr.append("\n\tSSO servlet response:");
         try {
             homeUri = SsoHelper.getHomeUri();
-        } catch (SsoIllegalUriException e) {
-            throw new ServletException("Failed to get Home URI (null or empty): " + e.getMessage(), e);
-        }
-        final URI redirectUri = SsoHelper.getRedirectUri();
-        if (authCode != null) {
+            logStr.append("\n\t\tResponse URI: ").append(homeUri);
+            final URIBuilder redirect = new URIBuilder(homeUri);
 
-            final JsonObject jsonObject;
-            try {
-                jsonObject = locator.getService().getAccessToken(authCode, redirectUri);
-            } catch (SsoException sje) {
-                throw new ServletException("Failed to get access token: " + sje.getMessage(), sje);
-            }
+            if (authCode != null) {
+                final URI redirectUri = SsoHelper.getRedirectUri();
+                final JsonObject jsonObject = locator.getService().getAccessToken(authCode, redirectUri);
 
-            // Get and clean jwks_uri property
-            final String accessToken = jsonObject.getString("access_token");
-            final String idToken = jsonObject.getString("id_token");
-            try {
-                final URIBuilder redirect = new URIBuilder(homeUri);
-                redirect.addParameter("access_token", accessToken);
-                redirect.addParameter("id_token", idToken);
+                // Get and clean jwks_uri property
+                final String accessToken = jsonObject.getString(ACCESS_TOKEN_PARAM);
+                final String idToken = jsonObject.getString(ID_TOKEN_PARAM);
+                redirect.addParameter(ACCESS_TOKEN_PARAM, accessToken);
+                redirect.addParameter(ID_TOKEN_PARAM, idToken);
                 resp.sendRedirect(redirect.toString());
-            } catch (final URISyntaxException e) {
-                throw new ServletException("Failed to parse redirect URL " + homeUri + " : " + e.getMessage(), e);
-            }
-        } else {
 
-            // access_token is null, collect possible error
-            final String error = req.getParameter("error");
-            String errorDescription = "";
-            if (error != null) {
-                errorDescription = req.getParameter("error_description");
-                logger.warn("Failed to log in: {}, error_description: {}", error, errorDescription);
+                logStr.append("\n\t\t").append(ACCESS_TOKEN_PARAM).append(": ").append(HIDDEN_SECRET);
+                logStr.append("\n\t\t").append(ID_TOKEN_PARAM).append(": ").append(HIDDEN_SECRET);
+                logger.debug("Successfully sent the redirect response to {}", homeUri);
             } else {
-                throw new ServletException("Invalid HttpServletRequest");
+
+                // access_token is null, collect possible error
+                final String error = req.getParameter(ERROR_PARAM);
+                if (error != null) {
+                    String errorDescription = req.getParameter(ERROR_DESCRIPTION_PARAM);
+                    redirect.addParameter(ERROR_PARAM, error);
+                    redirect.addParameter(ERROR_DESCRIPTION_PARAM, errorDescription);
+                    resp.sendRedirect(redirect.toString());
+
+                    logStr.append("\n\t\t").append(ERROR_PARAM).append(": ").append(error);
+                    logStr.append("\n\t\t").append(ERROR_DESCRIPTION_PARAM).append(": ").append(errorDescription);
+                    logger.warn("Failed to log in: {}, error_description: {}", error, errorDescription);
+                } else {
+                    resp.sendError(400);
+                    logStr.append("\n\t\t").append("Error: 400 Bad Request");
+                    logger.error("Invalid HttpServletRequest, both 'access_token' and 'error' parameters are 'null'");
+                }
             }
-            try {
-                final URIBuilder redirect = new URIBuilder(homeUri);
-                redirect.addParameter("error", error);
-                redirect.addParameter("error_description", errorDescription);
-                resp.sendRedirect(redirect.toString());
-            } catch (final URISyntaxException e) {
-                throw new ServletException("Failed to parse redirect URL " + homeUri + " : " + e.getMessage(), e);
-            }
+        } catch (SsoIllegalUriException siue) {
+            throw new ServletException("Failed to get Home URI (null or empty): " + siue.getMessage(), siue);
+        } catch (SsoAccessTokenException sate) {
+            throw new ServletException("Failed to get access token: " + sate.getMessage(), sate);
+        } catch (URISyntaxException use) {
+            throw new ServletException("Failed to parse redirect URL " + homeUri + " : " + use.getMessage(), use);
+        } finally {
+            logger.debug("{}", logStr);
         }
     }
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -102,6 +102,7 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
                     ConfigurationPrinter
                             .create()
                             .withLogger(LOG)
+                            .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                             .withTitle("Elasticsearch REST Provider Configuration")
                             .addParameter("Module Name", getClientConfiguration().getModuleName())
                             .addParameter("Cluster Name", getClientConfiguration().getClusterName())

--- a/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
@@ -72,6 +72,7 @@ public class TransportElasticsearchClientProvider implements ElasticsearchClient
                     ConfigurationPrinter
                             .create()
                             .withLogger(LOG)
+                            .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                             .withTitle("Elasticsearch Transport Provider Configuration")
                             .addParameter("Module Name", getClientConfiguration().getModuleName())
                             .addParameter("Cluster Name", getClientConfiguration().getClusterName())

--- a/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
+++ b/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
@@ -82,6 +82,7 @@ public class EsEmbeddedEngine implements Closeable {
                     ConfigurationPrinter
                             .create()
                             .withLogger(LOG)
+                            .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                             .withTitle("Elasticsearch Embedded Node Configuration")
                             .addParameter("Cluster name", clusterName)
                             .addParameter("Data Directory", defaultDataDirectory)

--- a/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnService.java
+++ b/sso/api/src/main/java/org/eclipse/kapua/sso/SingleSignOnService.java
@@ -11,7 +11,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.sso;
 
-import org.eclipse.kapua.sso.exception.SsoException;
+import org.eclipse.kapua.sso.exception.SsoAccessTokenException;
 import org.eclipse.kapua.sso.exception.uri.SsoUriException;
 
 import javax.json.JsonObject;
@@ -45,9 +45,9 @@ public interface SingleSignOnService {
      * @param authCode the authorization code from the HttpServletRequest.
      * @param redirectUri a URI object representing the redirect URI.
      * @return the access token in the form of a {@link JsonObject}.
-     * @throws SsoException if it fails to retrieve the access token.
+     * @throws SsoAccessTokenException if it fails to retrieve the access token.
      */
-    JsonObject getAccessToken(String authCode, URI redirectUri) throws SsoException;
+    JsonObject getAccessToken(String authCode, URI redirectUri) throws SsoAccessTokenException;
 
     /**
      * Get the Relying-Party-Initiated logout.


### PR DESCRIPTION
This PR adds some logging messages to SSO methods, in particular when performing HTTP requests and when retrieving URLs/URIs.

**Related Issue**
_n/a_

**Description of the solution adopted**
_n/a_

**Screenshots**
_n/a_

**Any side note on the changes made**
Exception handling has also been improved when required.

Please note that since the Kapua default logging level is `info`, while this PR uses `debug` Log4j methods, none of the info provided with this PR will be actually plotted in the log. However please note that PR #3086 introduces adjustable logging level, allowing one to set `default` as logging level. So, even if this PR doesn't require other PRs to be merged, it will only work when PR #3086 will be merged.