### PR TITLE
Added JUnit tests in broker/core module and broker/core/plugin/authentication package

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/KapuaBrokerJAXBContextLoaderTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/KapuaBrokerJAXBContextLoaderTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaBrokerJAXBContextLoaderTest extends Assert {
+
+    KapuaBrokerJAXBContextLoader kapuaBrokerJAXBContextLoader;
+
+    @Before
+    public void initialize() {
+        kapuaBrokerJAXBContextLoader = new KapuaBrokerJAXBContextLoader();
+    }
+
+    @Test
+    public void initTest() {
+        try {
+            kapuaBrokerJAXBContextLoader.init();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void resetTest() {
+        try {
+            kapuaBrokerJAXBContextLoader.reset();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/KapuaDatabaseCheckUpdateTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/KapuaDatabaseCheckUpdateTest.java
@@ -1,0 +1,51 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaDatabaseCheckUpdateTest extends Assert {
+
+    @Test
+    public void kapuaDatabaseCheckUpdateFalseTest() {
+        System.setProperty("commons.db.schema.update", "false");
+        try {
+            new KapuaDatabaseCheckUpdate();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void kapuaDatabaseCheckUpdateTrueTest() {
+        System.setProperty("commons.db.schema.update", "true");
+        System.setProperty("LIQUIBASE_ENABLED","false");
+
+        try {
+            new KapuaDatabaseCheckUpdate();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = SecurityException.class)
+    public void kapuaDatabaseCheckUpdateExceptionTest() {
+        System.setProperty("commons.db.schema.update", "true");
+        System.setProperty("LIQUIBASE_ENABLED","true");
+            new KapuaDatabaseCheckUpdate();
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthorizationEntryTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthorizationEntryTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.plugin.authentication;
+
+import org.eclipse.kapua.broker.core.plugin.Acl;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AuthorizationEntryTest extends Assert {
+
+    @Test
+    public void authorizationEntryTest() {
+        String[] addresses = {null, "", "address123", "AdReSs <12>", "Adr_ess adr-ess", "!#2 adress-1", "adress(123) adress_##"};
+        Acl[] aclArray = new Acl[]{null, Acl.ALL, Acl.READ, Acl.WRITE, Acl.ADMIN, Acl.WRITE_ADMIN, Acl.READ_ADMIN};
+
+        for (String address : addresses) {
+            for (Acl acl : aclArray) {
+                AuthorizationEntry authorizationEntry = new AuthorizationEntry(address, acl);
+                assertEquals("Expected and actual values should be the same.", address, authorizationEntry.getAddress());
+                assertEquals("Expected and actual values should be the same.", acl, authorizationEntry.getAcl());
+            }
+        }
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AdminAuthenticationLogicTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AdminAuthenticationLogicTest.java
@@ -1,0 +1,172 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import com.codahale.metrics.Counter;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.plugin.Acl;
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
+import org.eclipse.kapua.broker.core.plugin.authentication.AdminAuthenticationLogic;
+import org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry;
+import org.eclipse.kapua.broker.core.plugin.metric.LoginMetric;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class AdminAuthenticationLogicTest extends Assert {
+
+    Map<String, Object> options;
+    KapuaSecurityContext kapuaSecurityContext;
+    AdminAuthenticationLogic adminAuthenticationLogic;
+    Throwable[] throwables;
+    Counter adminStealingLinkDisconnectCount;
+
+    @Before
+    public void initialize() {
+        options = new HashMap<>();
+        kapuaSecurityContext = Mockito.mock(KapuaSecurityContext.class);
+        adminAuthenticationLogic = new AdminAuthenticationLogic(options);
+        throwables = new Throwable[]{null, new Throwable(), new Throwable("message"), new Exception(), new Throwable(new Exception())};
+        adminStealingLinkDisconnectCount = LoginMetric.getInstance().getAdminStealingLinkDisconnect();
+    }
+
+    @Test
+    public void adminAuthenticationLogicEmptyOptionsTest() {
+        try {
+            new AdminAuthenticationLogic(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void adminAuthenticationLogicTest() {
+        options.put("key1", "value1");
+        options.put("key2", "value2");
+        options.put("key3", 11);
+        options.put("key4", new Object());
+
+        try {
+            new AdminAuthenticationLogic(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void adminAuthenticationLogicNullTest() {
+        new AdminAuthenticationLogic(null);
+    }
+
+    @Test
+    public void connectWithoutPrefixTest() throws KapuaException {
+        List<AuthorizationEntry> authorizationEntryList = adminAuthenticationLogic.connect(kapuaSecurityContext);
+
+        assertEquals("Expected and actual values should be the same.", 2, authorizationEntryList.size());
+        assertEquals("Expected and actual values should be the same.", "null>", authorizationEntryList.get(0).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.ALL, authorizationEntryList.get(0).getAcl());
+        assertEquals("Expected and actual values should be the same.", "nullnull", authorizationEntryList.get(1).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.WRITE_ADMIN, authorizationEntryList.get(1).getAcl());
+    }
+
+    @Test
+    public void connectWithPrefixTest() throws KapuaException {
+        options.put("address_prefix", "prefix");
+        options.put("address_advisory_prefix", "advisory_prefix");
+        adminAuthenticationLogic = new AdminAuthenticationLogic(options);
+
+        List<AuthorizationEntry> authorizationEntryList = adminAuthenticationLogic.connect(kapuaSecurityContext);
+
+        assertEquals("Expected and actual values should be the same.", 2, authorizationEntryList.size());
+        assertEquals("Expected and actual values should be the same.", "prefix>", authorizationEntryList.get(0).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.ALL, authorizationEntryList.get(0).getAcl());
+        assertEquals("Expected and actual values should be the same.", "prefixadvisory_prefix", authorizationEntryList.get(1).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.WRITE_ADMIN, authorizationEntryList.get(1).getAcl());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void connectNullTest() throws KapuaException {
+        adminAuthenticationLogic.connect(null);
+    }
+
+    @Test
+    public void disconnectFalseStealingLinkTrueMissingTest() {
+        Mockito.when(kapuaSecurityContext.getOldConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.getConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.isMissing()).thenReturn(true);
+
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+            assertFalse("False expected.", (adminAuthenticationLogic.disconnect(kapuaSecurityContext, throwable)));
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+        }
+    }
+
+    @Test
+    public void disconnectFalseStealingLinkFalseMissingTest() {
+        Mockito.when(kapuaSecurityContext.getOldConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.getConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.isMissing()).thenReturn(false);
+
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+            assertTrue("True expected.", (adminAuthenticationLogic.disconnect(kapuaSecurityContext, throwable)));
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+        }
+    }
+
+    @Test
+    public void disconnectTrueStealingLinkFalseMissingTest() {
+        Mockito.when(kapuaSecurityContext.getOldConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.getConnectionId()).thenReturn("NewConnectionId");
+        Mockito.when(kapuaSecurityContext.isMissing()).thenReturn(false);
+
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+            assertFalse("False expected.", (adminAuthenticationLogic.disconnect(kapuaSecurityContext, throwable)));
+            assertEquals("Expected and actual values should be the same.", 1, adminStealingLinkDisconnectCount.getCount());
+
+            adminStealingLinkDisconnectCount.dec();
+        }
+    }
+
+    @Test
+    public void disconnectTrueStealingLinkTrueMissingTest() {
+        Mockito.when(kapuaSecurityContext.getOldConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.getConnectionId()).thenReturn("NewConnectionId");
+        Mockito.when(kapuaSecurityContext.isMissing()).thenReturn(true);
+
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, adminStealingLinkDisconnectCount.getCount());
+            assertFalse("False expected.", (adminAuthenticationLogic.disconnect(kapuaSecurityContext, throwable)));
+            assertEquals("Expected and actual values should be the same.", 1, adminStealingLinkDisconnectCount.getCount());
+
+            adminStealingLinkDisconnectCount.dec();
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void disconnectNullContextTest() {
+        for (Throwable throwable : throwables) {
+            adminAuthenticationLogic.disconnect(null, throwable);
+        }
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AuthenticationLogicTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AuthenticationLogicTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
+import org.eclipse.kapua.broker.core.plugin.authentication.AuthenticationLogic;
+import org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class AuthenticationLogicTest extends Assert {
+
+    private class AuthenticationLogicImpl extends AuthenticationLogic {
+        /**
+         * Default constructor
+         *
+         * @param addressPrefix     prefix address to prepend to all the addressed when building the ACL list
+         * @param addressClassifier address classifier used by the platform messages (not telemetry messages) (if defined by the platform)
+         * @param advisoryPrefix    address prefix for the advisory messages (if defined by the platform)
+         */
+        protected AuthenticationLogicImpl(String addressPrefix, String addressClassifier, String advisoryPrefix) {
+            super(addressPrefix, addressClassifier, advisoryPrefix);
+        }
+
+        @Override
+        public List<AuthorizationEntry> connect(KapuaSecurityContext kapuaSecurityContext) {
+            return null;
+        }
+
+        @Override
+        public boolean disconnect(KapuaSecurityContext kapuaSecurityContext, Throwable error) {
+            return false;
+        }
+
+        @Override
+        protected List<AuthorizationEntry> buildAuthorizationMap(KapuaSecurityContext kapuaSecurityContext) {
+            return null;
+        }
+    }
+
+    @Test
+    public void authenticationLogicTest() {
+        String[] addressPrefixes = {null, "", "address_Pre,,fix", "addressP..refix-123", "addressPrefix#3", "!address <Prefix>", "#5#"};
+        String[] addressClassifiers = {null, "", "add..ress_Classif,ier", "addressClassi,,fier-123", "addressClassifier#3", "!address <Classifier>", "#5#"};
+        String[] advisoryPrefixes = {null, "", "advisory_Pre--fix", "ad,.visoryPrefix-123", "adviso,,ryPrefix#3", "!advisory <Prefix>", "#5#"};
+
+        for (String addressPrefix : addressPrefixes) {
+            for (String addressClassifier : addressClassifiers) {
+                for (String advisoryPrefix : advisoryPrefixes) {
+                    try {
+                        new AuthenticationLogicImpl(addressPrefix, addressClassifier, advisoryPrefix);
+                    } catch (Exception e) {
+                        fail("Exception not expected.");
+                    }
+                }
+            }
+        }
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DefaultAuthenticatorTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DefaultAuthenticatorTest.java
@@ -1,0 +1,186 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import com.codahale.metrics.Counter;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.plugin.Acl;
+import org.eclipse.kapua.broker.core.plugin.KapuaSecurityContext;
+import org.eclipse.kapua.broker.core.plugin.authentication.AuthorizationEntry;
+import org.eclipse.kapua.broker.core.plugin.authentication.DefaultAuthenticator;
+import org.eclipse.kapua.broker.core.plugin.metric.ClientMetric;
+import org.eclipse.kapua.broker.core.plugin.metric.LoginMetric;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class DefaultAuthenticatorTest extends Assert {
+
+    KapuaSecurityContext kapuaSecurityContext;
+    Map<String, Object> options;
+    DefaultAuthenticator defaultAuthenticator;
+    Throwable[] throwables;
+    Counter kapuasysTokenAttemptCount, connectedKapuasysCount, disconnectedKapuasysCount, disconnectedClient;
+
+    @Before
+    public void initialize() {
+        kapuaSecurityContext = Mockito.mock(KapuaSecurityContext.class);
+        options = new HashMap<>();
+        throwables = new Throwable[]{null, new Throwable(), new Throwable("message"), new Exception(), new Throwable(new Exception())};
+        kapuasysTokenAttemptCount = LoginMetric.getInstance().getKapuasysTokenAttempt();
+        connectedKapuasysCount = ClientMetric.getInstance().getConnectedKapuasys();
+        disconnectedKapuasysCount = ClientMetric.getInstance().getDisconnectedKapuasys();
+        disconnectedClient = ClientMetric.getInstance().getDisconnectedClient();
+    }
+
+    @Test
+    public void defaultAuthenticatorEmptyOptionsTest() {
+        try {
+            new DefaultAuthenticator(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void defaultAuthenticatorTest() {
+        options.put("key1", "value");
+        options.put("key2", 11);
+        options.put("key3", new Object());
+
+        try {
+            new DefaultAuthenticator(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void defaultAuthenticatorNullOptionsTest() {
+        try {
+            new DefaultAuthenticator(null);
+            fail("KapuaException expected.");
+        } catch (Exception e) {
+            assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Cannot load instance null for class org.eclipse.kapua.broker.core.plugin.authentication.AdminAuthenticationLogic. Please check the configuration file!.", e.toString());
+        }
+    }
+
+    @Test
+    public void connectAdminEmptyOptionsTest() throws KapuaException {
+        defaultAuthenticator = new DefaultAuthenticator(options);
+
+        Mockito.when(kapuaSecurityContext.getUserName()).thenReturn("kapua-sys");
+
+        assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+
+        List<AuthorizationEntry> authorizationEntryList = defaultAuthenticator.connect(kapuaSecurityContext);
+
+        assertEquals("Expected and actual values should be the same.", 2, authorizationEntryList.size());
+        assertEquals("Expected and actual values should be the same.", "null>", authorizationEntryList.get(0).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.ALL, authorizationEntryList.get(0).getAcl());
+        assertEquals("Expected and actual values should be the same.", "nullnull", authorizationEntryList.get(1).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.WRITE_ADMIN, authorizationEntryList.get(1).getAcl());
+
+        assertEquals("Expected and actual values should be the same.", 1, kapuasysTokenAttemptCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 1, connectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+
+        kapuasysTokenAttemptCount.dec();
+        connectedKapuasysCount.dec();
+    }
+
+    @Test
+    public void connectAdminTest() throws KapuaException {
+        options.put("address_prefix", "prefix");
+        options.put("address_advisory_prefix", "advisory_prefix");
+        defaultAuthenticator = new DefaultAuthenticator(options);
+
+        Mockito.when(kapuaSecurityContext.getUserName()).thenReturn("kapua-sys");
+
+        assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+
+        List<AuthorizationEntry> authorizationEntryList = defaultAuthenticator.connect(kapuaSecurityContext);
+
+        assertEquals("Expected and actual values should be the same.", 2, authorizationEntryList.size());
+        assertEquals("Expected and actual values should be the same.", "prefix>", authorizationEntryList.get(0).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.ALL, authorizationEntryList.get(0).getAcl());
+        assertEquals("Expected and actual values should be the same.", "prefixadvisory_prefix", authorizationEntryList.get(1).getAddress());
+        assertEquals("Expected and actual values should be the same.", Acl.WRITE_ADMIN, authorizationEntryList.get(1).getAcl());
+
+        assertEquals("Expected and actual values should be the same.", 1, kapuasysTokenAttemptCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 1, connectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+        assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+
+        kapuasysTokenAttemptCount.dec();
+        connectedKapuasysCount.dec();
+    }
+
+    @Test
+    public void disconnectAdminTest() throws KapuaException {
+        defaultAuthenticator = new DefaultAuthenticator(options);
+        Mockito.when(kapuaSecurityContext.getUserName()).thenReturn("kapua-sys");
+
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+            defaultAuthenticator.disconnect(kapuaSecurityContext, throwable);
+            assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 1, disconnectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+
+            disconnectedKapuasysCount.dec();
+        }
+    }
+
+    @Test
+    public void disconnectUserTest() throws KapuaException {
+        defaultAuthenticator = new DefaultAuthenticator(options);
+        Mockito.when(kapuaSecurityContext.getOldConnectionId()).thenReturn("ConnectionId");
+        Mockito.when(kapuaSecurityContext.getConnectionId()).thenReturn("NewConnectionId");
+        Mockito.when(kapuaSecurityContext.getClientId()).thenReturn("clientid");
+
+        Mockito.when(kapuaSecurityContext.getUserName()).thenReturn("user");
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedClient.getCount());
+            defaultAuthenticator.disconnect(kapuaSecurityContext, throwable);
+            assertEquals("Expected and actual values should be the same.", 0, kapuasysTokenAttemptCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, connectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 0, disconnectedKapuasysCount.getCount());
+            assertEquals("Expected and actual values should be the same.", 1, disconnectedClient.getCount());
+
+            disconnectedClient.dec();
+        }
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/UserAuthenticationLogicTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/UserAuthenticationLogicTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.broker.core.plugin.authentication.UserAuthenticationLogic;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class UserAuthenticationLogicTest extends Assert {
+
+    @Test
+    public void userAuthenticationLogicTest() {
+        Map<String, Object> options = new HashMap<>();
+        options.put("address_prefix", "prefix");
+        options.put("address_advisory_prefix", "advisory_prefix");
+
+        try {
+            new UserAuthenticationLogic(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void userAuthenticationLogicEmptyOptionsTest() {
+        Map<String, Object> options = new HashMap<>();
+        try {
+            new UserAuthenticationLogic(options);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void userAuthenticationLogicNullTest() {
+        try {
+            new UserAuthenticationLogic(null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in broker/core module:

 - KapuaBrokerJAXBContextLoader class
 - KapuaDatabaseCheckUpdate class

 - plugin/authentication package:
      AdminAuthenticationLogic class
      AuthenticationLogic class
      AuthorizationEntry class
      DefaultAuthenticator class
      UserAuthenticationLogic class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
