### PR TITLE
Fix OutOfBound exception in ApiKey authentication Rest API 

### DIFF
--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -179,12 +179,12 @@ Scenario: Init Security Context for all scenarios
     And I create a job with the name "job0"
     When I find scheduler properties with name "Device Connect"
     Then A regular trigger creator with the name "schedule0" is created
-    And The trigger is set to start on 12-01-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-01-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     Then I create a new trigger from the existing creator with previously defined date properties
     And A regular trigger creator with the name "schedule1" is created
-    And The trigger is set to start on 12-12-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-12-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     And I create a new trigger from the existing creator with previously defined date properties
     And I logout
 
@@ -430,13 +430,13 @@ Scenario: Init Security Context for all scenarios
     And I create a job with the name "job0"
     When I find scheduler properties with name "Interval Job"
     Then A regular trigger creator with the name "schedule0" is created
-    And The trigger is set to start on 12-01-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-01-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     And I set retry interval to 1
     Then I create a new trigger from the existing creator with previously defined date properties
     And A regular trigger creator with the name "schedule1" is created
-    And The trigger is set to start on 12-12-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-12-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     And I set retry interval to 1
     And I create a new trigger from the existing creator with previously defined date properties
     And I logout
@@ -652,13 +652,13 @@ Scenario: Init Security Context for all scenarios
     And I create a job with the name "job0"
     When I find scheduler properties with name "Cron Job"
     Then A regular trigger creator with the name "schedule0" is created
-    And The trigger is set to start on 12-01-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-01-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     Then I set cron expression to "0 15 15 * * ?"
     Then I create a new trigger from the existing creator with previously defined date properties
     And A regular trigger creator with the name "schedule1" is created
-    And The trigger is set to start on 12-12-2020 at 10:10.
-    And The trigger is set to end on 15-12-2020 at 10:10.
+    And The trigger is set to start on 12-12-2030 at 10:10.
+    And The trigger is set to end on 15-12-2030 at 10:10.
     Then I set cron expression to "0 15 15 * * ?"
     And I create a new trigger from the existing creator with previously defined date properties
     And I logout

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -344,9 +344,14 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
 
     @Override
     public Credential findByApiKey(String apiKey) throws KapuaException {
+
+        KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
+        int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
+
         //
         // Argument Validation
         ArgumentValidator.notEmptyOrNull(apiKey, "apiKey");
+        ArgumentValidator.lengthRange(apiKey, preLength, null, "apiKey");
 
         //
         // Do the find
@@ -356,8 +361,6 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
 
             //
             // Build search query
-            KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
-            int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
             String preSeparator = setting.getString(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_SEPARATOR);
             String apiKeyPreValue = apiKey.substring(0, preLength).concat(preSeparator);
 


### PR DESCRIPTION
This PR fixes an OutOfBound exception caused by too short ApiKey credential when using the Rest APIs. Moreover, the stacktrace produced by an exception in the ApiKey authentication step is now hidden to the final user, and a clearer message is logged. 

**Related Issue**
_n/a_

**Description of the solution adopted**
The issue was caused by the length of the API key. If the API key was shorter than `KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH` (which is set by default to 8), the `substring` method failed, because such length was shorter that the `endIndex` parameter. Since it is not possible to have an API key that is shorter than `AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH`, the `findByApiKey` now will fail in this case.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
