### PR TITLE
Added Junit tests in router package

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndChainEndPointTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndChainEndPointTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.apache.camel.Exchange;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class EndChainEndPointTest extends Assert {
+
+    EndChainEndPoint endChainEndPoint;
+    Exchange[] exchanges;
+    Object[] values;
+    String[] previous;
+    Map<String, Object> properties;
+    StringBuffer buffer;
+    String[] prefixList;
+
+    @Before
+    public void initialize() {
+        endChainEndPoint = new EndChainEndPoint();
+        exchanges = new Exchange[]{null, Mockito.mock(Exchange.class)};
+        values = new Object[]{null, new Object(), "value", 10, 10.10, true, false, 'c',};
+        previous = new String[]{null, "", "Previous", "Previous1234567890", "PrEviouS-1pr23", "pR-12!viouS", "Previous!123#", "() _ + ?><|/.Previous!@#$ % ^&*"};
+        properties = new HashMap<>();
+        buffer = new StringBuffer();
+        prefixList = new String[]{"", "Prefix", "pre-fix", "123 prefix", "pre123fi_X21", "!PRE789fix", "PR#$"};
+    }
+
+    @Test
+    public void matchesEmptyPropertiesTest() {
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertTrue("True expected.", endChainEndPoint.matches(exchange, value, previousValue, properties));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void matchesTest() {
+        properties.put("key1", "value");
+        properties.put("key2", 10);
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertTrue("True expected.", endChainEndPoint.matches(exchange, value, previousValue, properties));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullPropertiesTest() {
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertTrue("True expected.", endChainEndPoint.matches(exchange, value, previousValue, null));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void getEndPointEmptyPropertiesTest() {
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertNull("Null expected.", endChainEndPoint.getEndPoint(exchange, value, previousValue, properties));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void getEndPointTest() {
+        properties.put("key1", "value");
+        properties.put("key2", 10);
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertNull("Null expected.", endChainEndPoint.getEndPoint(exchange, value, previousValue, properties));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void getEndPointNullPropertiesTest() {
+        for (Exchange exchange : exchanges) {
+            for (Object value : values) {
+                for (String previousValue : previous) {
+                    assertNull("Null expected.", endChainEndPoint.getEndPoint(exchange, value, previousValue, null));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void toLogTest() {
+        for (String prefix : prefixList) {
+            endChainEndPoint.toLog(buffer, prefix);
+            assertEquals("Expected and actual values should be the same.", "End chain", buffer.toString());
+            buffer.delete(0, 9);
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toLogNullBufferTest() {
+        for (String prefix : prefixList) {
+            endChainEndPoint.toLog(null, prefix);
+        }
+    }
+
+    @Test
+    public void toLogNullPrefixTest() {
+        endChainEndPoint.toLog(buffer, null);
+        assertEquals("Expected and actual values should be the same.", "End chain", buffer.toString());
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndPointContainerTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndPointContainerTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class EndPointContainerTest extends Assert {
+
+    @Test
+    public void endPointContainerTest() {
+        EndPointContainer container = new EndPointContainer();
+        assertEquals("Expected and actual values should be the same.", 0, container.getEndPoints().size());
+    }
+
+    @Test
+    public void setAndGetEndPointsTest() {
+        EndPointContainer container = new EndPointContainer();
+        List<EndPoint> endPointList = new ArrayList<>();
+        EndPoint endPoint1 = new EndChainEndPoint();
+        EndPoint endPoint2 = new EndChainEndPoint();
+
+        assertEquals("Expected and actual values should be the same.", 0, container.getEndPoints().size());
+
+        endPointList.add(endPoint1);
+        endPointList.add(endPoint2);
+        endPointList.add(null);
+        container.setEndPoints(endPointList);
+
+        assertEquals("Expected and actual values should be the same.", 3, container.getEndPoints().size());
+        assertEquals("Expected and actual values should be the same.", endPoint1, container.getEndPoints().get(0));
+        assertEquals("Expected and actual values should be the same.", endPoint2, container.getEndPoints().get(1));
+        assertNull("Null expected ", container.getEndPoints().get(2));
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndPointTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndPointTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.regex.Pattern;
+
+@Category(JUnitTests.class)
+public class EndPointTest extends Assert {
+
+    @Test
+    public void replacePlaceholderTest() {
+        String[] regexValues = {null, "\\", "regex", "re gex", "", "reg\fex", "rege\rx", "re\bgex", " re\1gex", " r\2Egex", "\3rege123x, re-gex\4, r\5egex, r\6egex, reg\7ex, r\0ege_x", "1234re\\gex", "re\tge", "reg\nex1234567890", "\'"};
+        for (String value : regexValues) {
+            assertEquals("Expected and actual values should be the same.", value, EndPoint.replacePlaceholder(value));
+        }
+    }
+
+    @Test
+    public void parseRegexNullTest() {
+        String[] regexValue = {null, "\\", "re\\gex"};
+        for (String value : regexValue) {
+            assertNull("Null expected.", EndPoint.parseRegex(value));
+        }
+    }
+
+    @Test
+    public void parseRegexTest() {
+        String[] regexValues = {"", "regex", "re\tge", "reg\nex1234567890", "!@#$%^&*()_+=-/.,?><|:;'|", "\'", "re gex"};
+        for (String value : regexValues) {
+            assertThat("Instance of Pattern expected.", EndPoint.parseRegex(value), IsInstanceOf.instanceOf(Pattern.class));
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndpointsUtilTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/EndpointsUtilTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.eclipse.kapua.broker.core.message.MessageConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+@Category(JUnitTests.class)
+public class EndpointsUtilTest extends Assert {
+
+    Exchange exchange;
+    Object[] values;
+    String[] previousList;
+    Map<String, Object> properties;
+    Pattern[] patterns;
+    String[] topics;
+    Message message;
+
+    @Before
+    public void initialize() {
+        exchange = Mockito.mock(Exchange.class);
+        values = new Object[]{null, true, false, 'c', "String", 10, 10L, 10.11f, 10.11d, 1, 0};
+        previousList = new String[]{"", "Previous", "Previous1234567890", "Previous!@#$%^&*()_+?><|/."};
+        properties = new HashMap<>();
+        patterns = new Pattern[]{Pattern.compile("String"), null};
+        topics = new String[]{"", "originalTopic", "Topic", "Topic1234567890", "Topic!@#$%^&*()_=-/."};
+        message = Mockito.mock(Message.class);
+    }
+
+    @Test
+    public void matchesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                for (Pattern pattern : patterns) {
+                    assertFalse("False expected.", EndpointsUtil.matches(exchange, value, previous, properties, pattern));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullExchangeTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                for (Pattern pattern : patterns) {
+                    assertFalse("False expected.", EndpointsUtil.matches(null, value, previous, properties, pattern));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullPropertiesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                for (Pattern pattern : patterns) {
+                    assertFalse("False expected.", EndpointsUtil.matches(exchange, value, previous, null, pattern));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousTrueTest() {
+        Pattern pattern = Pattern.compile("Topic");
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertTrue("True expected.", EndpointsUtil.matches(exchange, value, null, properties, pattern));
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousFalseTest() {
+        Pattern pattern = Pattern.compile("Different Topic");
+        for (Object value : values) {
+            for (String topic : topics) {
+                Mockito.when(exchange.getIn()).thenReturn(message);
+                Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn(topic);
+                assertFalse("False expected.", EndpointsUtil.matches(exchange, value, null, properties, pattern));
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void matchesNullPreviousNullPatternTest() {
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            EndpointsUtil.matches(exchange, value, null, properties, null);
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/ParentEndPointTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/ParentEndPointTest.java
@@ -1,0 +1,224 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.eclipse.kapua.broker.core.message.MessageConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class ParentEndPointTest extends Assert {
+
+    ParentEndPoint parentEndPoint;
+    Exchange exchange;
+    Object[] values;
+    String[] previousList;
+    Map<String, Object> properties;
+    Message message;
+    List<EndPoint> endPoints;
+    StringBuffer stringBuffer;
+    String[] prefixValue;
+
+    @Before
+    public void initialize() {
+        parentEndPoint = new ParentEndPoint();
+        exchange = Mockito.mock(Exchange.class);
+        values = new Object[]{null, true, false, 'c', "String", 10, 10L, 10.11f, 10.11d, 1, 0};
+        previousList = new String[]{"", "Previous", "Pre12345vious67890", "PrEviouS-1pr23", "pR-12!viouS", "Previous!123#", "() _ + ?><|/.Pre99vious!@#$ % ^&*"};
+        properties = new HashMap<>();
+        message = Mockito.mock(Message.class);
+        endPoints = new ArrayList<>();
+        stringBuffer = new StringBuffer();
+        prefixValue = new String[]{"", "Prefix", "pre-fix", "123 prefix", "pre123fi_X21", "!PRE789fix", "PR#$"};
+    }
+
+    @Test
+    public void matchesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", parentEndPoint.matches(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullExchangeTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", parentEndPoint.matches(null, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullPropertiesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", parentEndPoint.matches(exchange, value, previous, null));
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void matchesNullPreviousTest() {
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertFalse("False expected.", parentEndPoint.matches(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousFalseTest() {
+        parentEndPoint.setRegex("Different topic");
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertFalse("False expected.", parentEndPoint.matches(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousTrueTest() {
+        parentEndPoint.setRegex("Topic");
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertTrue("True expected.", parentEndPoint.matches(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointTest() {
+        EndPoint endPoint = new EndChainEndPoint();
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        for (Object value : values) {
+            for (String previous : previousList) {
+                //COMMENT: method getEndPoint(Exchange exchange, Object value, String previous, Map<String, Object> properties) {
+                //      in EndChainEndPoint class always returns null
+                assertNull("Null expected.", parentEndPoint.getEndPoint(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointFalseMatchesTest() {
+        EndPoint endPoint = Mockito.mock(EndPoint.class);
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        for (Object value : values) {
+            for (String previous : previousList) {
+                Mockito.when((endPoint.matches(exchange, value, previous, properties))).thenReturn(false);
+                assertNull("Null expected.", parentEndPoint.getEndPoint(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointsTest() {
+        List<EndPoint> endPoints = new ArrayList<>();
+        EndPoint endPoint = new EndChainEndPoint();
+
+        parentEndPoint.setEndPoints(endPoints);
+
+        assertEquals("Expected and actual values should be the same.", endPoints, parentEndPoint.getEndPoints());
+        assertTrue("True expected.", parentEndPoint.getEndPoints().isEmpty());
+
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        assertEquals("Expected and actual values should be the same.", endPoints, parentEndPoint.getEndPoints());
+        assertFalse("False expected.", parentEndPoint.getEndPoints().isEmpty());
+
+        parentEndPoint.setEndPoints(null);
+        assertNull("Null expected.", parentEndPoint.getEndPoints());
+    }
+
+    @Test
+    public void setAndGetRegexTest() {
+        String[] regexValues = {null, "\\", "re!12#gex", "re gex", "", "re\bg-12ex", " !@#re\1gex", " r\2Ege|,.x", "\3rege123x, re-gex\4, r\5egex, r\6egex, reg\7ex, r\0ege_x", "1234re\\gex", "re\tge", "reg\nex123<>4567_", "\'"};
+
+        assertNull("Null expected.", parentEndPoint.getRegex());
+
+        for (String regex : regexValues) {
+            parentEndPoint.setRegex(regex);
+            assertEquals("Expected and actual values should be the same.", regex, parentEndPoint.getRegex());
+        }
+        parentEndPoint.setRegex(null);
+        assertNull("Null expected.", parentEndPoint.getRegex());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toLogEndPointsNotSetTest() {
+        for (String prefix : prefixValue) {
+            parentEndPoint.toLog(stringBuffer, prefix);
+        }
+    }
+
+    @Test
+    public void toLogTest() {
+        parentEndPoint.setRegex("Regex");
+        List<EndPoint> endPoints = new ArrayList<>();
+        EndPoint endPoint = new EndChainEndPoint();
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        try {
+            for (String prefix : prefixValue) {
+                parentEndPoint.toLog(stringBuffer, prefix);
+                assertEquals("Expected and actual values should be the same.", prefix + "Regex: Regex\n" + prefix + "\tEnd chain\n", stringBuffer.toString());
+                stringBuffer.delete(0, 99);
+            }
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toLogNullBufferTest() {
+        parentEndPoint.setRegex("Regex");
+        List<EndPoint> endPoints = new ArrayList<>();
+        EndPoint endPoint = new EndChainEndPoint();
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        for (String prefix : prefixValue) {
+            parentEndPoint.toLog(null, prefix);
+        }
+    }
+
+    @Test
+    public void toLogNullPrefixTest() {
+        parentEndPoint.setRegex("Regex");
+        List<EndPoint> endPoints = new ArrayList<>();
+        EndPoint endPoint = new EndChainEndPoint();
+        endPoints.add(endPoint);
+        parentEndPoint.setEndPoints(endPoints);
+        try {
+            parentEndPoint.toLog(stringBuffer, null);
+            assertEquals("Expected and actual values should be the same.", null + "Regex: Regex\n" + null + "\tEnd chain\n", stringBuffer.toString());
+            stringBuffer.delete(0, 99);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacerTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/PlaceholderReplacerTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class PlaceholderReplacerTest extends Assert {
+
+    @Test
+    public void placeholderReplacerTest() throws Exception {
+        Constructor<PlaceholderReplacer> placeholderReplacer = PlaceholderReplacer.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(placeholderReplacer.getModifiers()));
+        placeholderReplacer.setAccessible(true);
+        placeholderReplacer.newInstance();
+    }
+
+    @Test
+    public void replaceTest() {
+        String[] replaceValues = {"", "test", "T123est", "test-123", "test_TEST", "!@T1 23est<>", "test(999)", "?>TeSt    01"};
+        for (String replaceValue : replaceValues) {
+            String stringValue = PlaceholderReplacer.replace(replaceValue);
+            assertEquals("Expected and actual values should be the same.", replaceValue, stringValue);
+        }
+    }
+
+    @Test
+    public void replaceNullTest() {
+        String stringValue = PlaceholderReplacer.replace(null);
+        assertNull("Null expected.", stringValue);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/SimpleEndPointTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/router/SimpleEndPointTest.java
@@ -1,0 +1,251 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.router;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.eclipse.kapua.broker.core.message.MessageConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class SimpleEndPointTest extends Assert {
+
+    SimpleEndPoint simpleEndPoint;
+    Exchange exchange;
+    Object[] values;
+    String[] previousList;
+    Map<String, Object> properties;
+    Message message;
+    StringBuffer stringBuffer;
+    String[] prefix;
+    String[] endPoints;
+    String[] regexList;
+
+    @Before
+    public void initialize() {
+        simpleEndPoint = new SimpleEndPoint();
+        exchange = Mockito.mock(Exchange.class);
+        values = new Object[]{null, true, false, 'c', "String", 10, 10L, 10.11f, 10.11d, 1, 0};
+        previousList = new String[]{"", "Previous!#", "Previous#<> 123456-7890", "PrEviouS-1pr23", "pR-12!viouS", "Previous!123#", "() _ + ?><|/.Previous!@#$ % ^&*"};
+        properties = new HashMap<>();
+        message = Mockito.mock(Message.class);
+        stringBuffer = new StringBuffer();
+        prefix = new String[]{"Prefix", "pre-fix", "123 prefix", "pre123fi_X21", "!PRE789fix", "PR#$"};
+        endPoints = new String[]{"", "endpoint", "endpoint 123", "123456_789-0", "!@#$%^&*()_+,.<>|", "end-point123", "!@eNd_poiNT", "end123Point()"};
+        regexList = new String[]{"", "Regex", "regex123", "regex-123", "rE_geX789", "!@#$%^&*()_|<>/", "re\rgex", "re\\g-123", "r\tgex", "reg\fex", "re gex", "", "re\bgex", " re\1gex", " r\2Egex", "\3regex, regex\4, r\5egex, r\6egex, reg\7ex, r\0egex", "re\\gex", "re\tge", "reg\nex1234567890", "!@#$%^&*()_+=-/.,?><|:;'|", "\'"};
+    }
+
+    @Test
+    public void matchesEmptyPropertiesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", simpleEndPoint.matches(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void matchesTest() {
+        properties.put("key1", "value");
+        properties.put("key2", 10);
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", simpleEndPoint.matches(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void matchesNullExchangeTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", simpleEndPoint.matches(null, value, previous, properties));
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void matchesNullPreviousTest() {
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            simpleEndPoint.matches(exchange, value, null, properties);
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousFalseTest() {
+        simpleEndPoint.setRegex("Different topic");
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertFalse("False expected.", simpleEndPoint.matches(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void matchesNullPreviousTrueTest() {
+        simpleEndPoint.setRegex("Topic");
+        for (Object value : values) {
+            Mockito.when(exchange.getIn()).thenReturn(message);
+            Mockito.when(message.getHeader(MessageConstants.PROPERTY_ORIGINAL_TOPIC, String.class)).thenReturn("Topic");
+            assertTrue("True expected.", simpleEndPoint.matches(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void matchesNullPropertiesTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                assertFalse("False expected.", simpleEndPoint.matches(exchange, value, previous, null));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointWithParametersTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                simpleEndPoint.setEndPoint("End Point");
+                assertEquals("Expected and actual values should be the same.", "End Point", simpleEndPoint.getEndPoint(exchange, value, previous, properties));
+                simpleEndPoint.setEndPoint(null);
+                assertNull("Null expected.", simpleEndPoint.getEndPoint(exchange, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointWithNullParametersTest() {
+        for (String endpoint : endPoints) {
+            simpleEndPoint.setEndPoint(endpoint);
+            assertEquals("Expected and actual values should be the same.", endpoint, simpleEndPoint.getEndPoint(null, null, null, null));
+        }
+        simpleEndPoint.setEndPoint(null);
+        assertNull("Null expected.", simpleEndPoint.getEndPoint(null, null, null, null));
+    }
+
+    @Test
+    public void setAndGetEndPointWithNullExchangeParameterTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                for (String endpoint : endPoints) {
+                    simpleEndPoint.setEndPoint(endpoint);
+                    assertEquals("Expected and actual values should be the same.", endpoint, simpleEndPoint.getEndPoint(null, value, previous, properties));
+                }
+                simpleEndPoint.setEndPoint(null);
+                assertNull("Null expected.", simpleEndPoint.getEndPoint(null, value, previous, properties));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointWithNullPreviousParameterTest() {
+        for (Object value : values) {
+            for (String endpoint : endPoints) {
+                simpleEndPoint.setEndPoint(endpoint);
+                assertEquals("Expected and actual values should be the same.", endpoint, simpleEndPoint.getEndPoint(exchange, value, null, properties));
+            }
+            simpleEndPoint.setEndPoint(null);
+            assertNull("Null expected.", simpleEndPoint.getEndPoint(exchange, value, null, properties));
+        }
+    }
+
+    @Test
+    public void setAndGetEndPointWithNullPropertiesParameterTest() {
+        for (Object value : values) {
+            for (String previous : previousList) {
+                for (String endpoint : endPoints) {
+                    simpleEndPoint.setEndPoint(endpoint);
+                    assertEquals("Expected and actual values should be the same.", endpoint, simpleEndPoint.getEndPoint(exchange, value, previous, null));
+                }
+                simpleEndPoint.setEndPoint(null);
+                assertNull("Null expected.", simpleEndPoint.getEndPoint(exchange, value, previous, null));
+            }
+        }
+    }
+
+    @Test
+    public void setAndGetRegexTest() {
+        assertNull("Null expected.", simpleEndPoint.getRegex());
+
+        for (String regex : regexList) {
+            simpleEndPoint.setRegex(regex);
+            assertEquals("Expected and actual values should be the same.", regex, simpleEndPoint.getRegex());
+        }
+        simpleEndPoint.setRegex(null);
+        assertNull("Null expected.", simpleEndPoint.getRegex());
+    }
+
+    @Test
+    public void setAndGetEndPointTest() {
+        for (String endPoint : endPoints) {
+            simpleEndPoint.setEndPoint(endPoint);
+            assertEquals("Expected and actual values should be the same.", endPoint, simpleEndPoint.getEndPoint());
+        }
+        simpleEndPoint.setEndPoint(null);
+        assertNull("Null expected.", simpleEndPoint.getEndPoint());
+    }
+
+    @Test
+    public void toLogTest() {
+        try {
+            for (String prefixValue : prefix) {
+                simpleEndPoint.toLog(stringBuffer, prefixValue);
+                assertEquals("Expected and actual values should be the same.", "Regex: null\n" + prefixValue + "\tEnd point: null", stringBuffer.toString());
+                stringBuffer.delete(0, 99);
+            }
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void toLogWithRegexAndEndPointTest() {
+        simpleEndPoint.setEndPoint("ENDPOINT");
+        simpleEndPoint.setRegex("REGEX");
+        try {
+            for (String prefixValue : prefix) {
+                simpleEndPoint.toLog(stringBuffer, prefixValue);
+                assertEquals("Expected and actual values should be the same.", "Regex: REGEX\n" + prefixValue + "\tEnd point: ENDPOINT", stringBuffer.toString());
+                stringBuffer.delete(0, 99);
+            }
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toLogNullBufferTest() {
+        for (String prefixValue : prefix) {
+            simpleEndPoint.toLog(null, prefixValue);
+        }
+    }
+
+    @Test
+    public void toLogNullPrefixTest() {
+        try {
+            simpleEndPoint.toLog(stringBuffer, null);
+            assertEquals("Expected and actual values should be the same.", "Regex: null\n" + null + "\tEnd point: null", stringBuffer.toString());
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}


### PR DESCRIPTION
Added Junit tests for broker/core/router package for:
CamelKapuaDefaultRouter class
EndChainEndPoint class
EndPointAdapter class
EndPointContainer class
EndPoint class
EndpointsUtil class
ParentEndPoint class
PlaceholderReplacer class
SimpleEndPoint class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/
**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
