### PR TITLE
Added JUnit tests for ScratchCode classes

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ScratchCodeDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ScratchCodeDAOTest.java
@@ -1,0 +1,335 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeDAO;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class ScratchCodeDAOTest extends Assert {
+
+    EntityManager entityManager;
+    ScratchCodeCreator scratchCodeCreator;
+    ScratchCodeImpl code, entityToFindOrDelete;
+    Date createdOn;
+    KapuaId createdBy, scopeId, scratchCodeId;
+    KapuaEid mfaOptionId;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        scratchCodeCreator = Mockito.mock(ScratchCodeCreator.class);
+        code = Mockito.mock(ScratchCodeImpl.class);
+        entityToFindOrDelete = Mockito.mock(ScratchCodeImpl.class);
+        createdOn = new Date();
+        createdBy = KapuaId.ONE;
+        scopeId = KapuaId.ONE;
+        mfaOptionId = new KapuaEid(KapuaId.ONE);
+        scratchCodeId = KapuaId.ONE;
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+
+        assertTrue("True expected.", ScratchCodeDAO.create(entityManager, scratchCodeCreator) instanceof ScratchCode);
+        assertTrue("True expected.", ScratchCodeDAO.create(entityManager, scratchCodeCreator).getCode().startsWith("$2a$12$"));
+        assertEquals("Expected and actual values should be the same.", scopeId, ScratchCodeDAO.create(entityManager, scratchCodeCreator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", mfaOptionId, ScratchCodeDAO.create(entityManager, scratchCodeCreator).getMfaOptionId());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        ScratchCodeDAO.create(entityManager, scratchCodeCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        ScratchCodeDAO.create(entityManager, scratchCodeCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithCauseTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        ScratchCodeDAO.create(entityManager, scratchCodeCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        ScratchCodeDAO.create(entityManager, scratchCodeCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(scratchCodeCreator.getCode()).thenReturn("code");
+        Mockito.when(scratchCodeCreator.getScopeId()).thenReturn(scopeId);
+        Mockito.when(scratchCodeCreator.getMfaOptionId()).thenReturn(mfaOptionId);
+
+        ScratchCodeDAO.create(null, scratchCodeCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullMfaOptionCreatorTest() throws KapuaException {
+        ScratchCodeDAO.create(entityManager, (ScratchCodeCreator) null);
+    }
+
+    @Test
+    public void updateTest() throws KapuaException {
+        Mockito.when(code.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        assertTrue("True expected.", ScratchCodeDAO.update(entityManager, code) instanceof ScratchCode);
+        assertEquals("Expected and actual values should be the same.", createdBy, ScratchCodeDAO.update(entityManager, code).getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, ScratchCodeDAO.update(entityManager, code).getCreatedOn());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullEntityManagerTest() throws KapuaException {
+        Mockito.when(code.getId()).thenReturn(KapuaId.ONE);
+        ScratchCodeDAO.update(null, code);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullCodeTest() throws KapuaException {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        ScratchCodeDAO.update(entityManager, null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId) instanceof ScratchCode);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(null);
+
+        assertNull("Null expected.", ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId) instanceof ScratchCode);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        ScratchCodeDAO.find(null, scopeId, scratchCodeId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", ScratchCodeDAO.find(entityManager, null, scratchCodeId) instanceof ScratchCode);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, ScratchCodeDAO.find(entityManager, null, scratchCodeId).getScopeId());
+    }
+
+    @Test
+    public void findNullMfaOptionIdTest() {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", ScratchCodeDAO.find(entityManager, scopeId, null) instanceof ScratchCode);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, ScratchCodeDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<ScratchCodeImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<ScratchCodeImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<ScratchCodeImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(ScratchCodeImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(ScratchCodeImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", ScratchCodeDAO.query(entityManager, kapuaQuery) instanceof ScratchCodeListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        ScratchCodeDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<ScratchCodeImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<ScratchCodeImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<ScratchCodeImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<ScratchCodeImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(ScratchCodeImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(ScratchCodeImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        ScratchCodeDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<ScratchCodeImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(ScratchCodeImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, ScratchCodeDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        ScratchCodeDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        ScratchCodeDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", ScratchCodeDAO.delete(entityManager, scopeId, scratchCodeId) instanceof ScratchCode);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        ScratchCodeDAO.delete(null, scopeId, scratchCodeId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", ScratchCodeDAO.delete(entityManager, null, scratchCodeId) instanceof ScratchCode);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullMfaOptionIdTest() throws KapuaEntityNotFoundException {
+        ScratchCodeDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(null);
+
+        ScratchCodeDAO.delete(entityManager, scopeId, scratchCodeId);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeCreatorImplTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ScratchCodeCreatorImplTest extends Assert {
+
+    KapuaId[] scopeIds, mfaOptionIds;
+    String[] codes;
+
+    @Before
+    public void initialize() {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        mfaOptionIds = new KapuaId[]{null, KapuaId.ONE};
+        codes = new String[]{null, "", "!!code-1", "#1(code-a.,/codeey)9--99", "!$$ 1-2 code//", "code(....)<00>", "co..,,000de@"};
+    }
+
+    @Test
+    public void scratchCodeCreatorImplScopeIdMfaOptionIdCodeParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId mfaOptionId : mfaOptionIds) {
+                for (String code : codes) {
+                    ScratchCodeCreatorImpl scratchCodeCreatorImpl = new ScratchCodeCreatorImpl(scopeId, mfaOptionId, code);
+                    assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeCreatorImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", mfaOptionId, scratchCodeCreatorImpl.getMfaOptionId());
+                    assertEquals("Expected and actual values should be the same.", code, scratchCodeCreatorImpl.getCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void scratchCodeCreatorImplScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCodeCreatorImpl scratchCodeCreatorImpl = new ScratchCodeCreatorImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeCreatorImpl.getScopeId());
+            assertNull("Null expected.", scratchCodeCreatorImpl.getMfaOptionId());
+            assertNull("Null expected.", scratchCodeCreatorImpl.getCode());
+        }
+    }
+
+    @Test
+    public void setAndGetMfaOptionIdTest() {
+        KapuaId[] newMfaOptionIds = {null, KapuaId.ANY};
+
+        ScratchCodeCreatorImpl scratchCodeCreatorImpl1 = new ScratchCodeCreatorImpl(KapuaId.ONE);
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeCreatorImpl1.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeCreatorImpl1.getMfaOptionId());
+        }
+
+        ScratchCodeCreatorImpl scratchCodeCreatorImpl2 = new ScratchCodeCreatorImpl(KapuaId.ONE, KapuaId.ANY, "code");
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeCreatorImpl2.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeCreatorImpl2.getMfaOptionId());
+        }
+    }
+
+    @Test
+    public void setAndGetCodeTest() {
+        String[] newCodes = {null, "", "new...!!code-1", "#1(new-a.,/codeey)9--99", "NEW!$$ 1-2 code//", "code(....)newCODE<00>", "co..,,000de@"};
+
+        ScratchCodeCreatorImpl scratchCodeCreatorImpl1 = new ScratchCodeCreatorImpl(KapuaId.ONE);
+        for (String newCode : newCodes) {
+            scratchCodeCreatorImpl1.setCode(newCode);
+            assertEquals("Expected and actual values should be the same.", newCode, scratchCodeCreatorImpl1.getCode());
+        }
+
+        ScratchCodeCreatorImpl scratchCodeCreatorImpl2 = new ScratchCodeCreatorImpl(KapuaId.ONE, KapuaId.ANY, "code");
+        for (String newCode : newCodes) {
+            scratchCodeCreatorImpl2.setCode(newCode);
+            assertEquals("Expected and actual values should be the same.", newCode, scratchCodeCreatorImpl2.getCode());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeEntityManagerFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeEntityManagerFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class ScratchCodeEntityManagerFactoryTest extends Assert {
+
+    @Test
+    public void scratchCodeEntityManagerFactoryTest() throws Exception {
+        Constructor<ScratchCodeEntityManagerFactory> scratchCodeEntityManagerFactoryTest = ScratchCodeEntityManagerFactory.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(scratchCodeEntityManagerFactoryTest.getModifiers()));
+        scratchCodeEntityManagerFactoryTest.setAccessible(true);
+        scratchCodeEntityManagerFactoryTest.newInstance();
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", ScratchCodeEntityManagerFactory.getInstance() instanceof EntityManagerFactory);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImplTest.java
@@ -1,0 +1,133 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class ScratchCodeFactoryImplTest extends Assert {
+
+    ScratchCodeFactoryImpl scratchCodeFactoryImpl;
+    KapuaId[] scopeIds;
+    KapuaEid[] mfaOptionIds;
+    String[] codes;
+    ScratchCode scratchCode;
+    Date modifiedOn;
+
+    @Before
+    public void initialize() {
+        scratchCodeFactoryImpl = new ScratchCodeFactoryImpl();
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        mfaOptionIds = new KapuaEid[]{null, new KapuaEid()};
+        codes = new String[]{null, "", "!!code-1", "#1(newMfa.,/code code)9--99", "!$$ 1-2 co de//", "co_de secret--(....)<00>"};
+        scratchCode = Mockito.mock(ScratchCode.class);
+        modifiedOn = new Date();
+    }
+
+
+    @Test
+    public void newCreatorScopeIdMfaOptionIdCodeParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaEid mfaOptionId : mfaOptionIds) {
+                for (String code : codes) {
+                    ScratchCodeCreatorImpl scratchCodeCreatorImpl = scratchCodeFactoryImpl.newCreator(scopeId, mfaOptionId, code);
+                    assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeCreatorImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", mfaOptionId, scratchCodeCreatorImpl.getMfaOptionId());
+                    assertEquals("Expected and actual values should be the same.", code, scratchCodeCreatorImpl.getCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("True expected.", scratchCodeFactoryImpl.newListResult() instanceof ScratchCodeListResult);
+    }
+
+    @Test
+    public void newEntityTest() {
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCode scratchCode = scratchCodeFactoryImpl.newEntity(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCode.getScopeId());
+        }
+    }
+
+    @Test
+    public void newScratchCodeTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId mfaOptionId : mfaOptionIds) {
+                for (String code : codes) {
+                    ScratchCode scratchCode = scratchCodeFactoryImpl.newScratchCode(scopeId, mfaOptionId, code);
+                    assertEquals("Expected and actual values should be the same.", scopeId, scratchCode.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", mfaOptionId, scratchCode.getMfaOptionId());
+                    assertEquals("Expected and actual values should be the same.", code, scratchCode.getCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newQueryTest() {
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCodeQuery scratchCodeQuery = scratchCodeFactoryImpl.newQuery(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeQuery.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCodeCreator scratchCodeCreator = scratchCodeFactoryImpl.newCreator(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void cloneTest() {
+        Mockito.when(scratchCode.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(scratchCode.getCode()).thenReturn("code");
+        Mockito.when(scratchCode.getMfaOptionId()).thenReturn(KapuaId.ONE);
+        Mockito.when(scratchCode.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(scratchCode.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(scratchCode.getOptlock()).thenReturn(10);
+
+        ScratchCode scratchCodeResult = scratchCodeFactoryImpl.clone(scratchCode);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, scratchCodeResult.getScopeId());
+        assertEquals("Expected and actual values should be the same.", "code", scratchCodeResult.getCode());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, scratchCodeResult.getMfaOptionId());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, scratchCodeResult.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, scratchCodeResult.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", 10, scratchCodeResult.getOptlock());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        scratchCodeFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeImplTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class ScratchCodeImplTest extends Assert {
+
+    KapuaId[] scopeIds;
+    KapuaEid[] mfaOptionIds, newMfaOptionIds;
+    String[] codes, newCodes;
+    ScratchCode scratchCode;
+    Date modifiedOn;
+
+    @Before
+    public void initialize() {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        mfaOptionIds = new KapuaEid[]{null, new KapuaEid()};
+        newMfaOptionIds = new KapuaEid[]{null, new KapuaEid()};
+        codes = new String[]{null, "", "!!code-1", "#1(code-a.,/codeey)9--99", "!$$ 1-2 code//", "code(....)<00>", "co..,,000de@"};
+        newCodes = new String[]{null, "", "NEW!!code-1", "#1(code-a.,/newcodeey)9--99", "new...!$$ 1-2 code//", "NEWCODE newcode(....)<00>", "n..w co..,,000de@"};
+        scratchCode = Mockito.mock(ScratchCode.class);
+        modifiedOn = new Date();
+    }
+
+    @Test
+    public void scratchCodeImplWithoutParametersTest() {
+        ScratchCodeImpl scratchCodeImpl = new ScratchCodeImpl();
+        assertNull("Null expected.", scratchCodeImpl.getScopeId());
+        assertNull("Null expected.", scratchCodeImpl.getMfaOptionId());
+        assertNull("Null expected.", scratchCodeImpl.getCode());
+    }
+
+    @Test
+    public void scratchCodeImplScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCodeImpl scratchCodeImpl = new ScratchCodeImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeImpl.getScopeId());
+            assertNull("Null expected.", scratchCodeImpl.getMfaOptionId());
+            assertNull("Null expected.", scratchCodeImpl.getCode());
+        }
+    }
+
+    @Test
+    public void scratchCodeImplScopeIdMfaOptionIdCodeParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId mfaOptionId : mfaOptionIds) {
+                for (String code : codes) {
+                    ScratchCodeImpl scratchCodeImpl = new ScratchCodeImpl(scopeId, mfaOptionId, code);
+                    assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeImpl.getScopeId());
+                    assertEquals("Expected and actual values should be the same.", mfaOptionId, scratchCodeImpl.getMfaOptionId());
+                    assertEquals("Expected and actual values should be the same.", code, scratchCodeImpl.getCode());
+                }
+            }
+        }
+    }
+
+    @Test
+    public void scratchCodeImplScratchCodeParameterTest() throws KapuaException {
+        Mockito.when(scratchCode.getCode()).thenReturn("code");
+        Mockito.when(scratchCode.getMfaOptionId()).thenReturn(KapuaId.ONE);
+        Mockito.when(scratchCode.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(scratchCode.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(scratchCode.getOptlock()).thenReturn(10);
+
+        ScratchCodeImpl scratchCodeImpl = new ScratchCodeImpl(scratchCode);
+
+        assertNull("Null expected.", scratchCodeImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, scratchCodeImpl.getMfaOptionId());
+        assertEquals("Expected and actual values should be the same.", "code", scratchCodeImpl.getCode());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, scratchCodeImpl.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, scratchCodeImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 10, scratchCodeImpl.getOptlock());
+    }
+
+
+    @Test
+    public void setAndGetMfaOptionIdTest() throws KapuaException {
+        ScratchCodeImpl scratchCodeImpl1 = new ScratchCodeImpl();
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeImpl1.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeImpl1.getMfaOptionId());
+        }
+
+        ScratchCodeImpl scratchCodeImpl2 = new ScratchCodeImpl(KapuaId.ONE);
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeImpl2.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeImpl2.getMfaOptionId());
+        }
+
+        ScratchCodeImpl scratchCodeImpl3 = new ScratchCodeImpl(KapuaId.ONE, new KapuaEid(), "code");
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeImpl3.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeImpl3.getMfaOptionId());
+        }
+
+        ScratchCodeImpl scratchCodeImpl4 = new ScratchCodeImpl(scratchCode);
+        for (KapuaId newMfaOptionId : newMfaOptionIds) {
+            scratchCodeImpl4.setMfaOptionId(newMfaOptionId);
+            assertEquals("Expected and actual values should be the same.", newMfaOptionId, scratchCodeImpl4.getMfaOptionId());
+        }
+    }
+
+    @Test
+    public void setAndGetCodeTest() throws KapuaException {
+        ScratchCodeImpl scratchCodeImpl1 = new ScratchCodeImpl();
+        for (String code : newCodes) {
+            scratchCodeImpl1.setCode(code);
+            assertEquals("Expected and actual values should be the same.", code, scratchCodeImpl1.getCode());
+        }
+
+        ScratchCodeImpl scratchCodeImpl2 = new ScratchCodeImpl(KapuaId.ONE);
+        for (String code : newCodes) {
+            scratchCodeImpl2.setCode(code);
+            assertEquals("Expected and actual values should be the same.", code, scratchCodeImpl2.getCode());
+        }
+
+        ScratchCodeImpl scratchCodeImpl3 = new ScratchCodeImpl(KapuaId.ONE, new KapuaEid(), "code");
+        for (String code : newCodes) {
+            scratchCodeImpl3.setCode(code);
+            assertEquals("Expected and actual values should be the same.", code, scratchCodeImpl3.getCode());
+        }
+
+        ScratchCodeImpl scratchCodeImpl4 = new ScratchCodeImpl(scratchCode);
+        for (String code : newCodes) {
+            scratchCodeImpl4.setCode(code);
+            assertEquals("Expected and actual values should be the same.", code, scratchCodeImpl4.getCode());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImplTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ScratchCodeQueryImplTest extends Assert {
+
+    @Test
+    public void scratchCodeQueryImplWithoutParameterTest() {
+        ScratchCodeQueryImpl scratchCodeQueryImpl = new ScratchCodeQueryImpl();
+        assertNull("Null expected.", scratchCodeQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", scratchCodeQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void scratchCodeQueryImplScopeIdParameterTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ONE};
+        for (KapuaId scopeId : scopeIds) {
+            ScratchCodeQueryImpl scratchCodeQueryImpl = new ScratchCodeQueryImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeQueryImpl.getScopeId());
+            assertNotNull("NotNull expected.", scratchCodeQueryImpl.getSortCriteria());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImplTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ScratchCodeServiceImplTest extends Assert {
+
+    @Test
+    public void scratchCodeServiceImplTest() {
+        ScratchCodeServiceImpl scratchCodeServiceImpl = new ScratchCodeServiceImpl();
+        assertNotNull("Null not expected.", scratchCodeServiceImpl.getEntityManagerSession());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in shiro/authentication/credential/mfa/shiro:
 - ScratchCodeDAO class
 - ScratchCodeCreatorImpl class
 - ScratchCodeEntityManagerFactory class
 - ScratchCodeFactoryImpl class
 - ScratchCodeImpl class
 - ScratchCodeQueryImpl class
 - ScratchCodeServiceImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
