### PR TITLE
Removed sslVerify property

### DIFF
--- a/commons/src/main/resources/kapua-environment-setting.properties
+++ b/commons/src/main/resources/kapua-environment-setting.properties
@@ -31,7 +31,6 @@ commons.db.connection.scheme=jdbc:h2:tcp
 commons.db.connection.host=192.168.33.10
 commons.db.connection.port=3306
 commons.db.connection.useSsl=false
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/commons/src/test/resources/kapua-environment-setting.properties
+++ b/commons/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/qa/integration/src/test/resources/kapua-environment-setting.properties
+++ b/qa/integration/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem:kapua;MODE=MySQL
 commons.db.connection.host=localhost
 commons.db.connection.port=3306
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/account/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/account/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/datastore/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/datastore/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/device/registry/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/job/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/job/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/scheduler/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/security/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/security/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/tag/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/tag/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 

--- a/service/user/test/src/test/resources/kapua-environment-setting.properties
+++ b/service/user/test/src/test/resources/kapua-environment-setting.properties
@@ -32,7 +32,6 @@ commons.db.connection.scheme=jdbc:h2:mem;MODE=MySQL
 commons.db.connection.host=
 commons.db.connection.port=
 commons.db.connection.useSsl=
-commons.db.connection.sslVerify=
 commons.db.connection.trust.store.url=
 commons.db.connection.trust.store.pwd=
 


### PR DESCRIPTION
This PR removes the `commons.db.connection.sslVerify` property.

**Related Issue**
Fixes #3139

**Description of the solution adopted**
_n/a_

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
