### PR TITLE
Added JUnit tests for authentication/credential/mfa/shiro package

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MfaOptionDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MfaOptionDAOTest.java
@@ -1,0 +1,334 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionDAO;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionImpl;
+import org.hamcrest.core.IsInstanceOf;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.math.BigInteger;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class MfaOptionDAOTest extends Assert {
+
+    EntityManager entityManager;
+    MfaOptionCreator mfaOptionCreator;
+    MfaOptionImpl mfaOption, entityToFindOrDelete;
+    Date createdOn;
+    KapuaId createdBy, scopeId, mfaOptionId;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        mfaOptionCreator = Mockito.mock(MfaOptionCreator.class);
+        mfaOption = Mockito.mock(MfaOptionImpl.class);
+        entityToFindOrDelete = Mockito.mock(MfaOptionImpl.class);
+        createdOn = new Date();
+        createdBy = KapuaId.ONE;
+        scopeId = KapuaId.ONE;
+        mfaOptionId = KapuaId.ONE;
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid(BigInteger.ONE));
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.create(entityManager, mfaOptionCreator), IsInstanceOf.instanceOf(MfaOption.class));
+        assertEquals("Expected and actual values should be the same.", "kOhsl1vEPvSuZcifFlMCvg", MfaOptionDAO.create(entityManager, mfaOptionCreator).getMfaSecretKey());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, MfaOptionDAO.create(entityManager, mfaOptionCreator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, MfaOptionDAO.create(entityManager, mfaOptionCreator).getUserId());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid(BigInteger.ONE));
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        MfaOptionDAO.create(entityManager, mfaOptionCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid(BigInteger.ONE));
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        MfaOptionDAO.create(entityManager, mfaOptionCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithCauseTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid(BigInteger.ONE));
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        MfaOptionDAO.create(entityManager, mfaOptionCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid(BigInteger.ONE));
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        MfaOptionDAO.create(entityManager, mfaOptionCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(mfaOptionCreator.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOptionCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOptionCreator.getUserId()).thenReturn(new KapuaEid());
+
+        MfaOptionDAO.create(null, mfaOptionCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullMfaOptionCreatorTest() throws KapuaException {
+        MfaOptionDAO.create(entityManager, (MfaOptionCreator) null);
+    }
+
+    @Test
+    public void updateTest() throws KapuaException {
+        Mockito.when(mfaOption.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(entityManager.find(MfaOptionImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.update(entityManager, mfaOption), IsInstanceOf.instanceOf(MfaOption.class));
+        assertEquals("Expected and actual values should be the same.", createdBy, MfaOptionDAO.update(entityManager, mfaOption).getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, MfaOptionDAO.update(entityManager, mfaOption).getCreatedOn());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullEntityManagerTest() throws KapuaException {
+        MfaOptionDAO.update(null, mfaOption);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullMfaOptionTest() throws KapuaException {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        MfaOptionDAO.update(entityManager, null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, scopeId, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, MfaOptionDAO.find(entityManager, scopeId, mfaOptionId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", MfaOptionDAO.find(entityManager, scopeId, mfaOptionId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(null);
+
+        assertNull("Null expected.", MfaOptionDAO.find(entityManager, scopeId, mfaOptionId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, scopeId, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        MfaOptionDAO.find(null, scopeId, mfaOptionId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, null, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, MfaOptionDAO.find(entityManager, null, mfaOptionId).getScopeId());
+    }
+
+    @Test
+    public void findNullMfaOptionIdTest() {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, scopeId, null), IsInstanceOf.instanceOf(MfaOption.class));
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, MfaOptionDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<MfaOptionImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<MfaOptionImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<MfaOptionImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(MfaOptionImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(MfaOptionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertThat("Instance of MfaOptionListResult object expected.", MfaOptionDAO.query(entityManager, kapuaQuery), IsInstanceOf.instanceOf(MfaOptionListResult.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        MfaOptionDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<MfaOptionImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<MfaOptionImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<MfaOptionImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<MfaOptionImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(MfaOptionImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(MfaOptionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        MfaOptionDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<MfaOptionImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(MfaOptionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertThat("Long object expected.", MfaOptionDAO.count(entityManager, kapuaQuery), IsInstanceOf.instanceOf(Long.class));
+            assertEquals("Expected and actual values should be the same.", number, MfaOptionDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        MfaOptionDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        MfaOptionDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.delete(entityManager, scopeId, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        MfaOptionDAO.delete(null, scopeId, mfaOptionId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+
+        assertThat("Instance of MfaOption object expected.", MfaOptionDAO.delete(entityManager, null, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullMfaOptionIdTest() throws KapuaEntityNotFoundException {
+        MfaOptionDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(null);
+
+        MfaOptionDAO.delete(entityManager, scopeId, mfaOptionId);
+    }
+}

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -84,10 +84,27 @@
             <artifactId>googleauth</artifactId>
         </dependency>
 
+
         <!-- QR code generation -->
         <dependency>
             <groupId>com.google.zxing</groupId>
             <artifactId>javase</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionCreatorImplTest.java
@@ -1,0 +1,89 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class MfaOptionCreatorImplTest extends Assert {
+
+    KapuaId[] scopeIds;
+    KapuaId[] userIds;
+    KapuaId[] newUserIds;
+    String[] mfaSecretKeys;
+    String[] newMfaSecretKeys;
+    MfaOptionCreatorImpl mfaOptionCreatorImpl1;
+    MfaOptionCreatorImpl mfaOptionCreatorImpl2;
+
+    @Before
+    public void initialize() {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        userIds = new KapuaId[]{null, KapuaId.ONE};
+        newUserIds = new KapuaId[]{null, KapuaId.ANY};
+        mfaSecretKeys = new String[]{null, "", "!!mfaSecretKey-1", "#1(newMfa.,/SecretKey)9--99", "!$$ 1-2 key//", "mfa_key(....)<00>"};
+        newMfaSecretKeys = new String[]{null, "", "new_mfaSecret,Key-1", "#1(new...MfaSecretKey)999", "!$$ 1-2 key", "mfa_key<00>"};
+        mfaOptionCreatorImpl1 = new MfaOptionCreatorImpl(KapuaId.ONE, KapuaId.ONE, "mfaSecretKey");
+        mfaOptionCreatorImpl2 = new MfaOptionCreatorImpl(KapuaId.ONE);
+    }
+
+    @Test
+    public void mfaOptionCreatorImplScopeIdUserIdSecretKeyParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId userId : userIds) {
+                for (String mfaSecretKey : mfaSecretKeys) {
+                    MfaOptionCreatorImpl mfaOptionCreatorImpl = new MfaOptionCreatorImpl(scopeId, userId, mfaSecretKey);
+                    assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionCreatorImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", userId, mfaOptionCreatorImpl.getUserId());
+                    assertEquals("Expected and actual values should be the same.", mfaSecretKey, mfaOptionCreatorImpl.getMfaSecretKey());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void mfaOptionCreatorImplScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            MfaOptionCreatorImpl mfaOptionCreatorImpl = new MfaOptionCreatorImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionCreatorImpl.getScopeId());
+            assertNull("Null expected.", mfaOptionCreatorImpl.getUserId());
+            assertNull("Null expected.", mfaOptionCreatorImpl.getMfaSecretKey());
+        }
+    }
+
+    @Test
+    public void setAndGetUserIdTest() {
+        for (KapuaId newUserId : newUserIds) {
+            mfaOptionCreatorImpl1.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionCreatorImpl1.getUserId());
+
+            mfaOptionCreatorImpl2.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionCreatorImpl2.getUserId());
+        }
+    }
+
+    @Test
+    public void setAndGetMfaSecretKeyTest() {
+        for (String newMfaSecretKey : newMfaSecretKeys) {
+            mfaOptionCreatorImpl1.setMfaSecretKey(newMfaSecretKey);
+            assertEquals("Expected and actual values should be the same.", newMfaSecretKey, mfaOptionCreatorImpl1.getMfaSecretKey());
+
+            mfaOptionCreatorImpl2.setMfaSecretKey(newMfaSecretKey);
+            assertEquals("Expected and actual values should be the same.", newMfaSecretKey, mfaOptionCreatorImpl2.getMfaSecretKey());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionEntityManagerFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionEntityManagerFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class MfaOptionEntityManagerFactoryTest extends Assert {
+
+    @Test
+    public void mfaOptionEntityManagerFactoryTest() throws Exception {
+        Constructor<MfaOptionEntityManagerFactory> mfaOptionEntityManagerFactory = MfaOptionEntityManagerFactory.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(mfaOptionEntityManagerFactory.getModifiers()));
+        mfaOptionEntityManagerFactory.setAccessible(true);
+        mfaOptionEntityManagerFactory.newInstance();
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("Instance of EntityManagerFactory expected.", MfaOptionEntityManagerFactory.getInstance() instanceof EntityManagerFactory);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionFactoryImplTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class MfaOptionFactoryImplTest extends Assert {
+
+    MfaOptionFactoryImpl mfaOptionFactoryImpl;
+    KapuaId[] scopeIds;
+    KapuaEid[] userIds;
+    String[] mfaSecretKeys;
+    MfaOption mfaOption;
+    Date trustExpirationDate;
+    Date modifiedOn;
+
+    @Before
+    public void initialize() {
+        mfaOptionFactoryImpl = new MfaOptionFactoryImpl();
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        userIds = new KapuaEid[]{null, new KapuaEid()};
+        mfaSecretKeys = new String[]{null, "", "!!mfaSecretKey-1", "#1(newMfa.,/SecretKey)9--99", "!$$ 1-2 key//", "mfa_key(....)<00>"};
+        mfaOption = Mockito.mock(MfaOption.class);
+        trustExpirationDate = new Date();
+        modifiedOn = new Date();
+    }
+
+    @Test
+    public void newCreatorScopeIdUserIdMfaSecretKeyParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaEid userId : userIds) {
+                for (String mfaSecretKey : mfaSecretKeys) {
+                    MfaOptionCreatorImpl mfaOptionCreatorImpl = mfaOptionFactoryImpl.newCreator(scopeId, userId, mfaSecretKey);
+                    assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionCreatorImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", userId, mfaOptionCreatorImpl.getUserId());
+                    assertEquals("Expected and actual values should be the same.", mfaSecretKey, mfaOptionCreatorImpl.getMfaSecretKey());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("Instance of MfaOptionListResult expected.", mfaOptionFactoryImpl.newListResult() instanceof MfaOptionListResult);
+    }
+
+    @Test
+    public void newEntityTest() {
+        for (KapuaId scopeId : scopeIds) {
+            MfaOption mfaOption = mfaOptionFactoryImpl.newEntity(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOption.getScopeId());
+        }
+    }
+
+    @Test
+    public void newMfaOptionTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId userId : userIds) {
+                for (String mfaSecretKey : mfaSecretKeys) {
+                    MfaOption mfaOption = mfaOptionFactoryImpl.newMfaOption(scopeId, userId, mfaSecretKey);
+                    assertEquals("Expected and actual values should be the same.", scopeId, mfaOption.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", userId, mfaOption.getUserId());
+                    assertEquals("Expected and actual values should be the same.", mfaSecretKey, mfaOption.getMfaSecretKey());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newQueryTest() {
+        for (KapuaId scopeId : scopeIds) {
+            MfaOptionQuery mfaOptionQuery = mfaOptionFactoryImpl.newQuery(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionQuery.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            MfaOptionCreator mfaOptionCreator = mfaOptionFactoryImpl.newCreator(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void cloneTest() {
+        Mockito.when(mfaOption.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOption.getTrustKey()).thenReturn("thrust key");
+        Mockito.when(mfaOption.getTrustExpirationDate()).thenReturn(trustExpirationDate);
+        Mockito.when(mfaOption.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(mfaOption.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getOptlock()).thenReturn(10);
+
+        MfaOption mfaOptionResult = mfaOptionFactoryImpl.clone(mfaOption);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionResult.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionResult.getUserId());
+        assertEquals("Expected and actual values should be the same.", "mfa secret key", mfaOptionResult.getMfaSecretKey());
+        assertEquals("Expected and actual values should be the same.", "thrust key", mfaOptionResult.getTrustKey());
+        assertEquals("Expected and actual values should be the same.", trustExpirationDate, mfaOptionResult.getTrustExpirationDate());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, mfaOptionResult.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionResult.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", 10, mfaOptionResult.getOptlock());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        mfaOptionFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImplTest.java
@@ -1,0 +1,315 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.LinkedList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class MfaOptionImplTest extends Assert {
+
+    KapuaId[] scopeIds;
+    KapuaEid[] userIds;
+    String[] mfaSecretKeys;
+    MfaOption mfaOption;
+    Date trustExpirationDate, modifiedOn;
+
+    @Before
+    public void initialize() {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        userIds = new KapuaEid[]{null, new KapuaEid()};
+        mfaSecretKeys = new String[]{null, "", "!!mfaSecretKey-1", "#1(newMfa.,/SecretKey)9--99", "!$$ 1-2 key//", "mfa_key(....)<00>"};
+        mfaOption = Mockito.mock(MfaOption.class);
+        trustExpirationDate = new Date();
+        modifiedOn = new Date();
+    }
+
+    @Test
+    public void mfaOptionImplWithoutParametersTest() {
+        MfaOptionImpl mfaOptionImpl = new MfaOptionImpl();
+        assertNull("Null expected.", mfaOptionImpl.getScopeId());
+        assertNull("Null expected.", mfaOptionImpl.getUserId());
+        assertNull("Null expected.", mfaOptionImpl.getMfaSecretKey());
+        assertNull("Null expected.", mfaOptionImpl.getTrustKey());
+        assertNull("Null expected.", mfaOptionImpl.getTrustExpirationDate());
+    }
+
+    @Test
+    public void mfaOptionImplScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            MfaOptionImpl mfaOptionImpl = new MfaOptionImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionImpl.getScopeId());
+            assertNull("Null expected.", mfaOptionImpl.getUserId());
+            assertNull("Null expected.", mfaOptionImpl.getMfaSecretKey());
+            assertNull("Null expected.", mfaOptionImpl.getTrustKey());
+            assertNull("Null expected.", mfaOptionImpl.getTrustExpirationDate());
+        }
+    }
+
+    @Test
+    public void mfaOptionImplScopeIdUserIdMfaSecretKeyParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId userId : userIds) {
+                for (String mfaSecretKey : mfaSecretKeys) {
+                    MfaOptionImpl mfaOptionImpl = new MfaOptionImpl(scopeId, userId, mfaSecretKey);
+                    assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", userId, mfaOptionImpl.getUserId());
+                    assertEquals("Expected and actual values should be the same.", mfaSecretKey, mfaOptionImpl.getMfaSecretKey());
+                    assertNull("Null expected.", mfaOptionImpl.getTrustKey());
+                    assertNull("Null expected.", mfaOptionImpl.getTrustExpirationDate());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void mfaOptionImplMfaOptionParameterTest() throws KapuaException {
+        Mockito.when(mfaOption.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getMfaSecretKey()).thenReturn("mfa secret key");
+        Mockito.when(mfaOption.getTrustKey()).thenReturn("trust key");
+        Mockito.when(mfaOption.getTrustExpirationDate()).thenReturn(trustExpirationDate);
+        Mockito.when(mfaOption.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(mfaOption.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(mfaOption.getOptlock()).thenReturn(10);
+
+        MfaOptionImpl mfaOptionImpl = new MfaOptionImpl(mfaOption);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionImpl.getUserId());
+        assertEquals("Expected and actual values should be the same.", "mfa secret key", mfaOptionImpl.getMfaSecretKey());
+        assertEquals("Expected and actual values should be the same.", "trust key", mfaOptionImpl.getTrustKey());
+        assertEquals("Expected and actual values should be the same.", trustExpirationDate, mfaOptionImpl.getTrustExpirationDate());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, mfaOptionImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, mfaOptionImpl.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", 10, mfaOptionImpl.getOptlock());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mfaOptionImplNullMfaOptionParameterTest() throws KapuaException {
+        new MfaOptionImpl((MfaOption) null);
+    }
+
+    @Test
+    public void setAndGetUserIdTest() throws KapuaException {
+        KapuaId[] newUserIds = {null, KapuaId.ANY};
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        for (KapuaId newUserId : newUserIds) {
+            mfaOptionImpl1.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionImpl1.getUserId());
+        }
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        for (KapuaId newUserId : newUserIds) {
+            mfaOptionImpl2.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionImpl2.getUserId());
+        }
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        for (KapuaId newUserId : newUserIds) {
+            mfaOptionImpl3.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionImpl3.getUserId());
+        }
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        for (KapuaId newUserId : newUserIds) {
+            mfaOptionImpl4.setUserId(newUserId);
+            assertEquals("Expected and actual values should be the same.", newUserId, mfaOptionImpl4.getUserId());
+        }
+    }
+
+    @Test
+    public void setAndGetMfaSecretKeyTest() throws KapuaException {
+        String[] newSecretKeys = {null, "new secret key"};
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        for (String newSecretKey : newSecretKeys) {
+            mfaOptionImpl1.setMfaSecretKey(newSecretKey);
+            assertEquals("Expected and actual values should be the same.", newSecretKey, mfaOptionImpl1.getMfaSecretKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        for (String newSecretKey : newSecretKeys) {
+            mfaOptionImpl2.setMfaSecretKey(newSecretKey);
+            assertEquals("Expected and actual values should be the same.", newSecretKey, mfaOptionImpl2.getMfaSecretKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        for (String newSecretKey : newSecretKeys) {
+            mfaOptionImpl3.setMfaSecretKey(newSecretKey);
+            assertEquals("Expected and actual values should be the same.", newSecretKey, mfaOptionImpl3.getMfaSecretKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        for (String newSecretKey : newSecretKeys) {
+            mfaOptionImpl4.setMfaSecretKey(newSecretKey);
+            assertEquals("Expected and actual values should be the same.", newSecretKey, mfaOptionImpl4.getMfaSecretKey());
+        }
+    }
+
+    @Test
+    public void setAndGetTrustKeyTest() throws KapuaException {
+        String[] newTrustKeys = {null, "new trust key"};
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        for (String newTrustKey : newTrustKeys) {
+            mfaOptionImpl1.setTrustKey(newTrustKey);
+            assertEquals("Expected and actual values should be the same.", newTrustKey, mfaOptionImpl1.getTrustKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        for (String newTrustKey : newTrustKeys) {
+            mfaOptionImpl2.setTrustKey(newTrustKey);
+            assertEquals("Expected and actual values should be the same.", newTrustKey, mfaOptionImpl2.getTrustKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        for (String newTrustKey : newTrustKeys) {
+            mfaOptionImpl3.setTrustKey(newTrustKey);
+            assertEquals("Expected and actual values should be the same.", newTrustKey, mfaOptionImpl3.getTrustKey());
+        }
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        for (String newTrustKey : newTrustKeys) {
+            mfaOptionImpl4.setTrustKey(newTrustKey);
+            assertEquals("Expected and actual values should be the same.", newTrustKey, mfaOptionImpl4.getTrustKey());
+        }
+    }
+
+    @Test
+    public void setAndGetTrustExpirationDateTest() throws KapuaException {
+        Date[] newTrustExpirationDates = {null, new Date()};
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        for (Date newTrustExpirationDate : newTrustExpirationDates) {
+            mfaOptionImpl1.setTrustExpirationDate(newTrustExpirationDate);
+            assertEquals("Expected and actual values should be the same.", newTrustExpirationDate, mfaOptionImpl1.getTrustExpirationDate());
+        }
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        for (Date newTrustExpirationDate : newTrustExpirationDates) {
+            mfaOptionImpl2.setTrustExpirationDate(newTrustExpirationDate);
+            assertEquals("Expected and actual values should be the same.", newTrustExpirationDate, mfaOptionImpl2.getTrustExpirationDate());
+        }
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        for (Date newTrustExpirationDate : newTrustExpirationDates) {
+            mfaOptionImpl3.setTrustExpirationDate(newTrustExpirationDate);
+            assertEquals("Expected and actual values should be the same.", newTrustExpirationDate, mfaOptionImpl3.getTrustExpirationDate());
+        }
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        for (Date newTrustExpirationDate : newTrustExpirationDates) {
+            mfaOptionImpl4.setTrustExpirationDate(newTrustExpirationDate);
+            assertEquals("Expected and actual values should be the same.", newTrustExpirationDate, mfaOptionImpl4.getTrustExpirationDate());
+        }
+    }
+
+    @Test
+    public void setAndGetQRCodeImageTest() throws KapuaException {
+        String[] newQrCodeImages = {null, "new qr Code Image"};
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        for (String newQrCodeImage : newQrCodeImages) {
+            mfaOptionImpl1.setQRCodeImage(newQrCodeImage);
+            assertEquals("Expected and actual values should be the same.", newQrCodeImage, mfaOptionImpl1.getQRCodeImage());
+        }
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        for (String newQrCodeImage : newQrCodeImages) {
+            mfaOptionImpl2.setQRCodeImage(newQrCodeImage);
+            assertEquals("Expected and actual values should be the same.", newQrCodeImage, mfaOptionImpl2.getQRCodeImage());
+        }
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        for (String newQrCodeImage : newQrCodeImages) {
+            mfaOptionImpl3.setQRCodeImage(newQrCodeImage);
+            assertEquals("Expected and actual values should be the same.", newQrCodeImage, mfaOptionImpl3.getQRCodeImage());
+        }
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        for (String newQrCodeImage : newQrCodeImages) {
+            mfaOptionImpl4.setQRCodeImage(newQrCodeImage);
+            assertEquals("Expected and actual values should be the same.", newQrCodeImage, mfaOptionImpl4.getQRCodeImage());
+        }
+    }
+
+    @Test
+    public void setAndGetScratchCodesEmptyListTest() throws KapuaException {
+        List<ScratchCode> scratchCodeList = new LinkedList<>();
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        mfaOptionImpl1.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl1.getScratchCodes());
+        assertTrue("True expected.", mfaOptionImpl1.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        mfaOptionImpl2.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl2.getScratchCodes());
+        assertTrue("True expected.", mfaOptionImpl2.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        mfaOptionImpl3.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl3.getScratchCodes());
+        assertTrue("True expected.", mfaOptionImpl3.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        mfaOptionImpl4.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl4.getScratchCodes());
+        assertTrue("True expected.", mfaOptionImpl4.getScratchCodes().isEmpty());
+    }
+
+    @Test
+    public void setAndGetScratchCodesTest() throws KapuaException {
+        List<ScratchCode> scratchCodeList = new LinkedList<>();
+        ScratchCode scratchCode1 = Mockito.mock(ScratchCode.class);
+        ScratchCode scratchCode2 = Mockito.mock(ScratchCode.class);
+
+        scratchCodeList.add(scratchCode1);
+        scratchCodeList.add(scratchCode2);
+
+        MfaOptionImpl mfaOptionImpl1 = new MfaOptionImpl();
+        mfaOptionImpl1.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl1.getScratchCodes());
+        assertFalse("False expected.", mfaOptionImpl1.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl2 = new MfaOptionImpl(KapuaId.ONE);
+        mfaOptionImpl2.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl2.getScratchCodes());
+        assertFalse("False expected.", mfaOptionImpl2.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl3 = new MfaOptionImpl(KapuaId.ONE, new KapuaEid(), "mfa secret key");
+        mfaOptionImpl3.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl3.getScratchCodes());
+        assertFalse("False expected.", mfaOptionImpl3.getScratchCodes().isEmpty());
+
+        MfaOptionImpl mfaOptionImpl4 = new MfaOptionImpl(mfaOption);
+        mfaOptionImpl4.setScratchCodes(scratchCodeList);
+        assertEquals("Expected and actual values should be the same.", scratchCodeList, mfaOptionImpl4.getScratchCodes());
+        assertFalse("False expected.", mfaOptionImpl4.getScratchCodes().isEmpty());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImplTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class MfaOptionQueryImplTest extends Assert {
+
+    @Test
+    public void mfaOptionQueryImplTest() {
+        MfaOptionQueryImpl mfaOptionQueryImpl = new MfaOptionQueryImpl();
+        assertNotNull("NotNull expected.", mfaOptionQueryImpl.getSortCriteria());
+        assertNull("Null expected.", mfaOptionQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void mfaOptionQueryImplScopeIdParameterTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ONE};
+
+        for (KapuaId scopeId : scopeIds) {
+            MfaOptionQueryImpl mfaOptionQueryImpl = new MfaOptionQueryImpl(scopeId);
+            assertNotNull("NotNull expected.", mfaOptionQueryImpl.getSortCriteria());
+            assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionQueryImpl.getScopeId());
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in authentication/credential/mfa/shiro package :
 - MfaOptionDAO class
 - MfaOptionCreatorImpl class
 - MfaOptionEntityManagerFactory class
 - MfaOptionFactoryImpl class
 - MfaOptionImpl class
 - MfaOptionQueryImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
