### PR TITLE
Added missing DeviceManagementExceptions w.r.t. error codes

### DIFF
--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/call/DeviceCallExecutor.java
@@ -21,7 +21,7 @@ import org.eclipse.kapua.service.device.call.message.app.request.DeviceRequestMe
 import org.eclipse.kapua.service.device.call.message.app.response.DeviceResponseMessage;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
-import org.eclipse.kapua.service.device.management.exception.DeviceManagementRequestBadMethodException;
+import org.eclipse.kapua.service.device.management.exception.DeviceRequestBadMethodException;
 import org.eclipse.kapua.service.device.management.exception.DeviceManagementSendException;
 import org.eclipse.kapua.service.device.management.exception.DeviceManagementTimeoutException;
 import org.eclipse.kapua.service.device.management.exception.DeviceNotConnectedException;
@@ -153,7 +153,7 @@ public class DeviceCallExecutor<C extends KapuaRequestChannel, P extends KapuaRe
                     responseMessage = deviceCall.write(deviceRequestMessage, timeout);
                     break;
                 default:
-                    throw new DeviceManagementRequestBadMethodException();
+                    throw new DeviceRequestBadMethodException();
             }
 
             //

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementConnectionErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementConnectionErrorCodes.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -14,10 +14,7 @@ package org.eclipse.kapua.service.device.management.exception;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionStatus;
 
-/**
- * @since 1.1.0
- */
-public enum DeviceManagementGenericErrorCodes implements DeviceManagementErrorCodes {
+public enum DeviceManagementConnectionErrorCodes implements DeviceManagementErrorCodes {
 
     /**
      * The device was never connected
@@ -28,50 +25,5 @@ public enum DeviceManagementGenericErrorCodes implements DeviceManagementErrorCo
     /**
      * The {@link Device} is not {@link DeviceConnectionStatus#CONNECTED}
      */
-    DEVICE_NOT_CONNECTED,
-
-    /**
-     * Request exception
-     */
-    REQUEST_EXCEPTION,
-
-    /**
-     * Bad request method
-     */
-    REQUEST_BAD_METHOD,
-
-    /**
-     * Response parse exception
-     */
-    RESPONSE_PARSE_EXCEPTION,
-
-    /**
-     * Bad request
-     */
-    RESPONSE_BAD_REQUEST,
-
-    /**
-     * Response not found
-     */
-    RESPONSE_NOT_FOUND,
-
-    /**
-     * Response internal error
-     */
-    RESPONSE_INTERNAL_ERROR,
-
-    /**
-     * An error occurred when sending the {@link org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage}.
-     *
-     * @since 1.1.0
-     */
-    SEND_ERROR,
-
-    /**
-     * A response as not been received within the given timeout.
-     *
-     * @since 1.1.0
-     */
-    TIMEOUT
-
+    DEVICE_NOT_CONNECTED
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementRequestErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementRequestErrorCodes.java
@@ -11,11 +11,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public enum DeviceManagementRequestErrorCodes implements DeviceManagementErrorCodes {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    /**
+     * Request exception
+     */
+    REQUEST_EXCEPTION,
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
-    }
+    /**
+     * Bad request method
+     */
+    REQUEST_BAD_METHOD
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementRequestException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementRequestException.java
@@ -29,7 +29,7 @@ public class DeviceManagementRequestException extends DeviceManagementException 
      * @since 1.1.0
      */
     public DeviceManagementRequestException(@NotNull Throwable cause, @NotNull KapuaSerializable kapuaSerializable) {
-        super(DeviceManagementGenericErrorCodes.REQUEST_EXCEPTION, cause, kapuaSerializable);
+        super(DeviceManagementRequestErrorCodes.REQUEST_EXCEPTION, cause, kapuaSerializable);
         this.kapuaSerializable = kapuaSerializable;
         this.object = null;
     }
@@ -41,7 +41,7 @@ public class DeviceManagementRequestException extends DeviceManagementException 
      * @since 1.1.0
      */
     public DeviceManagementRequestException(@NotNull Throwable cause, @NotNull Object object) {
-        super(DeviceManagementGenericErrorCodes.REQUEST_EXCEPTION, cause, object);
+        super(DeviceManagementRequestErrorCodes.REQUEST_EXCEPTION, cause, object);
         this.kapuaSerializable = null;
         this.object = object;
     }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementResponseErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementResponseErrorCodes.java
@@ -11,11 +11,25 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public enum DeviceManagementResponseErrorCodes implements DeviceManagementErrorCodes {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    /**
+     * Response parse exception
+     */
+    RESPONSE_PARSE_EXCEPTION,
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
-    }
+    /**
+     * Bad request
+     */
+    RESPONSE_BAD_REQUEST,
+
+    /**
+     * Response not found
+     */
+    RESPONSE_NOT_FOUND,
+
+    /**
+     * Response internal error
+     */
+    RESPONSE_INTERNAL_ERROR
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementResponseException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementResponseException.java
@@ -25,11 +25,20 @@ public class DeviceManagementResponseException extends DeviceManagementException
 
     /**
      * Constructor.
+     */
+    public DeviceManagementResponseException() {
+        super(DeviceManagementResponseErrorCodes.RESPONSE_PARSE_EXCEPTION);
+        this.responsePayload = null;
+        this.responsePayloadBody = null;
+    }
+
+    /**
+     * Constructor.
      *
      * @param cause the root cause of the {@link Exception}.
      */
     public DeviceManagementResponseException(@NotNull Throwable cause, @NotNull KapuaResponsePayload responsePayload) {
-        super(DeviceManagementGenericErrorCodes.RESPONSE_PARSE_EXCEPTION, cause, responsePayload);
+        super(DeviceManagementResponseErrorCodes.RESPONSE_PARSE_EXCEPTION, cause, responsePayload);
         this.responsePayload = responsePayload;
         this.responsePayloadBody = null;
     }
@@ -40,7 +49,7 @@ public class DeviceManagementResponseException extends DeviceManagementException
      * @param cause the root cause of the {@link Exception}.
      */
     public DeviceManagementResponseException(@NotNull Throwable cause, @NotNull Object responsePayloadBody) {
-        super(DeviceManagementGenericErrorCodes.RESPONSE_PARSE_EXCEPTION, cause, responsePayloadBody);
+        super(DeviceManagementResponseErrorCodes.RESPONSE_PARSE_EXCEPTION, cause, responsePayloadBody);
         this.responsePayload = null;
         this.responsePayloadBody = responsePayloadBody;
     }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendErrorCodes.java
@@ -11,11 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public enum DeviceManagementSendErrorCodes implements DeviceManagementErrorCodes {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    /**
+     * An error occurred when sending the {@link org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage}.
+     *
+     * @since 1.1.0
+     */
+    SEND_ERROR
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
-    }
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementSendException.java
@@ -33,7 +33,7 @@ public class DeviceManagementSendException extends DeviceManagementException {
      * @since 1.1.0
      */
     public DeviceManagementSendException(@NotNull KapuaRequestMessage requestMessage) {
-        super(DeviceManagementGenericErrorCodes.SEND_ERROR, requestMessage);
+        super(DeviceManagementSendErrorCodes.SEND_ERROR, requestMessage);
         this.requestMessage = requestMessage;
     }
 
@@ -45,7 +45,7 @@ public class DeviceManagementSendException extends DeviceManagementException {
      * @since 1.1.0
      */
     public DeviceManagementSendException(@NotNull Throwable cause, @NotNull KapuaRequestMessage requestMessage) {
-        super(DeviceManagementGenericErrorCodes.SEND_ERROR, cause, requestMessage);
+        super(DeviceManagementSendErrorCodes.SEND_ERROR, cause, requestMessage);
         this.requestMessage = requestMessage;
     }
 

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutErrorCodes.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutErrorCodes.java
@@ -11,11 +11,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public enum DeviceManagementTimeoutErrorCodes implements DeviceManagementErrorCodes {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    /**
+     * A response as not been received within the given timeout.
+     *
+     * @since 1.1.0
+     */
+    TIMEOUT
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
-    }
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceManagementTimeoutException.java
@@ -32,7 +32,7 @@ public class DeviceManagementTimeoutException extends DeviceManagementException 
      * @since 1.1.0
      */
     public DeviceManagementTimeoutException(@NotNull Throwable cause, @NotNull Long timeout) {
-        super(DeviceManagementGenericErrorCodes.TIMEOUT, cause, timeout);
+        super(DeviceManagementTimeoutErrorCodes.TIMEOUT, cause, timeout);
 
         this.timeout = timeout;
     }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceNotConnectedException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceNotConnectedException.java
@@ -33,7 +33,7 @@ public class DeviceNotConnectedException extends DeviceManagementException {
      * Constructor.
      */
     public DeviceNotConnectedException() {
-        super(DeviceManagementGenericErrorCodes.DEVICE_NOT_CONNECTED);
+        super(DeviceManagementConnectionErrorCodes.DEVICE_NOT_CONNECTED);
         this.deviceId = null;
         this.currentConnectionStatus = null;
     }
@@ -45,7 +45,7 @@ public class DeviceNotConnectedException extends DeviceManagementException {
      * @since 1.1.0
      */
     public DeviceNotConnectedException(@NotNull KapuaId deviceId) {
-        super(DeviceManagementGenericErrorCodes.DEVICE_NOT_CONNECTED, null);
+        super(DeviceManagementConnectionErrorCodes.DEVICE_NOT_CONNECTED, null);
         this.deviceId = deviceId;
         this.currentConnectionStatus = null;
     }
@@ -58,7 +58,7 @@ public class DeviceNotConnectedException extends DeviceManagementException {
      * @since 1.1.0
      */
     public DeviceNotConnectedException(@NotNull KapuaId deviceId, @NotNull DeviceConnectionStatus currentConnectionStatus) {
-        super(DeviceManagementGenericErrorCodes.DEVICE_NOT_CONNECTED, deviceId, currentConnectionStatus);
+        super(DeviceManagementConnectionErrorCodes.DEVICE_NOT_CONNECTED, deviceId, currentConnectionStatus);
         this.deviceId = deviceId;
         this.currentConnectionStatus = currentConnectionStatus;
     }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceRequestBadMethodException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceRequestBadMethodException.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public class DeviceRequestBadMethodException extends DeviceManagementException {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    private static final long serialVersionUID = 2544641159548768773L;
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
+    public DeviceRequestBadMethodException() {
+        super(DeviceManagementRequestErrorCodes.REQUEST_BAD_METHOD);
     }
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseBadRequestException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseBadRequestException.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ * Copyright (c) 2019, 2020 Eurotech and/or its affiliates and others
  *
  * All rights reserved. This program and the accompanying materials
  * are made available under the terms of the Eclipse Public License v1.0
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public class DeviceResponseBadRequestException extends DeviceManagementException{
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    private static final long serialVersionUID = 768897121791826654L;
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
+    public DeviceResponseBadRequestException() {
+        super(DeviceManagementResponseErrorCodes.RESPONSE_BAD_REQUEST);
     }
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseInternalErrorException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseInternalErrorException.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceNeverConnectedException extends DeviceManagementException {
+public class DeviceResponseInternalErrorException extends DeviceManagementException {
 
-    private static final long serialVersionUID = -8225341071813065890L;
+    private static final long serialVersionUID = -6932782062611595148L;
 
-    public DeviceNeverConnectedException() {
-        super(DeviceManagementConnectionErrorCodes.DEVICE_NEVER_CONNECTED);
+    public DeviceResponseInternalErrorException() {
+        super(DeviceManagementResponseErrorCodes.RESPONSE_INTERNAL_ERROR);
     }
 }

--- a/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseNotFoundException.java
+++ b/service/device/management/api/src/main/java/org/eclipse/kapua/service/device/management/exception/DeviceResponseNotFoundException.java
@@ -11,11 +11,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.exception;
 
-public class DeviceManagementRequestBadMethodException extends DeviceManagementException {
+public class DeviceResponseNotFoundException extends DeviceManagementException {
 
-    private static final long serialVersionUID = 2544641159548768773L;
+    private static final long serialVersionUID = 979552606398189720L;
 
-    public DeviceManagementRequestBadMethodException() {
-        super(DeviceManagementGenericErrorCodes.REQUEST_BAD_METHOD);
+    public DeviceResponseNotFoundException() {
+        super(DeviceManagementResponseErrorCodes.RESPONSE_NOT_FOUND);
     }
 }


### PR DESCRIPTION
This PR adds some missing `DeviceManagementException` classes w.r.t. existing error codes.

**Related Issue**
_n/a_

**Description of the solution adopted**
_n/a_

**Screenshots**
_n/a_

**Any side note on the changes made**
This is related to work carried on PR #3093
