### PR TITLE
Added Junit tests for pool and setting package

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPoolTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerPoolTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class JmsAssistantProducerPoolTest extends Assert {
+
+    @Test
+    public void jmsAssistantProducerPoolTest() {
+        String[] destinations = {"test", "destination1234", "","destination test",
+                "destinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationdestinationd",
+                "asd#$$%%/(@", "123", "-23", null};
+        for (String destination : destinations) {
+            JmsAssistantProducerPool pool = new JmsAssistantProducerPool(new JmsAssistantProducerWrapperFactory(destination));
+            assertEquals("Expected and actual values should be the same.", 10, pool.getMaxTotal());
+            assertEquals("Expected and actual values should be the same.", 10, pool.getMaxIdle());
+            assertEquals("Expected and actual values should be the same.", 5, pool.getMinIdle());
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void jmsAssistantProducerPoolNullTest() {
+       new JmsAssistantProducerPool(null);
+    }
+
+    @Test
+    public void getIOnstanceTest() {
+        JmsAssistantProducerPool pool = JmsAssistantProducerPool.getIOnstance(JmsAssistantProducerPool.DESTINATIONS.NO_DESTINATION);
+        assertEquals("Expected and actual values should be the same.", "org.eclipse.kapua.broker.core.pool.JmsAssistantProducerWrapperFactory<org.eclipse.kapua.broker.core.pool.JmsAssistantProducerWrapper>", pool.getFactoryType());
+    }
+
+    @Test
+    public void getIOnstanceNullTest() {
+        JmsAssistantProducerPool pool = JmsAssistantProducerPool.getIOnstance(null);
+        assertNull("Null expected.", pool);
+    }
+
+    @Test
+    public void closePools() {
+        try {
+            JmsAssistantProducerPool.closePools();
+        } catch (Exception e) {
+            fail("Exception should not be thrown");
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactoryTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperFactoryTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.apache.activemq.ActiveMQSession;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.PooledObjectState;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.jms.Connection;
+import javax.jms.JMSException;
+import javax.jms.MessageProducer;
+import javax.jms.Session;
+
+@Category(JUnitTests.class)
+public class JmsAssistantProducerWrapperFactoryTest extends Assert {
+
+    String[] destinations;
+    JmsAssistantProducerWrapper producerWrapper;
+    PooledObject<JmsAssistantProducerWrapper> pooledProducerWrapper;
+    Session session;
+    ActiveMQSession activeMQSession;
+    Connection connection;
+    MessageProducer producer;
+    ActiveMQConnectionFactory activeMQConnectionFactory;
+
+    @Before
+    public void initialize() {
+        destinations = new String[]{"", "destination", "destination1234567890", "dEsTiNaTion-1pr23", "De-12!stinatioN   123#$%", "  dest0-=,...,,ination!123#", "() _ + ?><|/.des-=44tinat,,ion'!@#$ % ^&*"};
+        producerWrapper = Mockito.mock(JmsAssistantProducerWrapper.class);
+        pooledProducerWrapper = Mockito.mock(PooledObject.class);
+        session = Mockito.mock(Session.class);
+        activeMQSession = Mockito.mock(ActiveMQSession.class);
+        connection = Mockito.mock(Connection.class);
+        producer = Mockito.mock(MessageProducer.class);
+        activeMQConnectionFactory = Mockito.mock(ActiveMQConnectionFactory.class);
+    }
+
+    @Test
+    public void jmsAssistantProducerWrapperFactoryTest() {
+        for (String destination : destinations) {
+            try {
+                new JmsAssistantProducerWrapperFactory(destination);
+            } catch (Exception e) {
+                fail("No exception should be thrown");
+            }
+        }
+    }
+
+    @Test
+    public void wrapTest() {
+        for (String destination : destinations) {
+            JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory(destination);
+            assertEquals("Expected and actual values should be the same.", PooledObjectState.IDLE, wrapperFactory.wrap(producerWrapper).getState());
+            assertTrue("True expected.", wrapperFactory.wrap(producerWrapper) instanceof PooledObject);
+        }
+    }
+
+    @Test
+    public void wrapNullTest() {
+        for (String destination : destinations) {
+            JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory(destination);
+            assertEquals("Expected and actual values should be the same.", PooledObjectState.IDLE, wrapperFactory.wrap(null).getState());
+            assertTrue("True expected.", wrapperFactory.wrap(null) instanceof PooledObject);
+        }
+    }
+
+    @Test
+    public void validateObjectTest() throws KapuaException, JMSException {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(session.createProducer(session.createQueue("destination"))).thenReturn(producer);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(true, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        JmsAssistantProducerWrapper producerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "destination", true, true);
+        Mockito.when(pooledProducerWrapper.getObject()).thenReturn(producerWrapper);
+        JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory("destination");
+
+        assertTrue("True expected.", wrapperFactory.validateObject(pooledProducerWrapper));
+    }
+
+    @Test
+    public void validateObjectActiveMQSessionTrueTest() throws KapuaException, JMSException {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(activeMQSession.createProducer(activeMQSession.createQueue("destination"))).thenReturn(producer);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(true, Session.AUTO_ACKNOWLEDGE)).thenReturn(activeMQSession);
+        JmsAssistantProducerWrapper producerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "destination", true, true);
+        Mockito.when(pooledProducerWrapper.getObject()).thenReturn(producerWrapper);
+        JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory("destination");
+
+        assertTrue("True expected.", wrapperFactory.validateObject(pooledProducerWrapper));
+    }
+
+    @Test
+    public void validateObjectActiveMQSessionFalseTest() throws KapuaException, JMSException {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(activeMQSession.createProducer(activeMQSession.createQueue("destination"))).thenReturn(producer);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(true, Session.AUTO_ACKNOWLEDGE)).thenReturn(activeMQSession);
+        JmsAssistantProducerWrapper producerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "destination", true, true);
+        Mockito.when(pooledProducerWrapper.getObject()).thenReturn(producerWrapper);
+        JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory("destination");
+        Mockito.when(activeMQSession.isClosed()).thenReturn(true);
+
+        assertFalse("False expected.", wrapperFactory.validateObject(pooledProducerWrapper));
+    }
+
+
+    @Test(expected = NullPointerException.class)
+    public void validateNullTest() {
+        JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory("destination");
+        wrapperFactory.validateObject(null);
+    }
+
+    @Test
+    public void destroyObjectTest() {
+        for (String destination : destinations) {
+            JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory(destination);
+            Mockito.when(pooledProducerWrapper.getObject()).thenReturn(producerWrapper);
+            try {
+                wrapperFactory.destroyObject(pooledProducerWrapper);
+            } catch (Exception e) {
+                fail("Exception not expected.");
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void destroyObjectNullTest() throws Exception {
+        for (String destination : destinations) {
+            JmsAssistantProducerWrapperFactory wrapperFactory = new JmsAssistantProducerWrapperFactory(destination);
+            wrapperFactory.destroyObject(null);
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsAssistantProducerWrapperTest.java
@@ -1,0 +1,198 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.jms.Session;
+import javax.jms.Connection;
+import javax.jms.MessageProducer;
+import javax.jms.TextMessage;
+import javax.jms.JMSException;
+
+@Category(JUnitTests.class)
+public class JmsAssistantProducerWrapperTest extends Assert {
+
+    Session session;
+    Connection connection;
+    String destination;
+    String[] topics;
+    String[] messages;
+    boolean[] transacted;
+    boolean[] start;
+    MessageProducer producer;
+    ActiveMQConnectionFactory activeMQConnectionFactory;
+    KapuaSecurityContext kapuaSecurityContext;
+    TextMessage textMessage;
+    JmsAssistantProducerWrapper jmsAssistantProducerWrapper;
+
+    @Before
+    public void initialize() throws JMSException {
+        session = Mockito.mock(Session.class);
+        connection = Mockito.mock(Connection.class);
+        destination = "Destination";
+        topics = new String[]{"", "Topic", "Topic123", "Topic!@#$%^&*(?>)_+"};
+        messages = new String[]{"", "Message", "Message123", "Message!@#$%^&*(?>)_+"};
+        transacted = new boolean[]{true, false};
+        start = new boolean[]{true, false};
+        producer = Mockito.mock(MessageProducer.class);
+        activeMQConnectionFactory = Mockito.mock(ActiveMQConnectionFactory.class);
+        kapuaSecurityContext = Mockito.mock(KapuaSecurityContext.class);
+        textMessage = Mockito.mock(TextMessage.class);
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+        Mockito.when(session.createTextMessage()).thenReturn(textMessage);
+        Mockito.when(kapuaSecurityContext.getBrokerId()).thenReturn("Broker Id");
+    }
+
+    @Test
+    public void jmsAssistantProducerWrapperTest() throws KapuaException, JMSException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, destination, transactedValue, startValue);
+
+                assertEquals("Expected and actual values should be the same.", "Destination", jmsAssistantProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsAssistantProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsAssistantProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsAssistantProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setJmsAssistantProducerWrapperNullFactoryTest() throws KapuaException, JMSException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                new JmsAssistantProducerWrapper(null, destination, transactedValue, startValue);
+            }
+        }
+    }
+
+    @Test
+    public void setJmsAssistantProducerWrapperNullDestinationTest() throws KapuaException, JMSException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                JmsAssistantProducerWrapper jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, null, transactedValue, startValue);
+
+                assertNull("Null expected.", jmsAssistantProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsAssistantProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsAssistantProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsAssistantProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test
+    public void setJmsAssistantProducerWrapperEmptyDestinationTest() throws KapuaException, JMSException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                JmsAssistantProducerWrapper jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "", transactedValue, startValue);
+
+                assertEquals("Expected and actual values should be the same.", "", jmsAssistantProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsAssistantProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsAssistantProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsAssistantProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test
+    public void sendTest() {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                for (String topic : topics) {
+                    for (String message : messages) {
+                        try {
+                            Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                            jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+                            jmsAssistantProducerWrapper.send(topic, message, kapuaSecurityContext);
+                        } catch (Exception e) {
+                            fail("Exception not expected.");
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void sendNullTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+                jmsAssistantProducerWrapper.send(null, null, null);
+            }
+        }
+    }
+
+    @Test
+    public void sendNullTopicTest() {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                for (String message : messages) {
+                    try {
+                        Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                        jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+                        jmsAssistantProducerWrapper.send(null, message, kapuaSecurityContext);
+                    } catch (Exception e) {
+                        fail("Exception not expected.");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void sendNullMessageTest() {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                for (String topic : topics) {
+                    try {
+                        Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                        jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+                        jmsAssistantProducerWrapper.send(topic, null, kapuaSecurityContext);
+                    } catch (Exception e) {
+                        fail("Exception not expected.");
+                    }
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void sendNullKapuaSecurityContextTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                for (String topic : topics) {
+                    for (String message : messages) {
+                        Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                        jmsAssistantProducerWrapper = new JmsAssistantProducerWrapper(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+                        jmsAssistantProducerWrapper.send(topic, message, null);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactoryTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsConnectionFactoryTest.java
@@ -1,0 +1,47 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class JmsConnectionFactoryTest extends Assert {
+
+    @Test
+    public void jmsConnectionFactoryTest() throws Exception {
+        Constructor<JmsConnectionFactory> jmsConnectionFactory = JmsConnectionFactory.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(jmsConnectionFactory.getModifiers()));
+        jmsConnectionFactory.setAccessible(true);
+        jmsConnectionFactory.newInstance();
+    }
+
+    @Test
+    public void staticBlockTest() {
+        ActiveMQConnectionFactory connectionFactory = JmsConnectionFactory.VM_CONN_FACTORY;
+
+        assertFalse("False expected.", connectionFactory.isAlwaysSessionAsync());
+        assertFalse("False expected.", connectionFactory.isAlwaysSyncSend());
+        assertFalse("False expected.", connectionFactory.isCopyMessageOnSend());
+        assertFalse("False expected.", connectionFactory.isDispatchAsync());
+        assertFalse("False expected.", connectionFactory.isOptimizeAcknowledge());
+        assertTrue("True expected.", connectionFactory.isOptimizedMessageDispatch());
+        assertTrue("True expected.", connectionFactory.isUseAsyncSend());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsConsumerWrapperTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsConsumerWrapperTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.jms.JMSException;
+import javax.jms.MessageListener;
+
+@Category(JUnitTests.class)
+public class JmsConsumerWrapperTest {
+
+    @Test(expected = KapuaException.class)
+    public void jmsConsumerWrapperTest() throws KapuaException, JMSException {
+        MessageListener messageListener = Mockito.mock(MessageListener.class);
+        boolean[] transacted = new boolean[]{true, false};
+        boolean[] start = new boolean[]{true, false};
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                new JmsConsumerWrapper("", transactedValue, startValue, messageListener);
+            }
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapperTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/pool/JmsProducerWrapperTest.java
@@ -1,0 +1,176 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.pool;
+
+import org.apache.activemq.ActiveMQConnectionFactory;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.jms.Session;
+import javax.jms.Connection;
+import javax.jms.MessageProducer;
+import javax.jms.JMSException;
+
+@Category(JUnitTests.class)
+public class JmsProducerWrapperTest extends Assert {
+
+    private class JmsProducerWrapperImpl extends JmsProducerWrapper {
+        /**
+         * @param vmconnFactory
+         * @param destination   if it's null the producer will not be bound to any destination so it can sends messages to the whole topic space.<BR>
+         *                      Otherwise if it isn't null the producer will be bound to a queue destination as specified by the parameter.
+         * @param transacted
+         * @param start         start activeMQ connection
+         * @throws JMSException
+         * @throws KapuaException
+         */
+        protected JmsProducerWrapperImpl(ActiveMQConnectionFactory vmconnFactory, String destination, boolean transacted, boolean start) throws JMSException, KapuaException {
+            super(vmconnFactory, destination, transacted, start);
+        }
+    }
+
+    Session session;
+    Connection connection;
+    String destination;
+    MessageProducer producer;
+    ActiveMQConnectionFactory activeMQConnectionFactory;
+    boolean[] transacted;
+    boolean[] start;
+
+    @Before
+    public void initialize() {
+        session = Mockito.mock(Session.class);
+        connection = Mockito.mock(Connection.class);
+        destination = "Destination";
+        producer = Mockito.mock(MessageProducer.class);
+        activeMQConnectionFactory = Mockito.mock(ActiveMQConnectionFactory.class);
+        transacted = new boolean[]{true, false};
+        start = new boolean[]{true, false};
+    }
+
+    @Test
+    public void jmsProducerWrapperEmptyDestinationTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+                JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "", transactedValue, startValue);
+
+                assertEquals("Expected and actual values should be the same.", "", jmsProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test
+    public void jmsProducerWrapperTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+                JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+
+                assertEquals("Expected and actual values should be the same.", "Destination", jmsProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test
+    public void jmsProducerWrapperNullDestinationTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                Mockito.when(session.createProducer(null)).thenReturn(producer);
+                JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, null, transactedValue, startValue);
+
+                assertNull("Null expected.", jmsProducerWrapper.destination);
+                assertEquals("Expected and actual values should be the same.", session, jmsProducerWrapper.session);
+                assertEquals("Expected and actual values should be the same.", connection, jmsProducerWrapper.connection);
+                assertEquals("Expected and actual values should be the same.", producer, jmsProducerWrapper.producer);
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jmsProducerWrapperNullFactoryTest() throws JMSException, KapuaException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                new JmsProducerWrapperImpl(null, "Destination", transactedValue, startValue);
+            }
+        }
+    }
+
+    @Test
+    public void closeTest() throws JMSException, KapuaException {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(true, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+        JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "Destination", true, true);
+        try {
+            jmsProducerWrapper.close();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void closeExceptionTest() throws JMSException, KapuaException {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(false, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+        JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "Destination", false, false);
+        Mockito.doThrow(new JMSException("Message")).when(connection).close();
+
+        jmsProducerWrapper.close();
+    }
+
+    @Test
+    public void getDestinationTest() throws KapuaException, JMSException {
+        for (boolean transactedValue : transacted) {
+            for (boolean startValue : start) {
+                Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+                Mockito.when(activeMQConnectionFactory.createConnection().createSession(transactedValue, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+                Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+                JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "Destination", transactedValue, startValue);
+
+                assertEquals("Expected and actual values should be the same.", "Destination", jmsProducerWrapper.getDestination());
+            }
+        }
+    }
+
+    @Test
+    public void finalizeTest() throws Throwable {
+        Mockito.when(activeMQConnectionFactory.createConnection()).thenReturn(connection);
+        Mockito.when(activeMQConnectionFactory.createConnection().createSession(true, Session.AUTO_ACKNOWLEDGE)).thenReturn(session);
+        Mockito.when(session.createProducer(session.createQueue(destination))).thenReturn(producer);
+        JmsProducerWrapper jmsProducerWrapper = new JmsProducerWrapperImpl(activeMQConnectionFactory, "Destination", true, true);
+        try {
+            jmsProducerWrapper.finalize();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKeyTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKeyTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class BrokerSettingKeyTest extends Assert {
+
+    @Test
+    public void keysTest() {
+        assertEquals("broker.connector.descriptor.default.disable", BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key());
+        assertEquals("broker.connector.descriptor.configuration.uri", BrokerSettingKey.CONFIGURATION_URI.key());
+        assertEquals("broker.jaxb_context_class_name", BrokerSettingKey.BROKER_JAXB_CONTEXT_CLASS_NAME.key());
+        assertEquals("broker.ip_resolver_class_name", BrokerSettingKey.BROKER_IP_RESOLVER_CLASS_NAME.key());
+        assertEquals("broker.id_resolver_class_name", BrokerSettingKey.BROKER_ID_RESOLVER_CLASS_NAME.key());
+        assertEquals("broker.ip", BrokerSettingKey.BROKER_IP.key());
+        assertEquals("broker.system.message_creator_class_name", BrokerSettingKey.SYSTEM_MESSAGE_CREATOR_CLASS_NAME.key());
+        assertEquals("broker.authenticator_class_name", BrokerSettingKey.AUTHENTICATOR_CLASS_NAME.key());
+        assertEquals("broker.authorizer_class_name", BrokerSettingKey.AUTHORIZER_CLASS_NAME.key());
+        assertEquals("broker.stealing_link.enabled", BrokerSettingKey.BROKER_STEALING_LINK_ENABLED.key());
+        assertEquals("broker.stealing_link.initialization_max_wait_time", BrokerSettingKey.STEALING_LINK_INITIALIZATION_MAX_WAIT_TIME.key());
+        assertEquals("broker.client_pool.no_dest_total_max_size", BrokerSettingKey.BROKER_CLIENT_POOL_NO_DEST_TOTAL_MAX_SIZE.key());
+        assertEquals("broker.client_pool.no_dest_max_size", BrokerSettingKey.BROKER_CLIENT_POOL_NO_DEST_MAX_SIZE.key());
+        assertEquals("broker.client_pool.no_dest_min_size", BrokerSettingKey.BROKER_CLIENT_POOL_NO_DEST_MIN_SIZE.key());
+        assertEquals("broker.name", BrokerSettingKey.BROKER_NAME.key());
+        assertEquals("broker.security.published.message_size.log_threshold", BrokerSettingKey.PUBLISHED_MESSAGE_SIZE_LOG_THRESHOLD.key());
+        assertEquals("camel.default_route.configuration_file_name", BrokerSettingKey.CAMEL_DEFAULT_ROUTE_CONFIGURATION_FILE_NAME.key());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/setting/BrokerSettingTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/setting/BrokerSettingTest.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class BrokerSettingTest extends Assert {
+
+    @Test
+    public void brokerSettingTest() throws Exception {
+        Constructor<BrokerSetting> brokerSetting = BrokerSetting.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(brokerSetting.getModifiers()));
+        brokerSetting.setAccessible(true);
+        brokerSetting.newInstance();
+    }
+
+    @Test
+    public void getInstanceTest() {
+        Object brokerSetting = BrokerSetting.getInstance();
+        assertNotNull("NotNull expected.", brokerSetting);
+        assertTrue("True expected.", brokerSetting instanceof BrokerSetting);
+
+        Object brokerSettingInstanceNotNull = BrokerSetting.getInstance();
+        assertNotNull("NotNull expected.", brokerSettingInstanceNotNull);
+        assertTrue("True expected.", brokerSetting instanceof BrokerSetting);
+    }
+
+    @Test
+    public void resetInstanceTest() {
+        try {
+            String brokerInstance1 = BrokerSetting.getInstance().toString();
+            BrokerSetting.resetInstance();
+            String brokerInstance2 = BrokerSetting.getInstance().toString();
+
+            assertNotEquals("The two instances should not be the same!", brokerInstance1, brokerInstance2);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}


### PR DESCRIPTION
Added Junit tests for classes in broker/core module:

pool package:
JmsAssistantProducerPool class
JmsAssistantProducerWrapper class
JmsAssistantProducerWrapperFactory class
JmsConnectionFactory class
JmsProducerWrapper class
JmsConsumerWrapper class

setting package:
BrokerSetting class
BrokerSettingKeyTest class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
Tests for create () method in JmsAssistantProducerWrapperFactory class were not written because it took too long to create the connection. This also applies to tests in JmsConsumerWrapper class. 
