### PR TITLE
Cache exception handling improvement

### DIFF
--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -116,8 +116,7 @@ public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableServic
             }
             return DeviceConnectionDAO.update(entityManager, deviceConnection);
         }).onBeforeHandler(() -> {
-            ((DeviceRegistryCache) entityCache).removeByDeviceConnectionId(deviceConnection.getScopeId(),
-                    deviceConnection.getId());
+            ((DeviceRegistryCache) entityCache).removeByDeviceConnectionId(deviceConnection.getScopeId(), deviceConnection.getId());
             return null;
         }));
     }
@@ -216,8 +215,7 @@ public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableServic
                 throw new KapuaEntityNotFoundException(DeviceConnection.TYPE, deviceConnectionId);
             }
             return DeviceConnectionDAO.delete(entityManager, scopeId, deviceConnectionId);
-        }).onAfterHandler((emptyParam) -> ((DeviceRegistryCache) entityCache).removeByDeviceConnectionId(scopeId,
-                deviceConnectionId)));
+        }).onAfterHandler((emptyParam) -> ((DeviceRegistryCache) entityCache).removeByDeviceConnectionId(scopeId, deviceConnectionId)));
     }
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCache.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryCache.java
@@ -42,16 +42,24 @@ public class DeviceRegistryCache extends EntityCache {
 
     public KapuaEntity getByClientId(KapuaId scopeId, String clientId) {
         if (clientId != null) {
-            KapuaId entityId = (KapuaId) deviceByClientIdCache.get(clientId);
-            return get(scopeId, entityId);
+            try {
+                KapuaId entityId = (KapuaId) deviceByClientIdCache.get(clientId);
+                return get(scopeId, entityId);
+            } catch (Exception e) {
+                cacheErrorLogger("getByClientId", deviceByClientIdCache.getName(), clientId, e);
+            }
         }
         return null;
     }
 
     public KapuaEntity getByDeviceConnectionId(KapuaId scopeId, KapuaId deviceConnectionId) {
         if (deviceConnectionId != null) {
-            KapuaId entityId = (KapuaId) deviceByConnectionIdCache.get(deviceConnectionId);
-            return get(scopeId, entityId);
+            try {
+                KapuaId entityId = (KapuaId) deviceByConnectionIdCache.get(deviceConnectionId);
+                return get(scopeId, entityId);
+            } catch (Exception e) {
+                cacheErrorLogger("getByDeviceConnectionId", deviceByConnectionIdCache.getName(), deviceConnectionId, e);
+            }
         }
         return null;
     }
@@ -59,10 +67,27 @@ public class DeviceRegistryCache extends EntityCache {
     @Override
     public void put(KapuaEntity entity) {
         if (entity != null) {
-            idCache.put(entity.getId(), entity);
-            deviceByClientIdCache.put(((Device) entity).getClientId(), entity.getId());
-            if (((Device) entity).getConnectionId() != null) {
-                deviceByConnectionIdCache.put(((Device) entity).getConnectionId(), entity.getId());
+            try {
+                idCache.put(entity.getId(), entity);
+            } catch (Exception e) {
+                cacheErrorLogger("put", idCache.getName(), entity.getId(), e);
+                return; // the 'put' on the deviceBy caches is performed only if the 'put' on idCache has been successful (the latter is needed by the former)
+            }
+            boolean putOnConnectionCache = false;  // used only for error management
+            try {
+                deviceByClientIdCache.put(((Device) entity).getClientId(), entity.getId());
+                if (((Device) entity).getConnectionId() != null) {
+                    putOnConnectionCache = true;
+                    deviceByConnectionIdCache.put(((Device) entity).getConnectionId(), entity.getId());
+                }
+            } catch (Exception e) {
+                // if the insertion on one of the deviceBy caches is failing, but the one on the idCache was successful, the situation is still ok:
+                // a 'get' from the idCache will work anyway, while a 'get' from the deviceBy cache will not work, forcing again a 'put' in the next operation
+                if (putOnConnectionCache) {
+                    cacheErrorLogger("put", deviceByConnectionIdCache.getName(), ((Device) entity).getConnectionId(), e);
+                } else {
+                    cacheErrorLogger("put", deviceByClientIdCache.getName(), ((Device) entity).getClientId(), e);
+                }
             }
         }
     }
@@ -71,9 +96,19 @@ public class DeviceRegistryCache extends EntityCache {
     public KapuaEntity remove(KapuaId scopeId, KapuaId kapuaId) {
         KapuaEntity kapuaEntity = super.remove(scopeId, kapuaId);
         if (kapuaEntity != null) {
-            deviceByClientIdCache.remove(((Device) kapuaEntity).getClientId());
-            if (((Device) kapuaEntity).getConnectionId() != null) {
-                deviceByConnectionIdCache.remove(((Device) kapuaEntity).getConnectionId());
+            boolean putOnConnectionCache = false;  // used only for error management
+            try {
+                deviceByClientIdCache.remove(((Device) kapuaEntity).getClientId());
+                if (((Device) kapuaEntity).getConnectionId() != null) {
+                    putOnConnectionCache = true;
+                    deviceByConnectionIdCache.remove(((Device) kapuaEntity).getConnectionId());
+                }
+            } catch (Exception e) {
+                if (putOnConnectionCache) {
+                    cacheErrorLogger("remove", deviceByConnectionIdCache.getName(), ((Device) kapuaEntity).getConnectionId(), e);
+                } else {
+                    cacheErrorLogger("remove", deviceByClientIdCache.getName(), ((Device) kapuaEntity).getClientId(), e);
+                }
             }
         }
         return kapuaEntity;


### PR DESCRIPTION
This PR introduces cache exception handling in the `EntityCache` class and its subclasses. 

**Related Issue**
_n/a_

**Description of the solution adopted**
Cache errors are usually handled by the cache client (that implements the JCache interface). However, in some cases the exceptions are thrown by the cache client itself (e.g. a timeout exception). Since we are agnostic w.r.t. the underlying JCache implementation, we cannot catch precise exceptions. Thus, this PR introduces a way to treat such exceptions properly, in a conservative way w.r.t. the data, and to log them via the logger and the metrics.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
