### PR TITLE
Added JUnit tests for client/gateway/mqtt package

### DIFF
--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -66,6 +66,16 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannelTest.java
+++ b/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannelTest.java
@@ -1,0 +1,217 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.client.gateway.mqtt.fuse;
+
+import org.eclipse.kapua.client.gateway.BinaryPayloadCodec;
+import org.eclipse.kapua.client.gateway.Credentials;
+import org.eclipse.kapua.client.gateway.mqtt.MqttMessageHandler;
+import org.eclipse.kapua.client.gateway.mqtt.MqttNamespace;
+import org.eclipse.kapua.client.gateway.spi.Channel;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.fusesource.hawtbuf.Buffer;
+import org.fusesource.mqtt.client.Callback;
+import org.fusesource.mqtt.client.CallbackConnection;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class FuseChannelTest extends Assert {
+
+    private FuseChannel.Builder builder;
+
+    @Before
+    public void init() throws URISyntaxException {
+        builder = new FuseChannel.Builder();
+        builder.broker(new URI("string"));
+        builder.clientId("clientId");
+        builder.namespace(Mockito.mock(MqttNamespace.class));
+        builder.codec(Mockito.mock(BinaryPayloadCodec.class));
+        builder.credentials(Mockito.mock(Credentials.UserAndPassword.class));
+    }
+
+    @Test
+    public void builderBuilderTest() {
+        FuseChannel.Builder builderExpected = new FuseChannel.Builder();
+        assertEquals("Actual and expected values should be the same.", builderExpected, builderExpected.builder());
+    }
+
+    @Test(expected = NoClassDefFoundError.class)
+    public void builderBuildTest() throws Exception {
+        builder.credentials(Credentials.userAndPassword("kapua-sys", new char[]{'a', 'b', 'c'}));
+        assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
+    }
+
+    @Test(expected = NoClassDefFoundError.class)
+    public void builderBuildCredentialsNullTest() throws Exception {
+        builder.credentials(null);
+        assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
+    }
+
+    @Test
+    public void handleConnectedTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        Channel.Context context = Mockito.mock(Channel.Context.class);
+        fuseChannel.handleInit(context);
+        fuseChannel.handleConnected();
+        Mockito.verify(context).notifyConnected();
+    }
+
+    @Test
+    public void handleDisconnectedTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        Channel.Context context = Mockito.mock(Channel.Context.class);
+        fuseChannel.handleInit(context);
+        fuseChannel.handleClose(context);
+        fuseChannel.handleDisconnected();
+        Mockito.verify(context).notifyDisconnected();
+    }
+
+    @Test
+    public void handleInitTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        Channel.Context context = Mockito.mock(Channel.Context.class);
+        fuseChannel.handleInit(context);
+        final CallbackConnection connection = Mockito.mock(CallbackConnection.class);
+        Mockito.verify(connection, Mockito.times(0)).connect(null);
+    }
+
+    @Test
+    public void handleInitContextNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        fuseChannel.handleInit(null);
+        final CallbackConnection connection = Mockito.mock(CallbackConnection.class);
+        Mockito.verify(connection, Mockito.times(0)).connect(null);
+    }
+
+    @Test
+    public void handleCloseTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        Channel.Context context = Mockito.mock(Channel.Context.class);
+        fuseChannel.handleClose(context);
+        final CallbackConnection connection = Mockito.mock(CallbackConnection.class);
+        Mockito.verify(connection, Mockito.times(0)).disconnect(null);
+    }
+
+    @Test
+    public void handleCloseContextNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        fuseChannel.handleClose(null);
+        final CallbackConnection connection = Mockito.mock(CallbackConnection.class);
+        Mockito.verify(connection, Mockito.times(0)).disconnect(null);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void publishMqttTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        fuseChannel.handleInit(Mockito.mock(Channel.Context.class));
+        final ByteBuffer payload = Mockito.mock(ByteBuffer.class);
+        fuseChannel.publishMqtt(topic, payload);
+    }
+
+    @Test(expected = UnsupportedOperationException.class)
+    public void publishMqttTopicNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        fuseChannel.handleInit(Mockito.mock(Channel.Context.class));
+        final ByteBuffer payload = Mockito.mock(ByteBuffer.class);
+        fuseChannel.publishMqtt(null, payload);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void publishMqttPayloadNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        fuseChannel.handleInit(Mockito.mock(Channel.Context.class));
+        fuseChannel.publishMqtt(topic, null);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void subscribeMqttTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        final MqttMessageHandler messageHandler = Mockito.mock(MqttMessageHandler.class);
+        fuseChannel.subscribeMqtt(topic, messageHandler);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void subscribeMqttTopicNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final MqttMessageHandler messageHandler = Mockito.mock(MqttMessageHandler.class);
+        fuseChannel.subscribeMqtt(null, messageHandler);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void subscribeMqttMessageHandlerNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        fuseChannel.subscribeMqtt(topic, null);
+    }
+
+    @Test(expected = AssertionError.class)
+    public void unsubscribeMqttTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        Set<String> topics = new HashSet<>();
+        topics.add("India");
+        fuseChannel.unsubscribeMqtt(topics);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void unsubscribeMqttTopicsNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        fuseChannel.unsubscribeMqtt(null);
+    }
+
+    @Test
+    public void handleMessageArrivedTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        final Buffer payload = Mockito.mock(Buffer.class);
+        final Callback<Callback<Void>> ack = Mockito.mock(Callback.class);
+        fuseChannel.handleMessageArrived(topic, payload, ack);
+    }
+
+    @Test
+    public void handleMessageArrivedTopicNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final Buffer payload = Mockito.mock(Buffer.class);
+        final Callback<Callback<Void>> ack = Mockito.mock(Callback.class);
+        fuseChannel.handleMessageArrived(null, payload, ack);
+    }
+
+    @Test
+    public void handleMessageArrivedPayloadNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        final Callback<Callback<Void>> ack = Mockito.mock(Callback.class);
+        fuseChannel.handleMessageArrived(topic, null, ack);
+    }
+
+    @Test
+    public void handleMessageArrivedAckNullTest() throws Exception {
+        FuseChannel fuseChannel = builder.build();
+        final String topic = "string";
+        final Buffer payload = Mockito.mock(Buffer.class);
+        final Callback<Callback<Void>> ack = Mockito.mock(Callback.class);
+        fuseChannel.handleMessageArrived(topic, payload, null);
+    }
+}

--- a/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/CallbacksTest.java
+++ b/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/CallbacksTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.client.gateway.mqtt.fuse.internal;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.fusesource.mqtt.client.Callback;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.CompletableFuture;
+
+@Category(JUnitTests.class)
+public class CallbacksTest extends Assert {
+
+    @Test
+    public void callbacksTest() throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
+        Constructor<Callbacks> constructor = Callbacks.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
+
+    @Test
+    public void asCallbackTest() {
+        final CompletableFuture<Object> future = Mockito.mock(CompletableFuture.class);
+        Throwable value = Mockito.mock(Throwable.class);
+        Callback<Object> callbacks = Callbacks.asCallback(future);
+        callbacks.onSuccess(future);
+        callbacks.onFailure(value);
+        Mockito.verify(future).complete(future);
+        Mockito.verify(future).completeExceptionally(value);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void asCallbackFutureNullTest() {
+        Callback<Object> callbacks = Callbacks.asCallback(null);
+        callbacks.onSuccess(null);
+    }
+
+    @Test
+    public void asCallbackThrowableNullTest() {
+        final CompletableFuture<Object> future = Mockito.mock(CompletableFuture.class);
+        Callback<Object> callbacks = Callbacks.asCallback(future);
+        callbacks.onSuccess(future);
+        callbacks.onFailure(null);
+        Mockito.verify(future).complete(future);
+        Mockito.verify(future).completeExceptionally(null);
+    }
+}

--- a/client/gateway/provider/mqtt/pom.xml
+++ b/client/gateway/provider/mqtt/pom.xml
@@ -53,6 +53,21 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/client/gateway/provider/mqtt/src/test/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannelTest.java
+++ b/client/gateway/provider/mqtt/src/test/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannelTest.java
@@ -1,0 +1,429 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.client.gateway.mqtt;
+
+import org.eclipse.kapua.client.gateway.BinaryPayloadCodec;
+import org.eclipse.kapua.client.gateway.Credentials;
+import org.eclipse.kapua.client.gateway.ErrorHandler;
+import org.eclipse.kapua.client.gateway.MessageHandler;
+import org.eclipse.kapua.client.gateway.Payload;
+import org.eclipse.kapua.client.gateway.Topic;
+import org.eclipse.kapua.client.gateway.spi.Channel;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.CompletionStage;
+
+@Category(JUnitTests.class)
+public class AbstractMqttChannelTest extends Assert {
+
+    private BinaryPayloadCodec codec;
+    private MqttNamespace namespace;
+    private String clientId;
+    private AbstractMqttChannel mqttChannel;
+    private AbstractMqttChannel.Builder builder;
+
+    @Before
+    public void init() {
+        codec = Mockito.mock(BinaryPayloadCodec.class);
+        namespace = Mockito.mock(MqttNamespace.class);
+        clientId = "clientId";
+        mqttChannel = new ActualMqttChannel(codec, namespace, clientId);
+        builder = new ActualBuilder();
+    }
+
+    private class ActualMqttChannel extends AbstractMqttChannel {
+
+        public ActualMqttChannel(BinaryPayloadCodec codec, MqttNamespace namespace, String clientId) {
+            super(codec, namespace, clientId);
+        }
+
+        @Override
+        protected CompletionStage<?> publishMqtt(String topic, ByteBuffer payload) {
+            return null;
+        }
+
+        @Override
+        protected CompletionStage<?> subscribeMqtt(String topic, MqttMessageHandler messageHandler) {
+            return null;
+        }
+
+        @Override
+        protected void unsubscribeMqtt(Set<String> mqttTopics) throws Exception {
+
+        }
+
+        @Override
+        public void handleInit(Context context) {
+
+        }
+
+        @Override
+        public void handleClose(Context context) {
+
+        }
+    }
+
+    private class ActualBuilder extends AbstractMqttChannel.Builder {
+
+        @Override
+        protected AbstractMqttChannel.Builder builder() {
+            return null;
+        }
+
+        @Override
+        public Channel build() throws Exception {
+            return null;
+        }
+    }
+
+    @Test
+    public void builderCodecTest() {
+        assertNull("Expected null value.", builder.codec());
+        builder.codec(codec);
+        assertEquals("Expected and actual values should be the same.", codec, builder.codec());
+        assertThat("Instance of BinaryPayloadCodec expected", builder.codec(), IsInstanceOf.instanceOf(BinaryPayloadCodec.class));
+    }
+
+    @Test
+    public void builderCodecNullTest() {
+        builder.codec(null);
+        assertNull("Expected null value.", builder.codec());
+    }
+
+    @Test
+    public void builderNamespaceTest() {
+        assertNull("Expected null value.", builder.namespace());
+        builder.namespace(namespace);
+        assertEquals("Expected and actual values should be the same.", namespace, builder.namespace());
+        assertThat("Instance of MqttNamespace expected", builder.namespace(), IsInstanceOf.instanceOf(MqttNamespace.class));
+    }
+
+    @Test
+    public void builderNamespaceNullTest() {
+        builder.namespace(null);
+        assertNull("Expected null value.", builder.namespace());
+    }
+
+    @Test
+    public void builderClientIdTest() {
+        assertNull("Expected null value.", builder.clientId());
+        builder.clientId(clientId);
+        assertEquals("Expected and actual values should be the same.", clientId, builder.clientId());
+        assertThat("Instance of String expected", builder.clientId(), IsInstanceOf.instanceOf(String.class));
+    }
+
+    @Test
+    public void builderClientIdNullTest() {
+        builder.clientId(null);
+        assertNull("Expected null value.", builder.clientId());
+    }
+
+    @Test
+    public void builderCredentialsTest() {
+        assertNull("Expected null value.", builder.credentials());
+        final Credentials.UserAndPassword userAndPassword = Credentials.userAndPassword("kapua-broker", "kapua-password");
+        builder.credentials(userAndPassword);
+        assertEquals("Expected and actual values should be the same.", userAndPassword, builder.credentials());
+        assertThat("Instance of Credentials.UserAndPassword expected", builder.credentials(), IsInstanceOf.instanceOf(Credentials.UserAndPassword.class));
+    }
+
+    @Test
+    public void builderCredentialsNullTest() {
+        builder.credentials(null);
+        assertNull("Expected null value.", builder.credentials());
+    }
+
+    @Test
+    public void builderBrokerStringIdTest() throws URISyntaxException {
+        assertNull("Expected null value.", builder.broker());
+        final String broker = "broker";
+        builder.broker(broker);
+        assertEquals("Expected and actual values should be the same.", new URI(broker), builder.broker());
+        assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
+
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void builderBrokerStringIdNullTest() throws URISyntaxException {
+        builder.broker((String) null);
+        builder.broker();
+    }
+
+    @Test
+    public void builderBrokerURIIdTest() throws URISyntaxException {
+        assertNull("Expected null value.", builder.broker());
+        final URI broker = new URI("string");
+        builder.broker(broker);
+        assertEquals("Expected and actual values should be the same.", broker, builder.broker());
+        assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void builderBrokerURIIdNullTest() throws URISyntaxException {
+        builder.broker((URI) null);
+        builder.broker();
+    }
+
+    @Test
+    public void abstractMqttChannelTest() {
+        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void abstractMqttChannelCodecNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, namespace, clientId);
+        assertNull("Expected null value.", mqttChannel.getCodec());
+        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void abstractMqttChannelNamespaceNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, null, clientId);
+        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void abstractMqttChannelNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, null, null);
+        assertNull("Expected null value.", mqttChannel.getCodec());
+        assertNull("Expected null value.", mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void abstractMqttChannelClientIdNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, namespace, null);
+        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        assertNull("Expected null.", mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void adaptTest() {
+        mqttChannel.adapt(MqttModuleContext.class);
+        mqttChannel.adapt(String.class);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void adaptClazzNullTest() {
+        mqttChannel.adapt(null);
+    }
+
+    @Test
+    public void publishTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        segments.add("STRING");
+        segments.add("0123456789");
+        final Topic topic = Topic.of(segments);
+        final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
+        assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, buffer));
+    }
+
+    @Test
+    public void publishApplicationIdNullTest() {
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        segments.add("STRING");
+        segments.add("0123456789");
+        final Topic topic = Topic.of(segments);
+        final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
+        assertNull("Expected null value.", mqttChannel.publish(null, topic, buffer));
+    }
+
+    @Test
+    public void publishTopicNullTest() {
+        final String applicationId = "appId";
+        final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
+        assertNull("Expected null value.", mqttChannel.publish(applicationId, null, buffer));
+    }
+
+    @Test
+    public void publishByteBufferNullTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        segments.add("STRING");
+        segments.add("0123456789");
+        final Topic topic = Topic.of(segments);
+        assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, null));
+    }
+
+    @Test
+    public void handlePublishTest() throws Exception {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final Payload payload = Mockito.mock(Payload.class);
+        Mockito.when(codec.encode(payload, null)).thenReturn(ByteBuffer.allocate(10));
+        mqttChannel.handlePublish(applicationId, topic, payload);
+    }
+
+    @Test
+    public void handlePublishApplicationIdNullTest() throws Exception {
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final Payload payload = Mockito.mock(Payload.class);
+        assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(null, topic, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+    }
+
+    @Test
+    public void handlePublishTopicNullTest() {
+        final String applicationId = "appId";
+        final Payload payload = Mockito.mock(Payload.class);
+        assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(applicationId, null, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void handlePublishPayloadNullTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        mqttChannel.handlePublish(applicationId, topic, null);
+    }
+
+    @Test
+    public void handleSubscribeTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
+        final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
+        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, errorHandler));
+    }
+
+    @Test
+    public void handleSubscribeApplicationIdNullTest() {
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
+        final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
+        assertNull("Expected null value.", mqttChannel.handleSubscribe(null, topic, messageHandler, errorHandler));
+    }
+
+    @Test
+    public void handleSubscribeTopicNullTest() {
+        final String applicationId = "appId";
+        final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
+        final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
+        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, null, messageHandler, errorHandler));
+    }
+
+    @Test
+    public void handleSubscribeMessageHandlerNullTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
+        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, null, errorHandler));
+    }
+
+    @Test
+    public void handleSubscribeErrorHandlerNullTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
+        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, null));
+    }
+
+    @Test
+    public void handleMessage() throws Exception {
+        final MessageHandler handler = Mockito.mock(MessageHandler.class);
+        final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
+        mqttChannel.handleMessage(handler, buffer);
+        Mockito.verify(handler, Mockito.times(1)).handleMessage(codec.decode(buffer));
+    }
+
+    @Test
+    public void subscribeTest() {
+        final String applicationId = "appId";
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        final MqttMessageHandler messageHandler = Mockito.mock(MqttMessageHandler.class);
+        assertNull("Expected null value.", mqttChannel.subscribe(applicationId, topic, messageHandler));
+    }
+
+    @Test
+    public void handleUnsubscribeTest() throws Exception {
+        final String applicationId = "appId";
+        Collection<Topic> topics = new ArrayList<>();
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        topics.add(topic);
+        mqttChannel.handleUnsubscribe(applicationId, topics);
+        Mockito.verify(namespace, Mockito.times(1)).dataTopic(clientId, applicationId, topic);
+    }
+
+    @Test
+    public void handleUnsubscribeApplicationIdNullTest() throws Exception {
+        Collection<Topic> topics = new ArrayList<>();
+        List<String> segments = new ArrayList<>();
+        segments.add("string");
+        final Topic topic = Topic.of(segments);
+        topics.add(topic);
+        mqttChannel.handleUnsubscribe(null, topics);
+        Mockito.verify(namespace, Mockito.times(1)).dataTopic(clientId, null, topic);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void handleUnsubscribeTopicsNullTest() throws Exception {
+        final String applicationId = "appId";
+        mqttChannel.handleUnsubscribe(applicationId, null);
+    }
+
+    @Test
+    public void getMqttClientIdTest() {
+        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void getMqttClientIdNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, namespace, null);
+        assertNull("Expected null value.", mqttChannel.getMqttClientId());
+    }
+
+    @Test
+    public void getCodecTest() {
+        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+    }
+
+    @Test
+    public void getCodecNullTest() {
+        AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, namespace, clientId);
+        assertNull("Expected null value.", mqttChannel.getCodec());
+    }
+}

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -62,6 +62,21 @@
             <artifactId>logback-classic</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
 </project>

--- a/client/gateway/provider/paho/src/test/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/ListenersTest.java
+++ b/client/gateway/provider/paho/src/test/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/ListenersTest.java
@@ -1,0 +1,149 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.client.gateway.mqtt.paho.internal;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.paho.client.mqttv3.IMqttActionListener;
+import org.eclipse.paho.client.mqttv3.IMqttToken;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Modifier;
+import java.util.concurrent.CompletableFuture;
+import java.util.function.Consumer;
+
+@Category(JUnitTests.class)
+public class ListenersTest extends Assert {
+
+    private Runnable success;
+    private Consumer<Throwable> failure;
+    private IMqttToken asyncActionToken;
+    private Throwable exception;
+    private CompletableFuture<Object> future;
+
+    @Before
+    public void init() {
+        success = Mockito.mock(Runnable.class);
+        failure = Mockito.mock(Consumer.class);
+        asyncActionToken = Mockito.mock(IMqttToken.class);
+        exception = Mockito.mock(Throwable.class);
+        future = Mockito.mock(CompletableFuture.class);
+    }
+
+    @Test
+    public void listenersTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
+        Constructor<Listeners> constructor = Listeners.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        constructor.setAccessible(true);
+        constructor.newInstance();
+    }
+
+    @Test
+    public void toListenerTest(){
+        Listeners.toListener(future).onSuccess(Mockito.mock(IMqttToken.class));
+        Listeners.toListener(future).onFailure(Mockito.mock(IMqttToken.class), new Throwable());
+    }
+
+    @Test
+    public void toListenerRunnableIdAndConsumerIdTest() {
+        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
+    }
+
+    @Test
+    public void toListenerRunnableIdNullAndConsumerIdTest() {
+        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
+    }
+
+    @Test
+    public void toListenerRunnableIdAndConsumerIdNullTest() {
+        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, null), IsInstanceOf.instanceOf(IMqttActionListener.class));
+    }
+
+    @Test
+    public void onSuccessTest() {
+        Listeners.toListener(success, failure).onSuccess(asyncActionToken);
+        Mockito.verify(success).run();
+    }
+
+    @Test
+    public void onSuccessSuccessNullTest() {
+        Listeners.toListener(null, failure).onSuccess(asyncActionToken);
+    }
+
+    @Test
+    public void onSuccessFailureNullTest() {
+        Listeners.toListener(success, null).onSuccess(asyncActionToken);
+        Mockito.verify(success).run();
+    }
+
+    @Test
+    public void onSuccessSuccessNullAndFailureNullTest() {
+        Listeners.toListener(null, null).onSuccess(asyncActionToken);
+    }
+
+    @Test
+    public void onSuccessIMqttTokenNullTest() {
+        Listeners.toListener(success, failure).onSuccess(null);
+        Mockito.verify(success).run();
+    }
+
+    @Test
+    public void onFailureTest() {
+        Listeners.toListener(success, failure).onFailure(asyncActionToken, exception);
+        Mockito.verify(failure).accept(exception);
+    }
+
+    @Test
+    public void onFailureSuccessNullTest() {
+        Listeners.toListener(null, failure).onFailure(asyncActionToken, exception);
+        Mockito.verify(failure).accept(exception);
+    }
+
+    @Test
+    public void onFailureFailureNullTest() {
+        Listeners.toListener(success, null).onFailure(asyncActionToken, exception);
+    }
+
+    @Test
+    public void onFailureSuccessNullAndFailureNullTest() {
+        Listeners.toListener(null, null).onFailure(asyncActionToken, exception);
+    }
+
+    @Test
+    public void onFailureIMqttTokenNullTest() {
+        Listeners.toListener(success, failure).onFailure(null, exception);
+        Mockito.verify(failure).accept(exception);
+    }
+
+    @Test
+    public void onFailureThrowableNullTest() {
+        Listeners.toListener(success, failure).onFailure(asyncActionToken, null);
+        Mockito.verify(failure).accept(null);
+    }
+
+    @Test
+    public void toListenerCompletableFutureIdTest() {
+        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(future), IsInstanceOf.instanceOf(IMqttActionListener.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toListenerCompletableFutureIdNullTest() {
+        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null), IsInstanceOf.instanceOf(IMqttActionListener.class));
+    }
+}


### PR DESCRIPTION
This commit contains unit tests for the following classes:
 - tests for client/gateway/provider/fuse/FuseChannel.java
 - tests for client/gateway/provider/fuse/internal/Callbacks.java
 - tests for client/gateway/provider/mqtt/AbstractMqttChannel.java
 - tests for client/gateway/provider/paho/Listeners.java

**Related Issue**
/

**Description of the solution adopted**
These are just simple unit tests that check if the functionality of the tested classes is as expected. I have run the tests localy and on my Travis and everything was OK, so I expect no problems.

**Screenshots**
/

**Any side note on the changes made**
Kudos to @VesnaGrumic, who actually wrote the tests. @Coduz, as discussed, I am opening new PR which will be easier to rebase to develop as Vesna is not in the team anymore. You can set PR #3103 to "draft" (as we did for some previous ones) and close it when this PR will be merged. Sorry for all the inconvenience.

Signed-off-by: Leonardo Gaube <leonardo.gaube@endava.com>