### PR TITLE
Added Junit tests for broker module

### DIFF
--- a/broker/api/pom.xml
+++ b/broker/api/pom.xml
@@ -28,6 +28,16 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-service-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainTest.java
+++ b/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class BrokerDomainTest extends Assert {
+
+    BrokerDomain brokerDomain;
+    BrokerDomain secondBrokerDomain;
+    Object[] objects;
+
+    @Before
+    public void initialize() {
+        brokerDomain = new BrokerDomain();
+        secondBrokerDomain = new BrokerDomain();
+        objects = new Object[]{0, 10, 100000, "String", 'c', -10, -1000000000, -100000000000L, 10L, 10.0f, null, 10.10d, true, false};
+    }
+
+    @Test
+    public void getNameTest() {
+        assertEquals("Expected and actual values should be the same.", "broker", brokerDomain.getName());
+    }
+
+    @Test
+    public void getActionsTest() {
+        assertEquals("Expected and actual values should be the same.", "[connect]", brokerDomain.getActions().toString());
+    }
+
+    @Test
+    public void getGroupableTest() {
+        assertFalse("False expected.", brokerDomain.getGroupable());
+    }
+
+    @Test
+    public void equalsTest() {
+        assertTrue("True expected.", brokerDomain.equals(secondBrokerDomain));
+        for (Object object : objects) {
+            assertFalse("False expected.", brokerDomain.equals(object));
+        }
+    }
+
+    @Test
+    public void hashCodeTest() {
+        assertNotNull("NotNull expected.", brokerDomain.hashCode());
+    }
+}

--- a/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainsTest.java
+++ b/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainsTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class BrokerDomainsTest extends Assert {
+
+    @Test
+    public void brokerDomainsTest() throws Exception {
+        Constructor<BrokerDomains> brokerDomains = BrokerDomains.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(brokerDomains.getModifiers()));
+        brokerDomains.setAccessible(true);
+        brokerDomains.newInstance();
+    }
+
+    @Test
+    public void brokerDomainTest() {
+        BrokerDomain brokerDomain = BrokerDomains.BROKER_DOMAIN;
+        assertNotNull("NotNull expected.", brokerDomain);
+    }
+}

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -232,6 +232,11 @@
             <artifactId>kapua-locator-guice</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessageTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelKapuaMessageTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message;
+
+import org.eclipse.kapua.broker.core.plugin.ConnectorDescriptor;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class CamelKapuaMessageTest extends Assert {
+
+    CamelKapuaMessage camelKapuaMessage;
+
+    @Before
+    public void initialize() {
+        camelKapuaMessage = new CamelKapuaMessage(null, null, null);
+    }
+
+    @Test
+    public void setAndGetMessageTest() {
+        KapuaMessage kapuaMessage = Mockito.mock(KapuaMessage.class);
+
+        assertNull("Null expected.", camelKapuaMessage.getMessage());
+        camelKapuaMessage.setMessage(kapuaMessage);
+        assertEquals("Expected and actual values should be the same.", kapuaMessage, camelKapuaMessage.getMessage());
+        camelKapuaMessage.setMessage(null);
+        assertNull("Null expected.", camelKapuaMessage.getMessage());
+    }
+
+    @Test
+    public void setAndGetConnectionIdTest() {
+        KapuaId connectionId = KapuaId.ONE;
+
+        assertNull("Null expected.", camelKapuaMessage.getConnectionId());
+        camelKapuaMessage.setConnectionId(connectionId);
+        assertEquals("Expected and actual values should be the same.", connectionId, camelKapuaMessage.getConnectionId());
+        camelKapuaMessage.setConnectionId(null);
+        assertNull("Null expected.", camelKapuaMessage.getConnectionId());
+    }
+
+    @Test
+    public void setAndGetConnectorDescriptorTest() {
+        ConnectorDescriptor descriptor = Mockito.mock(ConnectorDescriptor.class);
+
+        assertNull("Null expected.", camelKapuaMessage.getConnectorDescriptor());
+        camelKapuaMessage.setConnectorDescriptor(descriptor);
+        assertEquals("Expected and actual values should be the same.", descriptor, camelKapuaMessage.getConnectorDescriptor());
+        camelKapuaMessage.setConnectorDescriptor(null);
+        assertNull("Null expected.", camelKapuaMessage.getConnectorDescriptor());
+    }
+
+    @Test
+    public void setAndGetDatastoreIdTest() {
+        String[] dataStoreIds = {null, "", "1", "awsd", "123123123", "-123", "ASDa12$%~", "~ˇ#$%&/()=?*\\", "DSUrCucsvb2qUwbdD5yyiCC5v1wwF5FmBIcWa2oXafNw5bqV2RAcyyN0gCHQTdL2JedME5A4PXsXt7iHekhys52GZVmiCNcA065RxFEsDasCcaH1dzeRioRvA14NoJPGmScHdHf8Mfzv03vWrs7n2W59f1In9NdUtnaxY1Wp5TjknB6X8U5ZRczLntQZNX3MSu5f4OzF29oTtuDcuPIUal6OBTKnm8qLVhsiu3oMK3YnFhoHuiATBk3Pl0q9LaL"};
+
+        assertNull("Null expected.", camelKapuaMessage.getDatastoreId());
+        for (String id : dataStoreIds) {
+            camelKapuaMessage.setDatastoreId(id);
+            assertEquals("Expected and actual values should be the same.", id, camelKapuaMessage.getDatastoreId());
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelUtilTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/CamelUtilTest.java
@@ -1,0 +1,96 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message;
+
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.ActiveMQTopic;
+import org.apache.camel.impl.DefaultMessage;
+import org.eclipse.kapua.broker.core.listener.CamelConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.jms.JMSException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class CamelUtilTest extends Assert {
+
+    @Test
+    public void camelUtilTest() throws Exception {
+        Constructor<CamelUtil> camelUtil = CamelUtil.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(camelUtil.getModifiers()));
+        camelUtil.setAccessible(true);
+        camelUtil.newInstance();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getTopicNullTest() throws JMSException {
+        CamelUtil.getTopic(null);
+    }
+
+    @Test
+    public void getTopicTest() throws JMSException {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put("originalTopic", "testTopic");
+        message.setHeaders(map);
+        String topic = CamelUtil.getTopic(message);
+        assertEquals("Expected and actual values should be the same.", "testTopic", topic);
+    }
+
+    @Test
+    public void getTopicWithActiveMQTopicTest() throws JMSException {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put(CamelConstants.JMS_HEADER_DESTINATION, new ActiveMQTopic("VirtualTopic.Topic"));
+        message.setHeaders(map);
+        String topic = CamelUtil.getTopic(message);
+        assertEquals("Expected and actual values should be the same.", "Topic", topic);
+    }
+
+    @Test
+    public void getTopicWithActiveMQDestinationTest() {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put(MessageConstants.PROPERTY_ORIGINAL_TOPIC, null);
+        map.put(CamelConstants.JMS_HEADER_DESTINATION, Mockito.mock(ActiveMQDestination.class));
+        message.setHeaders(map);
+        try {
+            CamelUtil.getTopic(message);
+            fail("JMSException expected.");
+        } catch (Exception e) {
+            assertTrue("True expected.", e.getMessage().contains("Unable to extract the destination. Wrong destination Mock for ActiveMQDestination"));
+        }
+    }
+
+    @Test
+    public void getTopicNullDestinationTest() {
+        org.apache.camel.Message message = new DefaultMessage();
+        Map<String, Object> map = new HashMap();
+        map.put(MessageConstants.PROPERTY_ORIGINAL_TOPIC, null);
+        map.put(CamelConstants.JMS_HEADER_DESTINATION, null);
+        message.setHeaders(map);
+        try {
+            CamelUtil.getTopic(message);
+            fail("JMSException expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new JMSException("Unable to extract the destination. Wrong destination null").toString(), e.toString());
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/MessageConstantsTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/MessageConstantsTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class MessageConstantsTest extends Assert {
+
+    @Test
+    public void messageConstantsTest() throws Exception {
+        Constructor<MessageConstants> messageConstants = MessageConstants.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(messageConstants.getModifiers()));
+        messageConstants.setAccessible(true);
+        messageConstants.newInstance();
+    }
+
+    @Test
+    public void constantsTest() {
+        assertEquals("Expected and actual values should be the same.", "username", MessageConstants.METRIC_USERNAME);
+        assertEquals("Expected and actual values should be the same.", "account", MessageConstants.METRIC_ACCOUNT);
+        assertEquals("Expected and actual values should be the same.", "clientId", MessageConstants.METRIC_CLIENT_ID);
+        assertEquals("Expected and actual values should be the same.", "ip", MessageConstants.METRIC_IP);
+        assertEquals("Expected and actual values should be the same.", "originalTopic", MessageConstants.PROPERTY_ORIGINAL_TOPIC);
+        assertEquals("Expected and actual values should be the same.", "enqueuedTimestamp", MessageConstants.PROPERTY_ENQUEUED_TIMESTAMP);
+        assertEquals("Expected and actual values should be the same.", "brokerId", MessageConstants.PROPERTY_BROKER_ID);
+        assertEquals("Expected and actual values should be the same.", "clientId", MessageConstants.PROPERTY_CLIENT_ID);
+        assertEquals("Expected and actual values should be the same.", "scopeId", MessageConstants.PROPERTY_SCOPE_ID);
+        assertEquals("Expected and actual values should be the same.", "userId", MessageConstants.METRIC_USER_ID);
+        assertEquals("Expected and actual values should be the same.", "nodeId", MessageConstants.METRIC_NODE_ID);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_CONNECTION_ID", MessageConstants.HEADER_KAPUA_CONNECTION_ID);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_RECEIVED_TIMESTAMP", MessageConstants.HEADER_KAPUA_RECEIVED_TIMESTAMP);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_CLIENT_ID", MessageConstants.HEADER_KAPUA_CLIENT_ID);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_DEVICE_PROTOCOL", MessageConstants.HEADER_KAPUA_CONNECTOR_DEVICE_PROTOCOL);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_SESSION", MessageConstants.HEADER_KAPUA_SESSION);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_BROKER_CONTEXT", MessageConstants.HEADER_KAPUA_BROKER_CONTEXT);
+        assertEquals("Expected and actual values should be the same.", "KAPUA_PROCESSING_EXCEPTION", MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreatorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/message/system/DefaultSystemMessageCreatorTest.java
@@ -1,0 +1,82 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.message.system;
+
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class DefaultSystemMessageCreatorTest extends Assert {
+
+    DefaultSystemMessageCreator messageCreator;
+    KapuaSecurityContext kapuaSecurityContext;
+
+    @Before
+    public void initialize() {
+        messageCreator = new DefaultSystemMessageCreator();
+        kapuaSecurityContext = new KapuaSecurityContext(new Long(1), "client1");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullTest() {
+        messageCreator.createMessage(null, null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullMessageTypeTest() {
+        messageCreator.createMessage(null, kapuaSecurityContext);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createMessageNullContextTest() {
+        messageCreator.createMessage(SystemMessageCreator.SystemMessageType.CONNECT, null);
+    }
+
+    @Test
+    public void createMessageConnectTypeTest() {
+        String result = messageCreator.createMessage(SystemMessageCreator.SystemMessageType.CONNECT, kapuaSecurityContext);
+        assertEquals("Expected and actual values should be the same.", "Event,CONNECT,,DeviceId,client1,,Username,null", result);
+    }
+
+    @Test
+    public void createMessageDisconnectTypeTest() {
+        String result = messageCreator.createMessage(SystemMessageCreator.SystemMessageType.DISCONNECT, kapuaSecurityContext);
+        assertEquals("Expected and actual values should be the same.", "Event,DISCONNECT,,DeviceId,client1,,Username,null", result);
+    }
+
+    @Test
+    public void convertFromTest() {
+        Map<String, String> map = messageCreator.convertFrom("DeviceId,device1,,Username,user1");
+        assertEquals("Expected and actual values should be the same.", "device1", messageCreator.getDeviceId(map));
+        assertEquals("Expected and actual values should be the same.", "user1", messageCreator.getUsername(map));
+    }
+
+    @Test
+    public void convertFromWrongArgumentsTest() {
+        String[] values = {"a", "test,test,test,test", "::::", "test,test,,test,test,,test,test", ",,,,", "test, test, test, test, test"};
+        for (String value : values) {
+            try {
+                messageCreator.convertFrom(value);
+                fail("Exception expected.");
+            } catch (IllegalArgumentException e) {
+                assertEquals("IllegalArgumentException expected.", IllegalArgumentException.class, e.getClass());
+            }
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/ClientMetricTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import com.codahale.metrics.Counter;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class ClientMetricTest extends Assert {
+
+    ClientMetric clientMetric;
+
+    @Before
+    public void initialize() {
+        clientMetric = ClientMetric.getInstance();
+    }
+
+    @Test
+    public void clientMetricTest() throws Exception {
+        Constructor<ClientMetric> clientMetric = ClientMetric.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(clientMetric.getModifiers()));
+        clientMetric.setAccessible(true);
+        clientMetric.newInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), clientMetric.getConnectedClient().getCount());
+        assertTrue("Instance of Counter expected.", clientMetric.getConnectedClient() instanceof Counter);
+
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), clientMetric.getConnectedKapuasys().getCount());
+        assertTrue("Instance of Counter expected.", clientMetric.getConnectedKapuasys() instanceof Counter);
+
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), clientMetric.getDisconnectedClient().getCount());
+        assertTrue("Instance of Counter expected.", clientMetric.getDisconnectedClient() instanceof Counter);
+
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), clientMetric.getDisconnectedKapuasys().getCount());
+        assertTrue("Instance of Counter expected.", clientMetric.getDisconnectedKapuasys() instanceof Counter);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetricTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class LoginMetricTest extends Assert {
+
+    LoginMetric loginMetric;
+
+    @Before
+    public void initialize() {
+        loginMetric = LoginMetric.getInstance();
+    }
+
+    @Test
+    public void loginMetricTest() throws Exception {
+        Constructor<LoginMetric> loginMetric = LoginMetric.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(loginMetric.getModifiers()));
+        loginMetric.setAccessible(true);
+        loginMetric.newInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertTrue("Instance of Counter expected.", loginMetric.getSuccess() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getFailure() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getInvalidUserPassword() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getInvalidClientId() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getKapuasysTokenAttempt() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getInternalConnectorAttempt() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getNormalUserAttempt() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getStealingLinkConnect() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getStealingLinkDisconnect() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getRemoteStealingLinkDisconnect() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getAdminStealingLinkDisconnect() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getInternalConnectorConnected() instanceof Counter);
+        assertTrue("Instance of Counter expected.", loginMetric.getInternalConnectorDisconnected() instanceof Counter);
+        assertTrue("Instance of Timer expected.", loginMetric.getAddConnectionTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getNormalUserTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getShiroLoginTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getCheckAccessTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getFindDeviceConnectionTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getUpdateDeviceConnectionTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getShiroLogoutTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getSendLoginUpdateMsgTime() instanceof Timer);
+        assertTrue("Instance of Timer expected.", loginMetric.getRemoveConnectionTime() instanceof Timer);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/PublishMetricTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Histogram;
+import com.codahale.metrics.Timer;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class PublishMetricTest extends Assert {
+
+    PublishMetric publishMetric;
+
+    @Before
+    public void initialize() {
+        publishMetric = PublishMetric.getInstance();
+    }
+
+    @Test
+    public void publishMetricTest() throws Exception {
+        Constructor<PublishMetric> publishMetric = PublishMetric.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(publishMetric.getModifiers()));
+        publishMetric.setAccessible(true);
+        publishMetric.newInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertTrue("Instance of Counter expected.", publishMetric.getAllowedMessages() instanceof Counter);
+        assertTrue("Instance of Counter expected.", publishMetric.getNotAllowedMessages() instanceof Counter);
+        assertTrue("Instance of Timer expected.", publishMetric.getTime() instanceof Timer);
+        assertTrue("Instance of Histogram expected.", publishMetric.getMessageSizeAllowed() instanceof Histogram);
+        assertTrue("Instance of Histogram expected.", publishMetric.getMessageSizeNotAllowed() instanceof Histogram);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SecurityMetricsTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SecurityMetricsTest.java
@@ -1,0 +1,33 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class SecurityMetricsTest extends Assert {
+
+    @Test
+    public void securityMetricsTest() throws Exception {
+        Constructor<SecurityMetrics> securityMetrics = SecurityMetrics.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(securityMetrics.getModifiers()));
+        securityMetrics.setAccessible(true);
+        securityMetrics.newInstance();
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetricTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/metric/SubscribeMetricTest.java
@@ -1,0 +1,55 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.metric;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class SubscribeMetricTest extends Assert {
+
+    SubscribeMetric subscribeMetric;
+
+    @Before
+    public void initialize() {
+        subscribeMetric = SubscribeMetric.getInstance();
+    }
+
+    @Test
+    public void subscribeMetricTest() throws Exception {
+        Constructor<SubscribeMetric> subscribeMetric = SubscribeMetric.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(subscribeMetric.getModifiers()));
+        subscribeMetric.setAccessible(true);
+        subscribeMetric.newInstance();
+    }
+
+    @Test
+    public void gettersTest() {
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), subscribeMetric.getAllowedMessages().getCount());
+        assertTrue("Instance of Counter expected.", subscribeMetric.getAllowedMessages() instanceof Counter);
+
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), subscribeMetric.getNotAllowedMessages().getCount());
+        assertTrue("Instance of Counter expected.", subscribeMetric.getNotAllowedMessages() instanceof Counter);
+
+        assertEquals("Expected and actual values should be the same.", Long.parseLong("0"), subscribeMetric.getTime().getCount());
+        assertTrue("Instance of Timer expected.", subscribeMetric.getTime() instanceof Timer);
+    }
+}


### PR DESCRIPTION
Added Junit test for classes in:

broker/api module:
BrokerDomain class
BrokerDomains class

broker/core/message package:
CamelKapuaMessage class
CamelUtil class
MessageConstants class
DefaultSystemMessageCreator class

broker/core/plugin/metric package:
ClientMetric class
LoginMetric class
PublishMetric class
SecurityMetrics class
SubscribeMetric class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
This PR has no related issue, but closes PR #3075.

**Description of the solution adopted**
/
**Screenshots**
/
**Any side note on the changes made**
/
