### PR TITLE
Changed checkstyle rule

### DIFF
--- a/build-tools/src/main/resources/checkstyle/kapua.xml
+++ b/build-tools/src/main/resources/checkstyle/kapua.xml
@@ -89,7 +89,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^/\*{79}$\n^ \* Copyright \(c\) (|\d{4}, )2020 (.*) and others\.?$\n^ \*$\n^ \* This program and the accompanying materials are made$\n^ \* available under the terms of the Eclipse Public License 2.0$\n^ \* which is available at https://www.eclipse.org/legal/epl-2.0/$\n^ \*$\n^ \* SPDX-License-Identifier: EPL-2.0$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
+            value="^/\*{79}$\n^ \* Copyright \(c\) (|\d{4}, )2020|2021 (.*) and others\.?$\n^ \*$\n^ \* This program and the accompanying materials are made$\n^ \* available under the terms of the Eclipse Public License 2.0$\n^ \* which is available at https://www.eclipse.org/legal/epl-2.0/$\n^ \*$\n^ \* SPDX-License-Identifier: EPL-2.0$\n^ \*$\n^ \* Contributors:$\n^ \*     (.*)(| - .*)$\n^ \*{79}/\n^package" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="11" />
         <property name="fileExtensions" value="java" />
@@ -97,7 +97,7 @@
 
     <module name="RegexpHeader">
         <property name="header"
-            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) (|\d{4}, )2020 (.*) and others\.?$\n^$\n^    This program and the accompanying materials are made$\n^    available under the terms of the Eclipse Public License 2\.0$\n^    which is available at https\:\/\/www.eclipse.org/legal/epl-2.0/$\n^$\n^    SPDX-License-Identifier: EPL-2.0$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
+            value="^&lt;\?xml.*&gt;$\n^&lt;!--$\n^    Copyright \(c\) (|\d{4}, )2020|2021 (.*) and others\.?$\n^$\n^    This program and the accompanying materials are made$\n^    available under the terms of the Eclipse Public License 2\.0$\n^    which is available at https\:\/\/www.eclipse.org/legal/epl-2.0/$\n^$\n^    SPDX-License-Identifier: EPL-2.0$\n^$\n^    Contributors\:$\n^        (.*)(| - .*)$\n^ ?--&gt;$" />
         <property name="charset" value="UTF-8" />
         <property name="multiLines" value="12" />
         <property name="fileExtensions" value="xml" />


### PR DESCRIPTION
I have changed checkstyle rule (added "|2021" in the header) as this will be needed in 2021.
@lorthirk can you please merge this so we can rebase all our PRs and other braches that are currently in review? Thank you! 

**Related Issue**
There is no related issue. 

**Description of the solution adopted**
/

**Any side note on the changes made**
/

Signed-off-by: Leonardo Gaube <leonardo.gaube@endava.com>