### PR TITLE
Adding adjustable logging level

### DIFF
--- a/assembly/broker/configurations/logback.xml
+++ b/assembly/broker/configurations/logback.xml
@@ -21,7 +21,7 @@
 
     <logger name="liquibase" level="WARN"/>
 
-    <root level="info">
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
         <appender-ref ref="console"/>
     </root>
 </configuration>

--- a/console/web/src/main/resources/logback.xml
+++ b/console/web/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
 
     <logger name="liquibase" level="WARN"/>
 
-    <root level="info">
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
         <appender-ref ref="console"/>
     </root>
 </configuration>

--- a/deployment/docker/README.md
+++ b/deployment/docker/README.md
@@ -122,3 +122,16 @@ Again, All the values should be exported as inline values. e.g.:
 export KAPUA_KEYSTORE=$(base64 /path/to/keystore.pkcs)
 export KAPUA_KEYSTORE_PASSWORD=keystore_password
 ```
+
+##### Providing custom logging level
+
+The `info` logging level is used as default root level in container logs.
+To provide a different logging level you can set the following environment variable:
+
+- **LOGBACK_LOG_LEVEL**: The logging level value
+
+Allowed logging level values are: `trace`, `debug`, `info`, `warn`, `error`, `all` or `off`.  e.g.:
+
+```bash
+export LOGBACK_LOG_LEVEL=debug
+```

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -42,6 +42,7 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
   kapua-console:
     image: kapua/kapua-console:${IMAGE_VERSION}
     ports:
@@ -61,6 +62,7 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
   kapua-api:
     image: kapua/kapua-api:${IMAGE_VERSION}
     ports:
@@ -80,3 +82,4 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL

--- a/deployment/docker/compose/sso/sso-docker-compose.yml
+++ b/deployment/docker/compose/sso/sso-docker-compose.yml
@@ -39,6 +39,7 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
   kapua-console:
     image: kapua/kapua-console:sso
     ports:
@@ -59,6 +60,7 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
   kapua-api:
     image: kapua/kapua-api:${IMAGE_VERSION}
     ports:
@@ -77,6 +79,7 @@ services:
       - KAPUA_KEY_PASSWORD
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
   keycloak:
     image: keycloak:sso
     ports:

--- a/rest-api/web/src/main/resources/logback.xml
+++ b/rest-api/web/src/main/resources/logback.xml
@@ -21,7 +21,7 @@
 
     <logger name="liquibase" level="WARN"/>
 
-    <root level="info">
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
         <appender-ref ref="console"/>
     </root>
 </configuration>


### PR DESCRIPTION
This PR adds adjustable root logging level to the containers.

**Related Issue**
This PR fixes/closes _#3085_

**Description of the solution adopted**
This PR exploits the Logback variable substitution feature (see [here](http://logback.qos.ch/manual/configuration.html#variableSubstitution) for further details) in order to capture the logging level value from an environment variable. When using the docker deployment, the environment variable can be defined through the `docker_compose.yaml` file; if the variable is not set, `info` is used as default root level.

This change has been applied to all the containers that use Logback in order to manage logging: _broker_, _console_, _rest-api_. Allowed logging level values are: `trace`, `debug`, `info`, `warn`, `error`, `all` or `off`. See [here](http://logback.qos.ch/manual/configuration.html#rootElement) for further information.

**Screenshots**
_N/A_

**Any side note on the changes made**
The containers must be restarted in order to change the root logging level. Each container can use a different logging level.
