### PR TITLE
Upgradend Quartz Scheduler Version to  from 2.2.3 to 2.3.2 - CVE-2019-13990 - CWE-611

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,7 +87,7 @@
         <qpid-jms-client.version>0.40.0</qpid-jms-client.version>
         <qpid-proton.version>0.31.0</qpid-proton.version>
         <qpid-geronimo-jms.version>1.0-alpha-2</qpid-geronimo-jms.version>
-        <quartz-scheduler.version>2.2.3</quartz-scheduler.version>
+        <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.9.10</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.5.3</shiro.version>
@@ -1373,8 +1373,18 @@
                 <exclusions>
                     <exclusion>
                         <!-- This is not required. We are using EclipseLink connection pooling. -->
-                        <groupId>c3p0</groupId>
+                        <groupId>com.mchange</groupId>
                         <artifactId>c3p0</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- This is not required. We are using EclipseLink connection pooling. -->
+                        <groupId>com.mchange</groupId>
+                        <artifactId>mchange-commons-java</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- This is not required. We are using EclipseLink connection pooling. -->
+                        <groupId>com.zaxxer</groupId>
+                        <artifactId>HikariCP-java7</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
This PR bumps the version of Quartz Scheduler to 2.3.2

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
https://mvnrepository.com/artifact/org.quartz-scheduler/quartz/2.3.2

CQ for Quartz: [22979](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22979)

Following transitive dependencies have been excluded since we are using EclipseLink connection pooling.

- com.mchange:c3p0
- com.mchange:mchange-commons-java
- com.zaxxer: HikariCP-java7

Transient dependency on `slf4j-api` is already used by Kapua, and we recently upgraded it to the latest available.

**Screenshots**
_None_

**Any side note on the changes made**
_None_