### PR TITLE
Bump slf4j-api dependency version from 1.7.26 to 1.7.30

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <reflections.version>0.9.10</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.3.2</shiro.version>
-        <slf4j.version>1.7.26</slf4j.version>
+        <slf4j.version>1.7.30</slf4j.version>
         <spring-security.version>4.1.3.RELEASE</spring-security.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>


### PR DESCRIPTION
This PR bumps the version of `slf4j-api` dependencies to 1.7.30

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version to the latest 1.7.x version

Also following bridge implementations have been upgraded:

- jcl-over-slf4j
- jul-to-slf4j
- log4j-over-slf4j

**Screenshots**
_None_

**Any side note on the changes made**
We don't need a new CQs since it is a patches version upgrade.
Original CQ are 

- slf4j-api: [20182](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=20182)
- jcl-over-slf4j: [13406](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13406)
- jul-to-slf4j: [13405](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13405)
- log4j-over-slf4j: [13407](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=13407)