### PR TITLE
Security broker filter - make user/admin authentication logic pluggable

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/DefaultAuthenticator.java
@@ -45,10 +45,14 @@ public class DefaultAuthenticator implements Authenticator {
 
     private static final String SYSTEM_MESSAGE_CREATOR_CLASS_NAME;
     private static final String ADMIN_USERNAME;
+    private static final String ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME;
+    private static final String USER_AUTHENTICATION_LOGIC_CLASS_NAME;
 
     static {
         SYSTEM_MESSAGE_CREATOR_CLASS_NAME = BrokerSetting.getInstance().getString(BrokerSettingKey.SYSTEM_MESSAGE_CREATOR_CLASS_NAME);
         ADMIN_USERNAME = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_USERNAME);
+        ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME = BrokerSetting.getInstance().getString(BrokerSettingKey.ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME);
+        USER_AUTHENTICATION_LOGIC_CLASS_NAME = BrokerSetting.getInstance().getString(BrokerSettingKey.USER_AUTHENTICATION_LOGIC_CLASS_NAME);
     }
 
     private Map<String, Object> options;
@@ -68,8 +72,18 @@ public class DefaultAuthenticator implements Authenticator {
      */
     public DefaultAuthenticator(Map<String, Object> options) throws KapuaException {
         this.options = options;
-        adminAuthenticationLogic = new AdminAuthenticationLogic(options);
-        userAuthenticationLogic = new UserAuthenticationLogic(options);
+        logger.info(">>> Security broker filter: calling start... Instantiating admin authentication logic {} (fallback: {}", ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME, AdminAuthenticationLogic.class);
+        adminAuthenticationLogic = ClassUtil.newInstance(
+                ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME,
+                AdminAuthenticationLogic.class,
+                new Class[] {Map.class},
+                new Object[] {options});
+        logger.info(">>> Security broker filter: calling start... Instantiating user authentication logic {} (fallback: {}", USER_AUTHENTICATION_LOGIC_CLASS_NAME, UserAuthenticationLogic.class);
+        userAuthenticationLogic = ClassUtil.newInstance(
+                USER_AUTHENTICATION_LOGIC_CLASS_NAME,
+                UserAuthenticationLogic.class,
+                new Class[] {Map.class},
+                new Object[] {options});
         logger.info(">>> Security broker filter: calling start... Initialize system message creator");
         systemMessageCreator = ClassUtil.newInstance(SYSTEM_MESSAGE_CREATOR_CLASS_NAME, DefaultSystemMessageCreator.class);
     }

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKey.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/setting/BrokerSettingKey.java
@@ -52,6 +52,14 @@ public enum BrokerSettingKey implements SettingKey {
      */
     AUTHENTICATOR_CLASS_NAME("broker.authenticator_class_name"),
     /**
+     * Admin authentication logic custom implementation
+     */
+    ADMIN_AUTHENTICATION_LOGIC_CLASS_NAME("broker.authentication_logic_admin_class_name"),
+    /**
+     * User authentication logic custom implementation
+     */
+    USER_AUTHENTICATION_LOGIC_CLASS_NAME("broker.authentication_logic_user_class_name"),
+    /**
      * Authorizer implementation
      */
     AUTHORIZER_CLASS_NAME("broker.authorizer_class_name"),


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>

Security plugin should allow authentication logic to be pluggable through configuration parameter

**Related Issue**
fix #3119 

**Description of the solution adopted**
Both authentication logic implamentations can be specified by parameters and instantiated via reflection by the DefaultAuthenticator

**Screenshots**
none

**Any side note on the changes made**
none