### PR TITLE
Added Junit tests for broker/core/plugin package

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvidersTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorProvidersTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class ConnectorDescriptorProvidersTest extends Assert {
+
+    @Test
+    public void connectorDescriptorProvidersTest() throws Exception {
+        Constructor<ConnectorDescriptorProviders> connectorDescriptorProviders = ConnectorDescriptorProviders.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(connectorDescriptorProviders.getModifiers()));
+        connectorDescriptorProviders.setAccessible(true);
+        connectorDescriptorProviders.newInstance();
+    }
+
+    @Test
+    public void getInstanceNullProviderTest() {
+        assertThat("Instance of ConnectorDescriptorProvider expected.", ConnectorDescriptorProviders.getInstance(), IsInstanceOf.instanceOf(ConnectorDescriptorProvider.class));
+    }
+
+    @Test
+    public void getInstanceProviderTest() {
+        ConnectorDescriptorProviders.getInstance();
+        assertThat("Instance of ConnectorDescriptorProvider expected.", ConnectorDescriptorProviders.getInstance(), IsInstanceOf.instanceOf(ConnectorDescriptorProvider.class));
+    }
+
+    @Test
+    public void getDescriptorNullTest() {
+        assertThat("Instance of ConnectorDescriptor expected.", ConnectorDescriptorProviders.getDescriptor(null), IsInstanceOf.instanceOf(ConnectorDescriptor.class));
+    }
+
+    @Test
+    public void getDescriptorTest() {
+        String[] connectorNames = {"1234567890", "", "connectorName", "connectorName1234567890", "a", "@#$%^&*()_><connectorName", "@{123213#$%&/(/"};
+        for (String connectorName : connectorNames) {
+            assertThat("Instance of ConnectorDescriptor expected.", ConnectorDescriptorProviders.getDescriptor(connectorName), IsInstanceOf.instanceOf(ConnectorDescriptor.class));
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/ConnectorDescriptorTest.java
@@ -30,7 +30,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 @Category(JUnitTests.class)
-public class ConnectorDescriptorTest {
+public class ConnectorDescriptorTest extends Assert {
 
     private static final String BROKER_IP_RESOLVER_CLASS_NAME;
 
@@ -53,82 +53,65 @@ public class ConnectorDescriptorTest {
         kapuaBrokerJAXBContextLoader.reset();
     }
 
-    /**
-     * A simple test to get a default descriptor
-     */
     @Test
-    public void testNonNull() {
+    public void nonNullProviderTest() {
         ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
-        Assert.assertNotNull(provider);
+        assertNotNull("Null not expected.", provider);
     }
 
-    /**
-     * A simple test to get a descriptor
-     */
     @Test
-    public void testDefault1a() {
+    public void defaultDescriptorFromProviderTest() {
         ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
         ConnectorDescriptor descriptor = provider.getDescriptor("foo");
-        Assert.assertNotNull(descriptor);
+        assertNotNull("Null not expected.", descriptor);
     }
 
-    /**
-     * A simple test to get a descriptor
-     */
     @Test
-    public void testDefault1b() {
-        Assert.assertNotNull(ConnectorDescriptorProviders.getDescriptor("foo"));
+    public void getDescriptorFromProvidersClassTest() {
+        assertNotNull("Null not expected.", ConnectorDescriptorProviders.getDescriptor("foo"));
     }
 
-    /**
-     * Use a default provider, disabling the default descriptor
-     * <p>
-     * The result has to be a {@code null} descriptor
-     * </p>
-     */
     @Test
-    public void testDefault2() {
+    public void getTransportProtocolTest() {
+        ConnectorDescriptorProvider provider = ConnectorDescriptorProviders.getInstance();
+        ConnectorDescriptor descriptor = provider.getDescriptor("foo");
+        assertEquals("Expected and actual values should be the same.", "MQTT", descriptor.getTransportProtocol());
+    }
+
+    @Test
+    public void defaultProviderWithDisabledDefaultDescriptorTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
 
         Tests.runWithProperties(properties, () -> {
             DefaultConnectorDescriptionProvider provider = new DefaultConnectorDescriptionProvider();
             ConnectorDescriptor descriptor = provider.getDescriptor("foo");
-            Assert.assertNull(descriptor);
+            assertNull("Null expected.", descriptor);
         });
     }
 
-    /**
-     * Use a default provider, configuring a file which does not exist
-     */
     @Test(expected = Exception.class)
-    public void testDefault3() {
+    public void defaultProviderWithNonExistingFileTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/does-not-exist.properties");
 
         Tests.runWithProperties(properties, DefaultConnectorDescriptionProvider::new);
     }
 
-    /**
-     * Use a default provider, configuring a file which does exist, but allow default fallback
-     */
     @Test
-    public void testDefault4() {
+    public void defaultProviderAllowingDefaultFallbackTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/1.properties");
 
         Tests.runWithProperties(properties, () -> {
             DefaultConnectorDescriptionProvider provider = new DefaultConnectorDescriptionProvider();
             ConnectorDescriptor descriptor = provider.getDescriptor("foo");
-            Assert.assertNotNull(descriptor);
+            assertNotNull("Null not expected.", descriptor);
         });
     }
 
-    /**
-     * Use a default provider, configuring an empty file, disabling default
-     */
     @Test
-    public void testDefault5() {
+    public void defaultProviderWithEmptyFileTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/1.properties");
@@ -136,39 +119,33 @@ public class ConnectorDescriptorTest {
         Tests.runWithProperties(properties, () -> {
             DefaultConnectorDescriptionProvider provider = new DefaultConnectorDescriptionProvider();
             ConnectorDescriptor descriptor = provider.getDescriptor("foo");
-            Assert.assertNull(descriptor);
+            assertNull("Null expected.", descriptor);
         });
     }
 
-    /**
-     * Use a default provider, configuring a non-empty configuration
-     */
     @Test
-    public void testDefault6() throws Exception {
+    public void defaultProviderUsingNonEmptyConfigurationTest() throws Exception {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/2.properties");
 
         Tests.runWithProperties(properties, () -> {
             DefaultConnectorDescriptionProvider provider = new DefaultConnectorDescriptionProvider();
-            Assert.assertNull(provider.getDescriptor("foo"));
+            assertNull("Null expected.", provider.getDescriptor("foo"));
 
             ConnectorDescriptor descriptor = provider.getDescriptor("mqtt");
-            Assert.assertNotNull(descriptor);
+            assertNotNull("Null not expected.", descriptor);
 
-            Assert.assertEquals(org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MessageType.APP));
-            Assert.assertEquals(org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MessageType.APP));
+            assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MessageType.APP));
+            assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MessageType.APP));
 
-            Assert.assertNull(descriptor.getDeviceClass(MessageType.DATA));
-            Assert.assertNull(descriptor.getKapuaClass(MessageType.DATA));
+            assertNull("Null expected.", descriptor.getDeviceClass(MessageType.DATA));
+            assertNull("Null expected.", descriptor.getKapuaClass(MessageType.DATA));
         });
     }
 
-    /**
-     * Use a default provider, configuring a non-empty, invalid configuration
-     */
     @Test(expected = Exception.class)
-    public void testDefault7() {
+    public void defaultProviderWithInvalidConfigurationTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.DISABLE_DEFAULT_CONNECTOR_DESCRIPTOR.key(), "true");
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "file:src/test/resources/conector.descriptor/3.properties");
@@ -176,11 +153,8 @@ public class ConnectorDescriptorTest {
         Tests.runWithProperties(properties, DefaultConnectorDescriptionProvider::new);
     }
 
-    /**
-     * Empty configuration URL
-     */
     @Test
-    public void testConfig1() {
+    public void emptyConfigurationUrlTest() {
         final Map<String, String> properties = new HashMap<>();
         properties.put(BrokerSettingKey.CONFIGURATION_URI.key(), "");
 
@@ -194,7 +168,7 @@ public class ConnectorDescriptorTest {
 
         BrokerIpResolver brokerIpResolver = newInstance(BROKER_IP_RESOLVER_CLASS_NAME, DefaultBrokerIpResolver.class);
         String ipOrHostName = brokerIpResolver.getBrokerIpOrHostName();
-        Assert.assertEquals("192.168.33.10", ipOrHostName);
+        assertEquals("Expected and actual values should be the same.", "192.168.33.10", ipOrHostName);
     }
 
     @Test
@@ -204,7 +178,7 @@ public class ConnectorDescriptorTest {
 
         BrokerIpResolver brokerIpResolver = newInstance(BROKER_IP_RESOLVER_CLASS_NAME, DefaultBrokerIpResolver.class);
         String ipOrHostName = brokerIpResolver.getBrokerIpOrHostName();
-        Assert.assertEquals("192.168.33.10", ipOrHostName);
+        assertEquals("Expected and actual values should be the same.", "192.168.33.10", ipOrHostName);
     }
 
     @Test
@@ -214,7 +188,7 @@ public class ConnectorDescriptorTest {
 
         BrokerIpResolver brokerIpResolver = newInstance(BROKER_IP_RESOLVER_CLASS_NAME, DefaultBrokerIpResolver.class);
         String ipOrHostName = brokerIpResolver.getBrokerIpOrHostName();
-        Assert.assertEquals("192.168.33.10", ipOrHostName);
+        assertEquals("Expected and actual values should be the same.", "192.168.33.10", ipOrHostName);
     }
 
     @Test(expected = Exception.class)

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIdResolverTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIdResolverTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.apache.activemq.broker.BrokerFilter;
+import org.apache.activemq.command.BrokerId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class DefaultBrokerIdResolverTest extends Assert {
+
+    DefaultBrokerIdResolver defaultBrokerIdResolver;
+
+    @Before
+    public void initialize() {
+        defaultBrokerIdResolver = new DefaultBrokerIdResolver();
+    }
+
+    @Test
+    public void getBrokerIdTest() {
+        String[] ids = {"", "broker id", "id1234567890", "id_)(*&^%$#@!?.,,.|", "broker-id123", "321broker_id!@", " bRoKeR&ID=99", ".broker1!*", "BROKER <id1> "};
+        BrokerFilter brokerFilter = Mockito.mock(BrokerFilter.class);
+
+        for (String id : ids) {
+            BrokerId brokerId = new BrokerId(id);
+            Mockito.when(brokerFilter.getBrokerId()).thenReturn(brokerId);
+            assertEquals("Expected and actual values should be the same", id, defaultBrokerIdResolver.getBrokerId(brokerFilter));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getBrokerIdNullTest() {
+        defaultBrokerIdResolver.getBrokerId(null);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolverTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultBrokerIpResolverTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DefaultBrokerIpResolverTest extends Assert {
+
+    @Test
+    public void defaultBrokerIpResolverTest() throws KapuaException {
+        System.setProperty("broker.ip", "192.168.33.10");
+        DefaultBrokerIpResolver defaultBrokerIpResolver = new DefaultBrokerIpResolver();
+
+        assertEquals("Expected and actual values should be the same", "192.168.33.10", defaultBrokerIpResolver.getBrokerIpOrHostName());
+    }
+
+    @Test(expected = KapuaException.class)
+    public void defaultBrokerIpResolverExceptionTest() throws KapuaException {
+        System.setProperty("broker.ip", "");
+
+        new DefaultBrokerIpResolver();
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void defaultBrokerIpResolverNullTest() throws KapuaException {
+        System.setProperty("broker.ip", null);
+        new DefaultBrokerIpResolver();
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdExceptionTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaDuplicateClientIdExceptionTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaDuplicateClientIdExceptionTest extends Assert {
+
+    @Test
+    public void kapuaDuplicateClientIdException() {
+        String[] clientIds = {null, "", "Client Id", "id1234567890", "id?><|+_)(*&^%$#@!~`", "client-id123", "321client_id!@", " cLiEnTID=99", ".client1!*", "CLIENT <id1> "};
+        for (String id : clientIds) {
+            KapuaDuplicateClientIdException kapuaDuplicateClientIdException = new KapuaDuplicateClientIdException(id);
+            assertEquals("Expected and actual values should be the same.", KapuaBrokerErrorCodes.DUPLICATED_CLIENT_ID, kapuaDuplicateClientIdException.getCode());
+            assertNull("Null expected.", kapuaDuplicateClientIdException.getCause());
+            assertEquals("Expected and actual values should be the same.", "Error: " + id, kapuaDuplicateClientIdException.getMessage());
+        }
+    }
+
+    @Test(expected = KapuaDuplicateClientIdException.class)
+    public void throwingKapuaDuplicateClientIdExceptionTest() throws KapuaDuplicateClientIdException {
+        throw new KapuaDuplicateClientIdException("Client Id");
+    }
+
+    @Test(expected = KapuaDuplicateClientIdException.class)
+    public void throwingKapuaDuplicateNullClientIdExceptionTest() throws KapuaDuplicateClientIdException {
+        throw new KapuaDuplicateClientIdException(null);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImplTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaPrincipalImplTest.java
@@ -1,0 +1,181 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.id.KapuaIdStatic;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.math.BigInteger;
+
+@Category(JUnitTests.class)
+public class KapuaPrincipalImplTest extends Assert {
+
+    AccessToken accessToken1;
+    AccessToken accessToken2;
+    String[] username;
+    String[] clientId;
+    String[] clientIp;
+
+    @Before
+    public void initialize() {
+        accessToken1 = new AccessTokenImpl();
+        accessToken2 = new AccessTokenImpl();
+        username = new String[]{"username", "username1234567890", "name!~#$%^&*()_=|?><,./", null};
+        clientId = new String[]{"clientId", "id1234567890", "id-!~#$%^&*()_=|?><,./", null};
+        clientIp = new String[]{"192.168.1.1", "clientIp", null};
+    }
+
+    @Test
+    public void kapuaPrincipalImplTest() {
+        accessToken1.setTokenId("token id");
+        accessToken1.setUserId(KapuaId.ONE);
+        accessToken1.setScopeId(KapuaId.ONE);
+
+        for (String name : username) {
+            for (String id : clientId) {
+                for (String ip : clientIp) {
+                    KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, name, id, ip);
+                    assertEquals("Expected and actual values should be the same.", name, kapuaPrincipal.getName());
+                    assertEquals("Expected and actual values should be the same.", "token id", kapuaPrincipal.getTokenId());
+                    assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaPrincipal.getUserId());
+                    assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaPrincipal.getAccountId());
+                    assertEquals("Expected and actual values should be the same.", id, kapuaPrincipal.getClientId());
+                    assertEquals("Expected and actual values should be the same.", ip, kapuaPrincipal.getClientIp());
+                }
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void kapuaPrincipalImplNullTokenTest() {
+        for (String name : username) {
+            for (String id : clientId) {
+                for (String ip : clientIp) {
+                    new KapuaPrincipalImpl(null, name, id, ip);
+                }
+            }
+        }
+    }
+
+    @Test
+    public void hasCodeNullAccountIdTest() {
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, "username", "clientId", "192.168.1.1");
+        assertEquals("Expected and actual values should be the same.", -265712489, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hasCodeNullAccountIdNullNameIdTest() {
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, null, "clientId", "192.168.1.1");
+        assertEquals("Expected and actual values should be the same.", 961, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hasCodeNullNameIdTest() {
+        accessToken1.setScopeId(new KapuaIdStatic(BigInteger.TEN));
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, null, "clientId", "192.168.1.1");
+        assertEquals("Expected and actual values should be the same.", 2232, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void hasCodeTest() {
+        accessToken1.setScopeId(new KapuaIdStatic(BigInteger.TEN));
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, "username", "clientId", "192.168.1.1");
+        assertEquals("Expected and actual values should be the same.", -265711218, kapuaPrincipal.hashCode());
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, "username", "client1", "clientIp");
+        assertTrue("True expected.", kapuaPrincipal.equals(kapuaPrincipal));
+    }
+
+    @Test
+    public void equalsNullTest() {
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, "username", "client1", "clientIp");
+        assertFalse("False expected.", kapuaPrincipal.equals(null));
+    }
+
+    @Test
+    public void equalsDifferentClassTest() {
+        KapuaPrincipalImpl kapuaPrincipal = new KapuaPrincipalImpl(accessToken1, "username", "client1", "clientIp");
+        assertFalse("False expected.", kapuaPrincipal.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNullAccountIdTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        accessToken2.setScopeId(KapuaId.ONE);
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsNullAccountIdsTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsDifferentAccountIdsTest() {
+        accessToken1.setScopeId(new KapuaIdStatic(BigInteger.ONE));
+        accessToken2.setScopeId(new KapuaIdStatic(BigInteger.TEN));
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsSameAccountIdsTest() {
+        accessToken1.setScopeId(new KapuaIdStatic(BigInteger.ONE));
+        accessToken2.setScopeId(new KapuaIdStatic(BigInteger.ONE));
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsNullNameTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, null, "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsDifferentNamesTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username2", "client2", "192.168.1.2");
+        assertFalse("False expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsNullNamesTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, null, "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, null, "client2", "192.168.1.2");
+        assertTrue("True expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+
+    @Test
+    public void equalsSameNamesTest() {
+        KapuaPrincipalImpl kapuaPrincipal1 = new KapuaPrincipalImpl(accessToken1, "username1", "client1", "192.168.1.1");
+        KapuaPrincipalImpl kapuaPrincipal2 = new KapuaPrincipalImpl(accessToken2, "username1", "client2", "192.168.1.2");
+        assertTrue("True expected.", kapuaPrincipal1.equals(kapuaPrincipal2));
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContextTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContextTest.java
@@ -1,0 +1,532 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.apache.activemq.command.ConnectionId;
+import org.apache.activemq.command.ConnectionInfo;
+import org.apache.activemq.security.AuthorizationMap;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaPrincipal;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+import java.security.Principal;
+import java.security.cert.Certificate;
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class KapuaSecurityContextTest extends Assert {
+
+    String clientId;
+    Long[] scopeId;
+    String[] expectedFullClientId;
+    KapuaSession kapuaSession;
+    AccessToken accessToken;
+    ConnectionInfo connectionInfo;
+    ConnectionId connectionId;
+    KapuaPrincipal kapuaPrincipal;
+    Certificate[] certificates;
+    KapuaSecurityContext securityContext1;
+    KapuaSecurityContext securityContext2;
+    Set<Principal> expectedPrincipals;
+    ConnectorDescriptor expectedConnectorDescriptor;
+    String key;
+    String value;
+    String defaultValue;
+
+    @Before
+    public void initialize() {
+        clientId = "client1";
+        scopeId = new Long[]{-1000000L, -10L, -1L, 0L, 1L, 10L, 10000000000L};
+        expectedFullClientId = new String[]{"-1,000,000:client1", "-10:client1", "-1:client1", "0:client1", "1:client1", "10:client1", "10,000,000,000:client1"};
+        kapuaSession = new KapuaSession();
+        KapuaSecurityUtils.setSession(kapuaSession);
+        accessToken = new AccessTokenImpl();
+        connectionInfo = new ConnectionInfo();
+        connectionId = new ConnectionId("connection id");
+        connectionInfo.setConnectionId(connectionId);
+        connectionInfo.setClientId("client ID");
+        connectionInfo.setClientIp("client IP");
+        accessToken.setTokenId("token id");
+        accessToken.setUserId(KapuaId.ONE);
+        accessToken.setScopeId(KapuaId.ONE);
+        kapuaPrincipal = new KapuaPrincipalImpl(accessToken, "username", "clientId", "clientIp");
+        certificates = new Certificate[]{Mockito.mock(Certificate.class), Mockito.mock(Certificate.class)};
+        securityContext1 = new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+        securityContext2 = new KapuaSecurityContext(10L, "clientID");
+        expectedPrincipals = new HashSet<Principal>();
+        expectedPrincipals.add(kapuaPrincipal);
+        expectedConnectorDescriptor = ConnectorDescriptorProviders.getDescriptor("connectorName");
+        key = "Key";
+        value = "value";
+        defaultValue = "defaultValue";
+    }
+
+    @Test
+    public void kapuaSecurityContextScopeIdClientIdTest() {
+        for (int i = 0; i < scopeId.length; i++) {
+            KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(scopeId[i], clientId);
+            assertEquals("Expected and actual values should be the same.", new KapuaEid(BigInteger.valueOf(scopeId[i])), kapuaSecurityContext.getScopeId());
+            assertEquals("Expected and actual values should be the same.", clientId, kapuaSecurityContext.getClientId());
+            assertNull("Null expected.", kapuaSecurityContext.getUserName());
+            assertEquals("Expected and actual values should be the same.", expectedFullClientId[i], kapuaSecurityContext.getFullClientId());
+        }
+    }
+
+    @Test
+    public void kapuaSecurityContextScopeIdClientIdWithoutSessionTest() {
+        KapuaSecurityUtils.clearSession();
+        for (int i = 0; i < scopeId.length; i++) {
+            KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(scopeId[i], clientId);
+            assertEquals("Expected and actual values should be the same.", new KapuaEid(BigInteger.valueOf(scopeId[i])), kapuaSecurityContext.getScopeId());
+            assertEquals("Expected and actual values should be the same.", clientId, kapuaSecurityContext.getClientId());
+            assertNull("NUll expected.", kapuaSecurityContext.getUserName());
+            assertEquals("Expected and actual values should be the same.", expectedFullClientId[i], kapuaSecurityContext.getFullClientId());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void kapuaSecurityContextNullScopeIdClientIdTest() {
+        new KapuaSecurityContext(null, clientId);
+    }
+
+    @Test
+    public void kapuaSecurityContextScopeIdNullClientIdTest() {
+        String[] expectedFullClientId = {"-1,000,000:null", "-10:null", "-1:null", "0:null", "1:null", "10:null", "10,000,000,000:null"};
+        for (int i = 0; i < scopeId.length; i++) {
+            KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(scopeId[i], null);
+            assertEquals("Expected and actual values should be the same.", new KapuaEid(BigInteger.valueOf(scopeId[i])), kapuaSecurityContext.getScopeId());
+            assertNull("NUll expected.", kapuaSecurityContext.getClientId());
+            assertNull("NUll expected.", kapuaSecurityContext.getUserName());
+            assertEquals("Expected and actual values should be the same.", expectedFullClientId[i], kapuaSecurityContext.getFullClientId());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void kapuaSecurityContextWithoutSessionTest() {
+        KapuaSecurityUtils.clearSession();
+        new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+    }
+
+    @Test
+    public void kapuaSecurityContextTest() throws KapuaException {
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getPrincipal());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getKapuaPrincipal());
+        assertEquals("Expected and actual values should be the same.", expectedPrincipals, kapuaSecurityContext.getPrincipals());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getMainPrincipal());
+        assertEquals("Expected and actual values should be the same.", "brokerId", kapuaSecurityContext.getBrokerId());
+        assertEquals("Expected and actual values should be the same.", "brokerIpOrHostName", kapuaSecurityContext.getBrokerIpOrHostName());
+        assertEquals("Expected and actual values should be the same.", "accountName", kapuaSecurityContext.getAccountName());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getScopeId());
+        assertEquals("Expected and actual values should be the same.", 1L, kapuaSecurityContext.getScopeIdAsLong());
+        assertEquals("Expected and actual values should be the same.", "client ID", kapuaSecurityContext.getClientId());
+        assertEquals("Expected and actual values should be the same.", "client IP", kapuaSecurityContext.getClientIp());
+        assertEquals("Expected and actual values should be the same.", "connection id", kapuaSecurityContext.getConnectionId());
+        assertNull("Null expected.", kapuaSecurityContext.getClientCertificates());
+        assertEquals("Expected and actual values should be the same.", expectedConnectorDescriptor, kapuaSecurityContext.getConnectorDescriptor());
+        assertThat("Instance of KapuaSession expected.", kapuaSecurityContext.getKapuaSession(), IsInstanceOf.instanceOf(KapuaSession.class));
+        assertEquals("Expected and actual values should be the same.", "1:client ID", kapuaSecurityContext.getFullClientId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void kapuaSecurityContextNullPrincipalTest() {
+        new KapuaSecurityContext(null, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+    }
+
+    @Test
+    public void kapuaSecurityContextNullBrokerIdTest() throws KapuaException {
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, null, "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getPrincipal());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getKapuaPrincipal());
+        assertEquals("Expected and actual values should be the same.", expectedPrincipals, kapuaSecurityContext.getPrincipals());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getMainPrincipal());
+        assertNull("Null expected.", kapuaSecurityContext.getBrokerId());
+        assertEquals("Expected and actual values should be the same.", "brokerIpOrHostName", kapuaSecurityContext.getBrokerIpOrHostName());
+        assertEquals("Expected and actual values should be the same.", "accountName", kapuaSecurityContext.getAccountName());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getScopeId());
+        assertEquals("Expected and actual values should be the same.", "client ID", kapuaSecurityContext.getClientId());
+        assertEquals("Expected and actual values should be the same.", "client IP", kapuaSecurityContext.getClientIp());
+        assertEquals("Expected and actual values should be the same.", "connection id", kapuaSecurityContext.getConnectionId());
+        assertNull("Null expected.", kapuaSecurityContext.getClientCertificates());
+        assertEquals("Expected and actual values should be the same.", expectedConnectorDescriptor, kapuaSecurityContext.getConnectorDescriptor());
+        assertThat("Instance of KapuaSession expected.", kapuaSecurityContext.getKapuaSession(), IsInstanceOf.instanceOf(KapuaSession.class));
+        assertEquals("Expected and actual values should be the same.", "1:client ID", kapuaSecurityContext.getFullClientId());
+    }
+
+    @Test
+    public void kapuaSecurityContextNullBrokerIpOrHostNameTest() throws KapuaException {
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, "brokerId", null, "accountName", connectionInfo, "connectorName");
+
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getPrincipal());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getKapuaPrincipal());
+        assertEquals("Expected and actual values should be the same.", expectedPrincipals, kapuaSecurityContext.getPrincipals());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getMainPrincipal());
+        assertEquals("Expected and actual values should be the same.", "brokerId", kapuaSecurityContext.getBrokerId());
+        assertNull("Null expected.", kapuaSecurityContext.getBrokerIpOrHostName());
+        assertEquals("Expected and actual values should be the same.", "accountName", kapuaSecurityContext.getAccountName());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getScopeId());
+        assertEquals("Expected and actual values should be the same.", "client ID", kapuaSecurityContext.getClientId());
+        assertEquals("Expected and actual values should be the same.", "client IP", kapuaSecurityContext.getClientIp());
+        assertEquals("Expected and actual values should be the same.", "connection id", kapuaSecurityContext.getConnectionId());
+        assertNull("Null expected.", kapuaSecurityContext.getClientCertificates());
+        assertEquals("Expected and actual values should be the same.", expectedConnectorDescriptor, kapuaSecurityContext.getConnectorDescriptor());
+        assertThat("Instance of KapuaSession expected.", kapuaSecurityContext.getKapuaSession(), IsInstanceOf.instanceOf(KapuaSession.class));
+        assertEquals("Expected and actual values should be the same.", "1:client ID", kapuaSecurityContext.getFullClientId());
+    }
+
+    @Test
+    public void kapuaSecurityContextNullAccountNameTest() throws KapuaException {
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", null, connectionInfo, "connectorName");
+
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getPrincipal());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getKapuaPrincipal());
+        assertEquals("Expected and actual values should be the same.", expectedPrincipals, kapuaSecurityContext.getPrincipals());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getMainPrincipal());
+        assertEquals("Expected and actual values should be the same.", "brokerId", kapuaSecurityContext.getBrokerId());
+        assertEquals("Expected and actual values should be the same.", "brokerIpOrHostName", kapuaSecurityContext.getBrokerIpOrHostName());
+        assertNull("Null expected.", kapuaSecurityContext.getAccountName());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getScopeId());
+        assertEquals("Expected and actual values should be the same.", "client ID", kapuaSecurityContext.getClientId());
+        assertEquals("Expected and actual values should be the same.", "client IP", kapuaSecurityContext.getClientIp());
+        assertEquals("Expected and actual values should be the same.", "connection id", kapuaSecurityContext.getConnectionId());
+        assertNull("Null expected.", kapuaSecurityContext.getClientCertificates());
+        assertEquals("Expected and actual values should be the same.", expectedConnectorDescriptor, kapuaSecurityContext.getConnectorDescriptor());
+        assertThat("Instance of KapuaSession expected.", kapuaSecurityContext.getKapuaSession(), IsInstanceOf.instanceOf(KapuaSession.class));
+        assertEquals("Expected and actual values should be the same.", "1:client ID", kapuaSecurityContext.getFullClientId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void kapuaSecurityContextNullConnectionInfoTest() {
+        new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", null, "connectorName");
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void kapuaSecurityContextNullConnectorNameTest() {
+        new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, null);
+    }
+
+    @Test
+    public void kapuaSecurityContextCertificateTest() throws KapuaException {
+        connectionInfo.setTransportContext(certificates);
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getPrincipal());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getKapuaPrincipal());
+        assertEquals("Expected and actual values should be the same.", expectedPrincipals, kapuaSecurityContext.getPrincipals());
+        assertEquals("Expected and actual values should be the same.", kapuaPrincipal, kapuaSecurityContext.getMainPrincipal());
+        assertEquals("Expected and actual values should be the same.", "brokerId", kapuaSecurityContext.getBrokerId());
+        assertEquals("Expected and actual values should be the same.", "brokerIpOrHostName", kapuaSecurityContext.getBrokerIpOrHostName());
+        assertEquals("Expected and actual values should be the same.", "accountName", kapuaSecurityContext.getAccountName());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, kapuaSecurityContext.getScopeId());
+        assertEquals("Expected and actual values should be the same.", "client ID", kapuaSecurityContext.getClientId());
+        assertEquals("Expected and actual values should be the same.", "client IP", kapuaSecurityContext.getClientIp());
+        assertEquals("Expected and actual values should be the same.", "connection id", kapuaSecurityContext.getConnectionId());
+        assertArrayEquals("Expected and actual values should be the same.", certificates, kapuaSecurityContext.getClientCertificates());
+        assertEquals("Expected and actual values should be the same.", expectedConnectorDescriptor, kapuaSecurityContext.getConnectorDescriptor());
+        assertThat("Instance of KapuaSession expected.", kapuaSecurityContext.getKapuaSession(), IsInstanceOf.instanceOf(KapuaSession.class));
+        assertEquals("Expected and actual values should be the same.", "1:client ID", kapuaSecurityContext.getFullClientId());
+    }
+
+    @Test
+    public void setAndGetAuthorizationMapTest() {
+        AuthorizationMap authorizationMap = Mockito.mock(AuthorizationMap.class);
+
+        assertNull("Null expected.", securityContext1.getAuthorizationMap());
+        securityContext1.setAuthorizationMap(authorizationMap);
+        assertEquals("Expected and actual values should be the same.", authorizationMap, securityContext1.getAuthorizationMap());
+
+        assertNull("Null expected.", securityContext2.getAuthorizationMap());
+        securityContext2.setAuthorizationMap(authorizationMap);
+        assertEquals("Expected and actual values should be the same.", authorizationMap, securityContext2.getAuthorizationMap());
+    }
+
+    @Test
+    public void updateAndGetKapuaConnectionIdTest() {
+        DeviceConnection deviceConnection = Mockito.mock(DeviceConnection.class);
+
+        assertNull("Null expected.", securityContext1.getKapuaConnectionId());
+        securityContext1.updateKapuaConnectionId(null);
+        assertNull("Null expected.", securityContext1.getKapuaConnectionId());
+        securityContext1.updateKapuaConnectionId(deviceConnection);
+        assertNull("Null expected.", securityContext1.getKapuaConnectionId());
+        Mockito.when(deviceConnection.getId()).thenReturn(KapuaId.ONE);
+        securityContext1.updateKapuaConnectionId(deviceConnection);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, securityContext1.getKapuaConnectionId());
+
+        assertNull("Null expected.", securityContext2.getKapuaConnectionId());
+        securityContext2.updateKapuaConnectionId(null);
+        assertNull("Null expected.", securityContext2.getKapuaConnectionId());
+        securityContext2.updateKapuaConnectionId(deviceConnection);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, securityContext2.getKapuaConnectionId());
+        Mockito.when(deviceConnection.getId()).thenReturn(KapuaId.ONE);
+        securityContext2.updateKapuaConnectionId(deviceConnection);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, securityContext2.getKapuaConnectionId());
+    }
+
+    @Test
+    public void setAndIsMissingTest() {
+        assertFalse("False expected.", securityContext1.isMissing());
+        assertFalse("False expected.", securityContext1.getProperty(KapuaSecurityContext.PARAM_KEY_STATUS_MISSING, false));
+        securityContext1.setMissing();
+        assertTrue("True expected.", securityContext1.isMissing());
+        assertTrue("True expected.", securityContext1.getProperty(KapuaSecurityContext.PARAM_KEY_STATUS_MISSING, false));
+
+        assertFalse("False expected.", securityContext2.isMissing());
+        assertFalse("False expected.", securityContext2.getProperty(KapuaSecurityContext.PARAM_KEY_STATUS_MISSING, false));
+        securityContext2.setMissing();
+        assertTrue("True expected.", securityContext2.isMissing());
+        assertTrue("True expected.", securityContext2.getProperty(KapuaSecurityContext.PARAM_KEY_STATUS_MISSING, false));
+    }
+
+    @Test
+    public void updateAndHasPermissionsTest() {
+        boolean[] hasPermissions = {true, false, false, true, true, false};
+
+        assertNull("Null expected.", securityContext1.getHasPermissions());
+        securityContext1.updatePermissions(hasPermissions);
+        assertEquals("Expected and actual values should be the same.", hasPermissions, securityContext1.getHasPermissions());
+        assertTrue("True expected.", securityContext1.isBrokerConnect());
+        assertFalse("False expected.", securityContext1.isDeviceManage());
+        assertFalse("False expected.", securityContext1.isDataView());
+        assertTrue("True expected.", securityContext1.isDataManage());
+        assertTrue("True expected.", securityContext1.isDeviceView());
+
+        assertNull("Null expected.", securityContext2.getHasPermissions());
+        securityContext2.updatePermissions(hasPermissions);
+        assertEquals("Expected and actual values should be the same.", hasPermissions, securityContext2.getHasPermissions());
+        assertTrue("True expected.", securityContext2.isBrokerConnect());
+        assertFalse("False expected.", securityContext2.isDeviceManage());
+        assertFalse("False expected.", securityContext2.isDataView());
+        assertTrue("True expected.", securityContext2.isDataManage());
+        assertTrue("True expected.", securityContext2.isDeviceView());
+    }
+
+    @Test
+    public void updateAndGetOldConnectionIdTest() {
+        String[] oldConnectionIds = {"", "old connection id", "1234567890", "!@#$%^&*()_/.,>?"};
+
+        assertNull("Null expected.", securityContext1.getOldConnectionId());
+        for (String oldConnectionId : oldConnectionIds) {
+            securityContext1.updateOldConnectionId(oldConnectionId);
+            assertEquals("Expected and actual values should be the same.", oldConnectionId, securityContext1.getOldConnectionId());
+        }
+        securityContext1.updateOldConnectionId(null);
+        assertNull("Null expected.", securityContext1.getKapuaConnectionId());
+
+        assertNull("Null expected.", securityContext2.getOldConnectionId());
+        for (String oldConnectionId : oldConnectionIds) {
+            securityContext2.updateOldConnectionId(oldConnectionId);
+            assertEquals("Expected and actual values should be the same.", oldConnectionId, securityContext2.getOldConnectionId());
+        }
+        securityContext2.updateOldConnectionId(null);
+        assertNull("Null expected.", securityContext2.getKapuaConnectionId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void getScopeIdAsLongNullScopeIdTest() {
+        accessToken.setScopeId(null);
+        kapuaPrincipal = new KapuaPrincipalImpl(accessToken, "username", "clientId", "clientIp");
+        KapuaSecurityContext kapuaSecurityContext = new KapuaSecurityContext(kapuaPrincipal, "brokerId", "brokerIpOrHostName", "accountName", connectionInfo, "connectorName");
+        kapuaSecurityContext.getScopeIdAsLong();
+    }
+
+    @Test
+    public void setAndIsAdminTest() {
+        assertFalse("False expected.", securityContext1.isAdmin());
+        assertFalse("False expected.", securityContext1.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+        securityContext1.setAdmin(true);
+        assertTrue("True expected.", securityContext1.isAdmin());
+        assertTrue("True expected.", securityContext1.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+        securityContext1.setAdmin(false);
+        assertFalse("False expected.", securityContext1.isAdmin());
+        assertFalse("False expected.", securityContext1.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+
+        assertFalse("False expected.", securityContext2.isAdmin());
+        assertFalse("False expected.", securityContext2.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+        securityContext2.setAdmin(true);
+        assertTrue("True expected.", securityContext2.isAdmin());
+        assertTrue("True expected.", securityContext2.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+        securityContext2.setAdmin(false);
+        assertFalse("False expected.", securityContext2.isAdmin());
+        assertFalse("False expected.", securityContext2.getProperty(KapuaSecurityContext.PARAM_KEY_PROFILE_ADMIN, false));
+    }
+
+    @Test
+    public void isBrokerConnectNullPermissionsTest() {
+        try {
+            securityContext1.isBrokerConnect();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            securityContext2.isBrokerConnect();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void isDeviceViewNullPermissionsTest() {
+        try {
+            securityContext1.isDeviceView();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            securityContext2.isDeviceView();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void isDeviceManageNullPermissionsTest() {
+        try {
+            securityContext1.isDeviceManage();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            securityContext2.isDeviceManage();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void isDataViewNullPermissionsTest() {
+        try {
+            securityContext1.isDataView();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            securityContext2.isDataView();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void isDataManageNullPermissionsTest() {
+        try {
+            securityContext1.isDeviceManage();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            securityContext2.isDeviceManage();
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void setAndGetPropertyTest() {
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(key, defaultValue));
+        securityContext1.setProperty(key, value);
+        assertEquals("Expected and actual values should be the same.", value, securityContext1.getProperty(key, defaultValue));
+    }
+
+    @Test
+    public void setAndGetPropertyNullValueTest() {
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(key, defaultValue));
+        securityContext1.setProperty(key, null);
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(key, defaultValue));
+    }
+
+    @Test
+    public void setAndGetPropertyNullKeyTest() {
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(key, defaultValue));
+        securityContext1.setProperty(null, value);
+        assertEquals("Expected and actual values should be the same.", value, securityContext1.getProperty(null, defaultValue));
+    }
+
+    @Test
+    public void setAndGetPropertyNullKeyNullValueTest() {
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(key, defaultValue));
+        securityContext1.setProperty(null, null);
+        assertEquals("Expected and actual values should be the same.", defaultValue, securityContext1.getProperty(null, defaultValue));
+    }
+
+    @Test
+    public void addAuthDestinationToLogTest() {
+        String[] messages = {null, "", "message()", "message_123", "!m3ss@g3", " message me-ssa_ge", "m<123>"};
+
+        for (String message : messages) {
+            try {
+                securityContext1.addAuthDestinationToLog(message);
+            } catch (Exception e) {
+                fail("Exception not expected.");
+            }
+
+            try {
+                securityContext2.addAuthDestinationToLog(message);
+            } catch (Exception e) {
+                fail("Exception not expected.");
+            }
+        }
+    }
+
+    @Test
+    public void logAuthDestinationToLogTest() {
+        try {
+            securityContext1.logAuthDestinationToLog();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+
+        try {
+            securityContext2.logAuthDestinationToLog();
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in broker/core/plugin package:
 - ConnectorDescriptorProviders class
 - ConnectorDescriptor class
 - DefaultBrokerIdResolver class
 - DefaultBrokerIpResolver class
 - KapuaDuplicateClientIdException class
 - KapuaPrincipalImpl class
 - KapuaSecurityContext class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
