### PR TITLE
Added JUnit tests for classes in listener package

### DIFF
--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/AbstractListenerTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/AbstractListenerTest.java
@@ -1,0 +1,123 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.Timer;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AbstractListenerTest extends Assert {
+
+    private class AbstractListenerImpl extends AbstractListener {
+        protected AbstractListenerImpl(String name) {
+            super(name);
+        }
+
+        protected AbstractListenerImpl(String metricComponentName, String name) {
+            super(metricComponentName, name);
+        }
+    }
+
+    AbstractListener abstractListenerWithOneParameter, abstractListenerWithTwoParameters;
+    String[] names, metricComponentNames;
+
+    @Before
+    public void initialize() {
+        abstractListenerWithOneParameter = new AbstractListenerImpl("Abstract Listener");
+        abstractListenerWithTwoParameters = new AbstractListenerImpl("Component name", "Abstract Listener");
+        names = new String[]{null, "", "name-1", "name", "name_123_!@#", "!@name 999", "NaMe<555>", "   name 23.,,,.'||     ", "a", "name   ,.name<>4567 name -0     name [] name", "12   43naME &*(0name_9("};
+        metricComponentNames = new String[]{null, "", "metric    123<.com,,ponentNAME 955':;;", "a", "#21%$#met-tric;'|| name       component,|,.", "MeTrIc09)_=-0", "-0 metric name;',.COMPONENT", "name()   _  compone-net ;;,z"};
+    }
+
+    @Test
+    public void abstractListenerNameParameterTest() {
+        for (String name : names) {
+            AbstractListener abstractListener = new AbstractListenerImpl(name);
+            assertEquals("Expected and actual values should be the same.", name, abstractListener.name);
+        }
+    }
+
+    @Test
+    public void abstractListenerMetricComponentNameAndNameParameterTest() {
+        for (String name : names) {
+            for (String metricComponentName : metricComponentNames) {
+                AbstractListener abstractListener = new AbstractListenerImpl(metricComponentName, name);
+                assertEquals("Expected and actual values should be the same.", name, abstractListener.name);
+            }
+        }
+    }
+
+    @Test
+    public void registerCounterTest() {
+        assertThat("Instance of Counter expected.", abstractListenerWithOneParameter.registerCounter("Counter Name1", "Counter Name2", "Counter Name3"), IsInstanceOf.instanceOf(Counter.class));
+        assertThat("Instance of Counter expected.", abstractListenerWithTwoParameters.registerCounter("Counter Name1", "Counter Name2", "Counter Name3"), IsInstanceOf.instanceOf(Counter.class));
+    }
+
+    @Test
+    public void registerCounterOneNullNameTest() {
+        assertThat("Instance of Counter expected.", abstractListenerWithOneParameter.registerCounter("CounterName1", null, "CounterName3"), IsInstanceOf.instanceOf(Counter.class));
+        assertThat("Instance of Counter expected.", abstractListenerWithTwoParameters.registerCounter("CounterName1", null, "CounterName3"), IsInstanceOf.instanceOf(Counter.class));
+    }
+
+    @Test
+    public void registerCounterNullTest() {
+        try {
+            abstractListenerWithOneParameter.registerCounter(null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            abstractListenerWithTwoParameters.registerCounter(null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void registerTimerTest() {
+        assertThat("Instance of Timer expected.", abstractListenerWithOneParameter.registerTimer("Timer Name1", "Timer Name2", "Timer Name3"), IsInstanceOf.instanceOf(Timer.class));
+        assertThat("Instance of Timer expected.", abstractListenerWithTwoParameters.registerTimer("Timer Name1", "Timer Name2", "Timer Name3"), IsInstanceOf.instanceOf(Timer.class));
+    }
+
+    @Test
+    public void registerTimerOneNullNameTest() {
+        assertThat("Instance of Timer expected.", abstractListenerWithOneParameter.registerTimer("TimerName1", null, "TimerName3"), IsInstanceOf.instanceOf(Timer.class));
+        assertThat("Instance of Timer expected.", abstractListenerWithTwoParameters.registerTimer("TimerName1", null, "TimerName3"), IsInstanceOf.instanceOf(Timer.class));
+    }
+
+    @Test
+    public void registerTimerNullTest() {
+        try {
+            abstractListenerWithOneParameter.registerTimer(null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            abstractListenerWithTwoParameters.registerTimer(null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/AbstractProcessorTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/AbstractProcessorTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AbstractProcessorTest extends Assert {
+
+    private class AbstractProcessorImpl extends AbstractProcessor {
+        /**
+         * Creates a processor with the specified name (used by component metrics name)
+         *
+         * @param name
+         */
+        protected AbstractProcessorImpl(String name) {
+            super(name);
+        }
+
+        @Override
+        public void processMessage(Object message) {
+
+        }
+    }
+
+    @Test
+    public void abstractProcessorTest() {
+        String[] names = {null, "", "name-1", "name", "name_123_!@#", "!@name 999", "NaMe<555>", "   name 23.,,,.'||     ", "a", "name   ,.name<>4567 name -0     name [] name", "12   43naME &*(0name_9("};
+        for (String name : names) {
+            AbstractProcessor abstractProcessor = new AbstractProcessorImpl(name);
+
+            assertEquals("Expected and actual values should be the same.", name, abstractProcessor.name);
+        }
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/CamelConstantsTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/CamelConstantsTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class CamelConstantsTest extends Assert {
+
+    @Test
+    public void camelConstantsTest() throws Exception {
+        Constructor<CamelConstants> camelConstants = CamelConstants.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(camelConstants.getModifiers()));
+        camelConstants.setAccessible(true);
+        camelConstants.newInstance();
+    }
+
+    @Test
+    public void checkConstantsTest() {
+        assertEquals("Expected and actual values should be the same.", "CamelFailureEndpoint", CamelConstants.JMS_EXCHANGE_FAILURE_ENDPOINT);
+        assertEquals("Expected and actual values should be the same.", "CamelExceptionCaught", CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION);
+        assertEquals("Expected and actual values should be the same.", "JMSRedelivered", CamelConstants.JMS_EXCHANGE_REDELIVERED);
+        assertEquals("Expected and actual values should be the same.", "JMSTimestamp", CamelConstants.JMS_HEADER_TIMESTAMP);
+        assertEquals("Expected and actual values should be the same.", "JMSDestination", CamelConstants.JMS_HEADER_DESTINATION);
+        assertEquals("Expected and actual values should be the same.", "JMSCorrelationID", CamelConstants.JMS_CORRELATION_ID);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DataStoreMetricsTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DataStoreMetricsTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class DataStoreMetricsTest extends Assert {
+
+    @Test
+    public void dataStoreMetricsTest() throws Exception {
+        Constructor<DataStoreMetrics> dataStoreMetrics = DataStoreMetrics.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(dataStoreMetrics.getModifiers()));
+        dataStoreMetrics.setAccessible(true);
+        dataStoreMetrics.newInstance();
+    }
+
+    @Test
+    public void checkConstantsTest() {
+        assertEquals("Expected and actual values should be the same.", "datastore", DataStoreMetrics.METRIC_MODULE_NAME);
+        assertEquals("Expected and actual values should be the same.", "datastore", DataStoreMetrics.METRIC_COMPONENT_NAME);
+        assertEquals("Expected and actual values should be the same.", "store", DataStoreMetrics.METRIC_STORE);
+        assertEquals("Expected and actual values should be the same.", "queue", DataStoreMetrics.METRIC_QUEUE);
+        assertEquals("Expected and actual values should be the same.", "communication", DataStoreMetrics.METRIC_COMMUNICATION);
+        assertEquals("Expected and actual values should be the same.", "configuration", DataStoreMetrics.METRIC_CONFIGURATION);
+        assertEquals("Expected and actual values should be the same.", "generic", DataStoreMetrics.METRIC_GENERIC);
+        assertEquals("Expected and actual values should be the same.", "error", DataStoreMetrics.METRIC_ERROR);
+        assertEquals("Expected and actual values should be the same.", "count", DataStoreMetrics.METRIC_COUNT);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DeviceManagementRegistryNotificationMetricsTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/DeviceManagementRegistryNotificationMetricsTest.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class DeviceManagementRegistryNotificationMetricsTest extends Assert {
+
+    @Test
+    public void deviceManagementRegistryNotificationMetricsTest() throws Exception {
+        Constructor<DeviceManagementRegistryNotificationMetrics> deviceManagementRegistryNotificationMetrics = DeviceManagementRegistryNotificationMetrics.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(deviceManagementRegistryNotificationMetrics.getModifiers()));
+        deviceManagementRegistryNotificationMetrics.setAccessible(true);
+        deviceManagementRegistryNotificationMetrics.newInstance();
+    }
+
+    @Test
+    public void checkConstantsTest() {
+        assertEquals("Expected and actual values should be the same.", "device_management_registry", DeviceManagementRegistryNotificationMetrics.METRIC_MODULE_NAME);
+        assertEquals("Expected and actual values should be the same.", "notification", DeviceManagementRegistryNotificationMetrics.METRIC_COMPONENT_NOTIFICATION);
+        assertEquals("Expected and actual values should be the same.", "deviceLifeCycle", DeviceManagementRegistryNotificationMetrics.METRIC_COMPONENT_DEVICE_LIFE_CYCLE);
+        assertEquals("Expected and actual values should be the same.", "messages", DeviceManagementRegistryNotificationMetrics.METRIC_MESSAGES);
+        assertEquals("Expected and actual values should be the same.", "process_queue", DeviceManagementRegistryNotificationMetrics.METRIC_PROCESS_QUEUE);
+        assertEquals("Expected and actual values should be the same.", "communication", DeviceManagementRegistryNotificationMetrics.METRIC_COMMUNICATION);
+        assertEquals("Expected and actual values should be the same.", "configuration", DeviceManagementRegistryNotificationMetrics.METRIC_CONFIGURATION);
+        assertEquals("Expected and actual values should be the same.", "generic", DeviceManagementRegistryNotificationMetrics.METRIC_GENERIC);
+        assertEquals("Expected and actual values should be the same.", "apps", DeviceManagementRegistryNotificationMetrics.METRIC_APPS);
+        assertEquals("Expected and actual values should be the same.", "birth", DeviceManagementRegistryNotificationMetrics.METRIC_BIRTH);
+        assertEquals("Expected and actual values should be the same.", "dc", DeviceManagementRegistryNotificationMetrics.METRIC_DC);
+        assertEquals("Expected and actual values should be the same.", "missing", DeviceManagementRegistryNotificationMetrics.METRIC_MISSING);
+        assertEquals("Expected and actual values should be the same.", "unmatched", DeviceManagementRegistryNotificationMetrics.METRIC_UNMATCHED);
+        assertEquals("Expected and actual values should be the same.", "error", DeviceManagementRegistryNotificationMetrics.METRIC_ERROR);
+        assertEquals("Expected and actual values should be the same.", "count", DeviceManagementRegistryNotificationMetrics.METRIC_COUNT);
+    }
+}

--- a/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListenerTest.java
+++ b/broker/core/src/test/java/org/eclipse/kapua/broker/core/listener/ErrorMessageListenerTest.java
@@ -1,0 +1,197 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.broker.core.listener;
+
+import org.apache.camel.Exchange;
+import org.apache.camel.Message;
+import org.apache.commons.lang3.SerializationUtils;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.message.MessageConstants;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import com.codahale.metrics.Counter;
+
+import java.util.Base64;
+
+@Category(JUnitTests.class)
+public class ErrorMessageListenerTest extends Assert {
+
+    ErrorMessageListener errorMessageListener;
+    Exchange exchange;
+    Message exchangeMessage;
+    Object[] messages;
+    Counter error;
+    Counter errorLifeCycleMessage;
+    Throwable throwable;
+    byte[] throwableBytes;
+    String stringThrowable;
+
+    @Before
+    public void initialize() {
+        errorMessageListener = new ErrorMessageListener();
+        exchange = Mockito.mock(Exchange.class);
+        exchangeMessage = Mockito.mock(Message.class);
+        messages = new Object[]{null, new Object()};
+        error = errorMessageListener.registerCounter("messages", "generic", "count");
+        errorLifeCycleMessage = errorMessageListener.registerCounter("messages", "life_cycle", "count");
+        throwable = new Throwable("message");
+        throwableBytes = SerializationUtils.serialize(throwable);
+        stringThrowable = Base64.getEncoder().encodeToString(throwableBytes);
+    }
+
+    @Test
+    public void errorMessageListenerNameTest() {
+        assertEquals("Expected and actual values should be the same.", "error", errorMessageListener.name);
+    }
+
+    @Test
+    public void processMessageNullThrowableNullExchangeTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(null);
+        Mockito.when(exchange.getException()).thenReturn(null);
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            errorMessageListener.processMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 1L, error.getCount());
+
+            error.dec();
+        }
+    }
+
+    @Test
+    public void processMessageNullExchangeTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(new Throwable());
+        Mockito.when(exchange.getException()).thenReturn(null);
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.processMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 1L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+
+            error.dec();
+        }
+    }
+
+    @Test
+    public void processMessageNullThrowableTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(null);
+        Mockito.when(exchange.getException()).thenReturn(new Exception());
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.processMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 1L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+
+            error.dec();
+        }
+    }
+
+    @Test
+    public void processMessageTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(stringThrowable);
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.processMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 1L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+
+            error.dec();
+        }
+    }
+
+    @Test
+    public void lifeCycleMessageNullThrowableNullExchangeTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(null);
+        Mockito.when(exchange.getException()).thenReturn(null);
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.lifeCycleMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 1L, errorLifeCycleMessage.getCount());
+
+            errorLifeCycleMessage.dec();
+        }
+    }
+
+    @Test
+    public void lifeCycleMessageNullExchangeTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(new Throwable());
+        Mockito.when(exchange.getException()).thenReturn(null);
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.lifeCycleMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 1L, errorLifeCycleMessage.getCount());
+
+            errorLifeCycleMessage.dec();
+        }
+    }
+
+    @Test
+    public void lifeCycleMessageNullThrowableTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(null);
+        Mockito.when(exchange.getProperty(CamelConstants.JMS_EXCHANGE_FAILURE_EXCEPTION)).thenReturn(null);
+        Mockito.when(exchange.getException()).thenReturn(new Exception());
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.lifeCycleMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 1L, errorLifeCycleMessage.getCount());
+
+            errorLifeCycleMessage.dec();
+        }
+    }
+
+    @Test
+    public void lifeCycleMessageTest() throws KapuaException {
+        Mockito.when(exchange.getIn()).thenReturn(exchangeMessage);
+        Mockito.when(exchangeMessage.getHeader(MessageConstants.HEADER_KAPUA_PROCESSING_EXCEPTION, String.class)).thenReturn(stringThrowable);
+
+        for (Object message : messages) {
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 0L, errorLifeCycleMessage.getCount());
+            errorMessageListener.lifeCycleMessage(exchange, message);
+            assertEquals("Expected and actual values should be the same.", 0L, error.getCount());
+            assertEquals("Expected and actual values should be the same.", 1L, errorLifeCycleMessage.getCount());
+
+            errorLifeCycleMessage.dec();
+        }
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DataStorageMessageProcessorTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DataStorageMessageProcessorTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import com.codahale.metrics.Counter;
+import org.apache.camel.Exchange;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.listener.DataStorageMessageProcessor;
+import org.eclipse.kapua.broker.core.listener.DataStoreMetrics;
+import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class DataStorageMessageProcessorTest extends Assert {
+
+    DataStorageMessageProcessor dataStorageMessageProcessor;
+    CamelKapuaMessage camelKapuaMessage;
+    KapuaMessage kapuaMessage;
+    Exchange exchange;
+    Counter queueConfigurationErrorCount, queueGenericErrorCount;
+
+    @Before
+    public void initialize() {
+        dataStorageMessageProcessor = new DataStorageMessageProcessor();
+        camelKapuaMessage = Mockito.mock(CamelKapuaMessage.class);
+        kapuaMessage = Mockito.mock(KapuaMessage.class);
+        exchange = Mockito.mock(Exchange.class);
+        queueConfigurationErrorCount = MetricServiceFactory.getInstance().getCounter(DataStoreMetrics.METRIC_MODULE_NAME, DataStoreMetrics.METRIC_COMPONENT_NAME, DataStoreMetrics.METRIC_STORE, DataStoreMetrics.METRIC_QUEUE, DataStoreMetrics.METRIC_CONFIGURATION, DataStoreMetrics.METRIC_ERROR, DataStoreMetrics.METRIC_COUNT);
+        queueGenericErrorCount = MetricServiceFactory.getInstance().getCounter(DataStoreMetrics.METRIC_MODULE_NAME, DataStoreMetrics.METRIC_COMPONENT_NAME, DataStoreMetrics.METRIC_STORE, DataStoreMetrics.METRIC_QUEUE, DataStoreMetrics.METRIC_GENERIC, DataStoreMetrics.METRIC_ERROR, DataStoreMetrics.METRIC_COUNT);
+
+        Mockito.when(camelKapuaMessage.getMessage()).thenReturn(kapuaMessage);
+        Mockito.when(kapuaMessage.getId()).thenReturn(new UUID(10, 1));
+        Mockito.when(camelKapuaMessage.getDatastoreId()).thenReturn("datastore ID");
+    }
+
+    @Test
+    public void processConfigurationErrorMessageTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        dataStorageMessageProcessor.processConfigurationErrorMessage(exchange, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueConfigurationErrorCount.getCount());
+
+        queueConfigurationErrorCount.inc();
+    }
+
+    @Test
+    public void processConfigurationErrorMessageNullExchangeTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        dataStorageMessageProcessor.processConfigurationErrorMessage(null, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueConfigurationErrorCount.getCount());
+
+        queueConfigurationErrorCount.inc();
+    }
+
+    @Test
+    public void processConfigurationErrorNullMessageTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        try {
+            dataStorageMessageProcessor.processConfigurationErrorMessage(exchange, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+    }
+
+    @Test
+    public void processConfigurationErrorNullTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        try {
+            dataStorageMessageProcessor.processConfigurationErrorMessage(null, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+    }
+
+    @Test
+    public void processGenericErrorMessageTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        dataStorageMessageProcessor.processGenericErrorMessage(exchange, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueGenericErrorCount.getCount());
+
+        queueGenericErrorCount.inc();
+    }
+
+    @Test
+    public void processGenericErrorMessageNullExchangeTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        dataStorageMessageProcessor.processGenericErrorMessage(null, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueGenericErrorCount.getCount());
+
+        queueGenericErrorCount.inc();
+    }
+
+    @Test
+    public void processGenericErrorNullMessageTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        try {
+            dataStorageMessageProcessor.processGenericErrorMessage(exchange, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+    }
+
+    @Test
+    public void processGenericErrorNullTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        try {
+            dataStorageMessageProcessor.processGenericErrorMessage(null, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DeviceManagementNotificationMessageProcessorTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DeviceManagementNotificationMessageProcessorTest.java
@@ -1,0 +1,138 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import com.codahale.metrics.Counter;
+import org.apache.camel.Exchange;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.broker.core.listener.DeviceManagementNotificationMessageProcessor;
+import org.eclipse.kapua.broker.core.listener.DeviceManagementRegistryNotificationMetrics;
+import org.eclipse.kapua.broker.core.message.CamelKapuaMessage;
+import org.eclipse.kapua.commons.metric.MetricServiceFactory;
+import org.eclipse.kapua.message.KapuaMessage;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class DeviceManagementNotificationMessageProcessorTest extends Assert {
+
+    DeviceManagementNotificationMessageProcessor deviceManagementNotificationMessageProcessor;
+    CamelKapuaMessage camelKapuaMessage;
+    Exchange exchange;
+    KapuaMessage message;
+    Counter queueConfigurationErrorCount, queueGenericErrorCount;
+
+    @Before
+    public void initialize() {
+        deviceManagementNotificationMessageProcessor = new DeviceManagementNotificationMessageProcessor();
+        camelKapuaMessage = Mockito.mock(CamelKapuaMessage.class);
+        exchange = Mockito.mock(Exchange.class);
+        message = Mockito.mock(KapuaMessage.class);
+        queueConfigurationErrorCount = MetricServiceFactory.getInstance().getCounter(DeviceManagementRegistryNotificationMetrics.METRIC_MODULE_NAME, DeviceManagementRegistryNotificationMetrics.METRIC_COMPONENT_NOTIFICATION, DeviceManagementRegistryNotificationMetrics.METRIC_PROCESS_QUEUE, DeviceManagementRegistryNotificationMetrics.METRIC_CONFIGURATION, DeviceManagementRegistryNotificationMetrics.METRIC_ERROR, DeviceManagementRegistryNotificationMetrics.METRIC_COUNT);
+        queueGenericErrorCount = MetricServiceFactory.getInstance().getCounter(DeviceManagementRegistryNotificationMetrics.METRIC_MODULE_NAME, DeviceManagementRegistryNotificationMetrics.METRIC_COMPONENT_NOTIFICATION, DeviceManagementRegistryNotificationMetrics.METRIC_PROCESS_QUEUE, DeviceManagementRegistryNotificationMetrics.METRIC_GENERIC, DeviceManagementRegistryNotificationMetrics.METRIC_ERROR, DeviceManagementRegistryNotificationMetrics.METRIC_COUNT);
+
+        Mockito.when(camelKapuaMessage.getDatastoreId()).thenReturn("datastoreID");
+        Mockito.when(camelKapuaMessage.getMessage()).thenReturn(message);
+        Mockito.when(message.getId()).thenReturn(new UUID(1, 10));
+    }
+
+    @Test
+    public void processConfigurationErrorMessageTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        deviceManagementNotificationMessageProcessor.processConfigurationErrorMessage(exchange, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueConfigurationErrorCount.getCount());
+
+        queueConfigurationErrorCount.inc();
+    }
+
+    @Test
+    public void processConfigurationErrorMessageNullExchangeTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        deviceManagementNotificationMessageProcessor.processConfigurationErrorMessage(null, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueConfigurationErrorCount.getCount());
+
+        queueConfigurationErrorCount.inc();
+    }
+
+    @Test
+    public void processConfigurationErrorNullMessageTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        try {
+            deviceManagementNotificationMessageProcessor.processConfigurationErrorMessage(exchange, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+    }
+
+    @Test
+    public void processConfigurationErrorNullTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+        try {
+            deviceManagementNotificationMessageProcessor.processConfigurationErrorMessage(null, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueConfigurationErrorCount.getCount());
+    }
+
+    @Test
+    public void processGenericErrorMessageTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        deviceManagementNotificationMessageProcessor.processGenericErrorMessage(exchange, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueGenericErrorCount.getCount());
+
+        queueGenericErrorCount.inc();
+    }
+
+    @Test
+    public void processGenericErrorMessageNullExchangeTest() throws KapuaException {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        deviceManagementNotificationMessageProcessor.processGenericErrorMessage(null, camelKapuaMessage);
+        assertEquals("Expected and actual values should be the same.", -1L, queueGenericErrorCount.getCount());
+
+        queueGenericErrorCount.inc();
+    }
+
+    @Test
+    public void processGenericErrorNullMessageTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        try {
+            deviceManagementNotificationMessageProcessor.processGenericErrorMessage(exchange, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+    }
+
+    @Test
+    public void processGenericErrorNullTest() {
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+        try {
+            deviceManagementNotificationMessageProcessor.processGenericErrorMessage(null, null);
+            fail("NullPointerException expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+        assertEquals("Expected and actual values should be the same.", 0L, queueGenericErrorCount.getCount());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in broker/core/listener package:
 - AbstractListener class
 - AbstractProcessor class
 - CamelConstants class
 - DataStorageMessageProcessor class
 - DataStoreMetrics class
 - DeviceManagementNotificationMessageProcessor class
 - DeviceManagementRegistryNotificationMetrics class
 - ErrorMessageListener class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
