### PR TITLE
Checks for MFA enable/disable

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/KapuaExistingMfaOptionException.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/KapuaExistingMfaOptionException.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+
+/**
+ * {@link KapuaExistingMfaOptionException} is thrown when an operation cannot be completed because the {@link MfaOption} already exists.
+ */
+public class KapuaExistingMfaOptionException extends KapuaException {
+
+    private static final long serialVersionUID = 9092695456934827181L;
+    private static final String MESSAGE_FORMAT = "MfaOption already exists for this user.";
+
+    /**
+     * Constructor for the {@link KapuaExistingMfaOptionException}.
+     */
+    public KapuaExistingMfaOptionException() {
+        super(KapuaErrorCodes.ENTITY_ALREADY_EXISTS, MESSAGE_FORMAT);
+    }
+}

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/KapuaExistingScratchCodesException.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/KapuaExistingScratchCodesException.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * All rights reserved. This program and the accompanying materials
+ * are made available under the terms of the Eclipse Public License v1.0
+ * which accompanies this distribution, and is available at
+ * http://www.eclipse.org/legal/epl-v10.html
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa;
+
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+
+/**
+ * {@link KapuaExistingScratchCodesException} is thrown when an operation cannot be completed because a {@link ScratchCodeListResult} already exists.
+ */
+public class KapuaExistingScratchCodesException extends KapuaException {
+
+    private static final long serialVersionUID = -310717682142223444L;
+    private static final String MESSAGE_FORMAT = "Scratch Codes already exists for this user.";
+
+    /**
+     * Constructor for the {@link KapuaExistingMfaOptionException}.
+     */
+    public KapuaExistingScratchCodesException() {
+        super(KapuaErrorCodes.ENTITY_ALREADY_EXISTS, MESSAGE_FORMAT);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -26,6 +26,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 import org.eclipse.kapua.service.authentication.AuthenticationDomains;
+import org.eclipse.kapua.service.authentication.credential.mfa.KapuaExistingMfaOptionException;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionAttributes;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
@@ -76,6 +77,13 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
         PermissionFactory permissionFactory = locator.getFactory(PermissionFactory.class);
         authorizationService.checkPermission(permissionFactory.newPermission(AuthenticationDomains.CREDENTIAL_DOMAIN, Actions.write,
                 mfaOptionCreator.getScopeId()));
+
+        //
+        // Check existing MfaOption
+        MfaOption existingMfaOption = findByUserId(mfaOptionCreator.getScopeId(), mfaOptionCreator.getUserId());
+        if (existingMfaOption != null) {
+            throw new KapuaExistingMfaOptionException();
+        }
 
         //
         // Do create

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
@@ -25,6 +25,7 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.model.query.predicate.QueryPredicate;
 import org.eclipse.kapua.service.authentication.AuthenticationDomains;
+import org.eclipse.kapua.service.authentication.credential.mfa.KapuaExistingScratchCodesException;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeAttributes;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
@@ -209,6 +210,13 @@ public class ScratchCodeServiceImpl extends AbstractKapuaService implements Scra
 
         List<String> codes = MFA_AUTHENTICATOR.generateCodes();
         ScratchCodeListResult scratchCodeListResult = new ScratchCodeListResultImpl();
+
+        //
+        // Check existing ScratchCodes
+        ScratchCodeListResult existingScratchCodeListResult = findByMfaOptionId(scratchCodeCreator.getScopeId(), scratchCodeCreator.getMfaOptionId());
+        if (!existingScratchCodeListResult.isEmpty()) {
+            throw new KapuaExistingScratchCodesException();
+        }
 
         for (String code : codes) {
             scratchCodeCreator.setCode(code);


### PR DESCRIPTION
This PR introduces two checks when enabling or disabling the Multi Factor Authentication for a given user.

**Related Issue**
_n/a_

**Description of the solution adopted**
As for MFA enabling, a check is added in the `MfaOptionService` `create` method, in order to verify wether an `MfaOption` exists for the given user. Two dedicated exceptions have also been created in order to highlight that an `MfaOption` entity or `ScratchCode` entities already exist.

As for MFA disabling, a check is introduced in the `DisableMfaDialog`, in order to be sure that an `MfaOption` entity actually exists.

**Screenshots**
_n/a_

**Any side note on the changes made**
This PR requires PR #3125 to be merged first.
