### PR TITLE
Added indexes on jBatch tables to improve performances

### DIFF
--- a/job-engine/jbatch/src/main/resources/liquibase/1.5.0/changelog-job-engine-1.5.0.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.5.0/changelog-job-engine-1.5.0.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+    <include relativeToChangelogFile="true" file="./job_engine_jbatch-performance_indexes.xml"/>
+
+</databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/1.5.0/job_engine_jbatch-performance_indexes.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/1.5.0/job_engine_jbatch-performance_indexes.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job_engine_jbatch-1.5.0.xml">
+
+    <changeSet id="changelog-job_engine_jbatch-1.5.0-performance_indexes" author="eurotech">
+        <createIndex tableName="jbtc_checkpoint_data" indexName="idx_checkpointdata_id">
+            <column name="id"/>
+        </createIndex>
+
+        <createIndex tableName="jbtc_execution_instance_data" indexName="idx_executioninstancedata_jobInstanceId-createTime">
+            <column name="jobinstanceid"/>
+            <column name="createtime"/>
+        </createIndex>
+
+        <createIndex tableName="jbtc_execution_instance_data" indexName="idx_executioninstancedata_batchStatus">
+            <column name="batchstatus"/>
+        </createIndex>
+
+        <createIndex tableName="jbtc_job_instance_data" indexName="idx_jobinstancedata_name">
+            <column name="name"/>
+        </createIndex>
+
+        <createIndex tableName="jbtc_step_execution_instance_data" indexName="idx_stepexecutioninstancedata_jobExecId-stepExecId">
+            <column name="jobexecid"/>
+            <column name="stepexecid"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
+++ b/job-engine/jbatch/src/main/resources/liquibase/changelog-job-engine-master.xml
@@ -19,5 +19,6 @@
     <include relativeToChangelogFile="true" file="./0.3.0/changelog-job-engine-0.3.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-engine-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-engine-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.5.0/changelog-job-engine-1.5.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
Looking at the access on jBatch SQL tables we found that some query where not using indexes, which could be a performance issue.

**Related Issue**
_None_

**Description of the solution adopted**
Checking the jBatch DAOs in `job-engine-jbatch` module, indexes have been created accordingly.

**Screenshots**
_None_

**Any side note on the changes made**
_None_