### PR TITLE
OpenID provider selection improvement in run-console

### DIFF
--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -31,10 +31,9 @@ if [ -n "$KEYCLOAK_URL" ] && [ -n "$KAPUA_CONSOLE_URL" ]; then
    JAVA_OPTS="$JAVA_OPTS -Dsso.keycloak.realm=${KEYCLOAK_REALM}"
 
    JAVA_OPTS="$JAVA_OPTS -Dconsole.sso.home.uri=${KAPUA_CONSOLE_URL}"
-fi
 
 # Check for generic OpenID Connect provider integration
-if [ -n "${KAPUA_CONSOLE_URL}" ] && [ -n "${OPENID_JWT_ISSUER}" ]; then
+elif [ -n "${KAPUA_CONSOLE_URL}" ] && [ -n "${OPENID_JWT_ISSUER}" ]; then
    echo "Activating OpenID Connect Generic integration..."
   echo "  OpenID Issuer: ${OPENID_JWT_ISSUER}"
   echo "  Console: ${KAPUA_CONSOLE_URL}"


### PR DESCRIPTION
This PR introduces `elif` statement in the `run-console` script.

**Related Issue**
Fixes #3145 

**Description of the solution adopted**
_n/a_

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
