### PR TITLE
Added Junit tests for broker/core and transport module

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/AclTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/AclTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AclTest extends Assert {
+
+    boolean[] readPermissions;
+    boolean[] writePermissions;
+    boolean[] adminPermission;
+
+    @Before
+    public void initialize() {
+        readPermissions = new boolean[]{true, false};
+        writePermissions = new boolean[]{true, false};
+        adminPermission = new boolean[]{true, false};
+    }
+
+    @Test
+    public void aclTest() {
+        for (boolean read : readPermissions) {
+            for (boolean write : writePermissions) {
+                for (boolean admin : adminPermission) {
+                    Acl acl = new Acl(read, write, admin);
+                    assertEquals("Expected and actual values should be the same.", read, acl.isRead());
+                    assertEquals("Expected and actual values should be the same.", write, acl.isWrite());
+                    assertEquals("Expected and actual values should be the same.", admin, acl.isAdmin());
+                }
+            }
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProviderTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/DefaultConnectorDescriptionProviderTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DefaultConnectorDescriptionProviderTest extends Assert {
+
+    String[] connectorName;
+
+    @Before
+    public void initialize() {
+        connectorName = new String[]{null, "", "connector name", "name1234567890", "connector!@#$%^&*()_<>/"};
+    }
+
+    @Test
+    public void getDescriptorTest() {
+        System.setProperty("broker.connector.descriptor.default.disable", "false");
+        System.setProperty("broker.connector.descriptor.configuration.uri", "file:src/test/resources/conector.descriptor/1.properties");
+        DefaultConnectorDescriptionProvider defaultConnectorDescriptionProvider = new DefaultConnectorDescriptionProvider();
+
+        for (String name : connectorName) {
+            assertThat("Instance of ConnectorDescriptor expected.", defaultConnectorDescriptionProvider.getDescriptor(name), IsInstanceOf.instanceOf(ConnectorDescriptor.class));
+        }
+    }
+
+    @Test
+    public void getDescriptorDisabledDefaultConnectorDescriptorTest() {
+        System.setProperty("broker.connector.descriptor.default.disable", "true");
+        System.setProperty("broker.connector.descriptor.configuration.uri", "");
+        DefaultConnectorDescriptionProvider defaultConnectorDescriptionProvider = new DefaultConnectorDescriptionProvider();
+
+        for (String name : connectorName) {
+            assertNull("Null expected.", defaultConnectorDescriptionProvider.getDescriptor(name));
+        }
+    }
+
+    @Test
+    public void getDescriptorConfigurationFirstPropertiesTest() {
+        System.setProperty("broker.connector.descriptor.default.disable", "true");
+        System.setProperty("broker.connector.descriptor.configuration.uri", "file:src/test/resources/conector.descriptor/1.properties");
+        DefaultConnectorDescriptionProvider defaultConnectorDescriptionProvider = new DefaultConnectorDescriptionProvider();
+
+        for (String name : connectorName) {
+            assertNull("Null expected.", defaultConnectorDescriptionProvider.getDescriptor(name));
+        }
+    }
+
+    @Test
+    public void getDescriptorConfigurationSecondPropertiesTest() {
+        System.setProperty("broker.connector.descriptor.configuration.uri", "file:src/test/resources/conector.descriptor/2.properties");
+        DefaultConnectorDescriptionProvider defaultConnectorDescriptionProvider = new DefaultConnectorDescriptionProvider();
+
+        for (String name : connectorName) {
+            assertThat("Instance of ConnectorDescriptor expected.", defaultConnectorDescriptionProvider.getDescriptor(name), IsInstanceOf.instanceOf(ConnectorDescriptor.class));
+        }
+    }
+
+    @Test(expected = Exception.class)
+    public void getDescriptorNoClassExceptionTest() {
+        System.setProperty("broker.connector.descriptor.default.disable", "true");
+        System.setProperty("broker.connector.descriptor.configuration.uri", "file:src/test/resources/conector.descriptor/3.properties");
+
+        DefaultConnectorDescriptionProvider defaultConnectorDescriptionProvider = new DefaultConnectorDescriptionProvider();
+        for (String name : connectorName) {
+            defaultConnectorDescriptionProvider.getDescriptor(name);
+        }
+    }
+
+    @Test(expected = Exception.class)
+    public void getDescriptorNoProtocolExceptionTest() {
+        System.setProperty("broker.connector.descriptor.configuration.uri", "aaa");
+        new DefaultConnectorDescriptionProvider();
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaApplicationBrokerFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaApplicationBrokerFilterTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.activemq.broker.Broker;
+import org.eclipse.kapua.broker.core.plugin.KapuaApplicationBrokerFilter;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class KapuaApplicationBrokerFilterTest extends Assert {
+
+    @Test
+    public void kapuaApplicationBrokerFilterTest() {
+        Broker broker = Mockito.mock(Broker.class);
+
+        try {
+            new KapuaApplicationBrokerFilter(broker);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void kapuaApplicationBrokerFilterNullTest() {
+        try {
+            new KapuaApplicationBrokerFilter(null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void stopTest() throws Exception {
+        KapuaApplicationBrokerFilter kapuaApplicationBrokerFilter = new KapuaApplicationBrokerFilter(Mockito.mock(Broker.class));
+        try {
+            kapuaApplicationBrokerFilter.stop();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void stopNullTest() throws Exception {
+        KapuaApplicationBrokerFilter kapuaApplicationBrokerFilter = new KapuaApplicationBrokerFilter(null);
+        kapuaApplicationBrokerFilter.stop();
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSecurityBrokerFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSecurityBrokerFilterTest.java
@@ -1,0 +1,342 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.activemq.command.ConnectionInfo;
+import org.apache.activemq.command.BrokerId;
+import org.apache.activemq.command.ActiveMQDestination;
+import org.apache.activemq.command.Message;
+import org.apache.activemq.broker.ProducerBrokerExchange;
+import org.apache.activemq.broker.TransportConnector;
+import org.apache.activemq.broker.Broker;
+import org.apache.activemq.broker.ConnectionContext;
+import org.apache.activemq.broker.Connection;
+import org.apache.activemq.command.ConsumerInfo;
+import org.apache.activemq.security.SecurityContext;
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityBrokerFilter;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class KapuaSecurityBrokerFilterTest extends Assert {
+
+    Broker broker;
+    BrokerId brokerId;
+    ConnectionContext connectionContext;
+    ConnectionInfo connectionInfo;
+    Connection connection;
+    TransportConnector connector;
+    ConsumerInfo consumerInfo;
+    KapuaSecurityBrokerFilter kapuaSecurityBrokerFilter;
+    KapuaSecurityBrokerFilter nullKapuaSecurityBrokerFilter;
+
+    @Before
+    public void initialize() {
+        broker = Mockito.mock(Broker.class);
+        brokerId = new BrokerId();
+        connectionContext = new ConnectionContext();
+        connectionInfo = new ConnectionInfo();
+        connection = Mockito.mock(Connection.class);
+        connector = Mockito.mock(TransportConnector.class);
+        consumerInfo = Mockito.mock(ConsumerInfo.class);
+        kapuaSecurityBrokerFilter = new KapuaSecurityBrokerFilter(broker);
+        nullKapuaSecurityBrokerFilter = new KapuaSecurityBrokerFilter(null);
+    }
+
+    @Test
+    public void startTest() {
+        try {
+            Mockito.when(broker.getBrokerId()).thenReturn(brokerId);
+            kapuaSecurityBrokerFilter.start();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void startNullBrokerTest() throws Exception {
+        nullKapuaSecurityBrokerFilter.start();
+    }
+
+    @Test
+    public void stopTest() {
+        try {
+            kapuaSecurityBrokerFilter.stop();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void stopNullBrokerTest() throws Exception {
+        nullKapuaSecurityBrokerFilter.stop();
+    }
+
+    @Test
+    public void addConnectionWithoutConnectorTest() {
+        connectionInfo.setUserName("kapua-sys");
+        connectionInfo.setPassword("kapua-password");
+        System.setProperty("broker.connector.internal.username", "kapua-sys");
+        System.setProperty("broker.connector.internal.password", "kapua-password");
+
+        try {
+            kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+
+    @Test
+    public void addConnectionWithConnectorAndTrueConnectionTest() {
+        connectionContext.setConnector(connector);
+        connectionContext.setConnection(connection);
+
+        Mockito.when(connection.isNetworkConnection()).thenReturn(true);
+        try {
+            kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+
+        try {
+            nullKapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void addConnectionWithConnectorNameVmTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("vm://message-broker");
+        Mockito.when(connectionContext.getSecurityContext()).thenReturn(Mockito.mock(SecurityContext.class));
+
+        try {
+            kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void addConnectionWithConnectorNameInternalTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+        connectionInfo.setUserName("kapua-sys");
+        connectionInfo.setPassword("kapua-password");
+        System.setProperty("broker.connector.internal.username", "kapua-sys");
+        System.setProperty("broker.connector.internal.password", "kapua-password");
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("internalMqtt");
+        try {
+            kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void addConnectionNullInfoTest() {
+        connectionContext.setConnector(connector);
+        connectionContext.setConnection(connection);
+
+        Mockito.when(connection.isNetworkConnection()).thenReturn(true);
+
+        try {
+            kapuaSecurityBrokerFilter.addConnection(connectionContext, null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.addConnection(connectionContext, null);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test(expected = SecurityException.class)
+    public void addConnectionDifferentUsernamesTest() throws Exception {
+        connectionInfo.setUserName("username");
+        connectionInfo.setPassword("kapua-password");
+        System.setProperty("broker.connector.internal.username", "kapua-sys");
+        System.setProperty("broker.connector.internal.password", "kapua-password");
+
+        kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+    }
+
+    @Test(expected = SecurityException.class)
+    public void addConnectionDifferentPasswordsTest() throws Exception {
+        ConnectionContext connectionContext = new ConnectionContext();
+        ConnectionInfo connectionInfo = new ConnectionInfo();
+        connectionInfo.setUserName("kapua-sys");
+        connectionInfo.setPassword("password");
+        System.setProperty("broker.connector.internal.username", "kapua-sys");
+        System.setProperty("broker.connector.internal.password", "kapua-password");
+
+        kapuaSecurityBrokerFilter.addConnection(connectionContext, connectionInfo);
+    }
+
+    @Test
+    public void removeConnectionTest() {
+        try {
+            kapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+
+        try {
+            nullKapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void removeConnectionWithNetworkConnectionTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+        Connection connection = Mockito.mock(Connection.class);
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("Connector name");
+        Mockito.when(connectionContext.getConnection()).thenReturn(connection);
+        Mockito.doReturn(true).when(connection).isNetworkConnection();
+        Mockito.when(connectionContext.getSecurityContext()).thenReturn(Mockito.mock(SecurityContext.class));
+
+        try {
+            kapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void removeConnectionConnectorNameVmTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("vm://message-broker");
+        Mockito.when(connectionContext.getConnection()).thenReturn(connection);
+        Mockito.doReturn(true).when(connection).isNetworkConnection();
+        Mockito.when(connectionContext.getSecurityContext()).thenReturn(Mockito.mock(SecurityContext.class));
+
+        try {
+            kapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test
+    public void removeConnectorConnectionNameInternalTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("internalMqtt");
+        Mockito.when(connectionContext.getConnection()).thenReturn(connection);
+        Mockito.doReturn(true).when(connection).isNetworkConnection();
+        Mockito.when(connectionContext.getSecurityContext()).thenReturn(Mockito.mock(SecurityContext.class));
+
+        try {
+            kapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+
+    @Test(expected = SecurityException.class)
+    public void removeInvalidSecurityContextTest() throws Exception {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+
+        Mockito.when(connectionContext.getConnector()).thenReturn(connector);
+        Mockito.when((connector).getName()).thenReturn("Connector name");
+        Mockito.when(connectionContext.getConnection()).thenReturn(connection);
+        Mockito.doReturn(false).when(connection).isNetworkConnection();
+        Mockito.when(connectionContext.getSecurityContext()).thenReturn(Mockito.mock(SecurityContext.class));
+        kapuaSecurityBrokerFilter.removeConnection(connectionContext, connectionInfo, new Throwable());
+    }
+
+    @Test(expected = SecurityException.class)
+    public void sendInvalidCharactersInDestinationNameTest() throws Exception {
+        String[] destinationName = {"Destination#", "+destination"};
+        ProducerBrokerExchange producerExchange = Mockito.mock(ProducerBrokerExchange.class);
+        Message messageSend = Mockito.mock(Message.class);
+        ActiveMQDestination activeMQDestination = Mockito.mock(ActiveMQDestination.class);
+        Mockito.when(messageSend.getDestination()).thenReturn(activeMQDestination);
+        for (String name : destinationName) {
+            Mockito.when(activeMQDestination.getPhysicalName()).thenReturn(name);
+            kapuaSecurityBrokerFilter.send(producerExchange, messageSend);
+        }
+    }
+
+    @Test
+    public void addConsumerTest() {
+        ConnectionContext connectionContext = Mockito.mock(ConnectionContext.class);
+        try {
+            kapuaSecurityBrokerFilter.addConsumer(connectionContext, consumerInfo);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+        try {
+            nullKapuaSecurityBrokerFilter.addConsumer(connectionContext, consumerInfo);
+            fail("Exception expected.");
+        } catch (Exception ex) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), ex.toString());
+        }
+    }
+}

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportClientGetExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportClientGetExceptionTest.java
@@ -14,123 +14,90 @@ package org.eclipse.kapua.transport.exception;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
-import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(JUnitTests.class)
 public class TransportClientGetExceptionTest extends Assert {
 
-    TransportClientGetException exception;
-
-    @Before
-    public void start() {
-        exception = new TransportClientGetException("127.0.0.1");
-    }
-
     @Test
-    public void constructorNullTest() {
-        try {
-            TransportClientGetException transportClientGetException = new TransportClientGetException(null);
-            assertNull(transportClientGetException.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown.");
-        }
-    }
-
-    @Test
-    public void constructorRandomStringsTest() {
-        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
-        for (String randomString : randomStrings) {
-            try {
-                TransportClientGetException transportClientGetException = new TransportClientGetException(randomString);
-                assertEquals(randomString, transportClientGetException.getRequestMessage());
-            } catch (Exception e) {
-                fail("Exception should not be thrown. The problem occurs when constructor gets \"" + randomString + "\" as a parameter.");
-            }
-        }
-    }
-
-    @Test
-    public void secondConstructorNullTest() {
-        try {
-            TransportClientGetException transportClientGetException = new TransportClientGetException(null, null);
-            assertNull(transportClientGetException.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown.");
-        }
-    }
-
-    @Test
-    public void secondConstructorRandomStringsTest() {
-        Throwable throwable = new Throwable();
-        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
-        for (String randomString : randomStrings) {
-            try {
-                TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, randomString);
-                assertEquals(randomString, transportClientGetException.getRequestMessage());
-            } catch (Exception e) {
-                fail("Exception should not be thrown. The problem occurs when constructor gets \"" + randomString + "\" as a parameter.");
-            }
-        }
-    }
-
-    @Test
-    public void secondConstructorNullThrowableTest() {
-        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
-        for (String randomString : randomStrings) {
-            try {
-                TransportClientGetException transportClientGetException = new TransportClientGetException(null, randomString);
-                assertEquals(randomString, transportClientGetException.getRequestMessage());
-            } catch (Exception e) {
-                fail("Exception should not be thrown. The problem occurs when constructor gets \"" + randomString + "\" as a parameter.");
-            }
-        }
-    }
-
-    @Test
-    public void secondConstructorNullServerIpTest() {
-        Throwable throwable = new Throwable();
-        try {
-            TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, null);
-            assertNull(transportClientGetException.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown.");
-        }
-    }
-
-    @Test(expected = TransportClientGetException.class)
-    public void throwingExceptionTest() throws TransportClientGetException {
-        throw exception;
-    }
-
-    @Test(expected = TransportClientGetException.class)
-    public void throwingExceptionUsingFirstConstructorTest() throws TransportClientGetException {
-        throw new TransportClientGetException("127.0.0.1");
-    }
-
-    @Test(expected = TransportClientGetException.class)
-    public void throwingExceptionUsingSecondConstructorTest() throws TransportClientGetException {
-        throw new TransportClientGetException(new Throwable(), "127.0.0.1");
-    }
-
-    @Test
-    public void getRequestMessageNullTest() {
+    public void transportClientGetExceptionNullServerIpTest() {
         TransportClientGetException transportClientGetException = new TransportClientGetException(null);
-        assertNull(transportClientGetException.getRequestMessage());
+        assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        assertNull("Null expected.", transportClientGetException.getCause());
     }
 
     @Test
-    public void getRequestMessageRandomStringTest() {
+    public void transportClientGetExceptionServerIpTest() {
+        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
+        for (String randomString : randomStrings) {
+            TransportClientGetException transportClientGetException = new TransportClientGetException(randomString);
+            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            assertNull("Null expected.", transportClientGetException.getCause());
+        }
+    }
+
+    @Test
+    public void transportClientGetExceptionCauseServerIpNullTest() {
+        TransportClientGetException transportClientGetException = new TransportClientGetException(null, null);
+        assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        assertNull("Null expected.", transportClientGetException.getCause());
+    }
+
+    @Test
+    public void transportClientGetExceptionCauseServerIpTest() {
         Throwable throwable = new Throwable();
         String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
         for (String randomString : randomStrings) {
-            try {
-                TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, randomString);
-                assertEquals(randomString, transportClientGetException.getRequestMessage());
-            } catch (Exception e) {
-                fail("Exception should not be thrown. The problem occurs when constructor gets \"" + randomString + "\" as a parameter.");
-            }
+            TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, randomString);
+            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
+        }
+    }
+
+    @Test
+    public void transportClientGetExceptionNullCauseServerIpTest() {
+        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
+        for (String randomString : randomStrings) {
+            TransportClientGetException transportClientGetException = new TransportClientGetException(null, randomString);
+            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            assertNull("Null expected.", transportClientGetException.getCause());
+        }
+    }
+
+    @Test
+    public void transportClientGetExceptionCauseNullServerIpTest() {
+        Throwable throwable = new Throwable();
+        TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, null);
+        assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
+    }
+
+    @Test(expected = TransportClientGetException.class)
+    public void throwingExceptionWithServerIpTest() throws TransportClientGetException {
+        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
+        for (String randomString : randomStrings) {
+            throw new TransportClientGetException(randomString);
+        }
+    }
+
+    @Test(expected = TransportClientGetException.class)
+    public void throwingExceptionWithCauseAndServerIpTest() throws TransportClientGetException {
+        String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
+        for (String randomString : randomStrings) {
+            throw new TransportClientGetException(new Throwable(), randomString);
         }
     }
 }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportExceptionTest.java
@@ -17,22 +17,170 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
+
+import javax.annotation.Nullable;
 
 @Category(JUnitTests.class)
 public class TransportExceptionTest extends Assert {
 
-    TransportException transportException;
-    private static final String KAPUA_ERROR_MESSAGES = "transport-client-error-messages";
+    TransportErrorCodes[] transportErrorCodes;
+    String kapuaErrorMessage;
+    String[] expectedMessageWithoutObject;
+    String[] expectedMessageWithObject;
+    Object object, stringObject, intObject;
+    Throwable[] throwable;
 
     @Before
-    public void start() {
-        transportException = Mockito.mock(TransportException.class);
-        Mockito.doCallRealMethod().when(transportException).getKapuaErrorMessagesBundle();
+    public void initialize() {
+        transportErrorCodes = new TransportErrorCodes[]{TransportErrorCodes.SEND_ERROR, TransportErrorCodes.TIMEOUT, TransportErrorCodes.CLIENT_GET};
+        kapuaErrorMessage = "transport-client-error-messages";
+        object = new Object();
+        stringObject = "String Object";
+        intObject = 11;
+        expectedMessageWithoutObject = new String[]{"An error occurred when sending the message: {0}", "The request has not received a response within the timeout of: {0}ms", "Cannot get an instance of the transport client to connect to host: {0}"};
+        expectedMessageWithObject = new String[]{"An error occurred when sending the message: " + object, "The request has not received a response within the timeout of: " + object + "ms", "Cannot get an instance of the transport client to connect to host: " + object};
+        throwable = new Throwable[]{new Throwable(), null};
+    }
+
+    private class TransportExceptionImpl extends TransportException {
+
+        protected TransportExceptionImpl(TransportErrorCodes code) {
+            super(code);
+        }
+
+        protected TransportExceptionImpl(TransportErrorCodes code, @Nullable Object... arguments) {
+            super(code, arguments);
+        }
+
+        protected TransportExceptionImpl(TransportErrorCodes code, Throwable cause, @Nullable Object... arguments) {
+            super(code, cause, arguments);
+        }
     }
 
     @Test
-    public void getKapuaErrorMessagesBundleTest() {
-        assertEquals(KAPUA_ERROR_MESSAGES, transportException.getKapuaErrorMessagesBundle());
+    public void transportExceptionCodeTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i]);
+            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            assertNull("Null expected.", transportException.getCause());
+        }
+    }
+
+    @Test
+    public void transportExceptionNullCodeTest() {
+        TransportException transportException = new TransportExceptionImpl(null);
+        assertNull("Null expected.", transportException.getCode());
+        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+        assertNull("Null expected.", transportException.getCause());
+        try {
+            transportException.getMessage();
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void transportExceptionCodeArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], object, stringObject, intObject);
+            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            assertNull("Null expected.", transportException.getCause());
+        }
+    }
+
+    @Test
+    public void transportExceptionCodeNullArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], null);
+            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            assertNull("Null expected.", transportException.getCause());
+        }
+    }
+
+    @Test
+    public void transportExceptionNullCodeArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            TransportException transportException = new TransportExceptionImpl(null, object, stringObject, intObject);
+            assertNull("Null expected.", transportException.getCode());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            assertNull("Null expected.", transportException.getCause());
+            try {
+                transportException.getMessage();
+            } catch (Exception e) {
+                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void transportExceptionCodeCauseArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            for (Throwable cause : throwable) {
+                TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], cause, object, stringObject, intObject);
+                assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+                assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
+                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void transportExceptionCodeCauseNullArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            for (Throwable cause : throwable) {
+                TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], cause, null);
+                assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+                assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void transportExceptionNullCodeCauseArgumentsTest() {
+        for (int i = 0; i < transportErrorCodes.length; i++) {
+            for (Throwable cause : throwable) {
+                TransportException transportException = new TransportExceptionImpl(null, cause, object, stringObject, intObject);
+                assertNull("Null expected.", transportException.getCode());
+                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+                try {
+                    transportException.getMessage();
+                } catch (Exception e) {
+                    assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                }
+            }
+        }
+    }
+
+    @Test(expected = TransportException.class)
+    public void throwingTransportExceptionCodeTest() throws TransportExceptionImpl {
+        for (TransportErrorCodes code : transportErrorCodes) {
+            throw new TransportExceptionImpl(code);
+        }
+    }
+
+    @Test(expected = TransportException.class)
+    public void throwingTransportExceptionCodeArgumentsTest() throws TransportExceptionImpl {
+        for (TransportErrorCodes code : transportErrorCodes) {
+            throw new TransportExceptionImpl(code, object, stringObject, intObject);
+        }
+    }
+
+    @Test(expected = TransportException.class)
+    public void throwingTransportExceptionCodeCauseArgumentsTest() throws TransportExceptionImpl {
+        for (TransportErrorCodes code : transportErrorCodes) {
+            for (Throwable cause : throwable) {
+                throw new TransportExceptionImpl(code, cause, object, stringObject, intObject);
+            }
+        }
     }
 }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportSendExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportSendExceptionTest.java
@@ -22,68 +22,81 @@ import org.junit.experimental.categories.Category;
 @Category(JUnitTests.class)
 public class TransportSendExceptionTest extends Assert {
 
-    TransportSendException transportSendException;
     TransportMessage transportMessage;
+    Throwable throwable;
 
     @Before
-    public void start() {
+    public void initialize() {
         transportMessage = new TransportMessage() {
             @Override
             public int hashCode() {
                 return super.hashCode();
             }
         };
-        transportSendException = new TransportSendException(new Throwable(), transportMessage);
+        throwable = new Throwable();
     }
 
     @Test
-    public void firstConstructorTest() {
-        try {
-            TransportSendException exception = new TransportSendException(transportMessage);
-            assertEquals(transportMessage, exception.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown");
-        }
+    public void transportSendExceptionWithMessageTest() {
+        TransportSendException transportSendException = new TransportSendException(transportMessage);
+        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
-    public void firstConstructorNullTest() {
-        try {
-            TransportSendException exception = new TransportSendException(null);
-            assertNull(exception.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown");
-        }
+    public void transportSendExceptionWithNullMessageTest() {
+        TransportSendException transportSendException = new TransportSendException(null);
+        assertNull("Null expected.", transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
-    public void secondConstructorTest() {
-        try {
-            TransportSendException exception = new TransportSendException(new Throwable(), transportMessage);
-            assertEquals(transportMessage, exception.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown");
-        }
+    public void transportSendExceptionWithCauseAndMessageTest() {
+        TransportSendException transportSendException = new TransportSendException(throwable, transportMessage);
+        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
     }
 
     @Test
-    public void secondConstructorNullTest() {
-        try {
-            TransportSendException exception = new TransportSendException(null, null);
-            assertNull(exception.getRequestMessage());
-        } catch (Exception e) {
-            fail("Exception should not be thrown");
-        }
+    public void transportSendExceptionWithCauseAndMessageNullTest() {
+        TransportSendException transportSendException = new TransportSendException(null, null);
+        assertNull("Null expected.", transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
-    public void getRequestMessageTest() {
-        assertEquals(transportMessage, transportSendException.getRequestMessage());
+    public void transportSendExceptionWithNullCauseAndMessageTest() {
+        TransportSendException transportSendException = new TransportSendException(null, transportMessage);
+        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
-    public void getRequestMessageNullTest() {
-        TransportSendException exception = new TransportSendException(null, null);
-        assertNull(exception.getRequestMessage());
+    public void transportSendExceptionWithCauseAndNullMessageTest() {
+        TransportSendException transportSendException = new TransportSendException(throwable, null);
+        assertNull("Null expected.", transportSendException.getRequestMessage());
+        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
+    }
+
+    @Test(expected = TransportSendException.class)
+    public void throwingTransportSendExceptionWithMessageTest() throws TransportSendException {
+        throw new TransportSendException(transportMessage);
+    }
+
+    @Test(expected = TransportSendException.class)
+    public void throwingTransportSendExceptionWithCauseAndMessageTest() throws TransportSendException {
+        throw new TransportSendException(throwable, transportMessage);
     }
 }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportTimeoutExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportTimeoutExceptionTest.java
@@ -14,24 +14,40 @@ package org.eclipse.kapua.transport.exception;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(JUnitTests.class)
 public class TransportTimeoutExceptionTest extends Assert {
 
-    @Test
-    public void getTimeoutTest() {
-        long[] values = {1, 3, -1000, -645361239, 1235563423, 0};
-        for (long value : values) {
-            TransportTimeoutException exception = new TransportTimeoutException(value);
-            assertEquals(value, exception.getTimeout().longValue());
-        }
+    Long[] values;
+    String[] expectedMessage;
+
+    @Before
+    public void initialize() {
+        values = new Long[]{1L, 3L, -1000L, -645361239L, 1235563423L, 0L, null};
+        expectedMessage = new String[]{"The request has not received a response within the timeout of: 1ms", "The request has not received a response within the timeout of: 3ms",
+                "The request has not received a response within the timeout of: -1,000ms", "The request has not received a response within the timeout of: -645,361,239ms",
+                "The request has not received a response within the timeout of: 1,235,563,423ms", "The request has not received a response within the timeout of: 0ms",
+                "The request has not received a response within the timeout of: nullms"};
     }
 
     @Test
-    public void getTimeoutIfNullTest() {
-        TransportTimeoutException exception = new TransportTimeoutException(null);
-        assertNull(exception.getTimeout());
+    public void transportTimeoutExceptionTest() {
+        for (int i = 0; i < values.length; i++) {
+            TransportTimeoutException transportTimeoutException = new TransportTimeoutException(values[i]);
+            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.TIMEOUT, transportTimeoutException.getCode());
+            assertEquals("Expected and actual values should be the same.", values[i], transportTimeoutException.getTimeout());
+            assertEquals("Expected and actual values should be the same.", expectedMessage[i], transportTimeoutException.getMessage());
+            assertNull("Null expected.", transportTimeoutException.getCause());
+        }
+    }
+
+    @Test(expected = TransportTimeoutException.class)
+    public void throwingTransportTimeoutExceptionTest() throws TransportTimeoutException {
+        for (Long value : values) {
+            throw new TransportTimeoutException(value);
+        }
     }
 }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/utils/ClientIdGeneratorTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/utils/ClientIdGeneratorTest.java
@@ -18,34 +18,45 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
 @Category(JUnitTests.class)
 public class ClientIdGeneratorTest extends Assert {
 
     ClientIdGenerator clientIdGenerator;
 
     @Before
-    public void start() {
+    public void initialize() {
         clientIdGenerator = ClientIdGenerator.getInstance();
     }
 
     @Test
-    public void nextWithoutParametersTest() {
-        String newId = clientIdGenerator.next();
-        assertTrue(newId.startsWith("Id"));
+    public void clientIdGeneratorTest() throws Exception {
+        Constructor<ClientIdGenerator> clientIdGenerator = ClientIdGenerator.class.getDeclaredConstructor();
+        assertTrue(Modifier.isPrivate(clientIdGenerator.getModifiers()));
+        clientIdGenerator.setAccessible(true);
+        clientIdGenerator.newInstance();
     }
 
     @Test
-    public void nextWithParametersTest() {
+    public void nextWithoutParameterTest() {
+        String newId = clientIdGenerator.next();
+        assertTrue("True expected.", newId.startsWith("Id"));
+    }
+
+    @Test
+    public void nextWithParameterTest() {
         String[] parameters = {"1", "testtest", "1232153", "!!$%&/&(())", "a1"};
         for (String parameter : parameters) {
             String newId = clientIdGenerator.next(parameter);
-            assertTrue(newId.startsWith(parameter));
+            assertTrue("True expected.", newId.startsWith(parameter));
         }
     }
 
     @Test
-    public void nextWithNullParametersTest() {
+    public void nextWithNullParameterTest() {
         String newId = clientIdGenerator.next(null);
-        assertTrue(newId.startsWith("null"));
+        assertTrue("True expected.", newId.startsWith("null"));
     }
 }


### PR DESCRIPTION
This PR contains second part of JUnit tests for classes in broker/core/plugin package:
 - Acl class
 - DefaultConnectorDescriptionProvider class
 - KapuaApplicationBrokerFilter class
 - KapuaSecurityBrokerFilter class

This PR also contains JUnit tests for classes in transport module.

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
