### PR TITLE
MariaDB TLS Protocol Version Selection feature

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/MariaDBJdbcConnectionUrlResolver.java
@@ -80,6 +80,13 @@ public class MariaDBJdbcConnectionUrlResolver implements JdbcConnectionUrlResolv
                 .append(useSsl)
                 .append("&");
 
+        String enabledSslProtocolSuites = config.getString(SystemSettingKey.DB_CONNECTION_ENABLED_SSL_PROTOCOL_SUITES);
+        if (enabledSslProtocolSuites != null) {
+            dbConnectionString.append("enabledSslProtocolSuites=")
+                    .append(enabledSslProtocolSuites)
+                    .append("&");
+        }
+
         if (StringUtils.isNotBlank(trustStore)) {
             dbConnectionString.append("trustStore=")
                     .append(trustStore)

--- a/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/setting/system/SystemSettingKey.java
@@ -91,6 +91,10 @@ public enum SystemSettingKey implements SettingKey {
      */
     DB_CONNECTION_USE_SSL("commons.db.connection.useSsl"),
     /**
+     * Database TLS/SSL Protocol Version Selection (for MariaDB only)
+     */
+    DB_CONNECTION_ENABLED_SSL_PROTOCOL_SUITES("commons.db.connection.enabledSslProtocolSuites"),
+    /**
      * Database truststore url
      */
     DB_CONNECTION_TRUSTSTORE_URL("commons.db.connection.trust.store.url"),


### PR DESCRIPTION
This PR introduces TLS Protocol Version Selction feature for MariaDB connection.

**Related Issue**
This PR fixes _#3116_

**Description of the solution adopted**
_n/a_

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_