### PR TITLE
Two Factor Authentication feature backend

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -25,6 +25,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -21,6 +21,10 @@
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -222,6 +222,7 @@
                 <include>org.springframework.security:spring-security-core</include>
                 <include>org.yaml:snakeyaml</include>
                 <include>javax.cache:cache-api</include>
+                <include>com.warrenstrange:googleauth</include>
 
                 <include>${pom.groupId}:kapua-account-api</include>
                 <include>${pom.groupId}:kapua-account-internal</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -402,6 +402,12 @@
             <artifactId>cache-api</artifactId>
         </dependency>
 
+        <!-- TOTP dependencies -->
+        <dependency>
+            <groupId>com.warrenstrange</groupId>
+            <artifactId>googleauth</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -25,6 +25,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -21,6 +21,10 @@
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -210,6 +210,12 @@
             <artifactId>org.eclipse.scada.utils</artifactId>
         </dependency>
 
+        <!-- QR code generation -->
+        <dependency>
+            <groupId>com.google.zxing</groupId>
+            <artifactId>javase</artifactId>
+        </dependency>
+
     </dependencies>
 
     <build>

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -45,6 +45,7 @@ import org.eclipse.kapua.service.authentication.AuthenticationService;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
 import org.eclipse.kapua.service.authentication.LoginCredentials;
+import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.registration.RegistrationService;
 import org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticationException;
@@ -105,6 +106,8 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             CredentialsFactory credentialsFactory = locator.getFactory(CredentialsFactory.class);
             if (gwtLoginCredentials.getUsername() != null && gwtLoginCredentials.getPassword() != null) {
                 credentials = credentialsFactory.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword());
+                ((UsernamePasswordCredentials) credentials).setAuthenticationCode(gwtLoginCredentials.getAuthenticationCode());
+                ((UsernamePasswordCredentials) credentials).setTrustKey(gwtLoginCredentials.getTrustKey());
             }
 
             // Login

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/ImageServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/ImageServlet.java
@@ -1,0 +1,218 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.core.servlet;
+
+import com.google.zxing.BarcodeFormat;
+import com.google.zxing.client.j2se.MatrixToImageWriter;
+import com.google.zxing.common.BitMatrix;
+import com.google.zxing.qrcode.QRCodeWriter;
+import org.apache.commons.fileupload.disk.DiskFileItemFactory;
+import org.apache.commons.fileupload.servlet.FileCleanerCleanup;
+import org.apache.commons.io.FileCleaningTracker;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaIllegalAccessException;
+import org.eclipse.kapua.KapuaUnauthenticatedException;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSetting;
+import org.eclipse.kapua.app.console.module.api.setting.ConsoleSettingKeys;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
+import org.eclipse.kapua.service.device.management.exception.DeviceManagementException;
+import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import javax.imageio.ImageIO;
+import javax.servlet.ServletContext;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.awt.Color;
+import java.awt.Graphics;
+import java.awt.image.BufferedImage;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.Callable;
+
+public class ImageServlet extends HttpServlet {
+    private static final long serialVersionUID = -5016170117606322129L;
+    private static final Logger logger = LoggerFactory.getLogger(ImageServlet.class);
+
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final AccountService accountService = locator.getService(AccountService.class);
+    private final UserService userService = locator.getService(UserService.class);
+
+    DiskFileItemFactory diskFileItemFactory;
+    FileCleaningTracker fileCleaningTracker;
+
+    private static final int QR_CODE_SIZE = 134;  // TODO: make this configurable?
+
+    @Override
+    public void destroy() {
+        super.destroy();
+        logger.info("Servlet {} destroyed", getServletName());
+        if (fileCleaningTracker != null) {
+            logger.info("Number of temporary files tracked: " + fileCleaningTracker.getTrackCount());
+        }
+    }
+
+    @Override
+    public void init() throws ServletException {
+        super.init();
+        logger.info("Servlet {} initialized", getServletName());
+
+        ServletContext ctx = getServletContext();
+        fileCleaningTracker = FileCleanerCleanup.getFileCleaningTracker(ctx);
+
+        int sizeThreshold = ConsoleSetting.getInstance().getInt(ConsoleSettingKeys.FILE_UPLOAD_INMEMORY_SIZE_THRESHOLD);
+        File repository = new File(System.getProperty("java.io.tmpdir"));
+
+        logger.info("DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD: {}", DiskFileItemFactory.DEFAULT_SIZE_THRESHOLD);
+        logger.info("DiskFileItemFactory: using size threshold of: {}", sizeThreshold);
+
+        diskFileItemFactory = new DiskFileItemFactory(sizeThreshold, repository);
+        diskFileItemFactory.setFileCleaningTracker(fileCleaningTracker);
+    }
+
+    @Override
+    protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        resp.setContentType("image/png");
+
+        String reqPathInfo = req.getPathInfo();
+        if (reqPathInfo == null) {
+            resp.sendError(404);
+            return;
+        }
+
+        logger.debug("req.getRequestURI(): {}", req.getRequestURI());
+        logger.debug("req.getRequestURL(): {}", req.getRequestURL());
+        logger.debug("req.getPathInfo(): {}", req.getPathInfo());
+
+        if (reqPathInfo.equals("/2FAQRcode")) {
+            doGetQRCode(req, resp);
+        } else {
+            resp.sendError(404);
+        }
+    }
+
+    private void doGetQRCode(HttpServletRequest req, HttpServletResponse resp) throws IOException {
+        try {
+            final String username = req.getParameter("username");
+            if (username == null || username.isEmpty()) {
+                throw new IllegalArgumentException("username");
+            }
+
+            final String accountName = req.getParameter("accountName");
+            if (accountName == null || accountName.isEmpty()) {
+                throw new IllegalArgumentException("accountName");
+            }
+
+            String key = req.getParameter("key");
+            if (key == null || key.isEmpty()) {
+                throw new IllegalArgumentException("key");
+            }
+
+            // this is only used to avoid that images are taken by the browser cache instead of being generated again
+            String timestamp = req.getParameter("timestamp");
+            if (timestamp == null || timestamp.isEmpty()) {
+                throw new IllegalArgumentException("timestamp");
+            }
+
+            // check session
+            final KapuaSession session = KapuaSecurityUtils.getSession();
+            if (session == null) {
+                throw new KapuaUnauthenticatedException();
+            }
+
+            // check account existence, using do privileged since the user might not have the required permissions
+            Account account = KapuaSecurityUtils.doPrivileged(new Callable<Account>() {
+
+                @Override
+                public Account call() throws Exception {
+                    return accountService.findByName(accountName);
+                }
+            });
+            if (account == null) {
+                throw new KapuaEntityNotFoundException(Account.TYPE, accountName);
+            }
+
+            // check user existence, using do privileged since the user might not have the required permissions
+            User user = KapuaSecurityUtils.doPrivileged(new Callable<User>() {
+
+                @Override
+                public User call() throws Exception {
+                    return userService.findByName(username);
+                }
+            });
+            if (user == null) {
+                throw new KapuaEntityNotFoundException(User.TYPE, accountName);
+            }
+
+            // decrypt the secret
+            String decryptedKey = AuthenticationUtils.decryptAes(key);
+
+            /*
+            Note that there is no need to verify the secret, since this servlet is only called when the secret has just been generated.
+            Moreover, it would not make any sense to perform it with a fake secret, since it wouldn't be usable for logging in.
+             */
+
+            // url to qr_barcode encoding
+            StringBuilder sb = new StringBuilder();
+            sb.append("otpauth://totp/")
+                    .append(username)
+                    .append("@")
+                    .append(accountName) // TODO: not sure that we also need the account name
+                    .append("?secret=")
+                    .append(decryptedKey);
+
+            BitMatrix bitMatrix = new QRCodeWriter().encode(sb.toString(),
+                    BarcodeFormat.QR_CODE,
+                    QR_CODE_SIZE,
+                    QR_CODE_SIZE);
+
+            BufferedImage resultImage = buildImage(bitMatrix);
+            ImageIO.write(resultImage, "png", resp.getOutputStream());
+
+        } catch (IllegalArgumentException iae) {
+            resp.sendError(400, "Illegal value for query parameter: " + iae.getMessage());
+        } catch (KapuaEntityNotFoundException eenfe) {
+            resp.sendError(400, eenfe.getMessage());
+        } catch (KapuaUnauthenticatedException eiae) {
+            resp.sendError(401, eiae.getMessage());
+        } catch (KapuaIllegalAccessException eiae) {
+            resp.sendError(403, eiae.getMessage());
+        } catch (DeviceManagementException edme) {
+            logger.error("Device menagement exception", edme);
+            resp.sendError(404, edme.getMessage());
+        } catch (Exception e) {
+            logger.error("Generic error", e);
+            resp.sendError(500, e.getMessage());
+        }
+    }
+
+    private BufferedImage buildImage(BitMatrix bitMatrix) {
+        BufferedImage qrCodeImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
+        BufferedImage resultImage = new BufferedImage(QR_CODE_SIZE,
+                QR_CODE_SIZE,
+                BufferedImage.TYPE_INT_RGB);
+
+        Graphics g = resultImage.getGraphics();
+        g.drawImage(qrCodeImage, 0, 0, new Color(232, 232, 232, 255), null);
+
+        return resultImage;
+    }
+}

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtLoginCredential.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/shared/model/authentication/GwtLoginCredential.java
@@ -43,4 +43,26 @@ public class GwtLoginCredential extends KapuaBaseModel {
     public void setPassword(String password) {
         set("password", password);
     }
+
+    public String getAuthenticationCode() {
+        if (get("authenticationCode") != null) {
+            return KapuaSafeHtmlUtils.htmlUnescape(get("authenticationCode").toString());
+        }
+        return null;
+    }
+
+    public void setAuthenticationCode(String authenticationCode) {
+        set("authenticationCode", authenticationCode);
+    }
+
+    public String getTrustKey() {
+        if (get("trustKey") != null) {
+            return KapuaSafeHtmlUtils.htmlUnescape(get("trustKey").toString());
+        }
+        return null;
+    }
+
+    public void setTrustKey(String trustKey) {
+        set("trustKey", trustKey);
+    }
 }

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -241,6 +241,14 @@
                 <artifactId>sanselan</artifactId>
                 <version>${sanselan.version}</version>
             </dependency>
+
+            <!-- QR code generation library -->
+            <dependency>
+                <groupId>com.google.zxing</groupId>
+                <artifactId>javase</artifactId>
+                <version>3.4.1</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -21,6 +21,10 @@
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
         <api>org.eclipse.kapua.service.authentication.registration.RegistrationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,6 +25,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.registration.RegistrationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>

--- a/console/web/src/main/webapp/WEB-INF/web.xml
+++ b/console/web/src/main/webapp/WEB-INF/web.xml
@@ -455,6 +455,16 @@
         <url-pattern>/file/*</url-pattern>
     </servlet-mapping>
 
+    <!-- Image servlet for QR code generation -->
+    <servlet>
+        <servlet-name>ImageServlet</servlet-name>
+        <servlet-class>org.eclipse.kapua.app.console.core.servlet.ImageServlet</servlet-class>
+    </servlet>
+    <servlet-mapping>
+        <servlet-name>ImageServlet</servlet-name>
+        <url-pattern>/image/*</url-pattern>
+    </servlet-mapping>
+
     <servlet>
         <servlet-name>skinServlet</servlet-name>
         <servlet-class>org.eclipse.kapua.app.console.core.servlet.SkinServlet</servlet-class>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.3.0/atht_mfa_credential_option-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.3.0/atht_mfa_credential_option-foreignkey_delete_cascade.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.3.0.xml">
+
+    <changeSet id="changelog-atht_mfa_credential_option-foreignkey-delete-cascade-1.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_mfa_credential_option"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_mfa_credential_option"/>
+                <tableExists tableName="usr_user"/>
+            </and>
+        </preConditions>
+        <addForeignKeyConstraint constraintName="fk_atht_mfa_credential_option_scopeId"
+                                 baseTableName="atht_mfa_credential_option"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+        <addForeignKeyConstraint constraintName="fk_atht_mfa_credential_option_userId"
+                                 baseTableName="atht_mfa_credential_option"
+                                 baseColumnNames="user_id"
+                                 referencedTableName="usr_user"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.3.0/atht_scratch_code-foreignkey_delete_cascade.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.3.0/atht_scratch_code-foreignkey_delete_cascade.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.3.0.xml">
+
+    <changeSet id="changelog-atht_scratch_code-foreignkey-delete-cascade-1.3.0" author="eurotech">
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="atht_scratch_code"/>
+                <tableExists tableName="act_account"/>
+            </and>
+            <and>
+                <tableExists tableName="atht_scratch_code"/>
+                <tableExists tableName="atht_mfa_credential_option"/>
+            </and>
+        </preConditions>
+        <addForeignKeyConstraint constraintName="fk_atht_scratch_code_scopeId"
+                                 baseTableName="atht_scratch_code"
+                                 baseColumnNames="scope_id"
+                                 referencedTableName="act_account"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+        <addForeignKeyConstraint constraintName="fk_atht_scratch_code_mfaCredentialOptionId"
+                                 baseTableName="atht_scratch_code"
+                                 baseColumnNames="mfa_credential_option_id"
+                                 referencedTableName="atht_mfa_credential_option"
+                                 referencedColumnNames="id"
+                                 onDelete="CASCADE"
+                                 onUpdate="RESTRICT"/>
+    </changeSet>
+
+</databaseChangeLog>

--- a/extras/foreignkeys/src/main/resources/liquibase/1.3.0/changelog-foreignkeys-1.3.0.xml
+++ b/extras/foreignkeys/src/main/resources/liquibase/1.3.0/changelog-foreignkeys-1.3.0.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
-    Copyright (c) 2017, 2020 Eurotech and/or its affiliates and others
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
 
     All rights reserved. This program and the accompanying materials
     are made available under the terms of the Eclipse Public License v1.0
@@ -13,10 +13,10 @@
 <databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
                    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
                    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                   logicalFilePath="KapuaDB/changelog-foreignkeys-1.3.0.xml">
 
-    <include relativeToChangelogFile="true" file="./0.3.0/changelog-foreignkeys-0.3.0.xml"/>
-    <include relativeToChangelogFile="true" file="./1.2.0/changelog-foreignkeys-1.2.0.xml"/>
-    <include relativeToChangelogFile="true" file="./1.3.0/changelog-foreignkeys-1.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./atht_mfa_credential_option-foreignkey_delete_cascade.xml"/>
+    <include relativeToChangelogFile="true" file="./atht_scratch_code-foreignkey_delete_cascade.xml"/>
 
 </databaseChangeLog>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -22,6 +22,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
 
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -18,6 +18,10 @@
 
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
 
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>

--- a/pom.xml
+++ b/pom.xml
@@ -1789,6 +1789,13 @@
                 <version>1.1.1</version>
             </dependency>
 
+            <!-- TOTP dependencies -->
+            <dependency>
+                <groupId>com.warrenstrange</groupId>
+                <artifactId>googleauth</artifactId>
+                <version>1.5.0</version>
+            </dependency>
+
         </dependencies>
     </dependencyManagement>
 

--- a/qa/common/src/main/resources/sql/all_delete.sql
+++ b/qa/common/src/main/resources/sql/all_delete.sql
@@ -16,6 +16,10 @@ DELETE FROM atht_credential WHERE NOT (scope_id = 1 AND id IN (1,2,3));
 
 DELETE FROM atht_access_token;
 
+DELETE FROM atht_mfa_credential_option;
+
+DELETE FROM atht_scratch_code;
+
 DELETE FROM athz_role WHERE NOT (scope_id = 1 AND id = 1);
 
 DELETE FROM athz_role_permission WHERE NOT (scope_id = 1 AND role_id = 1);
@@ -36,9 +40,9 @@ DELETE FROM athz_access_permission WHERE NOT (scope_id = 1 AND id = 1);
 
 DELETE FROM athz_access_role WHERE NOT (scope_id = 1 AND id = 1);
 
-DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21);
+DELETE FROM athz_domain_actions WHERE domain_id NOT IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23);
 
-DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21));
+DELETE FROM athz_domain WHERE NOT (scope_id IS null AND id IN (1,2,3,4,5,6,7,8,9,10,11,12,13,14,15,16,17,18,19,20,21,22,23));
 
 DELETE FROM athz_group;
 

--- a/qa/integration/src/test/resources/features/authorization/DomainService.feature
+++ b/qa/integration/src/test/resources/features/authorization/DomainService.feature
@@ -24,7 +24,7 @@ Scenario: Init Security Context for all scenarios
 
     When I login as user with name "kapua-sys" and password "kapua-password"
     When I count the domain entries in the database
-    Then I count 21
+    Then I count 23
 
   Scenario: Regular domain
   Create a regular domain entry. The newly created entry must match the

--- a/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserPermissionI9n.feature
@@ -546,19 +546,19 @@ Feature: User Permission tests
       | name    | displayName  | email             | phoneNumber     | status  | userType |
       | kapua-a | Kapua User a | kapua_a@kapua.com | +386 31 321 123 | ENABLED | INTERNAL |
     When I count the domain entries in the database
-    Then I count 21
+    Then I count 23
     And I create the domain
       | name          | actions             |
       | test_domain   | read, write, delete |
     When I search for the last created domain
     Then The domain matches the creator
     When I count the domain entries in the database
-    Then I count 22
+    Then I count 24
     When I delete the last created domain
     And I search for the last created domain
     Then There is no domain
     When I count the domain entries in the database
-    Then I count 21
+    Then I count 23
     And I logout
 
   Scenario: Add Domain domain permissions to new user
@@ -592,7 +592,7 @@ Feature: User Permission tests
     When I search for the last created domain
     And An exception was thrown
     When I count the domain entries in the database
-    Then I count 21
+    Then I count 23
     And I logout
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I select account "kapua-sys"
@@ -600,7 +600,7 @@ Feature: User Permission tests
       | name           | actions             |
       | test_domain2   | read, write, delete |
     When I count the domain entries in the database
-    Then I count 22
+    Then I count 24
     Then I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
     Then I search for the last created domain
@@ -609,7 +609,7 @@ Feature: User Permission tests
     When I delete the last created domain
     Then An exception was thrown
     When I count the domain entries in the database
-    Then I count 22
+    Then I count 24
     And I logout
 
   Scenario: Add Credential domain permissions to new user

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -24,6 +24,10 @@
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -28,6 +28,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -24,6 +24,7 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
+        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -20,6 +20,10 @@
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
+        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationDomains.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationDomains.java
@@ -12,6 +12,8 @@
 package org.eclipse.kapua.service.authentication;
 
 import org.eclipse.kapua.service.authentication.credential.CredentialDomain;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionDomain;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeDomain;
 import org.eclipse.kapua.service.authentication.token.AccessTokenDomain;
 
 public class AuthenticationDomains {
@@ -21,4 +23,8 @@ public class AuthenticationDomains {
     public static final CredentialDomain CREDENTIAL_DOMAIN = new CredentialDomain();
 
     public static final AccessTokenDomain ACCESS_TOKEN_DOMAIN = new AccessTokenDomain();
+
+    public static final MfaCredentialOptionDomain MFA_CREDENTIAL_OPTION_DOMAIN = new MfaCredentialOptionDomain();
+
+    public static final ScratchCodeDomain SCRATCH_CODE_DOMAIN = new ScratchCodeDomain();
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -35,6 +35,16 @@ public interface AuthenticationService extends KapuaService {
     AccessToken login(LoginCredentials loginCredentials) throws KapuaException;
 
     /**
+     * Login the provided user login credentials on the system (if the credentials are valid) and enable the trust key
+     *
+     * @param loginCredentials
+     * @param enableTrust
+     * @return
+     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     */
+    AccessToken login(LoginCredentials loginCredentials, boolean enableTrust) throws KapuaException;
+
+    /**
      * FIXME: add javadoc
      *
      * @param sessionCredentials

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -23,7 +23,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "usernamePasswordCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "username", "password" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
+@XmlType(propOrder = { "username", "password", "authenticationCode", "trustKey" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
 public interface UsernamePasswordCredentials extends LoginCredentials {
 
     /**
@@ -53,4 +53,32 @@ public interface UsernamePasswordCredentials extends LoginCredentials {
      * @param password
      */
     void setPassword(String password);
+
+    /**
+     * return the authenticationCode
+     *
+     * @return
+     */
+    String getAuthenticationCode();
+
+    /**
+     * Set the authenticationCode
+     *
+     * @param authenticationCode
+     */
+    void setAuthenticationCode(String authenticationCode);
+
+    /**
+     * return the trustKey
+     *
+     * @return the trust key
+     */
+    String getTrustKey();
+
+    /**
+     * Set the trust key
+     *
+     * @param trustKey
+     */
+    void setTrustKey(String trustKey);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOption.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOption.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.model.xml.DateXmlAdapter;
+import org.eclipse.kapua.service.authentication.credential.CredentialXmlRegistry;
+import org.eclipse.kapua.service.user.User;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+import java.util.Date;
+
+/**
+ * MfaCredentialOption definition.<br>
+ * Used to handle MfaCredentialOption needed by the various authentication algorithms.
+ */
+@XmlRootElement(name = "mfaCredentialOption")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = {
+        "userId",
+        "mfaCredentialKey",
+        "trustKey",
+        "trustExpirationDate"}, //
+        factoryClass = CredentialXmlRegistry.class, //
+        factoryMethod = "newMfaCredentialOption") //
+public interface MfaCredentialOption extends KapuaUpdatableEntity {
+
+    String TYPE = "mfaCredentialOption";
+
+    @Override
+    default String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Return the user identifier
+     *
+     * @return The user identifier.
+     */
+    @XmlElement(name = "userId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    KapuaId getUserId();
+
+    /**
+     * Sets the {@link User} id of this {@link MfaCredentialOption}
+     *
+     * @param userId The {@link User} id to set.
+     */
+    void setUserId(KapuaId userId);
+
+    /**
+     * Return the MfaCredentialOption key
+     *
+     * @return
+     */
+    @XmlElement(name = "mfaCredentialKey")
+    String getMfaCredentialKey();
+
+    /**
+     * Sets the MfaCredentialOption key
+     *
+     * @param mfaCredentialKey
+     */
+    void setMfaCredentialKey(String mfaCredentialKey);
+
+    /**
+     * Return the trust key
+     *
+     * @return
+     */
+    @XmlElement(name = "trustKey")
+    String getTrustKey();
+
+    /**
+     * Sets the trust key
+     *
+     * @param trustKey
+     */
+    void setTrustKey(String trustKey);
+
+    /**
+     * Gets the current trust key expiration date
+     *
+     * @return the current trust key expiration date
+     */
+    @XmlElement(name = "trustExpirationDate")
+    @XmlJavaTypeAdapter(DateXmlAdapter.class)
+    Date getTrustExpirationDate();
+
+    /**
+     * Sets the current trust expiration date
+     *
+     * @param trustExpirationDate the current trust expiration date
+     */
+    void setTrustExpirationDate(Date trustExpirationDate);
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionAttributes.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntityAttributes;
+
+/**
+ * MfaCredentialOption predicates used to build query predicates.
+ */
+public class MfaCredentialOptionAttributes extends KapuaUpdatableEntityAttributes {
+
+    public static final String USER_ID = "userId";
+    public static final String MFA_CREDENTIAL_KEY = "mfaCredentialKey";
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionCreator.java
@@ -1,0 +1,66 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * MfaCredentialOption creator service definition.
+ */
+@XmlRootElement(name = "mfaCredentialOptionCreator")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = {"userId",
+        "mfaCredentialKey"}, factoryClass = MfaCredentialOptionXmlRegistry.class, factoryMethod = "newMfaCredentialOptionCreator")
+public interface MfaCredentialOptionCreator extends KapuaEntityCreator<MfaCredentialOption> {
+
+    /**
+     * Gets the user id owner of this token
+     *
+     * @return The user id owner of this token
+     * @since 1.0
+     */
+    @XmlElement(name = "userId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    KapuaId getUserId();
+
+    /**
+     * Sets the user id owner of this token.
+     *
+     * @param userId The user id owner of this token.
+     * @since 1.0
+     */
+    void setUserId(KapuaId userId);
+
+    /**
+     * Return the MfaCredentialOption key
+     *
+     * @return
+     */
+    @XmlElement(name = "mfaCredentialKey")
+    String getMfaCredentialKey();
+
+    /**
+     * Set the MfaCredentialOption key
+     *
+     * @param mfaCredentialKey
+     */
+    void setMfaCredentialKey(String mfaCredentialKey);
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionDomain.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionDomain.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.domain.AbstractDomain;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.domain.Domain;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link MfaCredentialOption} domain.<br>
+ * Used to describe the {@link MfaCredentialOption} {@link Domain} in the {@link MfaCredentialOptionService}.
+ */
+public class MfaCredentialOptionDomain extends AbstractDomain {
+
+    private String name = "mfa_credential_option";
+    private Set<Actions> actions = new HashSet<>(Arrays.asList(Actions.read, Actions.delete, Actions.write));
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Set<Actions> getActions() {
+        return actions;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return false;
+    }
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaEntityFactory;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+
+/**
+ * {@link MfaCredentialOptionFactory} definition.
+ *
+ * @see KapuaEntityFactory
+ */
+public interface MfaCredentialOptionFactory extends KapuaEntityFactory<MfaCredentialOption, MfaCredentialOptionCreator, MfaCredentialOptionQuery,
+        MfaCredentialOptionListResult> {
+
+    /**
+     * Instantiates a new {@link MfaCredentialOption}.
+     *
+     * @param scopeId          The scope {@link KapuaId} to set into the {@link MfaCredentialOption}.
+     * @param userId           The {@link org.eclipse.kapua.service.user.User} {@link KapuaId} to set into the{@link AccessToken}.
+     * @param mfaCredentialKey The key to set into the {@link MfaCredentialOption}.
+     * @return The newly instantiated {@link MfaCredentialOption}
+     */
+    MfaCredentialOption newMfaCredentialOption(KapuaId scopeId, KapuaId userId, String mfaCredentialKey);
+
+    /**
+     * Instantiates a new {@link MfaCredentialOptionCreator}.
+     *
+     * @param scopeId          The scope {@link KapuaId} to set into the {@link MfaCredentialOptionCreator}.
+     * @param userId           The {@link org.eclipse.kapua.service.user.User} {@link KapuaId} to set into the{@link AccessToken}.
+     * @param mfaCredentialKey The key to set into the {@link MfaCredentialOptionCreator}.
+     * @return The newly instantiated {@link MfaCredentialOptionCreator}
+     */
+    MfaCredentialOptionCreator newCreator(KapuaId scopeId, KapuaId userId, String mfaCredentialKey);
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionListResult.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.query.KapuaListResult;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * MfaCredentialOption list result definition.
+ */
+@XmlRootElement(name = "mfaCredentialOptionListResult")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = MfaCredentialOptionXmlRegistry.class, factoryMethod = "newMfaCredentialOptionListResult")
+public interface MfaCredentialOptionListResult extends KapuaListResult<MfaCredentialOption> {
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionQuery.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.CredentialXmlRegistry;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * MfaCredentialOption query definition.
+ */
+@XmlRootElement(name = "query")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = CredentialXmlRegistry.class, factoryMethod = "newQuery")
+public interface MfaCredentialOptionQuery extends KapuaQuery {
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionService.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+
+/**
+ * MFA Credential service definition.
+ */
+public interface MfaCredentialOptionService extends KapuaEntityService<MfaCredentialOption, MfaCredentialOptionCreator>,
+        KapuaUpdatableEntityService<MfaCredentialOption> {
+
+    /**
+     * Return the MfaCredentialOption result looking by user identifier (and also scope identifier)
+     *
+     * @param scopeId
+     * @param userId
+     * @return
+     * @throws KapuaException
+     */
+    MfaCredentialOption findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;
+
+    /**
+     * Enables the trust machine for the given {@link MfaCredentialOption}.
+     *
+     * @param mfaCredentialOption the {@link MfaCredentialOption}
+     */
+    void enableTrust(MfaCredentialOption mfaCredentialOption) throws KapuaException;
+
+    /**
+     * Enables the trust machine for the {@link KapuaId} of the {@link MfaCredentialOption}.
+     *
+     * @param scopeId the scopeId
+     * @param mfaCredentialOptionId the {@link KapuaId} of the {@link MfaCredentialOption}
+     */
+    void enableTrust(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException;
+
+    /**
+     * Disable the trust machine for the given {@link MfaCredentialOption}.
+     *
+     * @param scopeId the scopeid
+     * @param mfaCredentialOptionId the {@link KapuaId} of the {@link MfaCredentialOption}
+     */
+    void disableTrust(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException;
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaCredentialOptionXmlRegistry.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class MfaCredentialOptionXmlRegistry {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final MfaCredentialOptionFactory MFA_CREDENTIAL_OPTION_FACTORY = LOCATOR.getFactory(MfaCredentialOptionFactory.class);
+
+    /**
+     * Creates a new MfaCredentialOption instance
+     *
+     * @return
+     */
+    public MfaCredentialOption newMfaCredentialOption() {
+        return MFA_CREDENTIAL_OPTION_FACTORY.newEntity(null);
+    }
+
+    /**
+     * Creates a new MfaCredentialOption list result instance
+     *
+     * @return
+     */
+    public MfaCredentialOptionListResult newMfaCredentialOptionListResult() {
+        return MFA_CREDENTIAL_OPTION_FACTORY.newListResult();
+    }
+
+    /**
+     * Creates a new MfaCredentialOption creator instance
+     *
+     * @return
+     */
+    public MfaCredentialOptionCreator newMfaCredentialOptionCreator() {
+        return MFA_CREDENTIAL_OPTION_FACTORY.newCreator(null, null, null);
+    }
+
+    public MfaCredentialOptionQuery newQuery() {
+        return MFA_CREDENTIAL_OPTION_FACTORY.newQuery(null);
+    }
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCode.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+import org.eclipse.kapua.service.authentication.credential.CredentialXmlRegistry;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * Scratch Codes definition.<br>
+ * Used to handle credentials needed by the various authentication algorithms.
+ */
+@XmlRootElement(name = "scratchCode")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = {
+        "mfaCredentialOptionId", //
+        "scratchCode"}, //
+        factoryClass = CredentialXmlRegistry.class, //
+        factoryMethod = "newScratchCode") //
+public interface ScratchCode extends KapuaUpdatableEntity {
+
+    String TYPE = "scratchCode";
+
+    @Override
+    default String getType() {
+        return TYPE;
+    }
+
+    /**
+     * Return the mfaCredentialOption identifier
+     *
+     * @return The mfaCredentialOption identifier.
+     */
+    @XmlElement(name = "mfaCredentialOptionId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    KapuaId getMfaCredentialOptionId();
+
+    /**
+     * Sets the {@link MfaCredentialOption} id of this {@link AccessToken}
+     *
+     * @param mfaCredentialOptionId The {@link MfaCredentialOption} id to set.
+     */
+    void setMfaCredentialOptionId(KapuaId mfaCredentialOptionId);
+
+    /**
+     * Return the scratch code
+     *
+     * @return
+     */
+    @XmlElement(name = "scratchCode")
+    String getCode();
+
+    /**
+     * Sets the scratch code
+     *
+     * @param code
+     */
+    void setCode(String code);
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeAttributes.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeAttributes.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaUpdatableEntityAttributes;
+
+/**
+ * ScratchCode predicates used to build query predicates.
+ */
+public class ScratchCodeAttributes extends KapuaUpdatableEntityAttributes {
+
+    public static final String MFA_CREDENTIAL_OPTION_ID = "mfaCredentialOptionId";
+    public static final String CODE = "scratchCode";
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeCreator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeCreator.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdAdapter;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+import javax.xml.bind.annotation.adapters.XmlJavaTypeAdapter;
+
+/**
+ * ScratchCode creator service definition.
+ */
+@XmlRootElement(name = "scratchCodeCreator")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(propOrder = {"mfaCredentialOptionId",
+        "scratchCode"}, factoryClass = ScratchCodeXmlRegistry.class, factoryMethod = "newScratchCodeCreator")
+public interface ScratchCodeCreator extends KapuaEntityCreator<ScratchCode> {
+
+    /**
+     * Return the MfaCredentialOption identifier
+     *
+     * @return
+     */
+    @XmlElement(name = "mfaCredentialOptionId")
+    @XmlJavaTypeAdapter(KapuaIdAdapter.class)
+    KapuaId getMfaCredentialOptionId();
+
+    /**
+     * Set the mfaCredentialOption id
+     *
+     * @param mfaCredentialOptionId
+     */
+    void setMfaCredentialOptionId(KapuaId mfaCredentialOptionId);
+
+    /**
+     * Return the scratch code
+     *
+     * @return
+     */
+    @XmlElement(name = "scratchCode")
+    String getCode();
+
+    /**
+     * Set the scratch code
+     *
+     * @param code
+     */
+    void setCode(String code);
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeDomain.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeDomain.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.domain.AbstractDomain;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.domain.Domain;
+
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * {@link ScratchCode} domain.<br>
+ * Used to describe the {@link ScratchCode} {@link Domain} in the {@link ScratchCodeService}.
+ */
+public class ScratchCodeDomain extends AbstractDomain {
+
+    private String name = "scratch_code";
+    private Set<Actions> actions = new HashSet<>(Arrays.asList(Actions.read, Actions.delete, Actions.write));
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public Set<Actions> getActions() {
+        return actions;
+    }
+
+    @Override
+    public boolean getGroupable() {
+        return false;
+    }
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeFactory.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeFactory.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.KapuaEntityFactory;
+import org.eclipse.kapua.model.id.KapuaId;
+
+/**
+ * {@link ScratchCodeFactory} definition.
+ *
+ * @see KapuaEntityFactory
+ */
+public interface ScratchCodeFactory extends KapuaEntityFactory<ScratchCode, ScratchCodeCreator, ScratchCodeQuery, ScratchCodeListResult> {
+
+    /**
+     * Instantiates a new {@link ScratchCode}.
+     *
+     * @param scopeId               The scope {@link KapuaId} to set into the {@link ScratchCode}.
+     * @param mfaCredentialOptionId The {@link MfaCredentialOption} {@link KapuaId} to set into the
+     *                              {@link ScratchCode}.
+     * @param code                  The code to set into the {@link ScratchCode}.
+     * @return The newly instantiated {@link ScratchCode}
+     */
+    ScratchCode newScratchCode(KapuaId scopeId, KapuaId mfaCredentialOptionId, String code);
+
+    /**
+     * Instantiates a new {@link ScratchCodeCreator}.
+     *
+     * @param scopeId               The scope {@link KapuaId} to set into the {@link ScratchCodeCreator}.
+     * @param mfaCredentialOptionId The {@link MfaCredentialOption} {@link KapuaId} to set into the
+     *                              {@link ScratchCode}.
+     * @param code                  The code to set into the {@link ScratchCode}.
+     * @return The newly instantiated {@link ScratchCodeCreator}
+     */
+    ScratchCodeCreator newCreator(KapuaId scopeId, KapuaId mfaCredentialOptionId, String code);
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeListResult.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeListResult.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.query.KapuaListResult;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * ScratchCode list result definition.
+ */
+@XmlRootElement(name = "scratchCodeListResult")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = ScratchCodeXmlRegistry.class, factoryMethod = "newScratchCodeListResult")
+public interface ScratchCodeListResult extends KapuaListResult<ScratchCode> {
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeQuery.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.CredentialXmlRegistry;
+
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlType;
+
+/**
+ * ScratchCode query definition.
+ */
+@XmlRootElement(name = "query")
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@XmlType(factoryClass = CredentialXmlRegistry.class, factoryMethod = "newQuery")
+public interface ScratchCodeQuery extends KapuaQuery {
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeService.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+
+/**
+ * ScratchCode service definition.
+ */
+public interface ScratchCodeService extends KapuaEntityService<ScratchCode, ScratchCodeCreator>, KapuaUpdatableEntityService<ScratchCode> {
+
+    /**
+     * Generates all the scratch codes.
+     * The number of generated scratch codes is decided through the MfaAuthenticationService.
+     * The scratch code provided within the scratchCodeCreator parameter is ignored.
+     *
+     * @param scratchCodeCreator
+     * @return
+     * @throws KapuaException
+     */
+    ScratchCodeListResult createAllScratchCodes(ScratchCodeCreator scratchCodeCreator) throws KapuaException;
+
+    /**
+     * Return the ScratchCode list result looking by MfaCredentialOption identifier (and also scope identifier)
+     *
+     * @param scopeId
+     * @param mfaCredentialOptionId
+     * @return
+     * @throws KapuaException
+     */
+    ScratchCodeListResult findByMfaCredentialOptionId(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException;
+
+
+    /**
+     * Queries for all MfaCredentialOption
+     *
+     * @param query
+     */
+    @Override
+    ScratchCodeListResult query(KapuaQuery query) throws KapuaException;
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeXmlRegistry.java
@@ -1,0 +1,54 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+
+import javax.xml.bind.annotation.XmlRegistry;
+
+@XmlRegistry
+public class ScratchCodeXmlRegistry {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final ScratchCodeFactory SCRATCH_CODE_FACTORY = LOCATOR.getFactory(ScratchCodeFactory.class);
+
+    /**
+     * Creates a new ScratchCode instance
+     *
+     * @return
+     */
+    public ScratchCode newScratchCode() {
+        return SCRATCH_CODE_FACTORY.newEntity(null);
+    }
+
+    /**
+     * Creates a new ScratchCode list result instance
+     *
+     * @return
+     */
+    public ScratchCodeListResult newScratchCodeListResult() {
+        return SCRATCH_CODE_FACTORY.newListResult();
+    }
+
+    /**
+     * Creates a new ScratchCode creator instance
+     *
+     * @return
+     */
+    public ScratchCodeCreator newScratchCodeCreator() {
+        return SCRATCH_CODE_FACTORY.newCreator(null, null, null);
+    }
+
+    public ScratchCodeQuery newQuery() {
+        return SCRATCH_CODE_FACTORY.newQuery(null);
+    }
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticationService.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.mfa;
+
+import org.eclipse.kapua.service.KapuaService;
+
+import java.util.List;
+
+/**
+ * MfaAuthenticationService interface
+ */
+public interface MfaAuthenticationService extends KapuaService {
+
+    /**
+     * @return true if the MfaAuthenticationService is enabled, false otherwise
+     */
+    boolean isEnabled();
+
+    /**
+     * Validates a code generated with the Google Authenticator app
+     *
+     * @param encryptedSecret  the encoded secret key
+     * @param verificationCode the verification code
+     * @return true if the verficationCode is valid, false otherwise
+     */
+    boolean authorize(String encryptedSecret, int verificationCode);
+
+    /**
+     * Validates a scratch code
+     *
+     * @param hasedScratchCode the hashed scratch code
+     * @param authCode    the plaintext authentication code
+     * @return true if the code match, false otherwise
+     */
+    boolean authorize(String hasedScratchCode, String authCode);
+
+    /**
+     * Generates the secret key
+     *
+     * @return the secret key in the form of a String
+     */
+    String generateKey();
+
+    /**
+     * Generates the scratch codes
+     *
+     * @return the list of scratch codes in the form of Strings
+     */
+    List<String> generateCodes();
+
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/package-info.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Mfa authentication
+ */
+package org.eclipse.kapua.service.authentication.mfa;

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -76,5 +76,11 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-core</artifactId>
         </dependency>
+
+        <!-- TOTP dependencies -->
+        <dependency>
+            <groupId>com.warrenstrange</groupId>
+            <artifactId>googleauth</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionCreatorImpl.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionCreator;
+
+/**
+ * MfaCredentialOption creator implementation.
+ */
+public class MfaCredentialOptionCreatorImpl extends AbstractKapuaEntityCreator<MfaCredentialOption> implements MfaCredentialOptionCreator {
+
+    private static final long serialVersionUID = -4619585500941519330L;
+
+    private KapuaId userId;
+    private String mfaCredentialKey;
+
+    /**
+     * Constructor
+     *
+     * @param scopeId          scope identifier
+     * @param userId           user identifier
+     * @param mfaCredentialKey the secret key
+     */
+    public MfaCredentialOptionCreatorImpl(KapuaId scopeId, KapuaId userId, String mfaCredentialKey) {
+        super(scopeId);
+        this.userId = userId;
+        this.mfaCredentialKey = mfaCredentialKey;
+    }
+
+    public MfaCredentialOptionCreatorImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    @Override
+    public KapuaId getUserId() {
+        return userId;
+    }
+
+    @Override
+    public void setUserId(KapuaId userId) {
+        this.userId = userId;
+    }
+
+    @Override
+    public String getMfaCredentialKey() {
+        return mfaCredentialKey;
+    }
+
+    @Override
+    public void setMfaCredentialKey(String mfaCredentialKey) {
+        this.mfaCredentialKey = mfaCredentialKey;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionDAO.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.ServiceDAO;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionListResult;
+import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
+
+/**
+ * {@link MfaCredentialOption} {@link ServiceDAO}
+ */
+public class MfaCredentialOptionDAO extends ServiceDAO {
+
+    /**
+     * Creates and return new credential
+     *
+     * @param em
+     * @param mfaCredentialCreator
+     * @return
+     * @throws KapuaException
+     */
+    public static MfaCredentialOption create(EntityManager em, MfaCredentialOptionCreator mfaCredentialCreator) throws KapuaException {
+
+        //
+        // Crypt MfaCredentialOption key
+        String cryptedSecretKey = AuthenticationUtils.encryptAes(mfaCredentialCreator.getMfaCredentialKey());
+
+        //
+        // Create MfaCredentialOption
+        MfaCredentialOptionImpl credentialImpl = new MfaCredentialOptionImpl(mfaCredentialCreator.getScopeId(), mfaCredentialCreator.getUserId(),
+                cryptedSecretKey);
+        //
+        // Do create
+        return ServiceDAO.create(em, credentialImpl);
+    }
+
+    /**
+     * Update the provided MfaCredentialOption
+     *
+     * @param em
+     * @param mfaCredentialOption
+     * @return
+     * @throws KapuaException
+     */
+    public static MfaCredentialOption update(EntityManager em, MfaCredentialOption mfaCredentialOption)
+            throws KapuaException {
+        //
+        // Update credential
+        MfaCredentialOptionImpl mfaCredentialOptionImpl = (MfaCredentialOptionImpl) mfaCredentialOption;
+
+        return ServiceDAO.update(em, MfaCredentialOptionImpl.class, mfaCredentialOptionImpl);
+    }
+
+    /**
+     * Find the MfaCredentialOption by mfaCredentialOption identifier
+     *
+     * @param em
+     * @param scopeId
+     * @param mfaCredentialOptionId
+     * @return
+     */
+    public static MfaCredentialOption find(EntityManager em, KapuaId scopeId, KapuaId mfaCredentialOptionId) {
+        return ServiceDAO.find(em, MfaCredentialOptionImpl.class, scopeId, mfaCredentialOptionId);
+    }
+
+    /**
+     * Return the MfaCredentialOption list matching the provided query
+     *
+     * @param em
+     * @param mfaCredentialOptionQuery
+     * @return
+     * @throws KapuaException
+     */
+    public static MfaCredentialOptionListResult query(EntityManager em, KapuaQuery mfaCredentialOptionQuery) throws KapuaException {
+        return ServiceDAO.query(em, MfaCredentialOption.class, MfaCredentialOptionImpl.class, new MfaCredentialOptionListResultImpl(), mfaCredentialOptionQuery);
+    }
+
+    /**
+     * Return the MfaCredentialOption count matching the provided query
+     *
+     * @param em
+     * @param mfaCredentialOptionQuery
+     * @return
+     * @throws KapuaException
+     */
+    public static long count(EntityManager em, KapuaQuery mfaCredentialOptionQuery) throws KapuaException {
+        return ServiceDAO.count(em, MfaCredentialOption.class, MfaCredentialOptionImpl.class, mfaCredentialOptionQuery);
+    }
+
+    /**
+     * Delete the MfaCredentialOption by MfaCredentialOption identifier
+     *
+     * @param em
+     * @param scopeId
+     * @param mfaCredentialOptionId
+     * @return deleted entity
+     * @throws KapuaEntityNotFoundException If {@link MfaCredentialOption} is now found.
+     */
+    public static MfaCredentialOption delete(EntityManager em, KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaEntityNotFoundException {
+        return ServiceDAO.delete(em, MfaCredentialOptionImpl.class, scopeId, mfaCredentialOptionId);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionEntityManagerFactory.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Entity manager factory for the {@link MfaCredentialOptionServiceImpl} module.
+ */
+public class MfaCredentialOptionEntityManagerFactory extends AbstractEntityManagerFactory {
+
+    private static final String PERSISTENCE_UNIT_NAME = "kapua-authentication";
+    private static final String DATASOURCE_NAME = "kapua-dbpool";
+    private static final Map<String, String> UNIQUE_CONSTRAINTS = new HashMap<>();
+
+    private static MfaCredentialOptionEntityManagerFactory instance = new MfaCredentialOptionEntityManagerFactory();
+
+    /**
+     * Constructs a new entity manager factory and configure it to use the user persistence unit.
+     */
+    private MfaCredentialOptionEntityManagerFactory() {
+        super(PERSISTENCE_UNIT_NAME, DATASOURCE_NAME, UNIQUE_CONSTRAINTS);
+    }
+
+    /**
+     * Return the {@link EntityManager} singleton instance
+     *
+     * @return
+     */
+    public static EntityManagerFactory getInstance() {
+        return instance;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionFactoryImpl.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionQuery;
+
+/**
+ * {@link MfaCredentialOptionFactory} implementation.
+ */
+@KapuaProvider
+public class MfaCredentialOptionFactoryImpl implements MfaCredentialOptionFactory {
+
+    @Override
+    public MfaCredentialOptionCreatorImpl newCreator(KapuaId scopeId, KapuaId userId, String mfaCredentialKey) {
+        return new MfaCredentialOptionCreatorImpl(scopeId, userId, mfaCredentialKey);
+    }
+
+    @Override
+    public MfaCredentialOptionListResult newListResult() {
+        return new MfaCredentialOptionListResultImpl();
+    }
+
+    @Override
+    public MfaCredentialOption newEntity(KapuaId scopeId) {
+        return new MfaCredentialOptionImpl(scopeId);
+    }
+
+    @Override
+    public MfaCredentialOption newMfaCredentialOption(KapuaId scopeId, KapuaId userId, String mfaCredentialKey) {
+        return new MfaCredentialOptionImpl(scopeId, userId, mfaCredentialKey);
+    }
+
+    @Override
+    public MfaCredentialOptionQuery newQuery(KapuaId scopeId) {
+        return new MfaCredentialOptionQueryImpl(scopeId);
+    }
+
+    @Override
+    public MfaCredentialOptionCreator newCreator(KapuaId scopeId) {
+        return new MfaCredentialOptionCreatorImpl(scopeId);
+    }
+
+    @Override
+    public MfaCredentialOption clone(MfaCredentialOption mfaCredentialOption) {
+        try {
+            return new MfaCredentialOptionImpl(mfaCredentialOption);
+        } catch (Exception e) {
+            throw new KapuaEntityCloneException(e, MfaCredentialOption.TYPE, mfaCredentialOption);
+        }
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionImpl.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.persistence.Temporal;
+import javax.persistence.TemporalType;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+import java.util.Date;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@Entity(name = "MfaCredentialOption")
+@Table(name = "atht_mfa_credential_option")
+/**
+ * {@link MfaCredentialOption} implementation.
+ */
+public class MfaCredentialOptionImpl extends AbstractKapuaUpdatableEntity implements MfaCredentialOption {
+
+    private static final long serialVersionUID = -1872939877726584407L;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "user_id", updatable = false, nullable = false))
+    })
+    private KapuaEid userId;
+
+    @Basic
+    @Column(name = "mfa_credential_key", nullable = false)
+    private String mfaCredentialKey;
+
+    @Basic
+    @Column(name = "trust_key")
+    private String trustKey;
+
+    @Temporal(TemporalType.TIMESTAMP)
+    @Column(name = "trust_expiration_date")
+    protected Date trustExpirationDate;
+
+
+    /**
+     * Constructor.
+     */
+    public MfaCredentialOptionImpl() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The scope {@link KapuaId} to set into the {@link MfaCredentialOption}.
+     */
+    public MfaCredentialOptionImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId          The scope {@link KapuaId} to set into the {@link MfaCredentialOption}.
+     * @param userId           user identifier
+     * @param mfaCredentialKey The credential key to set into the {@link MfaCredentialOption}.
+     */
+    public MfaCredentialOptionImpl(KapuaId scopeId, KapuaId userId, String mfaCredentialKey) {
+        super(scopeId);
+        this.userId = (KapuaEid) userId;
+        this.mfaCredentialKey = mfaCredentialKey;
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param credential
+     * @throws KapuaException
+     */
+    public MfaCredentialOptionImpl(MfaCredentialOption credential) throws KapuaException {
+        super(credential);
+        setUserId(credential.getUserId());
+        setMfaCredentialKey(credential.getMfaCredentialKey());
+        setTrustKey(credential.getTrustKey());
+        setTrustExpirationDate(credential.getTrustExpirationDate());
+    }
+
+    @Override
+    public KapuaId getUserId() {
+        return userId;
+    }
+
+    @Override
+    public void setUserId(KapuaId userId) {
+        this.userId = KapuaEid.parseKapuaId(userId);
+    }
+
+    @Override
+    public String getMfaCredentialKey() {
+        return mfaCredentialKey;
+    }
+
+    @Override
+    public void setMfaCredentialKey(String mfaCredentialKey) {
+        this.mfaCredentialKey = mfaCredentialKey;
+    }
+
+    @Override
+    public String getTrustKey() {
+        return this.trustKey;
+    }
+
+    @Override
+    public void setTrustKey(String trustKey) {
+        this.trustKey = trustKey;
+    }
+
+    @Override
+    public Date getTrustExpirationDate() {
+        return trustExpirationDate;
+    }
+
+    @Override
+    public void setTrustExpirationDate(Date trustExpirationDate) {
+        this.trustExpirationDate = trustExpirationDate;
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionListResultImpl.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionListResult;
+
+/**
+ * MfaCredentialOption list result implementation.
+ */
+public class MfaCredentialOptionListResultImpl extends KapuaListResultImpl<MfaCredentialOption> implements MfaCredentialOptionListResult {
+
+    private static final long serialVersionUID = -4204695192086365901L;
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionQueryImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionQuery;
+
+/**
+ * MfaCredentialOption query implementation.
+ */
+public class MfaCredentialOptionQueryImpl extends AbstractKapuaQuery implements MfaCredentialOptionQuery {
+
+    /**
+     * Constructor
+     */
+    public MfaCredentialOptionQueryImpl() {
+        super();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param scopeId
+     */
+    public MfaCredentialOptionQueryImpl(KapuaId scopeId) {
+        this();
+        setScopeId(scopeId);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionServiceImpl.java
@@ -1,0 +1,316 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.apache.commons.lang.time.DateUtils;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.QueryPredicate;
+import org.eclipse.kapua.service.authentication.AuthenticationDomains;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionAttributes;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService;
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
+import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Date;
+import java.util.UUID;
+
+/**
+ * {@link MfaCredentialOptionService} implementation.
+ */
+@KapuaProvider
+public class MfaCredentialOptionServiceImpl extends AbstractKapuaService implements MfaCredentialOptionService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MfaCredentialOptionServiceImpl.class);
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
+
+    private static final int TRUST_KEY_DURATION = 30; // duration of the trust key in days
+
+    public MfaCredentialOptionServiceImpl() {
+        super(MfaCredentialOptionEntityManagerFactory.getInstance());
+    }
+
+    @Override
+    public MfaCredentialOption create(MfaCredentialOptionCreator mfaCredentialOptionCreator) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(mfaCredentialOptionCreator, "mfaCredentialOptionCreator");
+        ArgumentValidator.notNull(mfaCredentialOptionCreator.getScopeId(), "mfaCredentialOptionCreator.scopeId");
+        ArgumentValidator.notNull(mfaCredentialOptionCreator.getUserId(), "mfaCredentialOptionCreator.userId");
+
+        //
+        // Check access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.write, mfaCredentialOptionCreator.getScopeId()));
+
+        //
+        // Do create
+        MfaCredentialOption mfaCredentialOption;
+        EntityManager em = AuthenticationEntityManagerFactory.getEntityManager();
+        try {
+            em.beginTransaction();
+
+            String fullKey = MFA_AUTH_SERVICE.generateKey();
+            mfaCredentialOptionCreator = new MfaCredentialOptionCreatorImpl(mfaCredentialOptionCreator.getScopeId(), mfaCredentialOptionCreator.getUserId(),
+                    fullKey);
+            mfaCredentialOption = MfaCredentialOptionDAO.create(em, mfaCredentialOptionCreator);
+            mfaCredentialOption = MfaCredentialOptionDAO.find(em, mfaCredentialOption.getScopeId(), mfaCredentialOption.getId());
+            em.commit();
+        } catch (Exception pe) {
+            em.rollback();
+            throw KapuaExceptionUtils.convertPersistenceException(pe);
+        } finally {
+            em.close();
+        }
+
+        return mfaCredentialOption;
+    }
+
+    @Override
+    public MfaCredentialOption update(MfaCredentialOption mfaCredentialOption) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(mfaCredentialOption, "mfaCredentialOption");
+        ArgumentValidator.notNull(mfaCredentialOption.getId(), "mfaCredentialOption.id");
+        ArgumentValidator.notNull(mfaCredentialOption.getScopeId(), "mfaCredentialOption.scopeId");
+        ArgumentValidator.notNull(mfaCredentialOption.getUserId(), "mfaCredentialOption.userId");
+        ArgumentValidator.notEmptyOrNull(mfaCredentialOption.getMfaCredentialKey(), "mfaCredentialOption.mfaCredentialKey");
+
+        //
+        // Check access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.write, mfaCredentialOption.getScopeId()));
+
+        return entityManagerSession.doTransactedAction(em -> {
+            MfaCredentialOption currentMfaCredentialOption = MfaCredentialOptionDAO.find(em, mfaCredentialOption.getScopeId(), mfaCredentialOption.getId());
+
+            if (currentMfaCredentialOption == null) {
+                throw new KapuaEntityNotFoundException(MfaCredentialOption.TYPE, mfaCredentialOption.getId());
+            }
+
+            // Passing attributes??
+            return MfaCredentialOptionDAO.update(em, mfaCredentialOption);
+        });
+    }
+
+    @Override
+    public MfaCredentialOption find(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+        // Validation of the fields
+        ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
+        ArgumentValidator.notNull(mfaCredentialOptionId, "mfaCredentialOptionId");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.read, scopeId));
+
+        return entityManagerSession.doAction(em -> MfaCredentialOptionDAO.find(em, scopeId, mfaCredentialOptionId));
+    }
+
+    @Override
+    public MfaCredentialOptionListResult query(KapuaQuery query) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.read, query.getScopeId()));
+
+        return entityManagerSession.doAction(em -> MfaCredentialOptionDAO.query(em, query));
+    }
+
+    @Override
+    public long count(KapuaQuery query) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.read, query.getScopeId()));
+
+        return entityManagerSession.doAction(em -> MfaCredentialOptionDAO.count(em, query));
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(mfaCredentialOptionId, "mfaCredentialOption.id");
+        ArgumentValidator.notNull(scopeId, "mfaCredentialOption.scopeId");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.delete, scopeId));
+
+        entityManagerSession.doTransactedAction(em -> {
+            if (MfaCredentialOptionDAO.find(em, scopeId, mfaCredentialOptionId) == null) {
+                throw new KapuaEntityNotFoundException(MfaCredentialOption.TYPE, mfaCredentialOptionId);
+            }
+            return MfaCredentialOptionDAO.delete(em, scopeId, mfaCredentialOptionId);
+        });
+    }
+
+    @Override
+    public MfaCredentialOption findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
+        ArgumentValidator.notNull(userId, MfaCredentialOptionAttributes.USER_ID);
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.MFA_CREDENTIAL_OPTION_DOMAIN, Actions.read, scopeId));
+
+        //
+        // Build query
+        MfaCredentialOptionQuery query = new MfaCredentialOptionQueryImpl(scopeId);
+        QueryPredicate predicate = query.attributePredicate(MfaCredentialOptionAttributes.USER_ID, userId);
+        query.setPredicate(predicate);
+
+        //
+        // Query and return result
+        MfaCredentialOptionListResult result = query(query);
+        if (!result.isEmpty()) {
+            return result.getFirstItem();
+        } else {
+            return null;
+        }
+    }
+
+    @Override
+    public void enableTrust(MfaCredentialOption mfaCredentialOption) throws KapuaException {
+
+        // Argument Validation (fields validation is performed inside the 'update' method)
+        ArgumentValidator.notNull(mfaCredentialOption, "mfaCredentialOption");
+
+        // If MfaCredentialOption has a code set, use that one, otherwise other trusted machines won't be able to login and a new trusted machine will be
+        // requested
+        String trustKey = mfaCredentialOption.getTrustKey();
+        if (trustKey == null || trustKey.isEmpty()) {
+            trustKey = generateTrustKey();
+        }
+
+        Date expirationDate = new Date(System.currentTimeMillis());
+        expirationDate = DateUtils.addDays(expirationDate, TRUST_KEY_DURATION);
+
+        mfaCredentialOption.setTrustKey(trustKey);
+        mfaCredentialOption.setTrustExpirationDate(expirationDate);
+        update(mfaCredentialOption);
+    }
+
+    @Override
+    public void enableTrust(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+
+        // Argument Validation
+        ArgumentValidator.notNull(mfaCredentialOptionId, "mfaCredentialOption.id");
+        ArgumentValidator.notNull(scopeId, "mfaCredentialOption.scopeId");
+
+        // extracting the MfaCredentialOption
+        MfaCredentialOption mfaCredentialOption = find(scopeId, mfaCredentialOptionId);
+        enableTrust(mfaCredentialOption);
+    }
+
+    @Override
+    public void disableTrust(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+
+        // Argument Validation
+        ArgumentValidator.notNull(mfaCredentialOptionId, "mfaCredentialOption.id");
+        ArgumentValidator.notNull(scopeId, "mfaCredentialOption.scopeId");
+
+        // extracting the MfaCredentialOption
+        MfaCredentialOption mfaCredentialOption = find(scopeId, mfaCredentialOptionId);
+
+        // Reset the trust machine fields
+        mfaCredentialOption.setTrustKey(null);
+        mfaCredentialOption.setTrustExpirationDate(null);
+
+        update(mfaCredentialOption);
+    }
+
+    /**
+     * Generate the trust key string.
+     *
+     * @return String
+     */
+    private String generateTrustKey() {
+        return UUID.randomUUID().toString();
+    }
+
+    private void deleteMfaCredentialByUserId(KapuaId scopeId, KapuaId credentialId) throws KapuaException {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        MfaCredentialOptionFactory mfaCredentialOptionFactory = locator.getFactory(MfaCredentialOptionFactory.class);
+
+        MfaCredentialOptionQuery query = mfaCredentialOptionFactory.newQuery(scopeId);
+        query.setPredicate(query.attributePredicate(MfaCredentialOptionAttributes.USER_ID, credentialId));
+
+        MfaCredentialOptionListResult credentialsToDelete = query(query);
+
+        for (MfaCredentialOption c : credentialsToDelete.getItems()) {
+            delete(c.getScopeId(), c.getId());
+        }
+    }
+
+    private void deleteMfaCredentialByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        MfaCredentialOptionFactory mfaCredentialOptionFactory = locator.getFactory(MfaCredentialOptionFactory.class);
+
+        MfaCredentialOptionQuery query = mfaCredentialOptionFactory.newQuery(accountId);
+
+        MfaCredentialOptionListResult credentialsToDelete = query(query);
+
+        for (MfaCredentialOption c : credentialsToDelete.getItems()) {
+            delete(c.getScopeId(), c.getId());
+        }
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeCreatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeCreatorImpl.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+
+/**
+ * ScratchCode creator implementation.
+ */
+public class ScratchCodeCreatorImpl extends AbstractKapuaEntityCreator<ScratchCode> implements ScratchCodeCreator {
+
+    private static final long serialVersionUID = 3925204275937566004L;
+
+    private String code;
+    private KapuaId mfaCredentialOptionId;
+
+    /**
+     * Constructor
+     *
+     * @param scopeId                scope identifier
+     * @param mfaCredentialOptionId credential identifier
+     * @param code
+     */
+    public ScratchCodeCreatorImpl(KapuaId scopeId, KapuaId mfaCredentialOptionId, String code) {
+        super(scopeId);
+        this.mfaCredentialOptionId = mfaCredentialOptionId;
+        this.code = code;
+    }
+
+    public ScratchCodeCreatorImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    @Override
+    public KapuaId getMfaCredentialOptionId() {
+        return this.mfaCredentialOptionId;
+    }
+
+    @Override
+    public void setMfaCredentialOptionId(KapuaId mfaCredentialOptionId) {
+        this.mfaCredentialOptionId = mfaCredentialOptionId;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeDAO.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeDAO.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.ServiceDAO;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
+import org.eclipse.kapua.service.authentication.shiro.utils.CryptAlgorithm;
+
+/**
+ * {@link ScratchCode} {@link ServiceDAO}
+ */
+public class ScratchCodeDAO extends ServiceDAO {
+
+    /**
+     * Creates and return new ScratchCode
+     *
+     * @param em
+     * @param scratchCodeCreator
+     * @return
+     * @throws KapuaException
+     */
+    public static ScratchCode create(EntityManager em, ScratchCodeCreator scratchCodeCreator) throws KapuaException {
+
+        //
+        // Crypto code (it's ok to do than if BCrypt is used when checking a provided scratch code against the stored one)
+        String cryptedCode = crypt(scratchCodeCreator.getCode());
+
+        //
+        // Create code
+        ScratchCodeImpl codeImpl = new ScratchCodeImpl(scratchCodeCreator.getScopeId(), scratchCodeCreator.getMfaCredentialOptionId(), cryptedCode);
+        //
+        // Do create
+        return ServiceDAO.create(em, codeImpl);
+    }
+
+    /**
+     * Update the provided ScratchCode
+     *
+     * @param em
+     * @param code
+     * @return
+     * @throws KapuaException
+     */
+    public static ScratchCode update(EntityManager em, ScratchCode code) throws KapuaException {
+        //
+        // Update credential
+        ScratchCodeImpl scratchCodeImpl = (ScratchCodeImpl) code;
+        return ServiceDAO.update(em, ScratchCodeImpl.class, scratchCodeImpl);
+    }
+
+    /**
+     * Find the ScratchCode by ScratchCode identifier
+     *
+     * @param em
+     * @param scopeId
+     * @param scratchCodeId
+     * @return
+     */
+    public static ScratchCode find(EntityManager em, KapuaId scopeId, KapuaId scratchCodeId) {
+        return ServiceDAO.find(em, ScratchCodeImpl.class, scopeId, scratchCodeId);
+    }
+
+    /**
+     * Return the ScratchCode list matching the provided query
+     *
+     * @param em
+     * @param scratchCodeQuery
+     * @return
+     * @throws KapuaException
+     */
+    public static ScratchCodeListResult query(EntityManager em, KapuaQuery scratchCodeQuery) throws KapuaException {
+        return ServiceDAO.query(em, ScratchCode.class, ScratchCodeImpl.class, new ScratchCodeListResultImpl(), scratchCodeQuery);
+    }
+
+    /**
+     * Return the ScratchCode count matching the provided query
+     *
+     * @param em
+     * @param scratchCodeQuery
+     * @return
+     * @throws KapuaException
+     */
+    public static long count(EntityManager em, KapuaQuery scratchCodeQuery) throws KapuaException {
+        return ServiceDAO.count(em, ScratchCode.class, ScratchCodeImpl.class, scratchCodeQuery);
+    }
+
+    /**
+     * Delete the ScratchCode by ScratchCode identifier
+     *
+     * @param em
+     * @param scopeId
+     * @param scratchCodeId
+     * @return deleted entity
+     * @throws KapuaEntityNotFoundException If {@link ScratchCode} is now found.
+     */
+    public static ScratchCode delete(EntityManager em, KapuaId scopeId, KapuaId scratchCodeId) throws KapuaEntityNotFoundException {
+        return ServiceDAO.delete(em, ScratchCodeImpl.class, scopeId, scratchCodeId);
+    }
+
+    //
+    // Private methods
+
+    //
+    private static String crypt(String scratchCodePlainCode) throws KapuaException {
+        return AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, scratchCodePlainCode);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeEntityManagerFactory.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeEntityManagerFactory.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Entity manager factory for the {@link ScratchCodeServiceImpl} module.
+ */
+public class ScratchCodeEntityManagerFactory extends AbstractEntityManagerFactory {
+
+    private static final String PERSISTENCE_UNIT_NAME = "kapua-authentication";
+    private static final String DATASOURCE_NAME = "kapua-dbpool";
+    private static final Map<String, String> UNIQUE_CONSTRAINTS = new HashMap<>();
+
+    private static ScratchCodeEntityManagerFactory instance = new ScratchCodeEntityManagerFactory();
+
+    /**
+     * Constructs a new entity manager factory and configure it to use the user persistence unit.
+     */
+    private ScratchCodeEntityManagerFactory() {
+        super(PERSISTENCE_UNIT_NAME, DATASOURCE_NAME, UNIQUE_CONSTRAINTS);
+    }
+
+    /**
+     * Return the {@link EntityManager} singleton instance
+     *
+     * @return
+     */
+    public static EntityManagerFactory getInstance() {
+        return instance;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImpl.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
+
+/**
+ * {@link ScratchCodeFactory} implementation.
+ */
+@KapuaProvider
+public class ScratchCodeFactoryImpl implements ScratchCodeFactory {
+
+    @Override
+    public ScratchCodeCreatorImpl newCreator(KapuaId scopeId, KapuaId credentialId, String mfaCredentialKey) {
+        return new ScratchCodeCreatorImpl(scopeId, credentialId, mfaCredentialKey);
+    }
+
+    @Override
+    public ScratchCodeListResult newListResult() {
+        return new ScratchCodeListResultImpl();
+    }
+
+    @Override
+    public ScratchCode newEntity(KapuaId scopeId) {
+        return new ScratchCodeImpl(scopeId);
+    }
+
+    @Override
+    public ScratchCode newScratchCode(KapuaId scopeId, KapuaId mfaCredentialOptionId, String code) {
+        return new ScratchCodeImpl(scopeId, mfaCredentialOptionId, code);
+    }
+
+    @Override
+    public ScratchCodeQuery newQuery(KapuaId scopeId) {
+        return new ScratchCodeQueryImpl(scopeId);
+    }
+
+    @Override
+    public ScratchCodeCreator newCreator(KapuaId scopeId) {
+        return new ScratchCodeCreatorImpl(scopeId);
+    }
+
+    @Override
+    public ScratchCode clone(ScratchCode scratchCode) {
+        try {
+            return new ScratchCodeImpl(scratchCode);
+        } catch (Exception e) {
+            throw new KapuaEntityCloneException(e, ScratchCode.TYPE, scratchCode);
+        }
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeImpl.java
@@ -1,0 +1,112 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+
+import javax.persistence.AttributeOverride;
+import javax.persistence.AttributeOverrides;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embedded;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlRootElement;
+
+@XmlRootElement
+@XmlAccessorType(XmlAccessType.PROPERTY)
+@Entity(name = "ScratchCode")
+@Table(name = "atht_scratch_code")
+/**
+ * {@link ScratchCode} implementation.
+ */
+public class ScratchCodeImpl extends AbstractKapuaUpdatableEntity implements ScratchCode {
+
+    private static final long serialVersionUID = -2785931432917205759L;
+
+    @Embedded
+    @AttributeOverrides({
+            @AttributeOverride(name = "eid", column = @Column(name = "mfa_credential_option_id", updatable = false, nullable = false))
+    })
+    private KapuaEid mfaCredentialOptionId;
+
+    @Basic
+    @Column(name = "scratch_code", nullable = false)
+    private String code;
+
+    /**
+     * Constructor.
+     */
+    public ScratchCodeImpl() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The scope {@link KapuaId} to set into the {@link MfaCredentialOption}.
+     */
+    public ScratchCodeImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The scope {@link KapuaId} to set into the {@link MfaCredentialOption}.
+     * @param code    The credential key to set into the {@link MfaCredentialOption}.
+     */
+    public ScratchCodeImpl(KapuaId scopeId, KapuaId mfaCredentialOptionId, String code) {
+        super(scopeId);
+        this.mfaCredentialOptionId = (KapuaEid) mfaCredentialOptionId;
+        this.code = code;
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param scratchCode
+     * @throws KapuaException
+     */
+    public ScratchCodeImpl(ScratchCode scratchCode) throws KapuaException {
+        super(scratchCode);
+        setCode(scratchCode.getCode());
+        setMfaCredentialOptionId(scratchCode.getMfaCredentialOptionId());
+    }
+
+    @Override
+    public KapuaId getMfaCredentialOptionId() {
+        return this.mfaCredentialOptionId;
+    }
+
+    @Override
+    public void setMfaCredentialOptionId(KapuaId mfaCredentialOptionId) {
+        this.mfaCredentialOptionId = KapuaEid.parseKapuaId(mfaCredentialOptionId);
+    }
+
+    @Override
+    public String getCode() {
+        return this.code;
+    }
+
+    @Override
+    public void setCode(String code) {
+        this.code = code;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeListResultImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeListResultImpl.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+
+/**
+ * ScratchCode list result implementation.
+ */
+public class ScratchCodeListResultImpl extends KapuaListResultImpl<ScratchCode> implements ScratchCodeListResult {
+
+    private static final long serialVersionUID = -5154461760797879319L;
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImpl.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
+
+/**
+ * ScratchCode query implementation.
+ */
+public class ScratchCodeQueryImpl extends AbstractKapuaQuery implements ScratchCodeQuery {
+
+    /**
+     * Constructor
+     */
+    public ScratchCodeQueryImpl() {
+        super();
+    }
+
+    /**
+     * Constructor
+     *
+     * @param scopeId
+     */
+    public ScratchCodeQueryImpl(KapuaId scopeId) {
+        this();
+        setScopeId(scopeId);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
@@ -1,0 +1,272 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.predicate.QueryPredicate;
+import org.eclipse.kapua.service.authentication.AuthenticationDomains;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeAttributes;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService;
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
+import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+/**
+ * {@link ScratchCodeService} implementation.
+ */
+@KapuaProvider
+public class ScratchCodeServiceImpl extends AbstractKapuaService implements ScratchCodeService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(ScratchCodeServiceImpl.class);
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
+
+    public ScratchCodeServiceImpl() {
+        super(ScratchCodeEntityManagerFactory.getInstance());
+    }
+
+    @Override
+    public ScratchCode create(ScratchCodeCreator scratchCodeCreator) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scratchCodeCreator, "scratchCodeCreator");
+        ArgumentValidator.notNull(scratchCodeCreator.getScopeId(), "scratchCodeCreator.scopeId");
+        ArgumentValidator.notNull(scratchCodeCreator.getMfaCredentialOptionId(), "scratchCodeCreator.mfaCredentialOptionId");
+        ArgumentValidator.notEmptyOrNull(scratchCodeCreator.getCode(), "credentialCreator.code");
+
+        //
+        // Check access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.write, scratchCodeCreator.getScopeId()));
+
+        //
+        // Do create
+        ScratchCode scratchCode = null;
+        EntityManager em = AuthenticationEntityManagerFactory.getEntityManager();
+        try {
+            em.beginTransaction();
+
+            //
+            // Do pre persist magic on key values
+            String fullKey = scratchCodeCreator.getCode();
+            scratchCode = ScratchCodeDAO.create(em, scratchCodeCreator);
+            scratchCode = ScratchCodeDAO.find(em, scratchCode.getScopeId(), scratchCode.getId());
+            em.commit();
+
+            // Do post persist magic on key values
+            scratchCode.setCode(fullKey);
+        } catch (Exception pe) {
+            em.rollback();
+            throw KapuaExceptionUtils.convertPersistenceException(pe);
+        } finally {
+            em.close();
+        }
+
+        return scratchCode;
+    }
+
+    @Override
+    public ScratchCode update(ScratchCode scratchCode) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scratchCode, "scratchCode");
+        ArgumentValidator.notNull(scratchCode.getId(), "scratchCode.id");
+        ArgumentValidator.notNull(scratchCode.getScopeId(), "scratchCode.scopeId");
+        ArgumentValidator.notNull(scratchCode.getMfaCredentialOptionId(), "scratchCode.mfaCredentialOptionId");
+        ArgumentValidator.notEmptyOrNull(scratchCode.getCode(), "scratchCode.code");
+
+        //
+        // Check access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.write, scratchCode.getScopeId()));
+
+        return entityManagerSession.doTransactedAction(em -> {
+            ScratchCode currentscratchCode = ScratchCodeDAO.find(em, scratchCode.getScopeId(), scratchCode.getId());
+
+            if (currentscratchCode == null) {
+                throw new KapuaEntityNotFoundException(ScratchCode.TYPE, scratchCode.getId());
+            }
+
+            // Passing attributes??
+            return ScratchCodeDAO.update(em, scratchCode);
+        });
+    }
+
+    @Override
+    public ScratchCode find(KapuaId scopeId, KapuaId scratchCodeId) throws KapuaException {
+        // Validation of the fields
+        ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
+        ArgumentValidator.notNull(scratchCodeId, "scratchCodeId");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.read, scopeId));
+
+        return entityManagerSession.doAction(em -> ScratchCodeDAO.find(em, scopeId, scratchCodeId));
+    }
+
+    @Override
+    public ScratchCodeListResult query(KapuaQuery query) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.read, query.getScopeId()));
+
+        return entityManagerSession.doAction(em -> ScratchCodeDAO.query(em, query));
+    }
+
+    @Override
+    public long count(KapuaQuery query) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(query, "query");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.read, query.getScopeId()));
+
+        return entityManagerSession.doAction(em -> ScratchCodeDAO.count(em, query));
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId scratchCodeId) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scratchCodeId, "scratchCode.id");
+        ArgumentValidator.notNull(scopeId, "scratchCode.scopeId");
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.delete, scopeId));
+
+        entityManagerSession.doTransactedAction(em -> {
+            if (ScratchCodeDAO.find(em, scopeId, scratchCodeId) == null) {
+                throw new KapuaEntityNotFoundException(ScratchCode.TYPE, scratchCodeId);
+            }
+            return ScratchCodeDAO.delete(em, scopeId, scratchCodeId);
+        });
+    }
+
+    @Override
+    public ScratchCodeListResult createAllScratchCodes(ScratchCodeCreator scratchCodeCreator) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scratchCodeCreator, "scratchCodeCreator");
+        ArgumentValidator.notNull(scratchCodeCreator.getScopeId(), "scratchCodeCreator.scopeId");
+        ArgumentValidator.notNull(scratchCodeCreator.getMfaCredentialOptionId(), "scratchCodeCreator.mfaCredentialOptionId");
+
+        List<String> codes = MFA_AUTH_SERVICE.generateCodes();
+        ScratchCodeListResult scratchCodeListResult = new ScratchCodeListResultImpl();
+
+        for (String code : codes) {
+            scratchCodeCreator.setCode(code);
+            ScratchCode scratchCode = create(scratchCodeCreator);
+            scratchCodeListResult.addItem(scratchCode);
+        }
+
+        return scratchCodeListResult;
+    }
+
+    @Override
+    public ScratchCodeListResult findByMfaCredentialOptionId(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
+        ArgumentValidator.notNull(mfaCredentialOptionId, ScratchCodeAttributes.MFA_CREDENTIAL_OPTION_ID);
+
+        //
+        // Check Access
+        KapuaLocator locator = KapuaLocator.getInstance();
+        AuthorizationService authorizationService = locator.getService(AuthorizationService.class);
+        PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
+        authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.SCRATCH_CODE_DOMAIN, Actions.read, scopeId));
+
+        //
+        // Build query
+        ScratchCodeQuery query = new ScratchCodeQueryImpl(scopeId);
+        QueryPredicate predicate = query.attributePredicate(ScratchCodeAttributes.MFA_CREDENTIAL_OPTION_ID, mfaCredentialOptionId);
+        query.setPredicate(predicate);
+
+        //
+        // Query and return result
+        return query(query);
+    }
+
+    private void deleteScratchCodeByMfaCredentialOptionId(KapuaId scopeId, KapuaId mfaCredentialOptionId) throws KapuaException {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        ScratchCodeFactory scratchCodeFactory = locator.getFactory(ScratchCodeFactory.class);
+
+        ScratchCodeQuery query = scratchCodeFactory.newQuery(scopeId);
+        query.setPredicate(query.attributePredicate(ScratchCodeAttributes.MFA_CREDENTIAL_OPTION_ID, mfaCredentialOptionId));
+
+        ScratchCodeListResult credentialsToDelete = query(query);
+
+        for (ScratchCode c : credentialsToDelete.getItems()) {
+            delete(c.getScopeId(), c.getId());
+        }
+    }
+
+    private void deleteScratchCodeByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
+        KapuaLocator locator = KapuaLocator.getInstance();
+        ScratchCodeFactory scratchCodeFactory = locator.getFactory(ScratchCodeFactory.class);
+
+        ScratchCodeQuery query = scratchCodeFactory.newQuery(accountId);
+
+        ScratchCodeListResult credentialsToDelete = query(query);
+
+        for (ScratchCode c : credentialsToDelete.getItems()) {
+            delete(c.getScopeId(), c.getId());
+        }
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -27,6 +27,8 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
 
     private String username;
     private String password;
+    private String authenticationCode;
+    private String trustKey;
 
     /**
      * Constructor
@@ -66,5 +68,25 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
     @Override
     public Object getCredentials() {
         return password;
+    }
+
+    @Override
+    public String getAuthenticationCode() {
+        return authenticationCode;
+    }
+
+    @Override
+    public void setAuthenticationCode(String authenticationCode) {
+        this.authenticationCode = authenticationCode;
+    }
+
+    @Override
+    public String getTrustKey() {
+        return trustKey;
+    }
+
+    @Override
+    public void setTrustKey(String trustKey) {
+        this.trustKey = trustKey;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceImpl.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.mfa;
+
+import com.warrenstrange.googleauth.GoogleAuthenticator;
+import com.warrenstrange.googleauth.GoogleAuthenticatorConfig;
+import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.util.ArgumentValidator;
+import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
+import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
+import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
+import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.crypto.bcrypt.BCrypt;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * The {@link MfaAuthenticationService} implementation that wraps code generation and authentication methods.
+ *
+ */
+@KapuaProvider
+public class MfaAuthenticationServiceImpl implements MfaAuthenticationService {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(MfaAuthenticationServiceImpl.class);
+
+    private static final GoogleAuthenticatorConfig GOOGLE_AUTHENTICATOR_CONFIG;
+
+    static {
+        // settings
+        KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
+        int timeStepSize = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_TIME_STEP_SIZE);
+        long timeStepSizeInMillis = TimeUnit.SECONDS.toMillis(timeStepSize);
+        int windowSize = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_WINDOW_SIZE);
+        int scratchCodeNumber = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_SCRATCH_CODES_NUMBER);
+        int codeDigitsNumber = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_CODE_DIGITS_NUMBER);
+
+        try {
+            ArgumentValidator.notNegative(timeStepSizeInMillis, "timeStepSizeInMillis");
+            ArgumentValidator.notNegative(windowSize, "windowSize");
+            ArgumentValidator.numRange(scratchCodeNumber, 0, 1000, "scratchCodeNumber");
+            ArgumentValidator.numRange(codeDigitsNumber, 6, 8, "codeDigitsNumber");
+
+            GOOGLE_AUTHENTICATOR_CONFIG = new GoogleAuthenticatorConfig.GoogleAuthenticatorConfigBuilder()
+                    .setTimeStepSizeInMillis(timeStepSizeInMillis) // the time step size, in milliseconds
+                    .setWindowSize(windowSize)  // the number of windows of size timeStepSizeInMillis checked during the validation
+                    .setNumberOfScratchCodes(scratchCodeNumber)  // number of scratch codes
+                    .setCodeDigits(codeDigitsNumber)  // the number of digits in the generated code
+                    .build();
+
+        } catch (KapuaException e) {
+            LOGGER.error("Error while initializing the Google Authenticator configuration", e);
+            throw new ExceptionInInitializerError(e);
+        }
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public boolean authorize(String encryptedSecret, int verificationCode) {
+        boolean isCodeValid;
+        String secret = AuthenticationUtils.decryptAes(encryptedSecret);
+
+        GoogleAuthenticator ga = new GoogleAuthenticator(GOOGLE_AUTHENTICATOR_CONFIG);
+        isCodeValid = ga.authorize(secret, verificationCode);
+        return isCodeValid;
+    }
+
+    @Override
+    public boolean authorize(String hasedScratchCode, String verificationCode) {
+        return BCrypt.checkpw(verificationCode, hasedScratchCode);
+    }
+
+    @Override
+    public String generateKey() {
+        GoogleAuthenticator gAuth = new GoogleAuthenticator();
+        GoogleAuthenticatorKey key = gAuth.createCredentials();
+        return key.getKey();
+    }
+
+    @Override
+    public List<String> generateCodes() {
+
+        // we're not using the same secret as the secret key for the scratch code generation
+        // this allows re-generating scratch codes independently from the secret
+
+        GoogleAuthenticator gAuth = new GoogleAuthenticator(GOOGLE_AUTHENTICATOR_CONFIG);
+        GoogleAuthenticatorKey key = gAuth.createCredentials();
+
+        List<String> scratchCodes = new ArrayList<>();
+        for (Integer scratchCode : key.getScratchCodes()) {
+            scratchCodes.add(scratchCode.toString());
+        }
+        return scratchCodes;
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -11,23 +11,37 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.realm;
 
+import org.apache.shiro.ShiroException;
+import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService;
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
 import org.eclipse.kapua.service.user.User;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
 /**
  * {@link ApiKeyCredentials} credential matcher implementation
- * 
+ *
  * @since 1.0
- * 
  */
 public class UserPassCredentialsMatcher implements CredentialsMatcher {
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
+    private static final MfaCredentialOptionService MFA_CREDENTIAL_OPTION_SERVICE = LOCATOR.getService(MfaCredentialOptionService.class);
+    private static final ScratchCodeService SCRATCH_CODE_SERVICE = LOCATOR.getService(ScratchCodeService.class);
 
     @Override
     public boolean doCredentialsMatch(AuthenticationToken authenticationToken, AuthenticationInfo authenticationInfo) {
@@ -37,6 +51,8 @@ public class UserPassCredentialsMatcher implements CredentialsMatcher {
         UsernamePasswordCredentials token = (UsernamePasswordCredentials) authenticationToken;
         String tokenUsername = token.getUsername();
         String tokenPassword = token.getPassword();
+        String tokenAuthenticationCode = token.getAuthenticationCode();
+        String tokenTrustKey = token.getTrustKey();
 
         //
         // Info data
@@ -47,10 +63,79 @@ public class UserPassCredentialsMatcher implements CredentialsMatcher {
         //
         // Match token with info
         boolean credentialMatch = false;
-        if (tokenUsername.equals(infoUser.getName()) && CredentialType.PASSWORD.equals(infoCredential.getCredentialType()) && BCrypt.checkpw(tokenPassword, infoCredential.getCredentialKey())) {
-            credentialMatch = true;
+        if (tokenUsername.equals(infoUser.getName()) && CredentialType.PASSWORD.equals(infoCredential.getCredentialType()) && BCrypt.checkpw(
+                tokenPassword, infoCredential.getCredentialKey())) {
 
-            // FIXME: if true cache token password for authentication performance improvement
+            if (!MFA_AUTH_SERVICE.isEnabled()) {
+                credentialMatch = true;
+                // FIXME: if true cache token password for authentication performance improvement
+            } else {
+
+                // first check if 2FA is enabled for the current user
+                MfaCredentialOption mfaCredentialOption;
+                try {
+                    mfaCredentialOption = KapuaSecurityUtils.doPrivileged(() -> MFA_CREDENTIAL_OPTION_SERVICE.findByUserId(infoUser.getScopeId(),
+                            infoUser.getId()));
+                } catch (AuthenticationException ae) {
+                    throw ae;
+                } catch (Exception e) {
+                    throw new ShiroException("Error while finding Mfa Credential!", e);
+                }
+                if (mfaCredentialOption != null) {
+                    if (tokenAuthenticationCode != null) {
+
+                        // do 2fa match
+                        boolean isCodeValid;
+                        try {
+                            isCodeValid = MFA_AUTH_SERVICE.authorize(mfaCredentialOption.getMfaCredentialKey(), Integer.parseInt(tokenAuthenticationCode));
+                        } catch (AuthenticationException ae) {
+                            throw ae;
+                        } catch (Exception e) {
+                            throw new ShiroException("Error while authenticating Mfa Credential!", e);
+                        }
+
+                        //  code is not valid, try scratch code login
+                        if (!isCodeValid) {
+                            ScratchCodeListResult scratchCodeListResult;
+                            try {
+                                scratchCodeListResult = KapuaSecurityUtils.doPrivileged(() -> SCRATCH_CODE_SERVICE.findByMfaCredentialOptionId(
+                                        mfaCredentialOption.getScopeId(), mfaCredentialOption.getId()));
+                            } catch (AuthenticationException ae) {
+                                throw ae;
+                            } catch (Exception e) {
+                                throw new ShiroException("Error while finding scratch codes!", e);
+                            }
+
+                            for (ScratchCode code : scratchCodeListResult.getItems()) {
+                                if (MFA_AUTH_SERVICE.authorize(code.getCode(), tokenAuthenticationCode)) {
+                                    isCodeValid = true;
+                                    try {
+                                        KapuaSecurityUtils.doPrivileged(() -> SCRATCH_CODE_SERVICE.delete(code.getScopeId(), code.getId()));
+                                    } catch (AuthenticationException ae) {
+                                        throw ae;
+                                    } catch (Exception e) {
+                                        throw new ShiroException("Error while removing used scratch code!", e);
+                                    }
+                                    break;
+                                }
+                            }
+                        }
+                        credentialMatch = isCodeValid;
+                    } else {
+                        // if authentication code is null then check the trust_key
+                        if (tokenTrustKey != null) {
+                            // check trust machine authentication on the server side
+                            if (mfaCredentialOption.getTrustKey() != null) {
+                                if (tokenTrustKey.equals(mfaCredentialOption.getTrustKey())) {
+                                    credentialMatch = true;
+                                }
+                            }
+                        }
+                    }
+                } else {
+                    credentialMatch = true;  // MFA service is enabled, but the user has no MFA enabled
+                }
+            }
         }
 
         return credentialMatch;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -48,7 +48,13 @@ public enum KapuaAuthenticationSettingKeys implements SettingKey {
     AUTHENTICATION_EVENT_ADDRESS("authentication.eventAddress"),
 
     // to enable the registration service
-    AUTHENTICATION_REGISTRATION_SERVICE_ENABLED("authentication.registration.service.enabled");
+    AUTHENTICATION_REGISTRATION_SERVICE_ENABLED("authentication.registration.service.enabled"),
+
+    // mfa authentication service configuration
+    AUTHENTICATION_MFA_TIME_STEP_SIZE("authentication.mfa.time.step.size"),  // the time step size, in seconds, min > 0
+    AUTHENTICATION_MFA_WINDOW_SIZE("authentication.mfa.window.size"),  // number of windows of size timeStepSizeInMillis checked during the validation, min > 0
+    AUTHENTICATION_MFA_SCRATCH_CODES_NUMBER("authentication.mfa.scratch.codes.number"),  // number of scratch codes, min is 0 max is 1000
+    AUTHENTICATION_MFA_CODE_DIGITS_NUMBER("authentication.mfa.code.digits.number");  // the number of digits in the generated code, min is 6 max is 8
 
     private String key;
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeys.java
@@ -27,6 +27,8 @@ public enum KapuaCryptoSettingKeys implements SettingKey {
     CRYPTO_SHA_ALGORITHM("crypto.sha.algorithm"),
 
     CRYPTO_SHA_SALT_LENGTH("crypto.sha.salt.length"),
+
+    CIPHER_KEY("cipher.key"),
     ;
 
     private String key;

--- a/service/security/shiro/src/main/resources/META-INF/persistence.xml
+++ b/service/security/shiro/src/main/resources/META-INF/persistence.xml
@@ -22,6 +22,8 @@
         <!-- Authentication -->
         <class>org.eclipse.kapua.service.authentication.credential.shiro.CredentialImpl</class>
         <class>org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl</class>
+        <class>org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaCredentialOptionImpl</class>
+        <class>org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeImpl</class>
 
         <!-- Base classes and External classes -->
         <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>

--- a/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
@@ -38,3 +38,9 @@ authentication.credential.apiKey.cache.ttl=300000
 authentication.eventAddress=authentication
 
 authentication.registration.service.enabled=false
+
+# mfa authentication properties
+authentication.mfa.time.step.size=30
+authentication.mfa.window.size=3
+authentication.mfa.scratch.codes.number=5
+authentication.mfa.code.digits.number=6

--- a/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-crypto-setting.properties
@@ -15,3 +15,7 @@ crypto.bCrypt.logRounds=12
 
 crypto.sha.algorithm=SHA512
 crypto.sha.salt.length=8
+
+# The following key is the default one for the MFA secret encryption/decryption
+# It MUST be changed by providing a custom one!
+cipher.key=rv;ipse329183!@#

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-mfa_credential_option-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-mfa_credential_option-domain.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <property name="selectMfaCredentialOptionDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'mfa_credential_option')"/>
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-authentication-1.3.0-mfaCredentialOptionDomain" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain">
+            <column name="created_on" valueComputed="${now}"/>
+            <column name="created_by" value="1"/>
+            <column name="name" value="mfa_credential_option"/>
+            <column name="serviceName" value="org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectMfaCredentialOptionDomainQuery}"/>
+            <column name="action" value="read"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectMfaCredentialOptionDomainQuery}"/>
+            <column name="action" value="write"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectMfaCredentialOptionDomainQuery}"/>
+            <column name="action" value="delete"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-mfa_credential_option.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-mfa_credential_option.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="changelog-authentication-1.3.0_createMfaCredentialOption" author="eurotech">
+        <createTable tableName="atht_mfa_credential_option">
+            <column name="scope_id" type="bigint(21) unsigned">
+                <constraints nullable="false" />
+            </column>
+            <column name="id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="user_id" type="bigint(21) unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="mfa_credential_key" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="trust_key" type="varchar(255)"/>
+            <column name="trust_expiration_date" type="timestamp(3) NULL"/>
+            <column name="created_on" type="timestamp(3) DEFAULT ${now}" defaultValueComputed="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="bigint(21) unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified_on" type="timestamp(3) DEFAULT ${now}" defaultValueComputed="${now}"/>
+            <column name="modified_by" type="bigint(21) unsigned"/>
+            <column name="optlock" type="int unsigned" />
+            <column name="attributes" type="text" />
+            <column name="properties" type="text" />
+        </createTable>
+
+        <createIndex tableName="atht_mfa_credential_option" indexName="idx_atht_mfa_credential_option_scope_id">
+            <column name="scope_id"/>
+        </createIndex>
+        <createIndex tableName="atht_mfa_credential_option" indexName="idx_atht_mfa_credential_option_user_id">
+            <column name="scope_id"/>
+            <column name="user_id"/>
+        </createIndex>
+
+        <sql dbms="h2">ALTER TABLE atht_mfa_credential_option ADD CHECK scope_id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_mfa_credential_option ADD CHECK id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_mfa_credential_option ADD CHECK user_id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_mfa_credential_option ADD CHECK created_by >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_mfa_credential_option ADD CHECK modified_by >= 0;</sql>
+
+        <rollback>
+            <dropIndex tableName="atht_mfa_credential_option" indexName="idx_atht_mfa_credential_option_user_id"/>
+            <dropIndex tableName="atht_mfa_credential_option" indexName="idx_atht_mfa_credential_option_scope_id"/>
+            <dropTable tableName="atht_mfa_credential_option"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-scratch_code-domain.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-scratch_code-domain.xml
@@ -1,0 +1,54 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <property name="selectScratchCodeDomainQuery" value="(SELECT id FROM athz_domain WHERE name = 'scratch_code')"/>
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-authentication-1.3.0-scratchCodeDomain" author="eurotech">
+
+        <preConditions onFail="CONTINUE">
+            <and>
+                <tableExists tableName="athz_domain"/>
+                <tableExists tableName="athz_domain_actions"/>
+            </and>
+        </preConditions>
+
+        <!-- Seed values -->
+        <insert tableName="athz_domain">
+            <column name="created_on" valueComputed="${now}"/>
+            <column name="created_by" value="1"/>
+            <column name="name" value="scratch_code"/>
+            <column name="serviceName" value="org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectScratchCodeDomainQuery}"/>
+            <column name="action" value="read"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectScratchCodeDomainQuery}"/>
+            <column name="action" value="write"/>
+        </insert>
+        <insert tableName="athz_domain_actions">
+            <column name="domain_id" valueComputed="${selectScratchCodeDomainQuery}"/>
+            <column name="action" value="delete"/>
+        </insert>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-scratch_code.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/atht-scratch_code.xml
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    All rights reserved. This program and the accompanying materials
+    are made available under the terms of the Eclipse Public License v1.0
+    which accompanies this distribution, and is available at
+    http://www.eclipse.org/legal/epl-v10.html
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-authentication-1.3.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+
+    <changeSet id="changelog-authentication-1.3.0_createScratchCode" author="eurotech">
+        <createTable tableName="atht_scratch_code">
+            <column name="scope_id" type="bigint(21) unsigned">
+                <constraints nullable="false" />
+            </column>
+            <column name="id" type="bigint(21) unsigned">
+                <constraints nullable="false" primaryKey="true"/>
+            </column>
+            <column name="mfa_credential_option_id" type="bigint(21) unsigned">
+                <constraints nullable="false" />
+            </column>
+            <column name="scratch_code" type="varchar(255)">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_on" type="timestamp(3) DEFAULT ${now}" defaultValueComputed="${now}">
+                <constraints nullable="false"/>
+            </column>
+            <column name="created_by" type="bigint(21) unsigned">
+                <constraints nullable="false"/>
+            </column>
+            <column name="modified_on" type="timestamp(3) DEFAULT ${now}" defaultValueComputed="${now}"/>
+            <column name="modified_by" type="bigint(21) unsigned"/>
+            <column name="optlock" type="int unsigned" />
+            <column name="attributes" type="text" />
+            <column name="properties" type="text" />
+        </createTable>
+
+        <createIndex tableName="atht_scratch_code" indexName="idx_atht_scratch_code_scope_id">
+            <column name="scope_id"/>
+        </createIndex>
+        <createIndex tableName="atht_scratch_code" indexName="idx_atht_scratch_code_mfa_credential_option_id">
+            <column name="scope_id"/>
+            <column name="mfa_credential_option_id"/>
+        </createIndex>
+
+        <sql dbms="h2">ALTER TABLE atht_scratch_code ADD CHECK scope_id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_scratch_code ADD CHECK id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_scratch_code ADD CHECK mfa_credential_option_id >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_scratch_code ADD CHECK created_by >= 0;</sql>
+        <sql dbms="h2">ALTER TABLE atht_scratch_code ADD CHECK modified_by >= 0;</sql>
+
+        <rollback>
+            <dropIndex tableName="atht_scratch_code" indexName="idx_atht_scratch_code_mfa_credential_option_id"/>
+            <dropIndex tableName="atht_scratch_code" indexName="idx_atht_scratch_code_scope_id"/>
+            <dropTable tableName="atht_scratch_code"/>
+        </rollback>
+
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
+++ b/service/security/shiro/src/main/resources/liquibase/1.3.0/changelog-authentication-1.3.0.xml
@@ -19,5 +19,9 @@
 
     <include relativeToChangelogFile="true" file="./atht-access_token-expires_index.xml"/>
     <include relativeToChangelogFile="true" file="./atht-access_token-refresh-expires_index.xml"/>
+    <include relativeToChangelogFile="true" file="./atht-mfa_credential_option.xml"/>
+    <include relativeToChangelogFile="true" file="./atht-scratch_code.xml"/>
+    <include relativeToChangelogFile="true" file="./atht-mfa_credential_option-domain.xml"/>
+    <include relativeToChangelogFile="true" file="./atht-scratch_code-domain.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds the backend implementation for the Two Factor Authentication (a.k.a. TFA or 2FA), a type of [Multi Factor Authentication](https://en.wikipedia.org/wiki/Multi-factor_authentication).

**Related Issue**
This PR partially closes _#3088_ (only implements the feature backend).

**Description of the solution adopted**
The following are the detailed additions and changes that are introduced with this PR:

- added MfaCredentialOption and ScratchCode entities and services in order to handle the TFA secret and the scratch codes;
- added AES algorithm encryption method to AuthenticationUtils for the TFA secret encryption;
- added MfaAuthenticationService to wrap the Google Authentication library methods;
- added ImageServlet for the QR code generation;
- modified authentication classes to handle MfaCredentialOption log in.

The TFA implementation requires two external libraries:
- the [Google Authentication library](https://github.com/wstrange/GoogleAuth)), which acts as One Time Password (OTP) generator; it is used to generate the TFA secret and to validate the OTPs;
- the [ZXing library](https://github.com/zxing/zxing), which is used in the ImageServlet for generating a QR code image from the TFA secret code.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
