### PR TITLE
Dedicated Service Locator for the MFA Authentication Service 

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -25,7 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -25,7 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,7 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.registration.RegistrationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -22,7 +22,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
 
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -28,7 +28,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -24,7 +24,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticationService.java
@@ -11,14 +11,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.mfa;
 
-import org.eclipse.kapua.service.KapuaService;
-
 import java.util.List;
 
 /**
  * MfaAuthenticationService interface
  */
-public interface MfaAuthenticationService extends KapuaService {
+public interface MfaAuthenticationService {
 
     /**
      * @return true if the MfaAuthenticationService is enabled, false otherwise

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/package-info.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/package-info.java
@@ -1,4 +1,0 @@
-/**
- * Mfa authentication
- */
-package org.eclipse.kapua.service.authentication.mfa;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaCredentialOptionServiceImpl.java
@@ -35,6 +35,7 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOpti
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaCredentialOptionService;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
+import org.eclipse.kapua.service.authentication.shiro.mfa.MfaAuthenticationServiceLocator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
@@ -51,8 +52,8 @@ public class MfaCredentialOptionServiceImpl extends AbstractKapuaService impleme
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MfaCredentialOptionServiceImpl.class);
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
+    private static final MfaAuthenticationServiceLocator MFA_AUTH_SERVICE_LOCATOR = MfaAuthenticationServiceLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = MFA_AUTH_SERVICE_LOCATOR.getMfaAuthenticationService();
 
     private static final int TRUST_KEY_DURATION = 30; // duration of the trust key in days
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
@@ -34,6 +34,7 @@ import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
+import org.eclipse.kapua.service.authentication.shiro.mfa.MfaAuthenticationServiceLocator;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
@@ -49,8 +50,8 @@ public class ScratchCodeServiceImpl extends AbstractKapuaService implements Scra
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScratchCodeServiceImpl.class);
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
+    private static final MfaAuthenticationServiceLocator MFA_AUTH_SERVICE_LOCATOR = MfaAuthenticationServiceLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = MFA_AUTH_SERVICE_LOCATOR.getMfaAuthenticationService();
 
     public ScratchCodeServiceImpl() {
         super(ScratchCodeEntityManagerFactory.getInstance());

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceImpl.java
@@ -16,7 +16,6 @@ import com.warrenstrange.googleauth.GoogleAuthenticatorConfig;
 import com.warrenstrange.googleauth.GoogleAuthenticatorKey;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
@@ -33,7 +32,6 @@ import java.util.concurrent.TimeUnit;
  * The {@link MfaAuthenticationService} implementation that wraps code generation and authentication methods.
  *
  */
-@KapuaProvider
 public class MfaAuthenticationServiceImpl implements MfaAuthenticationService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MfaAuthenticationServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceLocator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticationServiceLocator.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.mfa;
+
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
+
+/**
+ * The MfaAuthenticationService locator.
+ */
+public class MfaAuthenticationServiceLocator {
+
+    private static MfaAuthenticationServiceLocator locator;
+
+    private final MfaAuthenticationService mfaAuthenticationService;
+
+    private MfaAuthenticationServiceLocator() {
+        mfaAuthenticationService = new MfaAuthenticationServiceImpl();
+    }
+
+    public static MfaAuthenticationServiceLocator getInstance() {
+        if (locator == null) {
+            synchronized (MfaAuthenticationServiceLocator.class) {
+                if (locator == null) {
+                    locator = new MfaAuthenticationServiceLocator();
+                }
+            }
+        }
+        return locator;
+    }
+
+    /**
+     * Retrieve the MfaAuthenticationService.
+     *
+     * @return a {@link MfaAuthenticationService} object.
+     */
+    public MfaAuthenticationService getMfaAuthenticationService() {
+        return mfaAuthenticationService;
+    }
+
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -28,6 +28,7 @@ import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticationService;
+import org.eclipse.kapua.service.authentication.shiro.mfa.MfaAuthenticationServiceLocator;
 import org.eclipse.kapua.service.user.User;
 import org.springframework.security.crypto.bcrypt.BCrypt;
 
@@ -39,9 +40,10 @@ import org.springframework.security.crypto.bcrypt.BCrypt;
 public class UserPassCredentialsMatcher implements CredentialsMatcher {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-    private static final MfaAuthenticationService MFA_AUTH_SERVICE = LOCATOR.getService(MfaAuthenticationService.class);
     private static final MfaCredentialOptionService MFA_CREDENTIAL_OPTION_SERVICE = LOCATOR.getService(MfaCredentialOptionService.class);
     private static final ScratchCodeService SCRATCH_CODE_SERVICE = LOCATOR.getService(ScratchCodeService.class);
+    private static final MfaAuthenticationServiceLocator MFA_AUTH_SERVICE_LOCATOR = MfaAuthenticationServiceLocator.getInstance();
+    private static final MfaAuthenticationService MFA_AUTH_SERVICE = MFA_AUTH_SERVICE_LOCATOR.getMfaAuthenticationService();
 
     @Override
     public boolean doCredentialsMatch(AuthenticationToken authenticationToken, AuthenticationInfo authenticationInfo) {


### PR DESCRIPTION
This PR provides a dedicated service locator for the `MfaAuthenticationService`.

**Related Issue**
This PR partially takes into account this discussion: https://github.com/eclipse/kapua/pull/3090#discussion_r503985076

**Description of the solution adopted**
The `MfaAuthenticationService` was inheriting from `KapuaService` and getting implementations with a dedicated locator class. However, since this service does not provide an external api, it is now provided with a dedicated service locator and it is not using anymore `KapuaService`. 

**Any side note on the changes made**
This PR must be taken into account only when #3090 and #3112 are merged!