### PR TITLE
Fixed ConfigurationComponent Apply refresh on error

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -11,8 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.account.client;
 
-import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaMessageBox;
-
 import com.extjs.gxt.ui.client.Style.LayoutRegion;
 import com.extjs.gxt.ui.client.Style.Scroll;
 import com.extjs.gxt.ui.client.data.BaseTreeLoader;
@@ -44,7 +42,6 @@ import com.extjs.gxt.ui.client.widget.treepanel.TreePanelSelectionModel;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountService;
 import org.eclipse.kapua.app.console.module.account.shared.service.GwtAccountServiceAsync;
@@ -56,6 +53,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.SaveButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog.InfoDialogType;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaMessageBox;
 import org.eclipse.kapua.app.console.module.api.client.ui.label.Label;
 import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
 import org.eclipse.kapua.app.console.module.api.client.util.KapuaLoadListener;
@@ -67,6 +65,7 @@ import org.eclipse.kapua.app.console.module.api.shared.service.GwtConsoleService
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenService;
 import org.eclipse.kapua.app.console.module.api.shared.service.GwtSecurityTokenServiceAsync;
 import org.eclipse.kapua.app.console.module.device.client.messages.ConsoleDeviceMessages;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -100,7 +99,6 @@ public class AccountConfigComponents extends LayoutContainer {
     private AccountDetailsTabDescription accountDetailsTabDescription;
     private SeparatorToolItem separatorToolItem = new SeparatorToolItem();
 
-    @SuppressWarnings("rawtypes")
     private BaseTreeLoader loader;
     private TreeStore<ModelData> treeStore;
     private TreePanel<ModelData> tree;
@@ -116,8 +114,15 @@ public class AccountConfigComponents extends LayoutContainer {
         @Override
         public void onFailure(Throwable caught) {
             FailureHandler.handle(caught);
+
+            devConfPanel.unmask();
+            tree.unmask();
+
+            apply.setEnabled(true);
+            reset.setEnabled(true);
+            refreshButton.setEnabled(true);
+
             dirty = true;
-            refresh();
         }
 
         @Override
@@ -127,8 +132,7 @@ public class AccountConfigComponents extends LayoutContainer {
         }
     };
 
-    AccountConfigComponents(GwtSession currentSession,
-                            AccountTabConfiguration tabConfig) {
+    AccountConfigComponents(GwtSession currentSession, AccountTabConfiguration tabConfig) {
         this.currentSession = currentSession;
         this.tabConfig = tabConfig;
         dirty = false;
@@ -239,7 +243,6 @@ public class AccountConfigComponents extends LayoutContainer {
         toolBar.add(reset);
     }
 
-    @SuppressWarnings("unchecked")
     private void initConfigPanel() {
         configPanel = new ContentPanel();
         configPanel.setBorders(false);
@@ -294,7 +297,6 @@ public class AccountConfigComponents extends LayoutContainer {
         // make sure the form is not dirty before switching.
         tree.getSelectionModel().addListener(Events.BeforeSelect, new Listener<BaseEvent>() {
 
-            @SuppressWarnings("rawtypes")
             @Override
             public void handleEvent(BaseEvent be) {
 
@@ -517,8 +519,7 @@ public class AccountConfigComponents extends LayoutContainer {
                     } else {
                         kapuaIcon = new KapuaIcon(IconSet.PUZZLE_PIECE);
                     }
-                }
-                else {
+                } else {
                     kapuaIcon = new KapuaIcon(IconSet.PUZZLE_PIECE);
                 }
             }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceAssetsValues.java
@@ -11,7 +11,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.module.device.client.device.assets;
 
-import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaMessageBox;
 import com.extjs.gxt.ui.client.Style.LayoutRegion;
 import com.extjs.gxt.ui.client.Style.Scroll;
 import com.extjs.gxt.ui.client.data.BaseTreeLoader;
@@ -44,7 +43,6 @@ import com.extjs.gxt.ui.client.widget.treepanel.TreePanelSelectionModel;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.DiscardButton;
@@ -52,6 +50,7 @@ import org.eclipse.kapua.app.console.module.api.client.ui.button.RefreshButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.button.SaveButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.InfoDialog.InfoDialogType;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaMessageBox;
 import org.eclipse.kapua.app.console.module.api.client.ui.label.Label;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.CssLiterals;
@@ -98,7 +97,6 @@ public class DeviceAssetsValues extends LayoutContainer {
     private DeviceAssetsPanel assetValuesPanel;
     private BorderLayoutData centerData;
 
-    @SuppressWarnings("rawtypes")
     private BaseTreeLoader loader;
     private TreeStore<ModelData> treeStore;
     private TreePanel<ModelData> tree;
@@ -108,7 +106,7 @@ public class DeviceAssetsValues extends LayoutContainer {
     protected boolean applyProcess;
 
     public DeviceAssetsValues(GwtSession currentSession,
-            DeviceTabAssets tabAssets) {
+                              DeviceTabAssets tabAssets) {
         this.currentSession = currentSession;
         this.tabAssets = tabAssets;
         dirty = false;
@@ -210,7 +208,6 @@ public class DeviceAssetsValues extends LayoutContainer {
         toolBar.add(reset);
     }
 
-    @SuppressWarnings("unchecked")
     private void initAssetPanel() {
         assetValuesContainer = new ContentPanel();
         assetValuesContainer.setBorders(false);
@@ -283,7 +280,6 @@ public class DeviceAssetsValues extends LayoutContainer {
         // make sure the form is not dirty before switching.
         tree.getSelectionModel().addListener(Events.BeforeSelect, new Listener<BaseEvent>() {
 
-            @SuppressWarnings("rawtypes")
             @Override
             public void handleEvent(BaseEvent be) {
 
@@ -443,8 +439,13 @@ public class DeviceAssetsValues extends LayoutContainer {
                                                 @Override
                                                 public void onFailure(Throwable caught) {
                                                     FailureHandler.handle(caught);
-                                                    dirty = true;
-                                                    refresh();
+
+                                                    assetValuesPanel.unmask();
+                                                    tree.unmask();
+
+                                                    apply.setEnabled(true);
+                                                    reset.setEnabled(true);
+                                                    refreshButton.setEnabled(true);
                                                 }
 
                                                 @Override


### PR DESCRIPTION
This PR addresses an issue with the Configuration Component tabs that are refreshing the view even if there is an error.

**Related Issue**
This PR fixes #3108 

**Description of the solution adopted**
Removed the `refresh()` and unmasked all panels.

**Screenshots**
_None_

**Any side note on the changes made**
The issue is just about AccountConfig view but there was the same problem in Device Asset Tab and Device Configuration Tab