### PR TITLE
Extend accountSelfEdit support in Configurations

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableService.java
@@ -416,7 +416,7 @@ public abstract class AbstractKapuaConfigurableService extends AbstractKapuaServ
 
             if (preventChange) {
                 // ... prevent the change!
-                throw KapuaException.internalError(String.format("The configuration \"%s\" cannot be changed from an user of the account", ad.getId()));
+                throw KapuaException.internalError(String.format("The configuration \"%s\" cannot be changed by this user in this account", ad.getId()));
             }
         }
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionEntityService.java
@@ -14,10 +14,8 @@ package org.eclipse.kapua.commons.model.misc;
 
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaNamedEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 public interface CollisionEntityService extends KapuaEntityService<CollisionEntity, CollisionEntityCreator>,
-        KapuaNamedEntityService<CollisionEntity>,
-        KapuaConfigurableService {
+        KapuaNamedEntityService<CollisionEntity> {
 
 }

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/misc/CollisionServiceImpl.java
@@ -13,19 +13,16 @@
 package org.eclipse.kapua.commons.model.misc;
 
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableService;
 import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
-import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaListResult;
 import org.eclipse.kapua.model.query.KapuaQuery;
 
-import java.util.Map;
-
-public class CollisionServiceImpl extends AbstractKapuaConfigurableService implements CollisionEntityService {
+public class CollisionServiceImpl extends AbstractKapuaService implements CollisionEntityService {
 
     public CollisionServiceImpl() {
-        super(CollisionServiceImpl.class.getName(), CollisionEntityDomains.COLLISION_ENTITY_DOMAIN, CollisionEntityManagerFactory.getInstance());
+        super(CollisionEntityManagerFactory.getInstance(), null);
     }
 
     public CollisionEntity insert(String testField) throws KapuaException {
@@ -80,24 +77,6 @@ public class CollisionServiceImpl extends AbstractKapuaConfigurableService imple
     public CollisionEntity findByName(String name) throws KapuaException {
         // TODO Auto-generated method stub
         return null;
-    }
-
-    @Override
-    public KapuaTocd getConfigMetadata(KapuaId scopeId) throws KapuaException {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public Map<String, Object> getConfigValues(KapuaId scopeId) throws KapuaException {
-        // TODO Auto-generated method stub
-        return null;
-    }
-
-    @Override
-    public void setConfigValues(KapuaId scopeId, KapuaId parentId, Map<String, Object> values) throws KapuaException {
-        // TODO Auto-generated method stub
-
     }
 
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountConfigComponents.java
@@ -576,11 +576,4 @@ public class AccountConfigComponents extends LayoutContainer {
         }
     }
 
-    public void removeApplyAndResetButtons() {
-        if (toolBar != null) {
-            toolBar.remove(apply);
-            toolBar.remove(reset);
-            toolBar.remove(separatorToolItem);
-        }
-    }
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
@@ -74,7 +74,6 @@ public class AccountDetailsView extends AbstractView {
         tabPanel.setBorders(false);
         tabPanel.setBodyBorder(false);
         AccountTabConfiguration settingsTabItem = new AccountTabConfiguration(currentSession, this);
-        settingsTabItem.removeElements();
         settingsTabItem.setEntity(selectedAccount);
 
         AccountDetailsTabDescription accountDescriptionTab = new AccountDetailsTabDescription(currentSession);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfiguration.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountTabConfiguration.java
@@ -79,11 +79,6 @@ public class AccountTabConfiguration extends KapuaTabItem<GwtAccount> {
     public void setDescriptionTab(AccountDetailsTabDescription accountDetailsTabDescription) {
         this.accountDetailsTabDescription = accountDetailsTabDescription;
         configComponents.setDescriptionTab(accountDetailsTabDescription);
-
-    }
-
-    public void removeElements(){
-        configComponents.removeApplyAndResetButtons();
     }
 
 }

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionService.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link QueuedJobExecutionService} exposes APIs to manage {@link QueuedJobExecution} objects.<br>
@@ -26,8 +25,7 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
  * @since 1.1.0
  */
 public interface QueuedJobExecutionService extends KapuaEntityService<QueuedJobExecution, QueuedJobExecutionCreator>,
-        KapuaUpdatableEntityService<QueuedJobExecution>,
-        KapuaConfigurableService {
+        KapuaUpdatableEntityService<QueuedJobExecution> {
 
     /**
      * Returns the {@link QueuedJobExecutionListResult} with elements matching the provided query.

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
@@ -14,14 +14,12 @@ package org.eclipse.kapua.job.engine.queue.jbatch;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.job.engine.jbatch.JobEngineEntityManagerFactory;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecution;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
-import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionListResult;
-import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionQuery;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -32,15 +30,12 @@ import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.job.JobDomains;
 import org.eclipse.kapua.service.job.execution.JobExecution;
-import org.eclipse.kapua.service.job.execution.JobExecutionService;
 
 /**
  * {@link QueuedJobExecutionService} implementation
  */
 @KapuaProvider
-public class QueuedJobExecutionServiceImpl
-        extends AbstractKapuaConfigurableResourceLimitedService<QueuedJobExecution, QueuedJobExecutionCreator, QueuedJobExecutionService, QueuedJobExecutionListResult, QueuedJobExecutionQuery, QueuedJobExecutionFactory>
-        implements QueuedJobExecutionService {
+public class QueuedJobExecutionServiceImpl extends AbstractKapuaService implements QueuedJobExecutionService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
@@ -48,7 +43,7 @@ public class QueuedJobExecutionServiceImpl
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     public QueuedJobExecutionServiceImpl() {
-        super(JobExecutionService.class.getName(), JobDomains.JOB_DOMAIN, JobEngineEntityManagerFactory.getInstance(), QueuedJobExecutionService.class, QueuedJobExecutionFactory.class);
+        super(JobEngineEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
@@ -28,10 +28,6 @@ Scenario: Regular step creation
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
         | name  | type |
@@ -53,10 +49,6 @@ Scenario: Step with a null scope ID
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
@@ -84,10 +76,6 @@ Scenario: Change an existing step name
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
         | name  | type |
@@ -107,10 +95,6 @@ Scenario: Count steps in the database
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
@@ -143,10 +127,6 @@ Scenario: Delete an existing step
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
         | name  | type |
@@ -166,10 +146,6 @@ Scenario: Delete a non-existing step
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job step service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -28,10 +28,6 @@ Scenario: Regular target creation
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     Then No exception was thrown
@@ -42,10 +38,6 @@ Scenario: Target with a null scope ID
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
@@ -62,10 +54,6 @@ Scenario: Delete a job target
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     When I delete the last job target in the database
@@ -77,10 +65,6 @@ Scenario: Delete a job target twice
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
@@ -99,10 +83,6 @@ Scenario: Create and count multiple job targets
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     And A regular job target item
@@ -116,10 +96,6 @@ Scenario: Query for the targets of a specific job
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
@@ -150,10 +126,6 @@ Scenario: Update a job target TargetId
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob1"
     And A regular job target item
     When I update the job target target id
@@ -168,10 +140,6 @@ Scenario: Update a job target step index
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
     Given I create a job with the name "TestJob1"
     And A regular job target item
     When I update the job target step number to 3
@@ -182,10 +150,6 @@ Scenario: Update a job target status
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
-    And I configure the job target service
         | type    | name                       | value |
         | boolean | infiniteChildEntities      | true  |
         | integer | maxNumberChildEntities     | 5     |

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
@@ -15,9 +15,9 @@ package org.eclipse.kapua.service.device.management.job.internal;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -29,7 +29,6 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperation;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationCreator;
-import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationListResult;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationQuery;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService;
@@ -46,7 +45,7 @@ import java.util.Map;
  * @since 1.1.0
  */
 @KapuaProvider
-public class JobDeviceManagementOperationServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<JobDeviceManagementOperation, JobDeviceManagementOperationCreator, JobDeviceManagementOperationService, JobDeviceManagementOperationListResult, JobDeviceManagementOperationQuery, JobDeviceManagementOperationFactory>
+public class JobDeviceManagementOperationServiceImpl extends AbstractKapuaService
         implements JobDeviceManagementOperationService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
@@ -55,7 +54,7 @@ public class JobDeviceManagementOperationServiceImpl extends AbstractKapuaConfig
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     public JobDeviceManagementOperationServiceImpl() {
-        super(JobDeviceManagementOperationService.class.getName(), JobDomains.JOB_DOMAIN, JobDeviceManagementOperationEntityManagerFactory.getInstance(), JobDeviceManagementOperationService.class, JobDeviceManagementOperationFactory.class);
+        super(JobDeviceManagementOperationEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -15,9 +15,9 @@ package org.eclipse.kapua.service.endpoint.internal;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -52,7 +52,7 @@ import java.util.Map;
  */
 @KapuaProvider
 public class EndpointInfoServiceImpl
-        extends AbstractKapuaConfigurableResourceLimitedService<EndpointInfo, EndpointInfoCreator, EndpointInfoService, EndpointInfoListResult, EndpointInfoQuery, EndpointInfoFactory>
+        extends AbstractKapuaService
         implements EndpointInfoService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
@@ -70,7 +70,7 @@ public class EndpointInfoServiceImpl
     private static final String ENDPOINT_INFO_DNS = "endpointInfo.dns";
 
     public EndpointInfoServiceImpl() {
-        super(EndpointInfoService.class.getName(), EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, EndpointEntityManagerFactory.getInstance(), EndpointInfoService.class, EndpointInfoFactory.class);
+        super(EndpointEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link JobStepService} exposes APIs to manage JobStep objects.<br>
@@ -26,8 +25,7 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
  * @since 1.0
  */
 public interface JobStepService extends KapuaEntityService<JobStep, JobStepCreator>,
-        KapuaUpdatableEntityService<JobStep>,
-        KapuaConfigurableService {
+        KapuaUpdatableEntityService<JobStep> {
 
     /**
      * Returns the {@link JobStepListResult} with elements matching the provided query.

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link JobStepDefinitionService} exposes APIs to manage JobStepDefinition objects.<br>
@@ -26,8 +25,7 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
  * @since 1.0
  */
 public interface JobStepDefinitionService extends KapuaEntityService<JobStepDefinition, JobStepDefinitionCreator>,
-        KapuaUpdatableEntityService<JobStepDefinition>,
-        KapuaConfigurableService {
+        KapuaUpdatableEntityService<JobStepDefinition> {
 
     /**
      * Returns the {@link JobStepDefinitionListResult} with elements matching the provided query.

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link JobTargetService} exposes APIs to manage JobTarget objects.<br>
@@ -26,8 +25,7 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
  * @since 1.0
  */
 public interface JobTargetService extends KapuaEntityService<JobTarget, JobTargetCreator>,
-        KapuaUpdatableEntityService<JobTarget>,
-        KapuaConfigurableService {
+        KapuaUpdatableEntityService<JobTarget> {
 
     /**
      * Returns the {@link JobTargetListResult} with elements matching the provided query.

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionServiceImpl.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.job.step.definition.internal;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -26,9 +26,7 @@ import org.eclipse.kapua.service.job.JobDomains;
 import org.eclipse.kapua.service.job.internal.JobEntityManagerFactory;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinition;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionCreator;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionListResult;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionQuery;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService;
 
 import javax.inject.Inject;
@@ -41,10 +39,7 @@ import javax.inject.Inject;
  * @since 1.0
  */
 @KapuaProvider
-public class JobStepDefinitionServiceImpl
-        extends
-        AbstractKapuaConfigurableResourceLimitedService<JobStepDefinition, JobStepDefinitionCreator, JobStepDefinitionService, JobStepDefinitionListResult, JobStepDefinitionQuery, JobStepDefinitionFactory>
-        implements JobStepDefinitionService {
+public class JobStepDefinitionServiceImpl extends AbstractKapuaService implements JobStepDefinitionService {
 
     @Inject
     private AuthorizationService authorizationService;
@@ -52,7 +47,7 @@ public class JobStepDefinitionServiceImpl
     private PermissionFactory permissionFactory;
 
     public JobStepDefinitionServiceImpl() {
-        super(JobStepDefinitionService.class.getName(), JobDomains.JOB_DOMAIN, JobEntityManagerFactory.getInstance(), JobStepDefinitionService.class, JobStepDefinitionFactory.class);
+        super(JobEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -16,7 +16,7 @@ import org.eclipse.kapua.KapuaDuplicateNameException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -32,7 +32,6 @@ import org.eclipse.kapua.service.job.internal.JobEntityManagerFactory;
 import org.eclipse.kapua.service.job.step.JobStep;
 import org.eclipse.kapua.service.job.step.JobStepAttributes;
 import org.eclipse.kapua.service.job.step.JobStepCreator;
-import org.eclipse.kapua.service.job.step.JobStepFactory;
 import org.eclipse.kapua.service.job.step.JobStepIndex;
 import org.eclipse.kapua.service.job.step.JobStepListResult;
 import org.eclipse.kapua.service.job.step.JobStepQuery;
@@ -52,7 +51,7 @@ import java.util.Map;
  * @since 1.0.0
  */
 @KapuaProvider
-public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<JobStep, JobStepCreator, JobStepService, JobStepListResult, JobStepQuery, JobStepFactory>
+public class JobStepServiceImpl extends AbstractKapuaService
         implements JobStepService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
@@ -63,7 +62,7 @@ public class JobStepServiceImpl extends AbstractKapuaConfigurableResourceLimited
     private static final JobStepDefinitionService JOB_STEP_DEFINITION_SERVICE = LOCATOR.getService(JobStepDefinitionService.class);
 
     public JobStepServiceImpl() {
-        super(JobStepService.class.getName(), JobDomains.JOB_DOMAIN, JobEntityManagerFactory.getInstance(), JobStepService.class, JobStepFactory.class);
+        super(JobEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.service.job.targets.internal;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaProvider;
@@ -27,9 +27,7 @@ import org.eclipse.kapua.service.job.JobDomains;
 import org.eclipse.kapua.service.job.internal.JobEntityManagerFactory;
 import org.eclipse.kapua.service.job.targets.JobTarget;
 import org.eclipse.kapua.service.job.targets.JobTargetCreator;
-import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetListResult;
-import org.eclipse.kapua.service.job.targets.JobTargetQuery;
 import org.eclipse.kapua.service.job.targets.JobTargetService;
 
 /**
@@ -38,8 +36,7 @@ import org.eclipse.kapua.service.job.targets.JobTargetService;
  * @since 1.0.0
  */
 @KapuaProvider
-public class JobTargetServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<JobTarget, JobTargetCreator, JobTargetService, JobTargetListResult, JobTargetQuery, JobTargetFactory>
-        implements JobTargetService {
+public class JobTargetServiceImpl extends AbstractKapuaService implements JobTargetService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
@@ -47,7 +44,7 @@ public class JobTargetServiceImpl extends AbstractKapuaConfigurableResourceLimit
     private static final PermissionFactory PERMISSION_FACTORY = LOCATOR.getFactory(PermissionFactory.class);
 
     public JobTargetServiceImpl() {
-        super(JobTargetService.class.getName(), JobDomains.JOB_DOMAIN, JobEntityManagerFactory.getInstance(), JobTargetService.class, JobTargetFactory.class);
+        super(JobEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobServiceSteps.java
@@ -897,30 +897,6 @@ public class JobServiceSteps extends TestBase {
     // * Job Step Service Test steps                                                      *
     // ************************************************************************************
 
-    @When("^I configure the job step service$")
-    public void setJobStepConfigurationValue(List<CucConfig> cucConfigs) throws Exception {
-
-        Map<String, Object> valueMap = new HashMap<>();
-        KapuaId accId = getCurrentScopeId();
-        KapuaId scopeId = getCurrentParentId();
-
-        for (CucConfig config : cucConfigs) {
-            config.addConfigToMap(valueMap);
-            if (config.getParentId() != null) {
-                scopeId = getKapuaId(config.getParentId());
-            }
-            if (config.getScopeId() != null) {
-                accId = getKapuaId(config.getScopeId());
-            }
-        }
-        try {
-            primeException();
-            jobStepService.setConfigValues(accId, scopeId, valueMap);
-        } catch (KapuaException ke) {
-            verifyException(ke);
-        }
-    }
-
     @Given("^A regular step creator with the name \"(.*)\" and the following properties$")
     public void prepareARegularStepCreatorWithPropertyList(String name, List<CucJobStepProperty> list) {
 
@@ -1103,31 +1079,6 @@ public class JobServiceSteps extends TestBase {
     // ************************************************************************************
     // * Job Target Service Test steps                                                    *
     // ************************************************************************************
-
-    @When("^I configure the job target service$")
-    public void setJobTargetConfigurationValue(List<CucConfig> cucConfigs) throws Exception {
-
-        Map<String, Object> valueMap = new HashMap<>();
-        KapuaId accId = getCurrentScopeId();
-        KapuaId scopeId = getCurrentParentId();
-
-        for (CucConfig config : cucConfigs) {
-            config.addConfigToMap(valueMap);
-            if (config.getParentId() != null) {
-                scopeId = getKapuaId(config.getParentId());
-            }
-            if (config.getScopeId() != null) {
-                accId = getKapuaId(config.getScopeId());
-            }
-        }
-
-        primeException();
-        try {
-            jobTargetService.setConfigValues(accId, scopeId, valueMap);
-        } catch (KapuaException ke) {
-            verifyException(ke);
-        }
-    }
 
     @Given("^A regular job target item$")
     public void createARegularTarget()

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/TriggerService.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.KapuaEntityService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
-import org.eclipse.kapua.service.config.KapuaConfigurableService;
 
 /**
  * {@link TriggerService} exposes APIs to manage Trigger objects.<br>
@@ -26,8 +25,7 @@ import org.eclipse.kapua.service.config.KapuaConfigurableService;
  * @since 1.0
  */
 public interface TriggerService extends KapuaEntityService<Trigger, TriggerCreator>,
-        KapuaUpdatableEntityService<Trigger>,
-        KapuaConfigurableService {
+        KapuaUpdatableEntityService<Trigger> {
 
     /**
      * Returns the {@link TriggerListResult} with elements matching the provided query.

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -17,7 +17,7 @@ import org.eclipse.kapua.KapuaEndBeforeStartTimeException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
@@ -33,7 +33,6 @@ import org.eclipse.kapua.service.scheduler.quartz.driver.exception.TriggerNeverF
 import org.eclipse.kapua.service.scheduler.trigger.Trigger;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerAttributes;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerCreator;
-import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerListResult;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
@@ -60,7 +59,7 @@ import java.util.List;
  * @since 1.0.0
  */
 @KapuaProvider
-public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Trigger, TriggerCreator, TriggerService, TriggerListResult, TriggerQuery, TriggerFactory> implements TriggerService {
+public class TriggerServiceImpl extends AbstractKapuaService implements TriggerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TriggerServiceImpl.class);
 
@@ -82,7 +81,7 @@ public class TriggerServiceImpl extends AbstractKapuaConfigurableResourceLimited
      * @since 1.0.0
      */
     public TriggerServiceImpl() {
-        super(TriggerService.class.getName(), SchedulerDomains.SCHEDULER_DOMAIN, SchedulerEntityManagerFactory.getInstance(), TriggerService.class, TriggerFactory.class);
+        super(SchedulerEntityManagerFactory.getInstance(), null);
     }
 
     @Override

--- a/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authentication.credential.CredentialService.xml
+++ b/service/security/shiro/src/main/resources/META-INF/metatypes/org.eclipse.kapua.service.authentication.credential.CredentialService.xml
@@ -24,6 +24,7 @@
             cardinality="0"
             required="true"
             default="true"
+            allowSelfEdit="true"
             description="User lockout policy enable.">
         </AD>
 
@@ -34,6 +35,7 @@
             required="true"
             default="3"
             min="0"
+            allowSelfEdit="true"
             description="Number of consecutive login failures before the user gets locked. Valid if lockout policy is enabled."/>
 
         <AD id="lockoutPolicy.resetAfter"
@@ -43,6 +45,7 @@
             required="true"
             default="3600"
             min="0"
+            allowSelfEdit="true"
             description="The amount of time in seconds required after the last login failure to automatically reset the failure counter."/>
 
         <AD id="lockoutPolicy.lockDuration"
@@ -52,6 +55,7 @@
             required="true"
             default="10800"
             min="0"
+            allowSelfEdit="true"
             description="For a locked user the amount of time in seconds required after the last login failure to automatically unlock the user."/>
 
         <AD id="password.minLength"
@@ -62,6 +66,7 @@
             default=""
             min="0"
             max="255"
+            allowSelfEdit="true"
             description="The minimum length of the password. Changing this won't affect existing passwords. This value cannot be less than the system default value. If empty, system default value will be used."/>
     </OCD>
 


### PR DESCRIPTION
Extending support for `allowSelfEdit` in Service configurations. A field marked with `allowSelfEdit="true"` in the Service Metadata XML can be edited by users of the account itself, not only from the parent account. As a first use case, all the configurations of `CredentialsService` are now self-editable.

An user can edit its own `allowSelfEdit="true"` configurations in the "Settings" view of the console, or via REST API.

**Related Issue**
No related issues
