### PR TITLE
Removed redundant OpenID variables to trigger the generic OpenID provider

### DIFF
--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -33,27 +33,21 @@ if [ -n "$KEYCLOAK_URL" ] && [ -n "$KAPUA_CONSOLE_URL" ]; then
 fi
 
 # Check for generic OpenID Connect provider integration
-if [ -n "$KAPUA_CONSOLE_URL" ] && [ -n "$OPENID_JWT_ISSUER" ] && [ -n "$OPENID_AUTH_ENDPOINT" ] && [ -n "$OPENID_LOGOUT_ENDPOINT" ] && [ -n "$OPENID_TOKEN_ENDPOINT" ]; then
+if [ -n "${KAPUA_CONSOLE_URL}" ] && [ -n "${OPENID_JWT_ISSUER}" ]; then
    echo "Activating OpenID Connect Generic integration..."
-   echo "  Kapua:    $KAPUA_CONSOLE_URL"
-   echo "  OpenID Issuer: $OPENID_JWT_ISSUER"
-   echo "  Auth Endpoint: $OPENID_AUTH_ENDPOINT"
-   echo "  Logout Endpoint: $OPENID_LOGOUT_ENDPOINT"
-   echo "  Token Endpoint: $OPENID_TOKEN_ENDPOINT"
+  echo "  OpenID Issuer: ${OPENID_JWT_ISSUER}"
+  echo "  Console: ${KAPUA_CONSOLE_URL}"
 
-   : OPENID_CLIENT_ID=${OPENID_CLIENT_ID:=console}
-   : JWT_AUDIENCE=${JWT_AUDIENCE:=console}
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.provider=generic"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.openid.client.id=${OPENID_CLIENT_ID:-console}"
+  test -n "${CLIENT_SECRET}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.openid.client.secret=${CLIENT_SECRET}"
+  JAVA_OPTS="${JAVA_OPTS} -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
 
-   JAVA_OPTS="$JAVA_OPTS -Dsso.provider=generic"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.id=${OPENID_CLIENT_ID}"
-   test -n "$CLIENT_SECRET" && JAVA_OPTS="$JAVA_OPTS -Dsso.openid.client.secret=${CLIENT_SECRET}"
-   JAVA_OPTS="$JAVA_OPTS -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
-
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.audience.allowed=${JWT_AUDIENCE}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.jwt.issuer.allowed=${OPENID_JWT_ISSUER}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.auth=${OPENID_AUTH_ENDPOINT}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.logout=${OPENID_LOGOUT_ENDPOINT}"
-   JAVA_OPTS="$JAVA_OPTS -Dsso.generic.openid.server.endpoint.token=${OPENID_TOKEN_ENDPOINT}"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.jwt.audience.allowed=${JWT_AUDIENCE:-console}"
+  JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.jwt.issuer.allowed=${OPENID_JWT_ISSUER}"
+  test -n "${OPENID_AUTH_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.auth=${OPENID_AUTH_ENDPOINT}"
+  test -n "${OPENID_LOGOUT_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.logout=${OPENID_LOGOUT_ENDPOINT}"
+  test -n "${OPENID_TOKEN_ENDPOINT}" && JAVA_OPTS="${JAVA_OPTS} -Dsso.generic.openid.server.endpoint.token=${OPENID_TOKEN_ENDPOINT}"
 fi
 
 export JAVA_OPTS


### PR DESCRIPTION
Removed redundant OpenID Connect (SSO) variables in the `run-console` script for the `generic` OpenID Connect provider.

**Related Issue**
This PR fixes _#3127_

**Description of the solution adopted**
Now only `CONSOLE_URL` and `OPENID_JWT_ISSUER` are required to trigger the `generic` provider

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
