### PR TITLE
Added index on DeviceConnection table

### DIFF
--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -48,10 +48,7 @@ import org.slf4j.LoggerFactory;
  * @since 1.0
  */
 @KapuaProvider
-public class DeviceConnectionServiceImpl extends
-        //        AbstractKapuaConfigurableResourceLimitedService<DeviceConnection, DeviceConnectionCreator, DeviceConnectionService, DeviceConnectionListResult, DeviceConnectionQuery, DeviceConnectionFactory>
-        AbstractKapuaConfigurableService
-        implements DeviceConnectionService {
+public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableService implements DeviceConnectionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnectionServiceImpl.class);
 

--- a/service/device/registry/internal/src/main/resources/liquibase/1.4.0/changelog-device-1.4.0.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.4.0/changelog-device-1.4.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-1.4.0.xml">
+
+    <include relativeToChangelogFile="true" file="./device_connection-create_index_id.xml"/>
+
+</databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/1.4.0/device_connection-create_index_id.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/1.4.0/device_connection-create_index_id.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2020 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-device-1.2.0.xml">
+
+    <changeSet id="changelog-device_connection-1.4.0-create_index_id" author="eurotech">
+        <createIndex tableName="dvc_device_connection" indexName="idx_connection_id">
+            <column name="id"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/changelog-device-master.xml
@@ -23,5 +23,6 @@
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-device-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-device-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.3.0/changelog-device-1.3.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.4.0/changelog-device-1.4.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR improves the performances of the Device retrieval when DeviceConnection are to be fetched.

**Related Issue**
_None_

**Description of the solution adopted**
The JOIN performed was matching `device.connection_id = device_connection.id`.
On `dvc_device_connection` there are only indexes that starts with `scope_id`.
For some (forgotten) reasons `dvc_device_connection` has the PK as `(scope_id,id)`.
All of this results in a full search on the DeviceConnection table which kills performances.
Adding this index, access changes from full search to using the index, which is very very fast.

**Screenshots**
_None_

**Any side note on the changes made**
_None_