### PR TITLE
Configurable MFA machine trust key duration

### DIFF
--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -57,6 +57,7 @@ test -n "${MFA_TIME_STEP_SIZE}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.
 test -n "${MFA_WINDOW_SIZE}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.window.size=${MFA_WINDOW_SIZE}"
 test -n "${MFA_SCRATCH_CODES_NUMBER}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.scratch.codes.number=${MFA_SCRATCH_CODES_NUMBER}"
 test -n "${MFA_CODE_DIGITS_NUMBER}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.code.digits.number=${MFA_CODE_DIGITS_NUMBER}"
+test -n "${MFA_TRUST_KEY_DURATION}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.trust.key.duration=${MFA_TRUST_KEY_DURATION}"
 
 export JAVA_OPTS
 

--- a/docs/user-manual/en/mfa.md
+++ b/docs/user-manual/en/mfa.md
@@ -42,3 +42,4 @@ The following variables control the Multi Factor Authentication feature of the W
 | MFA_WINDOW_SIZE | 3 | Number of windows of size timeStepSizeInMillis checked during the MFA validation (min > 0). |
 | MFA_SCRATCH_CODES_NUMBER | 5 | Number of MFA scratch codes (min is 0 max is 1000). |
 | MFA_CODE_DIGITS_NUMBER | 6 | Number of digits in the generated MFA code (min is 6 max is 8). |
+| MFA_TRUST_KEY_DURATION | 30 | Machine trust key duration (in days). |

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -46,6 +46,8 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticator;
 import org.eclipse.kapua.service.authentication.shiro.AuthenticationEntityManagerFactory;
 import org.eclipse.kapua.service.authentication.shiro.mfa.MfaAuthenticatorServiceLocator;
+import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
+import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.user.User;
@@ -74,10 +76,12 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
     private static final MfaAuthenticator MFA_AUTHENTICATOR = MFA_AUTH_SERVICE_LOCATOR.getMfaAuthenticator();
     private static final int QR_CODE_SIZE = 134;  // TODO: make this configurable?
     private static final String IMAGE_FORMAT = "png";
-    private static final int TRUST_KEY_DURATION = 30; // duration of the trust key in days
     private final KapuaLocator locator = KapuaLocator.getInstance();
     private final AccountService accountService = locator.getService(AccountService.class);
     private final UserService userService = locator.getService(UserService.class);
+
+    private final KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
+    private final int trustKeyDuration = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_TRUST_KEY_DURATION);
 
     public MfaOptionServiceImpl() {
         super(MfaOptionEntityManagerFactory.getInstance());
@@ -278,7 +282,7 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
         }
 
         Date expirationDate = new Date(System.currentTimeMillis());
-        expirationDate = DateUtils.addDays(expirationDate, TRUST_KEY_DURATION);
+        expirationDate = DateUtils.addDays(expirationDate, trustKeyDuration);
 
         mfaOption.setTrustKey(trustKey);
         mfaOption.setTrustExpirationDate(expirationDate);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeys.java
@@ -56,7 +56,8 @@ public enum KapuaAuthenticationSettingKeys implements SettingKey {
     AUTHENTICATION_MFA_TIME_STEP_SIZE("authentication.mfa.time.step.size"),  // the time step size, in seconds, min > 0
     AUTHENTICATION_MFA_WINDOW_SIZE("authentication.mfa.window.size"),  // number of windows of size timeStepSizeInMillis checked during the validation, min > 0
     AUTHENTICATION_MFA_SCRATCH_CODES_NUMBER("authentication.mfa.scratch.codes.number"),  // number of scratch codes, min is 0 max is 1000
-    AUTHENTICATION_MFA_CODE_DIGITS_NUMBER("authentication.mfa.code.digits.number");  // the number of digits in the generated code, min is 6 max is 8
+    AUTHENTICATION_MFA_CODE_DIGITS_NUMBER("authentication.mfa.code.digits.number"),  // the number of digits in the generated code, min is 6 max is 8
+    AUTHENTICATION_MFA_TRUST_KEY_DURATION("authentication.mfa.trust.key.duration");  // machine trust key duration in days
 
     private String key;
 
@@ -64,6 +65,7 @@ public enum KapuaAuthenticationSettingKeys implements SettingKey {
         this.key = key;
     }
 
+    @Override
     public String key() {
         return key;
     }

--- a/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
+++ b/service/security/shiro/src/main/resources/kapua-authentication-setting.properties
@@ -41,8 +41,9 @@ authentication.eventAddress=authentication
 
 authentication.registration.service.enabled=false
 
-# mfa authenticator properties
+# mfa properties
 authentication.mfa.time.step.size=30
 authentication.mfa.window.size=3
 authentication.mfa.scratch.codes.number=5
 authentication.mfa.code.digits.number=6
+authentication.mfa.trust.key.duration=30


### PR DESCRIPTION
This PR introduces configurable duration for the Multi Factor Authentication trust key.

**Related Issue**
_n/a_

**Description of the solution adopted**
The trust key duration is defined via the `authentication.mfa.trust.key.duration` property, which is mapped through the `MFA_TRUST_KEY_DURATION` environment variable in the console entrypoint script. The duration is defined in days and the default value is of 30 days, defined in the `kapua-authentication-setting.properties` file.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
