### PR TITLE
Add Credentials documentation to Gitbook summary

### DIFF
--- a/docs/user-manual/en/summary.md
+++ b/docs/user-manual/en/summary.md
@@ -6,3 +6,4 @@
 * [Setup JWT security](jwt_security.md)
 * [Kapua Permissions](Permissions.md)
 * [Multi Factor Authentication](mfa.md)
+* [Credentials](credentials.md)


### PR DESCRIPTION
Adding the Credentials to the Gitbook Summary page after eclipse/kapua#3141

**Related Issue**
No related issues
