### PR TITLE
 Upgrade Elasticsearch version to 6.8.7

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -204,14 +204,14 @@
                 <include>org.eclipse.persistence:org.eclipse.persistence.moxy</include>
                 <include>org.eclipse.persistence:org.eclipse.persistence.extension</include>
                 <include>org.eclipse.persistence:javax.persistence</include>
-                <include>org.elasticsearch.client:rest</include>
+                <include>org.elasticsearch.client:elasticsearch-rest-client</include>
                 <include>org.elasticsearch.client:transport</include>
                 <include>org.elasticsearch.plugin:lang-mustache-client</include>
                 <include>org.elasticsearch.plugin:percolator-client</include>
                 <include>org.elasticsearch.plugin:reindex-client</include>
-                <include>org.elasticsearch.plugin:transport-netty3-client</include>
                 <include>org.elasticsearch.plugin:transport-netty4-client</include>
                 <include>org.elasticsearch:elasticsearch</include>
+                <include>org.elasticsearch:elasticsearch-x-content</include>
                 <include>org.elasticsearch:securesm</include>
                 <include>org.hdrhistogram:HdrHistogram</include>
                 <include>org.javassist:javassist</include>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -370,16 +370,16 @@
             <artifactId>elasticsearch</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-x-content</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.elasticsearch.client</groupId>
             <artifactId>transport</artifactId>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
-            <artifactId>rest</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty3-client</artifactId>
+            <artifactId>elasticsearch-rest-client</artifactId>
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/KapuaDateUtils.java
@@ -30,7 +30,16 @@ public final class KapuaDateUtils {
     private KapuaDateUtils() {
     }
 
-    public static final String ISO_DATE_PATTERN = "yyyy-MM-dd'T'HH:mm:ss.SSS'Z'"; // example 24/01/2017T11:22:10.999Z
+    /**
+     * {@literal uuuu} is used instead of {@literal yyyy} for the year because the latter is meant to be used together with the
+     * era of the date, while the former is the proleptic year. Also, {@literal X} is used at the end instead of {@literal 'Z'}
+     * because with {@literal 'Z'} we were blindly appending a Z at the end without actually relying on the timezone,
+     * while with {@literal X} Z is printed only if the time difference is 0 (i.e. the timezone is UTC)
+     *
+     * @see <a href=https://docs.oracle.com/javase/8/docs/api/java/time/format/DateTimeFormatter.html>DateTimeFormatter</a>
+     * @see <a href=https://stackoverflow.com/a/29014580/218901>Answer on StackOverflow</a>
+     */
+    public static final String ISO_DATE_PATTERN = "uuuu-MM-dd'T'HH:mm:ss.SSSX"; // example 2017-01-24T11:22:10.999Z
 
     private static final DateTimeFormatter FORMATTER = DateTimeFormatter
             .ofPattern(ISO_DATE_PATTERN)

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -198,10 +198,6 @@
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty3-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
         </dependency>
         <dependency>

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 8181:8181
       - 3306:3306
   es:
-    image: elasticsearch:5.4.0
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     ports:
       - 9200:9200
       - 9300:9300

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 8181:8181
       - 3306:3306
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
     ports:
       - 9200:9200
       - 9300:9300

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       - 8181:8181
       - 3306:3306
   es:
-    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.8.7
     ports:
       - 9200:9200
       - 9300:9300

--- a/deployment/openshift/templates/kapua-template-core.yml
+++ b/deployment/openshift/templates/kapua-template-core.yml
@@ -269,7 +269,7 @@ objects:
         - env:
           - name: ES_JAVA_OPTS
             value: "-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}"
-          image: elasticsearch:5.4
+          image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
           command:
             - 'elasticsearch'
             - '-Etransport.host=_site_'

--- a/deployment/openshift/templates/kapua-template-core.yml
+++ b/deployment/openshift/templates/kapua-template-core.yml
@@ -269,7 +269,7 @@ objects:
         - env:
           - name: ES_JAVA_OPTS
             value: "-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}"
-          image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
+          image: docker.elastic.co/elasticsearch/elasticsearch:6.8.7
           command:
             - 'elasticsearch'
             - '-Etransport.host=_site_'

--- a/deployment/openshift/templates/kapua-template-core.yml
+++ b/deployment/openshift/templates/kapua-template-core.yml
@@ -269,7 +269,7 @@ objects:
         - env:
           - name: ES_JAVA_OPTS
             value: "-Xms${ELASTIC_SEARCH_MEMORY} -Xmx${ELASTIC_SEARCH_MEMORY}"
-          image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
+          image: docker.elastic.co/elasticsearch/elasticsearch:6.8.5
           command:
             - 'elasticsearch'
             - '-Etransport.host=_site_'

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -16,7 +16,7 @@ network_address = '192.168.33.10'
 # Environment variables used in the scripts
 env_vars = {
   'BINDING_IP'            => network_address,
-  'ELASTICSEARCH_VERSION' => '6.8.5',
+  'ELASTICSEARCH_VERSION' => '6.8.7',
   'H2DB_VERSION'          => '1.4.192',
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -16,7 +16,7 @@ network_address = '192.168.33.10'
 # Environment variables used in the scripts
 env_vars = {
   'BINDING_IP'            => network_address,
-  'ELASTICSEARCH_VERSION' => '6.3.2',
+  'ELASTICSEARCH_VERSION' => '6.8.5',
   'H2DB_VERSION'          => '1.4.192',
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',

--- a/dev-tools/vagrant/Vagrantfile
+++ b/dev-tools/vagrant/Vagrantfile
@@ -16,7 +16,7 @@ network_address = '192.168.33.10'
 # Environment variables used in the scripts
 env_vars = {
   'BINDING_IP'            => network_address,
-  'ELASTICSEARCH_VERSION' => '5.4.0',
+  'ELASTICSEARCH_VERSION' => '6.3.2',
   'H2DB_VERSION'          => '1.4.192',
   'ACTIVEMQ_VERSION'      => '5.14.5',
   'ARTEMIS_VERSION'       => '2.2.0',

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
 
-    export ELASTICSEARCH_VERSION="6.3.2"
+    export ELASTICSEARCH_VERSION="6.8.5"
     export H2DB_VERSION="1.4.192"
     export ACTIVE_MQ_VERSION="5.14.5"
     export ARTEMIS_VERSION="2.2.0"

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
 
-    export ELASTICSEARCH_VERSION="6.8.5"
+    export ELASTICSEARCH_VERSION="6.8.7"
     export H2DB_VERSION="1.4.192"
     export ACTIVE_MQ_VERSION="5.14.5"
     export ARTEMIS_VERSION="2.2.0"

--- a/dev-tools/vagrant/baseBox/Vagrantfile
+++ b/dev-tools/vagrant/baseBox/Vagrantfile
@@ -32,7 +32,7 @@ Vagrant.configure(2) do |config|
   config.vm.provision "shell", inline: <<-SHELL
     export DEBIAN_FRONTEND=noninteractive
 
-    export ELASTICSEARCH_VERSION="5.4.0"
+    export ELASTICSEARCH_VERSION="6.3.2"
     export H2DB_VERSION="1.4.192"
     export ACTIVE_MQ_VERSION="5.14.5"
     export ARTEMIS_VERSION="2.2.0"

--- a/docs/kuraKapuaDocs.md
+++ b/docs/kuraKapuaDocs.md
@@ -53,7 +53,7 @@ CONTAINER ID        IMAGE                 COMMAND                  CREATED      
 505d32a0bb9e        kapua/kapua-api       "/home/kapua/run-j..."   4 hours ago         Created                                                                                           kapua-api             0B (virtual 180MB)
 dd9852845105        kapua/kapua-console   "/home/kapua/run-c..."   4 hours ago         Up 4 hours                 0.0.0.0:8080->8080/tcp, 8778/tcp                                       kapua-console         83kB (virtual 206MB)
 65c8e15ab7e9        kapua/kapua-broker    "/maven/bin/active..."   4 hours ago         Up 4 hours                 8778/tcp, 0.0.0.0:1883->1883/tcp, 0.0.0.0:61614->61614/tcp, 8883/tcp   kapua-broker          94.4kB (virtual 212MB)
-b3309e145e84        elasticsearch:5.4.0   "/docker-entrypoin..."   4 hours ago         Exited (137) 4 hours ago                                                                          kapua-elasticsearch   32.8kB (virtual 352MB)
+b3309e145e84        elasticsearch:6.3.2   "/docker-entrypoin..."   4 hours ago         Up 4 hours                                                                         kapua-elasticsearch   32.8kB (virtual 352MB)
 e097f77f1758        kapua/kapua-sql       "/home/kapua/run-h2"     4 hours ago         Up 4 hours                 0.0.0.0:3306->3306/tcp, 0.0.0.0:8181->8181/tcp, 8778/tcp               kapua-sql             32.8kB (virtual 86MB)
 785efe9976cf        kapua/kapua-events-broker:latest   "/run-artemis"           About an hour ago   Up About an hour    0.0.0.0:5672->5672/tcp                                                 compose_events-broker_1   410kB (virtual 130MB)
 ```

--- a/docs/kuraKapuaDocs.md
+++ b/docs/kuraKapuaDocs.md
@@ -53,7 +53,7 @@ CONTAINER ID        IMAGE                 COMMAND                  CREATED      
 505d32a0bb9e        kapua/kapua-api       "/home/kapua/run-j..."   4 hours ago         Created                                                                                           kapua-api             0B (virtual 180MB)
 dd9852845105        kapua/kapua-console   "/home/kapua/run-c..."   4 hours ago         Up 4 hours                 0.0.0.0:8080->8080/tcp, 8778/tcp                                       kapua-console         83kB (virtual 206MB)
 65c8e15ab7e9        kapua/kapua-broker    "/maven/bin/active..."   4 hours ago         Up 4 hours                 8778/tcp, 0.0.0.0:1883->1883/tcp, 0.0.0.0:61614->61614/tcp, 8883/tcp   kapua-broker          94.4kB (virtual 212MB)
-b3309e145e84        elasticsearch:6.3.2   "/docker-entrypoin..."   4 hours ago         Up 4 hours                                                                         kapua-elasticsearch   32.8kB (virtual 352MB)
+b3309e145e84        elasticsearch:6.8.5   "/docker-entrypoin..."   4 hours ago         Up 4 hours                                                                         kapua-elasticsearch   32.8kB (virtual 352MB)
 e097f77f1758        kapua/kapua-sql       "/home/kapua/run-h2"     4 hours ago         Up 4 hours                 0.0.0.0:3306->3306/tcp, 0.0.0.0:8181->8181/tcp, 8778/tcp               kapua-sql             32.8kB (virtual 86MB)
 785efe9976cf        kapua/kapua-events-broker:latest   "/run-artemis"           About an hour ago   Up About an hour    0.0.0.0:5672->5672/tcp                                                 compose_events-broker_1   410kB (virtual 130MB)
 ```

--- a/docs/kuraKapuaDocs.md
+++ b/docs/kuraKapuaDocs.md
@@ -53,7 +53,7 @@ CONTAINER ID        IMAGE                 COMMAND                  CREATED      
 505d32a0bb9e        kapua/kapua-api       "/home/kapua/run-j..."   4 hours ago         Created                                                                                           kapua-api             0B (virtual 180MB)
 dd9852845105        kapua/kapua-console   "/home/kapua/run-c..."   4 hours ago         Up 4 hours                 0.0.0.0:8080->8080/tcp, 8778/tcp                                       kapua-console         83kB (virtual 206MB)
 65c8e15ab7e9        kapua/kapua-broker    "/maven/bin/active..."   4 hours ago         Up 4 hours                 8778/tcp, 0.0.0.0:1883->1883/tcp, 0.0.0.0:61614->61614/tcp, 8883/tcp   kapua-broker          94.4kB (virtual 212MB)
-b3309e145e84        elasticsearch:6.8.5   "/docker-entrypoin..."   4 hours ago         Up 4 hours                                                                         kapua-elasticsearch   32.8kB (virtual 352MB)
+b3309e145e84        elasticsearch:6.8.7   "/docker-entrypoin..."   4 hours ago         Up 4 hours                                                                         kapua-elasticsearch   32.8kB (virtual 352MB)
 e097f77f1758        kapua/kapua-sql       "/home/kapua/run-h2"     4 hours ago         Up 4 hours                 0.0.0.0:3306->3306/tcp, 0.0.0.0:8181->8181/tcp, 8778/tcp               kapua-sql             32.8kB (virtual 86MB)
 785efe9976cf        kapua/kapua-events-broker:latest   "/run-artemis"           About an hour ago   Up About an hour    0.0.0.0:5672->5672/tcp                                                 compose_events-broker_1   410kB (virtual 130MB)
 ```

--- a/extras/es-migrator/README.md
+++ b/extras/es-migrator/README.md
@@ -1,0 +1,54 @@
+Elasticsearch 6.8 Indexes Migrator
+==========
+
+## Introduction
+
+This module contains a Java Application that leverages the Elasticsearch 6.8 High Level REST Client to change the
+Datastore indexes structure so that they are compatible with Elasticsearch 6.8
+
+## Background
+
+Kapua, up until version 1.3, uses Elasticsearch 5.3, which supports multiple mapping types for a single index.
+Specifically, the "registry" index for every account( named `.scopeId`, where `scopeId` is replaced by the actual
+Scope ID) supports three different mapping types since it contains data from different, heterogeneous nature (`channel`,
+`client` and `metric`); as said, such structure is no longer allowed in Elasticsearch 6.x since [Mapping Types have been
+removed](https://www.elastic.co/guide/en/elasticsearch/reference/6.8/removal-of-types.html).
+
+## Changes in Kapua 1.4
+
+In Kapua 1.4, the `.scopeId` index will be split in three different indexes (`.scopeId-channel`, `.scopeId-client` and
+`.scopeId-metric`, again with `scopeId` replaced by the actual Scope ID). Anyway, the change is not retroactive,
+meaning that it won't apply automatically to already existing indexes, that will make Elasticsearch 6.8 to fail during
+the startup phase. Moreover, the Date format supported until Elasticsearch 5.x has been deprecated in 6.0 and will be
+removed in 7.0, so in Kapua 1.4 a change to make the Datastore compatible with the new format will be released.
+
+## The ES Indexes Migration tool
+
+This tool has been developed to migrate data in already existing Elasticsearch clusters from the old structure to the
+new one.
+
+The application will scan all indexes in a given Elasticsearch cluster and, for every registry index, will create three
+new indexes as described above and process a `reindex` operation of existing documents in new indexes. For every data
+index, instead, a new temporary index will be created with the new Date format, and a `reindex` will take place; once
+completed, the old index will be deleted, and a new one with the same settings of the temporary one will be created,
+with another `reindex` following, to restore the original name of the index. Old registry indexes will not be deleted,
+but rather closed.
+
+If your Kapua instance is configured to use a prefix for the Elasticsearch indexes, via the `datastore.index.prefix`
+system property, make sure to set the same `datastore.index.prefix` when running the Migration Tool, otherwise the
+migration could fail. If your Elasticsearch cluster contains indexes with multiple prefixes, enter all the values
+separated with a `,`.
+
+### Settings
+
+The following settings are available as system properties when running the migration tool:
+
+|Name|Description|Default Value|
+|----|-----------|-------------|
+|elasticsearch.cluster.address|The address of the ES cluster|localhost|
+|elasticsearch.cluster.port|The port of the ES cluster|9200|
+|elasticsearch.cluster.scheme|The scheme of the ES cluster. Can be `http` or `https`|http|
+|datastore.index.refresh_interval|ES Refresh interval for the new indexes|5s|
+|datastore.index.number_of_shards|ES Number of Shards for the new indexes|1|
+|datastore.index.number_of_replicas|ES Number of Replicas for the new indexes|0|
+|datastore.index.prefix|ES Index Prefix; multiple values are allowed|*empty string*|

--- a/extras/es-migrator/pom.xml
+++ b/extras/es-migrator/pom.xml
@@ -1,0 +1,123 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>kapua-extras</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>1.4.0-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>kapua-es-migrator</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-io</groupId>
+            <artifactId>commons-io</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-beanutils</groupId>
+            <artifactId>commons-beanutils</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.core</groupId>
+            <artifactId>jackson-databind</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch.client</groupId>
+            <artifactId>elasticsearch-rest-high-level-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-to-slf4j</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-datastore-internal</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/DEPENDENCIES</exclude>
+                                <exclude>bundle.properties</exclude>
+                                <exclude>about.*</exclude>
+                                <exclude>OSGI-OPT/**</exclude>
+                                <exclude>LICENSE</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>com.eurotech.ec.es6migrator.Application</mainClass>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                            <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
+                    </transformers>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>app</shadedClassifierName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/Application.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/Application.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.esmigrator;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Application {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Application.class.getName());
+
+    private Application() { }
+
+    public static void main(String[] args) {
+        LOGGER.info("Starting Elasticsearch Index Migration Tool");
+        new Migrator().doMigrate();
+    }
+
+}

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/MappingType.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/MappingType.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.esmigrator;
+
+import java.io.IOException;
+
+import org.eclipse.kapua.commons.util.ResourceUtils;
+
+import org.apache.commons.io.IOUtils;
+
+public enum MappingType {
+
+    CHANNEL("mappings/channel.json"),
+    CLIENT("mappings/client.json"),
+    METRIC("mappings/metric.json");
+
+    private final String mappingFilePath;
+
+    MappingType(String mappingFilePath) {
+        this.mappingFilePath = mappingFilePath;
+    }
+
+    public String getMappingFilePath() {
+        return mappingFilePath;
+    }
+
+    public String getMapping() throws IOException {
+        return IOUtils.toString(ResourceUtils.getResource(mappingFilePath));
+    }
+}

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/Migrator.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/Migrator.java
@@ -1,0 +1,277 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.esmigrator;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+
+import org.eclipse.kapua.extras.esmigrator.settings.EsMigratorSetting;
+import org.eclipse.kapua.extras.esmigrator.settings.EsMigratorSettingKey;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
+import org.eclipse.kapua.service.datastore.internal.schema.MessageSchema;
+import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.apache.http.HttpHost;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.util.EntityUtils;
+import org.elasticsearch.action.admin.indices.close.CloseIndexRequest;
+import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
+import org.elasticsearch.client.Request;
+import org.elasticsearch.client.RequestOptions;
+import org.elasticsearch.client.Response;
+import org.elasticsearch.client.RestClient;
+import org.elasticsearch.client.RestClientBuilder;
+import org.elasticsearch.client.RestHighLevelClient;
+import org.elasticsearch.client.indices.CreateIndexRequest;
+import org.elasticsearch.client.indices.GetIndexRequest;
+import org.elasticsearch.client.indices.GetMappingsRequest;
+import org.elasticsearch.client.indices.GetMappingsResponse;
+import org.elasticsearch.cluster.metadata.MappingMetaData;
+import org.elasticsearch.common.settings.Settings;
+import org.elasticsearch.common.xcontent.XContentType;
+import org.elasticsearch.index.reindex.ReindexRequest;
+import org.elasticsearch.script.Script;
+import org.elasticsearch.script.ScriptType;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Migrator {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(Migrator.class.getName());
+
+    private static final String DEFAULT_ELASTICSEARCH_ADDRESS = "localhost";
+    private static final String DEFAULT_ELASTICSEARCH_SCHEME = "http";
+    private static final int DEFAULT_ELASTICSEARCH_PORT = 9200;
+
+    private static final String DEFAULT_INDEX_REFRESH_INTERVAL = "5s";
+    private static final int DEFAULT_INDEX_SHARD_NUMBER = 1;
+    private static final int DEFAULT_INDEX_REPLICA_NUMBER = 0;
+
+    private static final String CLIENT = "client";
+    private static final String CHANNEL = "channel";
+    private static final String METRIC = "metric";
+    private static final String FORMAT = "format";
+    private static final String DOC = "_doc";
+
+    private static final String INDEX_NUMBER_OF_SHARDS = "index.number_of_shards";
+    private static final String INDEX_NUMBER_OF_REPLICAS = "index.number_of_replicas";
+    private static final String INDEX_REFRESH_INTERVAL = "index.refresh_interval";
+
+    private static final String REINDEXING = "Reindexing {} to {}";
+    private static final String DELETING_INDEX = "Deleting index {}";
+
+    private final String indexRefreshInterval;
+    private final int indexShardNumber;
+    private final int indexReplicaNumber;
+    private final List<String> indexPrefixes;
+
+    private final ObjectMapper mapper = new ObjectMapper();
+
+    private final RestClientBuilder restClientBuilder;
+
+    public Migrator() {
+        EsMigratorSetting esMigratorSetting = EsMigratorSetting.getInstance();
+
+        String scheme = esMigratorSetting.getString(EsMigratorSettingKey.ELASTICSEARCH_CLUSTER_SCHEME, DEFAULT_ELASTICSEARCH_SCHEME);
+        String address = esMigratorSetting.getString(EsMigratorSettingKey.ELASTICSEARCH_CLUSTER_ADDRESS, DEFAULT_ELASTICSEARCH_ADDRESS);
+        int port = esMigratorSetting.getInt(EsMigratorSettingKey.ELASTICSEARCH_CLUSTER_PORT, DEFAULT_ELASTICSEARCH_PORT);
+
+        indexRefreshInterval = esMigratorSetting.getString(EsMigratorSettingKey.DATASTORE_INDEX_REFRESH_INTERVAL, DEFAULT_INDEX_REFRESH_INTERVAL);
+        indexShardNumber = esMigratorSetting.getInt(EsMigratorSettingKey.DATASTORE_INDEX_NUMBER_OF_SHARDS, DEFAULT_INDEX_SHARD_NUMBER);
+        indexReplicaNumber = esMigratorSetting.getInt(EsMigratorSettingKey.DATASTORE_INDEX_NUMBER_OF_REPLICAS, DEFAULT_INDEX_REPLICA_NUMBER);
+        indexPrefixes = esMigratorSetting.getList(String.class, EsMigratorSettingKey.DATASTORE_INDEX_PREFIX);
+
+        LOGGER.info("Elasticsearch Cluster Address: {}://{}:{}", scheme, address, port);
+
+        restClientBuilder = RestClient.builder(new HttpHost(address, port, scheme));
+    }
+
+    void doMigrate() {
+        try (RestHighLevelClient client = new RestHighLevelClient(restClientBuilder)) {
+            Request catIndicesRequest = new Request(HttpGet.METHOD_NAME, "_cat/indices?format=json");
+            Response catIndicesResponse = client.getLowLevelClient().performRequest(catIndicesRequest);
+            JsonNode[] catIndicesObject = mapper.readValue(EntityUtils.toString(catIndicesResponse.getEntity()), JsonNode[].class);
+            List<String> openIndexes = Stream.of(catIndicesObject)
+                    .filter(index -> index.get("status").asText().equals("open"))
+                    .map(index -> index.get("index").asText())
+                    .filter(index -> Stream.of("-channel", "-client", "-metric").noneMatch(index::endsWith))
+                    .collect(Collectors.toList());
+            LOGGER.debug("Found {} open indexes to be migrated", openIndexes.size());
+            for (String index : openIndexes) {
+                String indexWithoutPrefix = index;
+                Optional<String> indexPrefix = indexPrefixes.stream().filter(prefix -> index.startsWith(prefix + "-")).findFirst();
+                if (indexPrefix.isPresent()) {
+                    LOGGER.debug("The index {} matches one of the prefixes: {}", index, indexPrefix.get());
+                    // Trim out the optional index prefix to make sure the evaluation is done on the correct name
+                    indexWithoutPrefix = index.replace(indexPrefix.get() + "-", "");
+                }
+                if (indexWithoutPrefix.startsWith(".")) {
+                    migrateRegistryIndex(index, client);
+                } else {
+                    updateMappingDates(index, client);
+                }
+            }
+        } catch (IOException ioException) {
+            LOGGER.error("Error migrating Elasticsearch indexes: {}", ioException.getMessage());
+        }
+    }
+
+    @SuppressWarnings({ "unchecked" })
+    private void updateMappingDates(String index, RestHighLevelClient client) throws IOException {
+        LOGGER.info("Updating dates mapping for index {}", index);
+
+        String tmpIndex = index + "_tmp";
+
+        // First look for an existing temp index left from a previous execution, and delete if present
+        GetIndexRequest getTempIndexRequest = new GetIndexRequest(tmpIndex);
+        boolean tmpIndexExists = client.indices().exists(getTempIndexRequest, RequestOptions.DEFAULT);
+        if (tmpIndexExists) {
+            LOGGER.info("temp index already found: {}, deleting it", tmpIndex);
+            DeleteIndexRequest deleteIndexRequest = new DeleteIndexRequest(tmpIndex);
+            client.indices().delete(deleteIndexRequest, RequestOptions.DEFAULT);
+        }
+
+        GetMappingsRequest getMappingsRequest = new GetMappingsRequest().indices(index);
+        GetMappingsResponse getMappingsResponse = client.indices().getMapping(getMappingsRequest, RequestOptions.DEFAULT);
+
+        MappingMetaData mappingMetaData = getMappingsResponse.mappings().get(index);
+        Map<String, Object> sourceMap = mappingMetaData.getSourceAsMap();
+        sourceMap.remove("_all");
+        Map<String, Object> properties = (Map<String, Object>) sourceMap.get(SchemaKeys.FIELD_NAME_PROPERTIES);
+        Map<String, Object> capturedOn = (Map<String, Object>) properties.get(MessageSchema.MESSAGE_CAPTURED_ON);
+        Map<String, Object> receivedOn = (Map<String, Object>) properties.get(MessageSchema.MESSAGE_RECEIVED_ON);
+        Map<String, Object> sentOn = (Map<String, Object>) properties.get(MessageSchema.MESSAGE_SENT_ON);
+        Map<String, Object> timestamp = (Map<String, Object>) properties.get(MessageSchema.MESSAGE_TIMESTAMP);
+        Map<String, Object> position = (Map<String, Object>) properties.get(MessageSchema.MESSAGE_POSITION);
+        Map<String, Object> positionProperties = (Map<String, Object>) position.get(SchemaKeys.FIELD_NAME_PROPERTIES);
+        Map<String, Object> positionTimestamp = (Map<String, Object>) positionProperties.get(MessageSchema.MESSAGE_POS_TIMESTAMP);
+        capturedOn.put(FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT);
+        receivedOn.put(FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT);
+        sentOn.put(FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT);
+        timestamp.put(FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT);
+        positionTimestamp.put(FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT);
+
+        Settings settings = Settings.builder()
+                .put(INDEX_NUMBER_OF_SHARDS, indexShardNumber)
+                .put(INDEX_NUMBER_OF_REPLICAS, indexReplicaNumber)
+                .put(INDEX_REFRESH_INTERVAL, indexRefreshInterval)
+                .build();
+
+        CreateIndexRequest firstCreateIndexRequest = new CreateIndexRequest(tmpIndex)
+                .settings(settings)
+                .mapping(sourceMap);
+
+        String firstCreateIndexRequestBody = firstCreateIndexRequest.mappings().utf8ToString();
+        LOGGER.debug("Creating temporary index {}, body {}", index, firstCreateIndexRequestBody);
+
+        client.indices().create(firstCreateIndexRequest, RequestOptions.DEFAULT);
+
+        ReindexRequest firstReindexRequest = new ReindexRequest()
+                .setSourceIndices(index)
+                .setSourceDocTypes(mappingMetaData.type())
+                .setDestIndex(tmpIndex)
+                .setDestDocType(DOC);
+
+        LOGGER.debug(REINDEXING, index, tmpIndex);
+
+        client.reindex(firstReindexRequest, RequestOptions.DEFAULT);
+
+        DeleteIndexRequest firstDeleteIndexRequest = new DeleteIndexRequest(index);
+
+        LOGGER.debug(DELETING_INDEX, index);
+
+        client.indices().delete(firstDeleteIndexRequest, RequestOptions.DEFAULT);
+
+        CreateIndexRequest secondCreateIndexRequest = new CreateIndexRequest(index)
+                .settings(settings)
+                .mapping(sourceMap);
+
+        LOGGER.debug("Creating new index {}, same mappings as {}", index, tmpIndex);
+
+        client.indices().create(secondCreateIndexRequest, RequestOptions.DEFAULT);
+
+        ReindexRequest secondReindexRequest = new ReindexRequest()
+                .setSourceIndices(tmpIndex)
+                .setSourceDocTypes(DOC)
+                .setDestIndex(index)
+                .setDestDocType(DOC);
+
+        LOGGER.debug(REINDEXING, tmpIndex, index);
+
+        client.reindex(secondReindexRequest, RequestOptions.DEFAULT);
+
+        DeleteIndexRequest secondDeleteIndexRequest = new DeleteIndexRequest(tmpIndex);
+
+        LOGGER.debug(DELETING_INDEX, tmpIndex);
+
+        client.indices().delete(secondDeleteIndexRequest, RequestOptions.DEFAULT);
+    }
+
+    private void migrateRegistryIndex(String index, RestHighLevelClient client) throws IOException {
+        LOGGER.debug("Migrating index {}", index);
+        createIndex(index, MappingType.CHANNEL, client);
+        createIndex(index, MappingType.CLIENT, client);
+        createIndex(index, MappingType.METRIC, client);
+
+        reindex(index, MappingType.CHANNEL, client);
+        reindex(index, MappingType.CLIENT, client);
+        reindex(index, MappingType.METRIC, client);
+
+        closeIndex(index, client);
+    }
+
+    private void createIndex(String index, MappingType mappingType, RestHighLevelClient client) throws IOException {
+        String mapping = mappingType.getMapping();
+
+        String indexName = index + "-" + mappingType;
+        Settings settings = Settings.builder()
+                .put(INDEX_NUMBER_OF_SHARDS, indexShardNumber)
+                .put(INDEX_NUMBER_OF_REPLICAS, indexReplicaNumber)
+                .put(INDEX_REFRESH_INTERVAL, indexRefreshInterval)
+                .build();
+        CreateIndexRequest request = new CreateIndexRequest(indexName)
+                .settings(settings)
+                .mapping(mapping, XContentType.JSON);
+
+        LOGGER.info("Creating index for '{}' - refresh: '{}' - shards: '{}' replicas: '{}': ", indexName, indexRefreshInterval, indexShardNumber, indexReplicaNumber);
+        LOGGER.debug("Creating index {}, body: {}", indexName, mapping);
+
+        client.indices().create(request, RequestOptions.DEFAULT);
+        LOGGER.debug("Index {} created", indexName);
+    }
+
+    private void reindex(String index, MappingType mappingType, RestHighLevelClient client) throws IOException {
+        String mappingTypeName = mappingType.name().toLowerCase();
+        ReindexRequest request = new ReindexRequest()
+                .setSourceIndices(index)
+                .setSourceDocTypes(mappingTypeName)
+                .setScript(new Script(ScriptType.INLINE, "painless", "ctx._id = ctx._id.replace('/', '_').replace('+','-').replace('=', '')", Collections.emptyMap()))
+                .setDestIndex(index + "-" + mappingTypeName)
+                .setDestDocType(DOC);
+        client.reindex(request, RequestOptions.DEFAULT);
+        LOGGER.debug("Reindex complete for index {}", index);
+    }
+
+    private void closeIndex(String index, RestHighLevelClient client) throws IOException {
+        CloseIndexRequest request = new CloseIndexRequest(index);
+        client.indices().close(request, RequestOptions.DEFAULT);
+    }
+
+}

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/settings/EsMigratorSetting.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/settings/EsMigratorSetting.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.esmigrator.settings;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+public class EsMigratorSetting extends AbstractKapuaSetting<EsMigratorSettingKey> {
+
+    private static final String CONFIG_RESOURCE_NAME = "es-migrator-setting.properties";
+
+    private static EsMigratorSetting instance;
+
+    private EsMigratorSetting() {
+        super(CONFIG_RESOURCE_NAME);
+    }
+
+    /**
+     * Return the broker setting instance (singleton)
+     */
+    public static EsMigratorSetting getInstance() {
+        synchronized (EsMigratorSetting.class) {
+            if (instance == null) {
+                instance = new EsMigratorSetting();
+            }
+            return instance;
+        }
+    }
+
+    /**
+     * Allow re-setting the global instance
+     * <p>
+     * This method clears out the internal global instance in order to let the next call
+     * to {@link #getInstance()} return a fresh instance.
+     * </p>
+     * <p>
+     * This may be helpful for unit tests which need to change system properties for testing
+     * different behaviors.
+     * </p>
+     */
+    public static void resetInstance() {
+        synchronized (EsMigratorSetting.class) {
+            instance = null;
+        }
+    }
+
+}

--- a/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/settings/EsMigratorSettingKey.java
+++ b/extras/es-migrator/src/main/java/org/eclipse/kapua/extras/esmigrator/settings/EsMigratorSettingKey.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2020 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.esmigrator.settings;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+
+public enum EsMigratorSettingKey implements SettingKey {
+
+    /**
+     * Address of the Elasticsearch Cluster
+     */
+    ELASTICSEARCH_CLUSTER_ADDRESS("elasticsearch.cluster.address"),
+    /**
+     * Port of the Elasticsearch Cluster
+     */
+    ELASTICSEARCH_CLUSTER_PORT("elasticsearch.cluster.port"),
+    /**
+     * Scheme of the Elasticsearch Cluster. Allowed values: http, https
+     */
+    ELASTICSEARCH_CLUSTER_SCHEME("elasticsearch.cluster.scheme"),
+
+    /**
+     * The refresh interval for new indexes
+     */
+    DATASTORE_INDEX_REFRESH_INTERVAL("datastore.index.refresh_interval"),
+    /**
+     * The number of shards for new indexes
+     */
+    DATASTORE_INDEX_NUMBER_OF_SHARDS("datastore.index.number_of_shards"),
+    /**
+     * The number of replicas for new indexes
+     */
+    DATASTORE_INDEX_NUMBER_OF_REPLICAS("datastore.index.number_of_replicas"),
+    /**
+     * The prefix of all index names to operate on
+     */
+    DATASTORE_INDEX_PREFIX("datastore.index.prefix");
+
+    private String key;
+
+    private EsMigratorSettingKey(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+
+}

--- a/extras/es-migrator/src/main/resources/es-migrator-setting.properties
+++ b/extras/es-migrator/src/main/resources/es-migrator-setting.properties
@@ -1,0 +1,23 @@
+###############################################################################
+# Copyright (c) 2020 Eurotech and/or its affiliates and others
+#
+# All rights reserved. This program and the accompanying materials
+# are made available under the terms of the Eclipse Public License v1.0
+# which accompanies this distribution, and is available at
+# http://www.eclipse.org/legal/epl-v10.html
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+
+# ES Cluster parameters
+elasticsearch.cluster.address=localhost
+elasticsearch.cluster.port=9200
+elasticsearch.cluster.scheme=http
+
+# Index parameters
+datastore.index.refresh_interval=5s
+datastore.index.number_of_shards=1
+datastore.index.number_of_replicas=0
+datastore.index.prefix=

--- a/extras/es-migrator/src/main/resources/mappings/channel.json
+++ b/extras/es-migrator/src/main/resources/mappings/channel.json
@@ -1,0 +1,20 @@
+{
+  "properties": {
+    "channel": {
+      "type": "keyword"
+    },
+    "client_id": {
+      "type": "keyword"
+    },
+    "message_id": {
+      "type": "keyword"
+    },
+    "scope_id": {
+      "type": "keyword"
+    },
+    "timestamp": {
+      "type": "date",
+      "format": "8uuuu-MM-dd'T'HH:mm:ss.SSSX"
+    }
+  }
+}

--- a/extras/es-migrator/src/main/resources/mappings/client.json
+++ b/extras/es-migrator/src/main/resources/mappings/client.json
@@ -1,0 +1,17 @@
+{
+  "properties": {
+    "client_id": {
+      "type": "keyword"
+    },
+    "message_id": {
+      "type": "keyword"
+    },
+    "scope_id": {
+      "type": "keyword"
+    },
+    "timestamp": {
+      "type": "date",
+      "format": "8uuuu-MM-dd'T'HH:mm:ss.SSSX"
+    }
+  }
+}

--- a/extras/es-migrator/src/main/resources/mappings/metric.json
+++ b/extras/es-migrator/src/main/resources/mappings/metric.json
@@ -1,0 +1,35 @@
+{
+  "properties": {
+    "channel": {
+      "type": "keyword"
+    },
+    "client_id": {
+      "type": "keyword"
+    },
+    "metric": {
+      "dynamic": false,
+      "properties": {
+        "message_id": {
+          "type": "keyword"
+        },
+        "name": {
+          "type": "keyword"
+        },
+        "timestamp": {
+          "type": "date",
+          "format": "8uuuu-MM-dd'T'HH:mm:ss.SSSX"
+        },
+        "type": {
+          "type": "keyword"
+        },
+        "value": {
+          "type": "keyword"
+        }
+      }
+    },
+    "scope_id": {
+      "type": "keyword"
+    }
+  }
+}
+

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -26,6 +26,7 @@
 
     <modules>
         <module>foreignkeys</module>
+        <module>es-migrator</module>
     </modules>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -48,7 +48,6 @@
         <cucumber.version>1.2.4</cucumber.version>
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <eclipselink.version>2.7.7</eclipselink.version>
-        <elasticsearch.version>2.3.4</elasticsearch.version>
         <findbugs.version>2.0.1</findbugs.version>
         <gson.version>2.7</gson.version>
         <guava.version>27.1-jre</guava.version>
@@ -84,10 +83,9 @@
         <snakeyaml.version>1.15</snakeyaml.version>
         <cucumber.version>1.2.4</cucumber.version>
         <spotify.version>8.15.1</spotify.version>
-        <elasticsearch.version>5.3.0</elasticsearch.version>
-        <elasticsearch-client-transport.version>5.3.0</elasticsearch-client-transport.version>
-        <elasticsearch-client-rest.version>5.3.0</elasticsearch-client-rest.version>
-        <elasticsearch-netty-3.version>3.10.6.Final</elasticsearch-netty-3.version>
+        <elasticsearch.version>6.3.2</elasticsearch.version>
+        <elasticsearch-client-transport.version>6.3.2</elasticsearch-client-transport.version>
+        <elasticsearch-client-rest.version>6.3.2</elasticsearch-client-rest.version>
         <jackson.version>2.10.1</jackson.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->
@@ -1423,24 +1421,24 @@
                 <version>${elasticsearch.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.elasticsearch</groupId>
+                <artifactId>elasticsearch-x-content</artifactId>
+                <version>${elasticsearch.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.elasticsearch.client</groupId>
                 <artifactId>transport</artifactId>
-                <version>${elasticsearch-client-transport.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.client</groupId>
-                <artifactId>rest</artifactId>
-                <version>${elasticsearch-client-rest.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.elasticsearch.plugin</groupId>
-                <artifactId>transport-netty3-client</artifactId>
                 <version>${elasticsearch-client-transport.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.plugin</groupId>
                 <artifactId>transport-netty4-client</artifactId>
                 <version>${elasticsearch-client-transport.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-client</artifactId>
+                <version>${elasticsearch-client-rest.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.elasticsearch.plugin</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
         <snakeyaml.version>1.15</snakeyaml.version>
         <cucumber.version>1.2.4</cucumber.version>
         <spotify.version>8.15.1</spotify.version>
-        <elasticsearch.version>6.8.5</elasticsearch.version>
-        <elasticsearch-client-transport.version>6.8.5</elasticsearch-client-transport.version>
-        <elasticsearch-client-rest.version>6.8.5</elasticsearch-client-rest.version>
+        <elasticsearch.version>6.8.7</elasticsearch.version>
+        <elasticsearch-client-transport.version>6.8.7</elasticsearch-client-transport.version>
+        <elasticsearch-client-rest.version>6.8.7</elasticsearch-client-rest.version>
         <jackson.version>2.10.1</jackson.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->

--- a/pom.xml
+++ b/pom.xml
@@ -83,9 +83,9 @@
         <snakeyaml.version>1.15</snakeyaml.version>
         <cucumber.version>1.2.4</cucumber.version>
         <spotify.version>8.15.1</spotify.version>
-        <elasticsearch.version>6.3.2</elasticsearch.version>
-        <elasticsearch-client-transport.version>6.3.2</elasticsearch-client-transport.version>
-        <elasticsearch-client-rest.version>6.3.2</elasticsearch-client-rest.version>
+        <elasticsearch.version>6.8.5</elasticsearch.version>
+        <elasticsearch-client-transport.version>6.8.5</elasticsearch-client-transport.version>
+        <elasticsearch-client-rest.version>6.8.5</elasticsearch-client-rest.version>
         <jackson.version>2.10.1</jackson.version> <!-- Elastic Search uses 2.8.6 -->
         <log4j-api.version>2.8.2</log4j-api.version> <!-- same version used by elasticsearch -->
         <log4j-to-slf4j.version>2.8.2</log4j-to-slf4j.version> <!-- same version used by elasticsearch -->

--- a/pom.xml
+++ b/pom.xml
@@ -1441,6 +1441,11 @@
                 <version>${elasticsearch-client-rest.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.elasticsearch.client</groupId>
+                <artifactId>elasticsearch-rest-high-level-client</artifactId>
+                <version>${elasticsearch-client-rest.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>org.elasticsearch.plugin</groupId>
                 <artifactId>reindex-client</artifactId>
                 <version>${elasticsearch-client-transport.version}</version>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -197,10 +197,6 @@
         </dependency>
         <dependency>
             <groupId>org.elasticsearch.plugin</groupId>
-            <artifactId>transport-netty3-client</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>transport-netty4-client</artifactId>
         </dependency>
         <dependency>

--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/SchemaKeys.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/SchemaKeys.java
@@ -72,12 +72,6 @@ public class SchemaKeys {
      */
     public static final String SORT_DESCENDING_VALUE = "desc";
     /**
-     * All key
-     *
-     * @since 1.0.0
-     */
-    public static final String KEY_ALL = "_all";
-    /**
      * Format key
      *
      * @since 1.0.0
@@ -113,12 +107,6 @@ public class SchemaKeys {
      * @since 1.0.0
      */
     public static final String KEY_DYNAMIC = "dynamic";
-    /**
-     * Include in all key
-     *
-     * @since 1.0.0
-     */
-    public static final String KEY_INCLUDE_IN_ALL = "include_in_all";
     /**
      * Object binary type
      *

--- a/service/commons/elasticsearch/client-rest/pom.xml
+++ b/service/commons/elasticsearch/client-rest/pom.xml
@@ -37,7 +37,11 @@
         <!-- External dependencies -->
         <dependency>
             <groupId>org.elasticsearch.client</groupId>
-            <artifactId>rest</artifactId>
+            <artifactId>elasticsearch-rest-client</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.elasticsearch</groupId>
+            <artifactId>elasticsearch-x-content</artifactId>
         </dependency>
     </dependencies>
 </project>

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
@@ -16,8 +16,6 @@ import org.eclipse.kapua.service.elasticsearch.client.model.InsertRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 
 import javax.validation.constraints.NotNull;
-import java.io.UnsupportedEncodingException;
-import java.net.URLEncoder;
 
 /**
  * {@link RestElasticsearchClient} resource paths.
@@ -58,8 +56,8 @@ public class ElasticsearchResourcePaths {
     /**
      * @since 1.0.0
      */
-    public static String id(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) throws UnsupportedEncodingException {
-        return String.format("/%s/%s/%s", typeDescriptor.getIndex(), typeDescriptor.getType(), URLEncoder.encode(id, "UTF-8"));
+    public static String id(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) {
+        return String.format("/%s/%s/%s", typeDescriptor.getIndex(), typeDescriptor.getType(), id);
     }
 
     /**
@@ -111,7 +109,8 @@ public class ElasticsearchResourcePaths {
     /**
      * @since 1.0.0
      */
-    public static String upsert(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) throws UnsupportedEncodingException {
-        return String.format("/%s/%s/%s/_update", typeDescriptor.getIndex(), typeDescriptor.getType(), URLEncoder.encode(id, "UTF-8"));
+    public static String upsert(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) {
+        return String.format("/%s/%s/%s/_update", typeDescriptor.getIndex(), typeDescriptor.getType(), id);
     }
+
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/ElasticsearchResourcePaths.java
@@ -43,7 +43,7 @@ public class ElasticsearchResourcePaths {
      * @since 1.0.0
      */
     public static String deleteByQuery(@NotNull TypeDescriptor typeDescriptor) {
-        return String.format("/%s/%s/_delete_by_query", typeDescriptor.getIndex(), typeDescriptor.getType());
+        return String.format("/%s/_delete_by_query", typeDescriptor.getIndex());
     }
 
     /**
@@ -57,7 +57,7 @@ public class ElasticsearchResourcePaths {
      * @since 1.0.0
      */
     public static String id(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) {
-        return String.format("/%s/%s/%s", typeDescriptor.getIndex(), typeDescriptor.getType(), id);
+        return String.format("/%s/_doc/%s", typeDescriptor.getIndex(), id);
     }
 
     /**
@@ -82,14 +82,14 @@ public class ElasticsearchResourcePaths {
      * @since 1.0.0
      */
     public static String mapping(@NotNull TypeDescriptor typeDescriptor) {
-        return String.format("/%s/_mapping/%s", typeDescriptor.getIndex(), typeDescriptor.getType());
+        return String.format("/%s/_mapping?include_type_name=false", typeDescriptor.getIndex());
     }
 
     /**
      * @since 1.0.0
      */
     public static String search(@NotNull TypeDescriptor typeDescriptor) {
-        return String.format("/%s/%s/_search", typeDescriptor.getIndex(), typeDescriptor.getType());
+        return String.format("/%s/_search", typeDescriptor.getIndex());
     }
 
     /**
@@ -103,14 +103,14 @@ public class ElasticsearchResourcePaths {
      * @since 1.0.0
      */
     public static String type(@NotNull TypeDescriptor typeDescriptor) {
-        return String.format("/%s/%s", typeDescriptor.getIndex(), typeDescriptor.getType());
+        return String.format("/%s/_doc", typeDescriptor.getIndex());
     }
 
     /**
      * @since 1.0.0
      */
     public static String upsert(@NotNull TypeDescriptor typeDescriptor, @NotNull String id) {
-        return String.format("/%s/%s/%s/_update", typeDescriptor.getIndex(), typeDescriptor.getType(), id);
+        return String.format("/%s/_doc/%s/_update", typeDescriptor.getIndex(), id);
     }
 
 }

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -196,7 +196,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
             bulkOperation.append("{ \"update\": {\"_id\": \"")
                     .append(upsertRequest.getId())
                     .append("\", \"_type\": \"")
-                    .append(upsertRequest.getTypeDescriptor().getType())
+                    .append("_doc")
                     .append("\", \"_index\": \"")
                     .append(upsertRequest.getTypeDescriptor().getIndex())
                     .append("\"}\n");
@@ -454,7 +454,7 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
                         getClient()
                                 .performRequest(
                                         ElasticsearchKeywords.ACTION_PUT,
-                                        ElasticsearchResourcePaths.index(indexName),
+                                        ElasticsearchResourcePaths.index(indexName) + "?include_type_name=false",
                                         Collections.emptyMap(),
                                         ApplicationJsonEntityBuilder.buildFrom(json),
                                         new ContentTypeApplicationJsonHeader()),

--- a/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClient.java
@@ -36,7 +36,6 @@ import org.eclipse.kapua.service.elasticsearch.client.model.UpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateResponse;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexAction;
 import org.elasticsearch.action.admin.indices.delete.DeleteIndexRequest;
-import org.elasticsearch.action.admin.indices.delete.DeleteIndexResponse;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsRequest;
 import org.elasticsearch.action.admin.indices.exists.indices.IndicesExistsResponse;
 import org.elasticsearch.action.admin.indices.mapping.get.GetMappingsRequest;
@@ -52,6 +51,7 @@ import org.elasticsearch.action.delete.DeleteRequest;
 import org.elasticsearch.action.search.SearchPhaseExecutionException;
 import org.elasticsearch.action.search.SearchRequestBuilder;
 import org.elasticsearch.action.search.SearchResponse;
+import org.elasticsearch.action.support.master.AcknowledgedResponse;
 import org.elasticsearch.client.Client;
 import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
@@ -446,7 +446,7 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
         final DeleteIndexRequest request = DeleteIndexAction.INSTANCE.newRequestBuilder(client).request();
         request.indices(INDEXES_ALL);
         try {
-            DeleteIndexResponse deleteResponse = client.admin().indices().delete(request).actionGet(getQueryTimeout());
+            AcknowledgedResponse deleteResponse = client.admin().indices().delete(request).actionGet(getQueryTimeout());
             if (!deleteResponse.isAcknowledged()) {
                 throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_CANNOT_DELETE_INDEX_ERROR_MSG);
             }
@@ -462,7 +462,7 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
             request.indices(index);
             try {
                 LOG.debug("Deleting index {}", index);
-                DeleteIndexResponse deleteResponse = getClient().admin().indices().delete(request).actionGet(getQueryTimeout());
+                AcknowledgedResponse deleteResponse = getClient().admin().indices().delete(request).actionGet(getQueryTimeout());
                 if (!deleteResponse.isAcknowledged()) {
                     throw new ClientException(ClientErrorCodes.ACTION_ERROR, CLIENT_CANNOT_DELETE_INDEX_ERROR_MSG);
                 }

--- a/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClient.java
@@ -57,13 +57,13 @@ import org.elasticsearch.cluster.metadata.MappingMetaData;
 import org.elasticsearch.common.collect.ImmutableOpenMap;
 import org.elasticsearch.common.settings.Settings;
 import org.elasticsearch.common.unit.TimeValue;
+import org.elasticsearch.common.xcontent.LoggingDeprecationHandler;
 import org.elasticsearch.common.xcontent.NamedXContentRegistry;
 import org.elasticsearch.common.xcontent.XContentFactory;
 import org.elasticsearch.common.xcontent.XContentParser;
 import org.elasticsearch.common.xcontent.XContentType;
 import org.elasticsearch.index.IndexNotFoundException;
 import org.elasticsearch.index.VersionType;
-import org.elasticsearch.index.query.QueryParseContext;
 import org.elasticsearch.indices.InvalidIndexNameException;
 import org.elasticsearch.search.SearchHit;
 import org.elasticsearch.search.SearchHits;
@@ -240,7 +240,7 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
         Object queryFetchStyle = getModelConverter().getFetchStyle(query);
         if (searchHits != null) {
             for (SearchHit searchHit : searchHits) {
-                Map<String, Object> object = searchHit.getSource();
+                Map<String, Object> object = searchHit.getSourceAsMap();
                 object.put(ModelContext.TYPE_DESCRIPTOR_KEY, new TypeDescriptor(searchHit.getIndex(), searchHit.getType()));
                 object.put(getModelContext().getIdKeyName(), searchHit.getId());
                 object.put(QueryConverter.QUERY_FETCH_STYLE_KEY, queryFetchStyle);
@@ -326,10 +326,10 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
                 }
 
                 BulkRequest bulkRequest = new BulkRequest();
-                for (SearchHit hit : scrollResponse.getHits().hits()) {
-                    DeleteRequest delete = new DeleteRequest().index(hit.index())
-                            .type(hit.type())
-                            .id(hit.id());
+                for (SearchHit hit : scrollResponse.getHits().getHits()) {
+                    DeleteRequest delete = new DeleteRequest().index(hit.getIndex())
+                            .type(hit.getType())
+                            .id(hit.getId());
                     bulkRequest.add(delete);
                 }
 
@@ -431,10 +431,9 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
             searchSourceBuilder = new SearchSourceBuilder();
             SearchModule searchModule = new SearchModule(Settings.EMPTY, false, Collections.emptyList());
             XContentParser parser = XContentFactory.xContent(XContentType.JSON)
-                    .createParser(new NamedXContentRegistry(searchModule.getNamedXContents()), content);
-            searchSourceBuilder.parseXContent(new QueryParseContext(parser));
+                    .createParser(new NamedXContentRegistry(searchModule.getNamedXContents()), LoggingDeprecationHandler.INSTANCE, content);
+            searchSourceBuilder.parseXContent(parser);
             LOG.debug("Search builder: {}", searchSourceBuilder);
-
             return searchSourceBuilder;
         } catch (Exception e) {
             throw new ClientException(ClientErrorCodes.ACTION_ERROR, e, CLIENT_QUERY_PARSING_ERROR_MSG);
@@ -514,4 +513,5 @@ public class TransportElasticsearchClient extends AbstractElasticsearchClient<Cl
     public TimeValue getScrollTimeout() {
         return new TimeValue(MoreObjects.firstNonNull(getClientConfiguration().getRequestConfiguration().getScrollTimeout(), 60000));
     }
+
 }

--- a/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
@@ -24,7 +24,7 @@ import org.eclipse.kapua.service.elasticsearch.client.utils.InetAddressParser;
 import org.elasticsearch.client.transport.TransportClient;
 import org.elasticsearch.cluster.ClusterName;
 import org.elasticsearch.common.settings.Settings;
-import org.elasticsearch.common.transport.InetSocketTransportAddress;
+import org.elasticsearch.common.transport.TransportAddress;
 import org.elasticsearch.transport.client.PreBuiltTransportClient;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -117,7 +117,7 @@ public class TransportElasticsearchClientProvider implements ElasticsearchClient
                 InetAddressParser
                         .parseAddresses(getClientConfiguration().getNodes())
                         .stream()
-                        .map(InetSocketTransportAddress::new)
+                        .map(TransportAddress::new)
                         .forEachOrdered(internalElasticsearchTransportClient::addTransportAddress);
             } catch (Exception e) {
                 throw new ClientProviderInitException(e, "Error while parsing node addresses!");

--- a/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
+++ b/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
@@ -169,9 +169,16 @@ public class EsEmbeddedEngine implements Closeable {
     }
 
     private static class PluggableNode extends Node {
+
         public PluggableNode(Settings settings, Collection<Class<? extends Plugin>> plugins) {
-            super(InternalSettingsPreparer.prepareEnvironment(settings, null), plugins);
+            super(InternalSettingsPreparer.prepareEnvironment(settings, null), plugins, true);
         }
+
+        @Override
+        protected void registerDerivedNodeNameWithLogger(String s) {
+            // Nothing to do since we don't use node name in logger
+        }
+
     }
 
 }

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/IdsPredicateImpl.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/IdsPredicateImpl.java
@@ -109,7 +109,6 @@ public class IdsPredicateImpl extends StorablePredicateImpl implements IdsPredic
         ArrayNode idsList = newArrayNode(ids);
 
         ObjectNode idsNode = newObjectNode();
-        idsNode.set(PredicateConstants.TYPE_KEY, newTextNode(type));
         idsNode.set(PredicateConstants.VALUES_KEY, idsList);
 
         ObjectNode rootNode = newObjectNode();

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/PredicateConstants.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/PredicateConstants.java
@@ -83,13 +83,6 @@ public interface PredicateConstants {
     String TERM_KEY = "term";
 
     /**
-     * Type term.
-     *
-     * @since 1.0.0
-     */
-    String TYPE_KEY = "type";
-
-    /**
      * Values term.
      *
      * @since 1.0.0

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -102,9 +102,9 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
                     ChannelInfo storedField = find(channelInfo.getScopeId(), storableId);
                     if (storedField == null) {
                         Metadata metadata = mediator.getMetadata(channelInfo.getScopeId(), channelInfo.getFirstMessageOn().getTime());
-                        String registryIndexName = metadata.getRegistryIndexName();
+                        String registryIndexName = metadata.getChannelRegistryIndexName();
 
-                        UpdateRequest request = new UpdateRequest(channelInfo.getId().toString(), new TypeDescriptor(metadata.getRegistryIndexName(), ChannelInfoSchema.CHANNEL_TYPE_NAME), channelInfo);
+                        UpdateRequest request = new UpdateRequest(channelInfo.getId().toString(), new TypeDescriptor(metadata.getChannelRegistryIndexName(), ChannelInfoSchema.CHANNEL_TYPE_NAME), channelInfo);
                         response = getElasticsearchClient().upsert(request);
 
                         LOG.debug("Upsert on channel successfully executed [{}.{}, {} - {}]", registryIndexName, ChannelInfoSchema.CHANNEL_TYPE_NAME, channelInfoId, response.getId());
@@ -138,7 +138,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(scopeId);
+        String indexName = SchemaUtil.getChannelIndexName(scopeId);
         ChannelInfo channelInfo = find(scopeId, id);
         if (channelInfo != null) {
             mediator.onBeforeChannelInfoDelete(channelInfo);
@@ -191,7 +191,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
             return new ChannelInfoListResultImpl();
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getChannelIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ChannelInfoSchema.CHANNEL_TYPE_NAME);
         return new ChannelInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ChannelInfo.class));
     }
@@ -214,7 +214,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
             return 0;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getChannelIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ChannelInfoSchema.CHANNEL_TYPE_NAME);
         return getElasticsearchClient().count(typeDescriptor, query);
     }
@@ -239,7 +239,7 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getChannelIndexName(query.getScopeId());
         ChannelInfoListResult channels = query(query);
 
         for (ChannelInfo channelInfo : channels.getItems()) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -103,7 +103,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
                     ClientInfo storedField = find(clientInfo.getScopeId(), storableId);
                     if (storedField == null) {
                         Metadata metadata = mediator.getMetadata(clientInfo.getScopeId(), clientInfo.getFirstMessageOn().getTime());
-                        String kapuaIndexName = metadata.getRegistryIndexName();
+                        String kapuaIndexName = metadata.getClientRegistryIndexName();
 
                         UpdateRequest request = new UpdateRequest(clientInfo.getId().toString(), new TypeDescriptor(kapuaIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), clientInfo);
                         response = getElasticsearchClient().upsert(request);
@@ -138,7 +138,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(scopeId);
+        String indexName = SchemaUtil.getClientIndexName(scopeId);
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
         getElasticsearchClient().delete(typeDescriptor, id.toString());
     }
@@ -186,7 +186,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
             return new ClientInfoListResultImpl();
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getClientIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
         return new ClientInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ClientInfo.class));
     }
@@ -209,7 +209,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
             return 0;
         }
 
-        String dataIndexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String dataIndexName = SchemaUtil.getClientIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(dataIndexName, ClientInfoSchema.CLIENT_TYPE_NAME);
         return getElasticsearchClient().count(typeDescriptor, query);
     }
@@ -233,7 +233,7 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getClientIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
         getElasticsearchClient().deleteByQuery(typeDescriptor, query);
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -100,9 +100,9 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
             if (storedField == null) {
                 Metadata metadata = mediator.getMetadata(metricInfo.getScopeId(), metricInfo.getFirstMessageOn().getTime());
 
-                String kapuaIndexName = metadata.getRegistryIndexName();
+                String kapuaIndexName = metadata.getMetricRegistryIndexName();
 
-                UpdateRequest request = new UpdateRequest(metricInfo.getId().toString(), new TypeDescriptor(metadata.getRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo);
+                UpdateRequest request = new UpdateRequest(metricInfo.getId().toString(), new TypeDescriptor(metadata.getMetricRegistryIndexName(), MetricInfoSchema.METRIC_TYPE_NAME), metricInfo);
                 response = getElasticsearchClient().upsert(request);
 
                 LOG.debug("Upsert on metric successfully executed [{}.{}, {} - {}]", kapuaIndexName, MetricInfoSchema.METRIC_TYPE_NAME, metricInfoId, response.getId());
@@ -148,7 +148,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
                 bulkRequest.add(
                         new UpdateRequest(
                                 metricInfo.getId().toString(),
-                                new TypeDescriptor(metadata.getRegistryIndexName(),
+                                new TypeDescriptor(metadata.getMetricRegistryIndexName(),
                                         MetricInfoSchema.METRIC_TYPE_NAME),
                                 metricInfo)
                 );
@@ -208,7 +208,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(scopeId);
+        String indexName = SchemaUtil.getMetricIndexName(scopeId);
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, MetricInfoSchema.METRIC_TYPE_NAME);
         getElasticsearchClient().delete(typeDescriptor, id.toString());
     }
@@ -256,7 +256,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
             return new MetricInfoListResultImpl();
         }
 
-        String indexNme = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexNme = SchemaUtil.getMetricIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexNme, MetricInfoSchema.METRIC_TYPE_NAME);
         ResultList<MetricInfo> result = getElasticsearchClient().query(typeDescriptor, query, MetricInfo.class);
         return new MetricInfoListResultImpl(result);
@@ -280,7 +280,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
             return 0;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getMetricIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, MetricInfoSchema.METRIC_TYPE_NAME);
         return getElasticsearchClient().count(typeDescriptor, query);
     }
@@ -304,7 +304,7 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
             return;
         }
 
-        String indexName = SchemaUtil.getKapuaIndexName(query.getScopeId());
+        String indexName = SchemaUtil.getMetricIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, MetricInfoSchema.METRIC_TYPE_NAME);
         getElasticsearchClient().deleteByQuery(typeDescriptor, query);
     }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -52,7 +52,6 @@ import java.util.regex.Pattern;
 public class DatastoreUtils {
 
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreUtils.class);
-//    private static final MessageStoreService MESSAGE_STORE_SERVICE = KapuaLocator.getInstance().getService(MessageStoreService.class);
 
     private enum IndexType { CHANNEL, CLIENT, METRIC }
 
@@ -91,6 +90,8 @@ public class DatastoreUtils {
     public static final String INDEXING_WINDOW_OPTION_WEEK = "week";
     public static final String INDEXING_WINDOW_OPTION_DAY = "day";
     public static final String INDEXING_WINDOW_OPTION_HOUR = "hour";
+
+    public static final String DATASTORE_DATE_FORMAT = "8" + KapuaDateUtils.ISO_DATE_PATTERN; // example 2017-01-24T11:22:10.999Z
 
     private static final DateTimeFormatter DATA_INDEX_FORMATTER_WEEK = new DateTimeFormatterBuilder()
             .parseDefaulting(WeekFields.ISO.dayOfWeek(), 1)
@@ -627,7 +628,7 @@ public class DatastoreUtils {
                     convertedValue = KapuaDateUtils.parseDate((String) value);
                 } catch (ParseException e) {
                     throw new IllegalArgumentException(
-                            String.format("Type [%s] cannot be converted to Date. Allowed format [%s] - Value to convert [%s]!", getValueClass(value), KapuaDateUtils.ISO_DATE_PATTERN,
+                            String.format("Type [%s] cannot be converted to Date. Allowed format [%s] - Value to convert [%s]!", getValueClass(value), DATASTORE_DATE_FORMAT,
                                     value));
                 }
             } else {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -54,6 +54,8 @@ public class DatastoreUtils {
     private static final Logger LOG = LoggerFactory.getLogger(DatastoreUtils.class);
 //    private static final MessageStoreService MESSAGE_STORE_SERVICE = KapuaLocator.getInstance().getService(MessageStoreService.class);
 
+    private enum IndexType { CHANNEL, CLIENT, METRIC }
+
     private DatastoreUtils() {
     }
 
@@ -290,6 +292,18 @@ public class DatastoreUtils {
         return sb.toString();
     }
 
+    public static String getChannelIndexName(KapuaId scopeId) {
+        return getRegistryIndexName(scopeId, IndexType.CHANNEL);
+    }
+
+    public static String getClientIndexName(KapuaId scopeId) {
+        return getRegistryIndexName(scopeId, IndexType.CLIENT);
+    }
+
+    public static String getMetricIndexName(KapuaId scopeId) {
+        return getRegistryIndexName(scopeId, IndexType.METRIC);
+    }
+
     /**
      * Get the Kapua index name for the specified base name
      *
@@ -297,7 +311,7 @@ public class DatastoreUtils {
      * @return
      * @since 1.0.0
      */
-    public static String getRegistryIndexName(KapuaId scopeId) {
+    private static String getRegistryIndexName(KapuaId scopeId, IndexType indexType) {
         final StringBuilder sb = new StringBuilder();
         final String prefix = DatastoreSettings.getInstance().getString(DatastoreSettingsKey.INDEX_PREFIX);
         if (StringUtils.isNotEmpty(prefix)) {
@@ -305,6 +319,7 @@ public class DatastoreUtils {
         }
         String indexName = DatastoreUtils.normalizedIndexName(scopeId.toStringId());
         sb.append(".").append(indexName);
+        sb.append("-").append(indexType.name().toLowerCase());
         return sb.toString();
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/mediator/DatastoreUtils.java
@@ -138,7 +138,7 @@ public class DatastoreUtils {
 
         // ES 5.2 FIX
         // return Base64.encodeBytes(hashCode);
-        return Base64.getEncoder().encodeToString(hashCode);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(hashCode);
     }
 
     private static String normalizeIndexName(String name) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -81,8 +81,8 @@ public class ChannelInfoSchema {
      * @since 1.0.0
      */
     public static JsonNode getChannelTypeSchema(boolean sourceEnable) throws MappingException {
-
         ObjectNode channelNode = MappingUtils.newObjectNode();
+
         {
             ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             channelNode.set(SchemaKeys.KEY_SOURCE, sourceChannel);
@@ -106,10 +106,7 @@ public class ChannelInfoSchema {
             }
             channelNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
         }
-
-        ObjectNode rootNode = MappingUtils.newObjectNode();
-        rootNode.set(CHANNEL_TYPE_NAME, channelNode);
-        return rootNode;
+        return channelNode;
     }
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -75,21 +75,17 @@ public class ChannelInfoSchema {
     /**
      * Create and return the Json representation of the channel info schema
      *
-     * @param allEnable
      * @param sourceEnable
      * @return
      * @throws MappingException
      * @since 1.0.0
      */
-    public static JsonNode getChannelTypeSchema(boolean allEnable, boolean sourceEnable) throws MappingException {
+    public static JsonNode getChannelTypeSchema(boolean sourceEnable) throws MappingException {
 
         ObjectNode channelNode = MappingUtils.newObjectNode();
         {
             ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             channelNode.set(SchemaKeys.KEY_SOURCE, sourceChannel);
-
-            ObjectNode allChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
-            channelNode.set(SchemaKeys.KEY_ALL, allChannel);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link ChannelInfo} schema definition.
@@ -98,7 +98,7 @@ public class ChannelInfoSchema {
                 ObjectNode channelName = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CHANNEL_NAME, channelName);
 
-                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(CHANNEL_TIMESTAMP, channelTimestamp);
 
                 ObjectNode channelMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ChannelInfoSchema.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.datastore.internal.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
@@ -84,30 +85,30 @@ public class ChannelInfoSchema {
 
         ObjectNode channelNode = MappingUtils.newObjectNode();
         {
-            ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
+            ObjectNode sourceChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             channelNode.set(SchemaKeys.KEY_SOURCE, sourceChannel);
 
-            ObjectNode allChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable)});
+            ObjectNode allChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
             channelNode.set(SchemaKeys.KEY_ALL, allChannel);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode channelScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode channelScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CHANNEL_SCOPE_ID, channelScopeId);
 
-                ObjectNode channelClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode channelClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CHANNEL_CLIENT_ID, channelClientId);
 
-                ObjectNode channelName = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode channelName = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CHANNEL_NAME, channelName);
 
-                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode channelTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(CHANNEL_TIMESTAMP, channelTimestamp);
 
-                ObjectNode channelMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode channelMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CHANNEL_MESSAGE_ID, channelMessageId);
             }
-            channelNode.set("properties", propertiesNode);
+            channelNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
         }
 
         ObjectNode rootNode = MappingUtils.newObjectNode();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -80,10 +80,10 @@ public class ClientInfoSchema {
      */
     public static JsonNode getClientTypeSchema(boolean sourceEnable) throws MappingException {
 
-        ObjectNode clientNodeName = MappingUtils.newObjectNode();
+        ObjectNode clientNode = MappingUtils.newObjectNode();
         {
             ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
-            clientNodeName.set(SchemaKeys.KEY_SOURCE, sourceClient);
+            clientNode.set(SchemaKeys.KEY_SOURCE, sourceClient);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
@@ -99,12 +99,10 @@ public class ClientInfoSchema {
                 ObjectNode clientMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CLIENT_MESSAGE_ID, clientMessageId);
             }
-            clientNodeName.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
+            clientNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
         }
 
-        ObjectNode rootNode = MappingUtils.newObjectNode();
-        rootNode.set(CLIENT_TYPE_NAME, clientNodeName);
-        return rootNode;
+        return clientNode;
     }
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link ClientInfo} schema definition.
@@ -90,7 +90,7 @@ public class ClientInfoSchema {
                 ObjectNode clientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CLIENT_ID, clientId);
 
-                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(CLIENT_TIMESTAMP, clientTimestamp);
 
                 ObjectNode clientScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.datastore.internal.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
@@ -82,24 +83,24 @@ public class ClientInfoSchema {
 
         ObjectNode clientNodeName = MappingUtils.newObjectNode();
         {
-            ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
+            ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             clientNodeName.set(SchemaKeys.KEY_SOURCE, sourceClient);
 
-            ObjectNode allClient = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable)});
+            ObjectNode allClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
             clientNodeName.set(SchemaKeys.KEY_ALL, allClient);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode clientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode clientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CLIENT_ID, clientId);
 
-                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode clientTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(CLIENT_TIMESTAMP, clientTimestamp);
 
-                ObjectNode clientScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode clientScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CLIENT_SCOPE_ID, clientScopeId);
 
-                ObjectNode clientMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode clientMessageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(CLIENT_MESSAGE_ID, clientMessageId);
             }
             clientNodeName.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/ClientInfoSchema.java
@@ -73,21 +73,17 @@ public class ClientInfoSchema {
     /**
      * Create and return the Json representation of the client info schema
      *
-     * @param allEnable
      * @param sourceEnable
      * @return
      * @throws MappingException
      * @since 1.0.0
      */
-    public static JsonNode getClientTypeSchema(boolean allEnable, boolean sourceEnable) throws MappingException {
+    public static JsonNode getClientTypeSchema(boolean sourceEnable) throws MappingException {
 
         ObjectNode clientNodeName = MappingUtils.newObjectNode();
         {
             ObjectNode sourceClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             clientNodeName.set(SchemaKeys.KEY_SOURCE, sourceClient);
-
-            ObjectNode allClient = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
-            clientNodeName.set(SchemaKeys.KEY_ALL, allClient);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -270,20 +270,16 @@ public class MessageSchema {
     /**
      * Create and return the Json representation of the message schema
      *
-     * @param allEnable
      * @param sourceEnable
      * @return
      * @throws MappingException
      * @since 1.0.0
      */
-    public static JsonNode getMesageTypeSchema(boolean allEnable, boolean sourceEnable) throws MappingException {
+    public static JsonNode getMesageTypeSchema(boolean sourceEnable) throws MappingException {
         ObjectNode messageNode = MappingUtils.newObjectNode();
         {
             ObjectNode sourceMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             messageNode.set(SchemaKeys.KEY_SOURCE, sourceMessage);
-
-            ObjectNode allMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
-            messageNode.set(SchemaKeys.KEY_ALL, allMessage);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
@@ -319,7 +315,7 @@ public class MessageSchema {
 
                 ObjectNode positionNode = MappingUtils.newObjectNode(
                         new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
+                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false)  });
 
                 ObjectNode positionPropertiesNode = MappingUtils.newObjectNode();
                 {
@@ -355,7 +351,7 @@ public class MessageSchema {
 
             ObjectNode messageMetrics = MappingUtils.newObjectNode(
                     new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true)  });
             propertiesNode.set(MESSAGE_METRICS, messageMetrics);
 
             ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -315,7 +315,7 @@ public class MessageSchema {
 
                 ObjectNode positionNode = MappingUtils.newObjectNode(
                         new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false)  });
+                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false) });
 
                 ObjectNode positionPropertiesNode = MappingUtils.newObjectNode();
                 {
@@ -351,7 +351,7 @@ public class MessageSchema {
 
             ObjectNode messageMetrics = MappingUtils.newObjectNode(
                     new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true)  });
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true) });
             propertiesNode.set(MESSAGE_METRICS, messageMetrics);
 
             ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.message.Message;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link Message} schema definition.
@@ -286,10 +286,10 @@ public class MessageSchema {
                 ObjectNode messageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_ID, messageId);
 
-                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(MESSAGE_TIMESTAMP, messageTimestamp);
 
-                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(MESSAGE_RECEIVED_ON, messageReceivedOn);
 
                 ObjectNode messageIp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_IP) });
@@ -307,10 +307,10 @@ public class MessageSchema {
                 ObjectNode messageChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_CHANNEL, messageChannel);
 
-                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(MESSAGE_CAPTURED_ON, messageCapturedOn);
 
-                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 propertiesNode.set(MESSAGE_SENT_ON, messageSentOn);
 
                 ObjectNode positionNode = MappingUtils.newObjectNode(
@@ -334,7 +334,7 @@ public class MessageSchema {
                     ObjectNode messagePositionPropSpeed = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
                     positionPropertiesNode.set(MESSAGE_POS_SPEED, messagePositionPropSpeed);
 
-                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                     positionPropertiesNode.set(MESSAGE_POS_TIMESTAMP, messagePositionPropTime);
 
                     ObjectNode messagePositionPropSat = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MessageSchema.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.datastore.internal.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.message.Message;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
@@ -278,72 +279,72 @@ public class MessageSchema {
     public static JsonNode getMesageTypeSchema(boolean allEnable, boolean sourceEnable) throws MappingException {
         ObjectNode messageNode = MappingUtils.newObjectNode();
         {
-            ObjectNode sourceMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
+            ObjectNode sourceMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
             messageNode.set(SchemaKeys.KEY_SOURCE, sourceMessage);
 
-            ObjectNode allMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable)});
+            ObjectNode allMessage = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
             messageNode.set(SchemaKeys.KEY_ALL, allMessage);
 
             ObjectNode propertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode messageId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode messageId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_ID, messageId);
 
-                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode messageTimestamp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(MESSAGE_TIMESTAMP, messageTimestamp);
 
-                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode messageReceivedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(MESSAGE_RECEIVED_ON, messageReceivedOn);
 
-                ObjectNode messageIp = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_IP)});
+                ObjectNode messageIp = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_IP) });
                 propertiesNode.set(MESSAGE_IP_ADDRESS, messageIp);
 
-                ObjectNode messageScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode messageScopeId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_SCOPE_ID, messageScopeId);
 
-                ObjectNode messageDeviceId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode messageDeviceId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_DEVICE_ID, messageDeviceId);
 
-                ObjectNode messageClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode messageClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_CLIENT_ID, messageClientId);
 
-                ObjectNode messageChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode messageChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 propertiesNode.set(MESSAGE_CHANNEL, messageChannel);
 
-                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode messageCapturedOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(MESSAGE_CAPTURED_ON, messageCapturedOn);
 
-                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode messageSentOn = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 propertiesNode.set(MESSAGE_SENT_ON, messageSentOn);
 
                 ObjectNode positionNode = MappingUtils.newObjectNode(
-                        new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false)});
+                        new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                                new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
 
                 ObjectNode positionPropertiesNode = MappingUtils.newObjectNode();
                 {
-                    ObjectNode messagePositionPropLocation = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_GEO_POINT)});
+                    ObjectNode messagePositionPropLocation = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_GEO_POINT) });
                     positionPropertiesNode.set(MESSAGE_POS_LOCATION, messagePositionPropLocation);
 
-                    ObjectNode messagePositionPropAlt = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
+                    ObjectNode messagePositionPropAlt = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
                     positionPropertiesNode.set(MESSAGE_POS_ALT, messagePositionPropAlt);
 
-                    ObjectNode messagePositionPropPrec = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
+                    ObjectNode messagePositionPropPrec = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
                     positionPropertiesNode.set(MESSAGE_POS_PRECISION, messagePositionPropPrec);
 
-                    ObjectNode messagePositionPropHead = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
+                    ObjectNode messagePositionPropHead = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
                     positionPropertiesNode.set(MESSAGE_POS_HEADING, messagePositionPropHead);
 
-                    ObjectNode messagePositionPropSpeed = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE)});
+                    ObjectNode messagePositionPropSpeed = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DOUBLE) });
                     positionPropertiesNode.set(MESSAGE_POS_SPEED, messagePositionPropSpeed);
 
-                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                    ObjectNode messagePositionPropTime = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                     positionPropertiesNode.set(MESSAGE_POS_TIMESTAMP, messagePositionPropTime);
 
-                    ObjectNode messagePositionPropSat = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER)});
+                    ObjectNode messagePositionPropSat = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER) });
                     positionPropertiesNode.set(MESSAGE_POS_SATELLITES, messagePositionPropSat);
 
-                    ObjectNode messagePositionPropStat = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER)});
+                    ObjectNode messagePositionPropStat = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_INTEGER) });
                     positionPropertiesNode.set(MESSAGE_POS_STATUS, messagePositionPropStat);
                 }
                 positionNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, positionPropertiesNode);
@@ -353,11 +354,11 @@ public class MessageSchema {
             messageNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
 
             ObjectNode messageMetrics = MappingUtils.newObjectNode(
-                    new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false)});
+                    new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, true), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
             propertiesNode.set(MESSAGE_METRICS, messageMetrics);
 
-            ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE)});
+            ObjectNode messageBody = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_BINARY), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_FALSE) });
             propertiesNode.set(MESSAGE_BODY, messageBody);
         }
         return messageNode;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Metadata.java
@@ -25,14 +25,16 @@ import java.util.Map;
 public class Metadata {
 
     // Info fields does not change within the same account name
-    private String dataIndexName;
-    private String registryIndexName;
+    private final String dataIndexName;
+    private final String channelRegistryIndexName;
+    private final String clientRegistryIndexName;
+    private final String metricRegistryIndexName;
     //
 
     // Custom mappings can only increase within the same account
     // No removal of existing cached mappings or changes in the
     // existing mappings.
-    private Map<String, Metric> messageMappingsCache;
+    private final Map<String, Metric> messageMappingsCache;
     //
 
     /**
@@ -46,14 +48,16 @@ public class Metadata {
     }
 
     /**
-     * Contructor.
+     * Constructor.
      *
      * @since 1.0.0
      */
-    public Metadata(String dataIndexName, String registryIndexName) {
-        messageMappingsCache = new HashMap<>(100);
+    public Metadata(String dataIndexName, String channelRegistryIndexName, String clientRegistryIndexName, String metricRegistryIndexName) {
+        this.messageMappingsCache = new HashMap<>(100);
         this.dataIndexName = dataIndexName;
-        this.registryIndexName = registryIndexName;
+        this.channelRegistryIndexName = channelRegistryIndexName;
+        this.clientRegistryIndexName = clientRegistryIndexName;
+        this.metricRegistryIndexName = metricRegistryIndexName;
     }
 
     /**
@@ -67,12 +71,32 @@ public class Metadata {
     }
 
     /**
-     * Get the Kapua data index name
+     * Get the Kapua channel index name
      *
      * @return
-     * @since 1.0.0
+     * @since 1.4.0
      */
-    public String getRegistryIndexName() {
-        return registryIndexName;
+    public String getChannelRegistryIndexName() {
+        return channelRegistryIndexName;
+    }
+
+    /**
+     * Get the Kapua client index name
+     *
+     * @return
+     * @since 1.4.0
+     */
+    public String getClientRegistryIndexName() {
+        return clientRegistryIndexName;
+    }
+
+    /**
+     * Get the Kapua metric index name
+     *
+     * @return
+     * @since 1.4.0
+     */
+    public String getMetricRegistryIndexName() {
+        return metricRegistryIndexName;
     }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -150,10 +150,10 @@ public class MetricInfoSchema {
      */
     public static JsonNode getMetricTypeSchema(boolean sourceEnable) throws MappingException {
 
-        ObjectNode metricName = MappingUtils.newObjectNode();
+        ObjectNode metricNode = MappingUtils.newObjectNode();
 
         ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
-        metricName.set(SchemaKeys.KEY_SOURCE, sourceMetric);
+        metricNode.set(SchemaKeys.KEY_SOURCE, sourceMetric);
 
         ObjectNode propertiesNode = MappingUtils.newObjectNode();
         {
@@ -190,11 +190,9 @@ public class MetricInfoSchema {
 
             propertiesNode.set(METRIC_MTR, metricMtrNode);
         }
-        metricName.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
+        metricNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, propertiesNode);
 
-        ObjectNode rootNode = MappingUtils.newObjectNode();
-        rootNode.set(METRIC_TYPE_NAME, metricName);
-        return rootNode;
+        return metricNode;
     }
 
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -12,15 +12,15 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.schema;
 
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.node.ObjectNode;
-
-import org.eclipse.kapua.commons.util.KapuaDateUtils;
+import org.eclipse.kapua.service.datastore.internal.mediator.DatastoreUtils;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 
 /**
  * {@link MetricInfo} schema definition.
@@ -180,7 +180,7 @@ public class MetricInfoSchema {
                 ObjectNode metricMtrValueNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 metricMtrPropertiesNode.set(METRIC_MTR_VALUE, metricMtrValueNode);
 
-                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
+                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT) });
                 metricMtrPropertiesNode.set(METRIC_MTR_TIMESTAMP, metricMtrTimestampNode);
 
                 ObjectNode metricMtrMsgIdNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -143,21 +143,17 @@ public class MetricInfoSchema {
     /**
      * Create and return the Json representation of the metric info schema
      *
-     * @param allEnable
      * @param sourceEnable
      * @return
      * @throws MappingException
      * @since 1.0.0
      */
-    public static JsonNode getMetricTypeSchema(boolean allEnable, boolean sourceEnable) throws MappingException {
+    public static JsonNode getMetricTypeSchema(boolean sourceEnable) throws MappingException {
 
         ObjectNode metricName = MappingUtils.newObjectNode();
 
         ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
         metricName.set(SchemaKeys.KEY_SOURCE, sourceMetric);
-
-        ObjectNode allMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
-        metricName.set(SchemaKeys.KEY_ALL, allMetric);
 
         ObjectNode propertiesNode = MappingUtils.newObjectNode();
         {
@@ -172,7 +168,7 @@ public class MetricInfoSchema {
 
             ObjectNode metricMtrNode = MappingUtils.newObjectNode(
                     new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false) });
             ObjectNode metricMtrPropertiesNode = MappingUtils.newObjectNode();
             {
                 ObjectNode metricMtrNameNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/MetricInfoSchema.java
@@ -14,6 +14,7 @@ package org.eclipse.kapua.service.datastore.internal.schema;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+
 import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.elasticsearch.client.SchemaKeys;
@@ -152,41 +153,41 @@ public class MetricInfoSchema {
 
         ObjectNode metricName = MappingUtils.newObjectNode();
 
-        ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable)});
+        ObjectNode sourceMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, sourceEnable) });
         metricName.set(SchemaKeys.KEY_SOURCE, sourceMetric);
 
-        ObjectNode allMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable)});
+        ObjectNode allMetric = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_ENABLED, allEnable) });
         metricName.set(SchemaKeys.KEY_ALL, allMetric);
 
         ObjectNode propertiesNode = MappingUtils.newObjectNode();
         {
-            ObjectNode metricAccount = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+            ObjectNode metricAccount = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
             propertiesNode.set(METRIC_SCOPE_ID, metricAccount);
 
-            ObjectNode metricClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+            ObjectNode metricClientId = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
             propertiesNode.set(METRIC_CLIENT_ID, metricClientId);
 
-            ObjectNode metricChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+            ObjectNode metricChannel = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
             propertiesNode.set(METRIC_CHANNEL, metricChannel);
 
             ObjectNode metricMtrNode = MappingUtils.newObjectNode(
-                    new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
-                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false)});
+                    new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_OBJECT), new KeyValueEntry(SchemaKeys.KEY_ENABLED, true),
+                            new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, false), new KeyValueEntry(SchemaKeys.KEY_INCLUDE_IN_ALL, false) });
             ObjectNode metricMtrPropertiesNode = MappingUtils.newObjectNode();
             {
-                ObjectNode metricMtrNameNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode metricMtrNameNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 metricMtrPropertiesNode.set(METRIC_MTR_NAME, metricMtrNameNode);
 
-                ObjectNode metricMtrTypeNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode metricMtrTypeNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 metricMtrPropertiesNode.set(METRIC_MTR_TYPE, metricMtrTypeNode);
 
-                ObjectNode metricMtrValueNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode metricMtrValueNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 metricMtrPropertiesNode.set(METRIC_MTR_VALUE, metricMtrValueNode);
 
-                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                ObjectNode metricMtrTimestampNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN) });
                 metricMtrPropertiesNode.set(METRIC_MTR_TIMESTAMP, metricMtrTimestampNode);
 
-                ObjectNode metricMtrMsgIdNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE)});
+                ObjectNode metricMtrMsgIdNode = MappingUtils.newObjectNode(new KeyValueEntry[]{ new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_KEYWORD), new KeyValueEntry(SchemaKeys.KEY_INDEX, SchemaKeys.VALUE_TRUE) });
                 metricMtrPropertiesNode.set(METRIC_MTR_MSG_ID, metricMtrMsgIdNode);
             }
             metricMtrNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, metricMtrPropertiesNode);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -180,12 +180,10 @@ public class Schema {
         }
         // metrics mapping container (to be added to message mapping)
         ObjectNode typeNode = MappingUtils.newObjectNode(); // root
-        ObjectNode messageNode = MappingUtils.newObjectNode(); // message
         ObjectNode typePropertiesNode = MappingUtils.newObjectNode(); // properties
         ObjectNode metricsNode = MappingUtils.newObjectNode(); // metrics
         ObjectNode metricsPropertiesNode = MappingUtils.newObjectNode(); // properties (metric properties)
-        typeNode.set(SchemaKeys.FIELD_NAME_MESSAGE, messageNode);
-        messageNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, typePropertiesNode);
+        typeNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, typePropertiesNode);
         typePropertiesNode.set(SchemaKeys.FIELD_NAME_METRICS, metricsNode);
         metricsNode.set(SchemaKeys.FIELD_NAME_PROPERTIES, metricsPropertiesNode);
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.datastore.internal.schema;
 
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.util.KapuaDateUtils;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.internal.DatastoreCacheManager;
 import org.eclipse.kapua.service.datastore.internal.client.DatastoreClientFactory;
@@ -33,6 +32,7 @@ import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.model.utils.KeyValueEntry;
 import org.eclipse.kapua.service.storable.model.utils.MappingUtils;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -202,7 +202,7 @@ public class Schema {
                     break;
                 case SchemaKeys.TYPE_DATE:
                     valueMappingNode = MappingUtils.newObjectNode(
-                            new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, KapuaDateUtils.ISO_DATE_PATTERN)});
+                            new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, SchemaKeys.TYPE_DATE), new KeyValueEntry(SchemaKeys.KEY_FORMAT, DatastoreUtils.DATASTORE_DATE_FORMAT)});
                     break;
                 default:
                     valueMappingNode = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_TYPE, metric.getType())});

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -83,10 +83,9 @@ public class Schema {
                 LOG.info("Data index created: {}", dataIndexName);
             }
 
-            boolean enableAllField = false;
             boolean enableSourceField = true;
 
-            elasticsearchClient.putMapping(new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME), MessageSchema.getMesageTypeSchema(enableAllField, enableSourceField));
+            elasticsearchClient.putMapping(new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME), MessageSchema.getMesageTypeSchema(enableSourceField));
 
             // Check existence of the kapua internal indexes
             String channelRegistryIndexName = DatastoreUtils.getChannelIndexName(scopeId);
@@ -95,7 +94,7 @@ public class Schema {
                 elasticsearchClient.createIndex(channelRegistryIndexName, getMappingSchema(channelRegistryIndexName));
                 LOG.info("Channel Metadata index created: {}", channelRegistryIndexExistsResponse);
 
-                elasticsearchClient.putMapping(new TypeDescriptor(channelRegistryIndexName, ChannelInfoSchema.CHANNEL_TYPE_NAME), ChannelInfoSchema.getChannelTypeSchema(enableAllField, enableSourceField));
+                elasticsearchClient.putMapping(new TypeDescriptor(channelRegistryIndexName, ChannelInfoSchema.CHANNEL_TYPE_NAME), ChannelInfoSchema.getChannelTypeSchema(enableSourceField));
             }
 
             String clientRegistryIndexName = DatastoreUtils.getClientIndexName(scopeId);
@@ -104,7 +103,7 @@ public class Schema {
                 elasticsearchClient.createIndex(clientRegistryIndexName, getMappingSchema(clientRegistryIndexName));
                 LOG.info("Client Metadata index created: {}", clientRegistryIndexExistsResponse);
 
-                elasticsearchClient.putMapping(new TypeDescriptor(clientRegistryIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), ClientInfoSchema.getClientTypeSchema(enableAllField, enableSourceField));
+                elasticsearchClient.putMapping(new TypeDescriptor(clientRegistryIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), ClientInfoSchema.getClientTypeSchema(enableSourceField));
             }
 
             String metricRegistryIndexName = DatastoreUtils.getMetricIndexName(scopeId);
@@ -113,7 +112,7 @@ public class Schema {
                 elasticsearchClient.createIndex(metricRegistryIndexName, getMappingSchema(metricRegistryIndexName));
                 LOG.info("Metric Metadata index created: {}", metricRegistryIndexExistsResponse);
 
-                elasticsearchClient.putMapping(new TypeDescriptor(metricRegistryIndexName, MetricInfoSchema.METRIC_TYPE_NAME), MetricInfoSchema.getMetricTypeSchema(enableAllField, enableSourceField));
+                elasticsearchClient.putMapping(new TypeDescriptor(metricRegistryIndexName, MetricInfoSchema.METRIC_TYPE_NAME), MetricInfoSchema.getMetricTypeSchema(enableSourceField));
             }
 
             currentMetadata = new Metadata(dataIndexName, channelRegistryIndexName, clientRegistryIndexName, metricRegistryIndexName);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/Schema.java
@@ -50,14 +50,6 @@ public class Schema {
     private static final Logger LOG = LoggerFactory.getLogger(Schema.class);
 
     /**
-     * Constructor.
-     *
-     * @since 1.0.0
-     */
-    public Schema() {
-    }
-
-    /**
      * Synchronize metadata
      *
      * @param scopeId
@@ -95,19 +87,36 @@ public class Schema {
             boolean enableSourceField = true;
 
             elasticsearchClient.putMapping(new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME), MessageSchema.getMesageTypeSchema(enableAllField, enableSourceField));
-            // Check existence of the kapua internal index
-            String registryIndexName = DatastoreUtils.getRegistryIndexName(scopeId);
-            IndexResponse registryIndexExistsResponse = elasticsearchClient.isIndexExists(new IndexRequest(registryIndexName));
-            if (!registryIndexExistsResponse.isIndexExists()) {
-                elasticsearchClient.createIndex(registryIndexName, getMappingSchema(registryIndexName));
-                LOG.info("Metadata index created: {}", registryIndexExistsResponse);
 
-                elasticsearchClient.putMapping(new TypeDescriptor(registryIndexName, ChannelInfoSchema.CHANNEL_TYPE_NAME), ChannelInfoSchema.getChannelTypeSchema(enableAllField, enableSourceField));
-                elasticsearchClient.putMapping(new TypeDescriptor(registryIndexName, MetricInfoSchema.METRIC_TYPE_NAME), MetricInfoSchema.getMetricTypeSchema(enableAllField, enableSourceField));
-                elasticsearchClient.putMapping(new TypeDescriptor(registryIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), ClientInfoSchema.getClientTypeSchema(enableAllField, enableSourceField));
+            // Check existence of the kapua internal indexes
+            String channelRegistryIndexName = DatastoreUtils.getChannelIndexName(scopeId);
+            IndexResponse channelRegistryIndexExistsResponse = elasticsearchClient.isIndexExists(new IndexRequest(channelRegistryIndexName));
+            if (!channelRegistryIndexExistsResponse.isIndexExists()) {
+                elasticsearchClient.createIndex(channelRegistryIndexName, getMappingSchema(channelRegistryIndexName));
+                LOG.info("Channel Metadata index created: {}", channelRegistryIndexExistsResponse);
+
+                elasticsearchClient.putMapping(new TypeDescriptor(channelRegistryIndexName, ChannelInfoSchema.CHANNEL_TYPE_NAME), ChannelInfoSchema.getChannelTypeSchema(enableAllField, enableSourceField));
             }
 
-            currentMetadata = new Metadata(dataIndexName, registryIndexName);
+            String clientRegistryIndexName = DatastoreUtils.getClientIndexName(scopeId);
+            IndexResponse clientRegistryIndexExistsResponse = elasticsearchClient.isIndexExists(new IndexRequest(clientRegistryIndexName));
+            if (!clientRegistryIndexExistsResponse.isIndexExists()) {
+                elasticsearchClient.createIndex(clientRegistryIndexName, getMappingSchema(clientRegistryIndexName));
+                LOG.info("Client Metadata index created: {}", clientRegistryIndexExistsResponse);
+
+                elasticsearchClient.putMapping(new TypeDescriptor(clientRegistryIndexName, ClientInfoSchema.CLIENT_TYPE_NAME), ClientInfoSchema.getClientTypeSchema(enableAllField, enableSourceField));
+            }
+
+            String metricRegistryIndexName = DatastoreUtils.getMetricIndexName(scopeId);
+            IndexResponse metricRegistryIndexExistsResponse = elasticsearchClient.isIndexExists(new IndexRequest(metricRegistryIndexName));
+            if (!metricRegistryIndexExistsResponse.isIndexExists()) {
+                elasticsearchClient.createIndex(metricRegistryIndexName, getMappingSchema(metricRegistryIndexName));
+                LOG.info("Metric Metadata index created: {}", metricRegistryIndexExistsResponse);
+
+                elasticsearchClient.putMapping(new TypeDescriptor(metricRegistryIndexName, MetricInfoSchema.METRIC_TYPE_NAME), MetricInfoSchema.getMetricTypeSchema(enableAllField, enableSourceField));
+            }
+
+            currentMetadata = new Metadata(dataIndexName, channelRegistryIndexName, clientRegistryIndexName, metricRegistryIndexName);
             LOG.debug("Leaving updating metadata");
         }
 
@@ -187,7 +196,7 @@ public class Schema {
             Metric metric = esMetric.getValue();
             metricMapping = MappingUtils.newObjectNode(new KeyValueEntry[]{new KeyValueEntry(SchemaKeys.KEY_DYNAMIC, SchemaKeys.VALUE_TRUE)});
 
-            ObjectNode matricMappingPropertiesNode = MappingUtils.newObjectNode(); // properties (inside metric name)
+            ObjectNode metricMappingPropertiesNode = MappingUtils.newObjectNode(); // properties (inside metric name)
             ObjectNode valueMappingNode;
 
             switch (metric.getType()) {
@@ -203,8 +212,8 @@ public class Schema {
                     break;
             }
 
-            matricMappingPropertiesNode.set(DatastoreUtils.getClientMetricFromAcronym(metric.getType()), valueMappingNode);
-            metricMapping.set(SchemaKeys.FIELD_NAME_PROPERTIES, matricMappingPropertiesNode);
+            metricMappingPropertiesNode.set(DatastoreUtils.getClientMetricFromAcronym(metric.getType()), valueMappingNode);
+            metricMapping.set(SchemaKeys.FIELD_NAME_PROPERTIES, metricMappingPropertiesNode);
             metricsPropertiesNode.set(metric.getName(), metricMapping);
         }
         return typeNode;

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/schema/SchemaUtil.java
@@ -70,8 +70,28 @@ public class SchemaUtil {
      * @return
      * @since 1.0.0
      */
-    public static String getKapuaIndexName(KapuaId scopeId) {
-        return DatastoreUtils.getRegistryIndexName(scopeId);
+    public static String getChannelIndexName(KapuaId scopeId) {
+        return DatastoreUtils.getChannelIndexName(scopeId);
+    }
+
+    /**
+     * Get the Kapua data index name
+     *
+     * @param scopeId
+     * @return
+     */
+    public static String getClientIndexName(KapuaId scopeId) {
+        return DatastoreUtils.getClientIndexName(scopeId);
+    }
+
+    /**
+     * Get the Kapua data index name
+     *
+     * @param scopeId
+     * @return
+     */
+    public static String getMetricIndexName(KapuaId scopeId) {
+        return DatastoreUtils.getMetricIndexName(scopeId);
     }
 
 }

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -2512,7 +2512,7 @@ public class DatastoreSteps extends TestBase {
         query.setOffset(0);
 
         List<SortField> order = new ArrayList<>();
-        order.add(SortField.descending(MetricInfoSchema.METRIC_MTR_TIMESTAMP));
+        order.add(SortField.descending(MetricInfoSchema.METRIC_MTR_TIMESTAMP_FULL));
         query.setSortFields(order);
 
         return query;

--- a/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
+++ b/service/datastore/test/src/test/java/org/eclipse/kapua/service/datastore/test/junit/DatastoreUtilsIndexCalculatorTest.java
@@ -125,8 +125,18 @@ public class DatastoreUtilsIndexCalculatorTest extends Assert {
     }
 
     @Test
-    public void registryIndexNameByScopeId() {
-        assertEquals(".1", DatastoreUtils.getRegistryIndexName(KapuaId.ONE));
+    public void channelIndexNameByScopeId() {
+        assertEquals(".1-channel", DatastoreUtils.getChannelIndexName(KapuaId.ONE));
+    }
+
+    @Test
+    public void clientIndexNameByScopeId() {
+        assertEquals(".1-client", DatastoreUtils.getClientIndexName(KapuaId.ONE));
+    }
+
+    @Test
+    public void metricIndexNameByScopeId() {
+        assertEquals(".1-metric", DatastoreUtils.getMetricIndexName(KapuaId.ONE));
     }
 
     private void performTest(Date startDate, Date endDate, String[] expectedIndexes) throws DatastoreException {


### PR DESCRIPTION
This pull request is going to upgrade Elasticsearch to version 6.8.7. 

**Related Issue**
Fixes #3133

**Description of the solution adopted**
In ES 6.x, the whole concept of Mapping Type [has been removed](https://www.elastic.co/blog/removal-of-mapping-types-elasticsearch). Since we used three different types (metrics, channels and clients) for the `.scopeId` index, that held all registry data, I had to split those types in three different indexes. So, instead of only one `.scopeId` index, now there will be three different `.scopeId-client`, `.scopeId-channel` and `.scopeId-metric` indexes. In order to upgrade an existing ES storage to the new format, read the paragraph below.

**Any side note on the changes made**
Since there's a few breaking changes between ES 5.x and 6.x, an index migration is needed in order to use data from a 5.x cluster. To perform such migration, a little application has been developed in the `extras/es-migrator` Maven module.

**Requested CQs**

- [x] [lucene-grouping](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22784)
- [x] [lucene-misc](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22785)
- [x] [lucene-spatial](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22786)
- [x] [lucene-suggest](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22787)
- [x] [elasticsearch-jna](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22788)