### PR TITLE
Upgraded Shiro version from 1.3.2 to 1.5.3 -  CVE-2019-12422 - CVE-2020-1957 - CVE-2020-11989

### DIFF
--- a/assembly/broker/configurations/shiro.ini
+++ b/assembly/broker/configurations/shiro.ini
@@ -3,70 +3,25 @@
 # =======================
 
 [main]
-# Objects and their properties are defined here,
-# Such as the securityManager, Realms and anything
-# else needed to build the SecurityManager
 
-#authenticator
+# Authenticator
 authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
 securityManager.authenticator = $authenticator
 
-#
-# Auth filters
-# kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
-
-#cacheManager = org.eclipse.kapua.broker.core.experimental.CacheManager
-#securityManager.cacheManager = $cacheManager
-
-##########
-# Realms #
-##########
-# Login
+# Realms
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 
-# Session
-kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
-
-########################
-#Authorization section #
-########################
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
-#removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaUserPassAuthenticatingRealm
 
+# Authorizer
 authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
-#realms must be set again otherwise the authorizer will not have any.
-#The security manager (AuthorizingSecurityManager) is built in this way:
-#    AuthorizingSecurityManager()         //constructor
-#    setRealms(realms)                    //set realms (if any)
-#    afterRealmsSet()                     //set realms to authenticator (if any)
-#    setAuthorizer(Authorizer authorizer) //if any configured
-#    setAuthenticator()                   //if any custom authenticator is set
-#In this way the new authenticator must have the realms already configured once is set to the security manager.
-#Otherwise the security manager doesn't set it's own security manager to the authenticator
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 
-# SessionListeners only works with in the native SessionMode
-# This is not the mode we use when running in Tomcat.
-#securityManager.sessionMode = native
+# Session
 securityManager.sessionManager.globalSessionTimeout = -1
 securityManager.sessionManager.sessionValidationSchedulerEnabled = false
 
 securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
-
-[users]
-# The 'users' section is for simple deployments
-# when you only need a small number of statically-defined
-# set of User accounts.
-
-[roles]
-# The 'roles' section is for simple deployments
-# when you only need a small number of statically-defined
-# roles.
-
-[urls]
-# The 'urls' section is used for url-based security
-# in web applications.  We'll discuss this section in the
-# Web documentation

--- a/console/web/src/main/resources/shiro.ini
+++ b/console/web/src/main/resources/shiro.ini
@@ -3,31 +3,17 @@
 # =======================
 
 [main]
-# Objects and their properties are defined here,
-# Such as the securityManager, Realms and anything
-# else needed to build the SecurityManager
 
-#authenticator
+# Authenticator
 authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
 securityManager.authenticator = $authenticator
 
-#realms
+# Realms
 kapuaAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+
 securityManager.realms = $kapuaAuthorizingRealm, $kapuaAuthenticatingRealm, $jwtAuthenticatingRealm
 
-[users]
-# The 'users' section is for simple deployments
-# when you only need a small number of statically-defined
-# set of User accounts.
-
-[roles]
-# The 'roles' section is for simple deployments
-# when you only need a small number of statically-defined
-# roles.
-
-[urls]
-# The 'urls' section is used for url-based security
-# in web applications.  We'll discuss this section in the
-# Web documentation
+# Request Filtering
+filterChainResolver = org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver

--- a/pom.xml
+++ b/pom.xml
@@ -47,10 +47,10 @@
         <compress-lzf.version>1.0.3</compress-lzf.version>
         <cucumber.version>1.2.4</cucumber.version>
         <eclipselink.version>2.7.7</eclipselink.version>
+        <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <elasticsearch.version>6.8.7</elasticsearch.version>
         <elasticsearch-client-rest.version>6.8.7</elasticsearch-client-rest.version>
         <elasticsearch-client-transport.version>6.8.7</elasticsearch-client-transport.version>
-        <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <findbugs.version>2.0.1</findbugs.version>
         <googleauth.version>1.5.0</googleauth.version>
         <gson.version>2.7</gson.version>
@@ -90,7 +90,7 @@
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <reflections.version>0.9.10</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.4.2</shiro.version>
+        <shiro.version>1.5.3</shiro.version>
         <slf4j.version>1.7.30</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1421,6 +1421,16 @@
                 <groupId>org.apache.shiro</groupId>
                 <artifactId>shiro-core</artifactId>
                 <version>${shiro.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.shiro</groupId>
+                        <artifactId>shiro-crypto-hash</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <groupId>org.apache.shiro</groupId>
+                        <artifactId>shiro-crypto-cipher</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <!-- Apache shiro security framework web support -->

--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
         <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
         <reflections.version>0.9.10</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.3.2</shiro.version>
+        <shiro.version>1.4.2</shiro.version>
         <slf4j.version>1.7.30</slf4j.version>
         <snakeyaml.version>1.15</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>

--- a/qa/integration/src/test/resources/shiro.ini
+++ b/qa/integration/src/test/resources/shiro.ini
@@ -3,70 +3,31 @@
 # =======================
 
 [main]
-# Objects and their properties are defined here,
-# Such as the securityManager, Realms and anything
-# else needed to build the SecurityManager
 
-#authenticator
+# Authenticator
 authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
 securityManager.authenticator = $authenticator
-
-#
-# Auth filters
-# kapuaAuthcAccessToken = org.eclipse.kapua.app.api.auth.KapuaTokenAuthenticationFilter
-
-#cacheManager = org.eclipse.kapua.broker.core.experimental.CacheManager
-#securityManager.cacheManager = $cacheManager
 
 ##########
 # Realms #
 ##########
+
 # Login
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 
 # Session
 kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
 
-########################
-#Authorization section #
-########################
 # Authorization
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
-#removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
+
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
+# Authorizer
 authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
-#realms must be set again otherwise the authorizer will not have any.
-#The security manager (AuthorizingSecurityManager) is built in this way:
-#    AuthorizingSecurityManager()         //constructor
-#    setRealms(realms)                    //set realms (if any)
-#    afterRealmsSet()                     //set realms to authenticator (if any)
-#    setAuthorizer(Authorizer authorizer) //if any configured
-#    setAuthenticator()                   //if any custom authenticator is set
-#In this way the new authenticator must have the realms already configured once is set to the security manager.
-#Otherwise the security manager doesn't set it's own security manager to the authenticator
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 
-# SessionListeners only works with in the native SessionMode
-# This is not the mode we use when running in Tomcat.
-#securityManager.sessionMode = native
+# Session
 securityManager.sessionManager.globalSessionTimeout = -1
 securityManager.sessionManager.sessionValidationSchedulerEnabled = false
-
-securityManager.subjectDAO.sessionStorageEvaluator.sessionStorageEnabled = false
-
-[users]
-# The 'users' section is for simple deployments
-# when you only need a small number of statically-defined
-# set of User accounts.
-
-[roles]
-# The 'roles' section is for simple deployments
-# when you only need a small number of statically-defined
-# roles.
-
-[urls]
-# The 'urls' section is used for url-based security
-# in web applications.  We'll discuss this section in the
-# Web documentation

--- a/rest-api/web/src/main/resources/shiro.ini
+++ b/rest-api/web/src/main/resources/shiro.ini
@@ -3,21 +3,15 @@
 # =======================
 
 [main]
-# Objects and their properties are defined here,
-# Such as the securityManager, Realms and anything
-# else needed to build the SecurityManager
 
-#authenticator
+# Authenticator
 authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticator
 securityManager.authenticator = $authenticator
-
-#
-# Auth filters
-kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthenticationFilter
 
 ##########
 # Realms #
 ##########
+
 # Login
 kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
 kapuaApiKeyAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm
@@ -35,22 +29,13 @@ securityManager.realms = $kapuaAuthorizingRealm, $kapuaAccessTokenAuthenticating
 securityManager.rememberMeManager.cookie.name = kapua-rememberme
 securityManager.rememberMeManager.cookie.maxAge = 0
 
-[users]
-# The 'users' section is for simple deployments
-# when you only need a small number of statically-defined
-# set of User accounts.
-
-[roles]
-# The 'roles' section is for simple deployments
-# when you only need a small number of statically-defined
-# roles.
+#
+# Auth filters
+kapuaAuthcAccessToken = org.eclipse.kapua.app.api.core.auth.KapuaTokenAuthenticationFilter
 
 [urls]
-# The 'urls' section is used for url-based security
-# in web applications.  We'll discuss this section in the
-# Web documentation
 
-# Authentication
+# Filter Mappings
 /v1/authentication/info         = kapuaAuthcAccessToken
 
 /v1/authentication/logout       = kapuaAuthcAccessToken

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticator.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-
 import org.apache.shiro.ShiroException;
 import org.apache.shiro.authc.AuthenticationException;
 import org.apache.shiro.authc.AuthenticationInfo;
@@ -26,13 +22,18 @@ import org.apache.shiro.realm.Realm;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
 /**
- * Kapua Shiro Authenticator.<br>
+ * Kapua Shiro Authenticator.
+ * <p>
  * This authenticator provide more significantly exception message in a multi-realm configuration.<br>
- * The code is derived from the original {@link ModularRealmAuthenticator} because the <b>default Shiro implementation doesn't support detailed messages in a multirealm configuration.</b>
+ * The code is derived from the original {@link ModularRealmAuthenticator} because the
+ * <b>default Shiro implementation doesn't support detailed messages in a multirealm configuration.</b>
  *
- * since 1.0
- *
+ * @since 1.0.0
  */
 public class KapuaAuthenticator extends ModularRealmAuthenticator {
 
@@ -45,6 +46,7 @@ public class KapuaAuthenticator extends ModularRealmAuthenticator {
         if (logger.isTraceEnabled()) {
             logger.trace("Iterating through {} realms for PAM authentication", realms.size());
         }
+
         List<Throwable> exceptionList = new ArrayList<>();
         boolean loginSucceeded = false;
         boolean supportedRealmFound = false;
@@ -61,9 +63,7 @@ public class KapuaAuthenticator extends ModularRealmAuthenticator {
                 } catch (Exception exception) {
                     t = exception;
                     if (logger.isDebugEnabled()) {
-                        String msg = "Realm [" + realm
-                                + "] threw an exception during a multi-realm authentication attempt:";
-                        logger.debug(msg, t);
+                        logger.debug("Realm [{}] threw an exception during a multi-realm authentication attempt:", realm, t);
                     }
                 }
                 aggregate = strategy.afterAttempt(realm, token, info, aggregate, t);
@@ -80,6 +80,7 @@ public class KapuaAuthenticator extends ModularRealmAuthenticator {
                 // TODO move the error message to the message bundle
                 throw new ShiroException("Internal Error!");
             }
+
             if (exceptionList.get(0) instanceof AuthenticationException) {
                 throw (AuthenticationException) exceptionList.get(0);
             } else {


### PR DESCRIPTION
This PR bumps the version of Shiro from 1.3.2 to 1.5.3

**Related Issue**
_None_

**Description of the solution adopted**
Changed the version and fixed the `shiro.ini` configuration files.

CQs Submitted:

- shiro-core: [22973](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22973)
  - shiro-lang: [22974](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22974)
  - shiro-cache: [22975](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22975)
  - shiro-config-core: [22976](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22976)
  - shiro-config-ogdl: [22977](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22977)
  - shiro-event: [22978](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22978)
- shiro-web: [22972](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22972)
  - encoder: [22971](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22971)

Transient dependencies excluded:

- shiro-crypto-hash
- shiro-crypto-cipher



**Screenshots**
_None_

**Any side note on the changes made**
_None_