### PR TITLE
Device management response stacktrace show option

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -37,6 +37,7 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Dcertificate.jwt.private.key=file:///var/opt/jetty/key.pk8 \
                -Dcertificate.jwt.certificate=file:///var/opt/jetty/cert.pem \
                -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
+               -Ddevice.management.response.stacktrace.show=\${DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW:-false} \
                -Djavax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory"
 
 USER 0

--- a/assembly/console/entrypoint/run-console
+++ b/assembly/console/entrypoint/run-console
@@ -59,6 +59,10 @@ test -n "${MFA_SCRATCH_CODES_NUMBER}" && JAVA_OPTS="${JAVA_OPTS} -Dauthenticatio
 test -n "${MFA_CODE_DIGITS_NUMBER}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.code.digits.number=${MFA_CODE_DIGITS_NUMBER}"
 test -n "${MFA_TRUST_KEY_DURATION}" && JAVA_OPTS="${JAVA_OPTS} -Dauthentication.mfa.trust.key.duration=${MFA_TRUST_KEY_DURATION}"
 
+# Device Mannagement Configurations
+: DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW=${DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW:=false }
+test -n "${DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW}" && JAVA_OPTS="${JAVA_OPTS} -Ddevice.management.response.stacktrace.show${DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW}"
+
 export JAVA_OPTS
 
 # Continue with startup

--- a/deployment/minishift/README.md
+++ b/deployment/minishift/README.md
@@ -1,6 +1,7 @@
 # Kapua on Minishift
 
-To learn more on how to run Kapua in Minishift, please consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#minishift).
+To learn more on how to run Kapua in Minishift, please
+consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#minishift).
 
 The most recent version of the documentation can be viewed online at:
 
@@ -13,37 +14,49 @@ You are required to have _Docker_, _Minishift_ and _VirtualBox_ installed.<br>
 VirtualBox will be used as VM driver for Minishift.
 
 ### Fetching Docker images
+
 You'll need to have the images on your local Docker registry.<br>
 You can pull them from a Docker registry or build them from the code.
 
-If you choose to build them from the code please go to [Building containers from scratch](#Building-containers-from-scratch) section.
+If you choose to build them from the code please go
+to [Building containers from scratch](#Building-containers-from-scratch) section.
 
 If you want to pull them from a Docker registry, run:
+
 ```bash
 ./minishift-pull-images.sh
 ```
 
 ### Running
+
 First, you need the create and start the Minishift VM.<br>
 Run:
+
 ```bash
 ./minishift-initialize.sh
 ```
-This script will set _VirtualBox_ as VM driver of Minishift and start a Minishift VM with 6GB of RAM, 3 CPUs and 20GB of storage.
+
+This script will set _VirtualBox_ as VM driver of Minishift and start a Minishift VM with 6GB of RAM, 3 CPUs and 20GB of
+storage.
 
 After the Minishift VM has started you can deploy the Kapua components by running:
+
 ```bash
 ./minishift-deploy.sh
 ```
+
 This script will create new apps for each Kapua component.
 
 ### Accessing components
+
 After deployment and startup of containers, they can be accessed at the following endpoints
 
 | Application/Service | Endpoint                                         | User         | Password       | Others                            |
 |---------------------|--------------------------------------------------|--------------|----------------|-----------------------------------|
-| H2 SQL              | _None_                                           | _None_       | _None_         | This service is not exposed       |
-| Elasticsearch       | _None_                                           | _None_       | _None_         | This service is not exposed       |
+| H2 SQL              | _None_                                           | _None_       | _
+None_         | This service is not exposed       |
+| Elasticsearch       | _None_                                           | _None_       | _
+None_         | This service is not exposed       |
 | Broker              | broker-eclipse-kapua.192.168.99.100.nip.io:31883 | kapua-broker | kapua-password |                                   |
 | Admin WEB Console   | console-eclipse-kapua.192.168.99.100.nip.io:80   | kapua-sys    | kapua-password |                                   |
 | REST API endpoint   | api-eclipse-kapua.192.168.99.100.nip.io:80       | kapua-sys    | kapua-password | API KEY: `12345678kapua-password` |
@@ -51,21 +64,29 @@ After deployment and startup of containers, they can be accessed at the followin
 Please note that endpoints are available only from the host machine.
 
 ### Checking
-You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web Console.
+
+You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web
+Console.
 
 To access the OpenShift Web Console you can run:
+
 ```bash
 minishift dashboard
 ```
 
 ### Tear down
+
 To stop and remove the Eclipse Kapua project from OpenShift, run:
+
 ```bash
 ./minishift-undeploy.sh
 ```
-This command can take a while to be executed. Even if the `Eclipse Kapua` project has disappeared, processing still going on underneath.
+
+This command can take a while to be executed. Even if the `Eclipse Kapua` project has disappeared, processing still
+going on underneath.
 
 To destroy the Minishift VM, runL
+
 ```bash
 ./minishift-destroy.sh
 ```
@@ -73,32 +94,40 @@ To destroy the Minishift VM, runL
 ### Advanced options
 
 #### Setting the Kapua version
+
 Other than the default deployment it is possible to run other versions of Kapua.
 
-By default the `latest` version of Kapua will be brought up. 
-You can change the version of Kapua by exporting the environment variable `IMAGE_VERSION`.
+By default the `latest` version of Kapua will be brought up. You can change the version of Kapua by exporting the
+environment variable `IMAGE_VERSION`.
 
 Example:
+
 ```bash
 export IMAGE_VERSION=1.0.0
 ``` 
 
 #### Passing additional JAVA_OPTS
-If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment variable.<br>
+
+If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment
+variable.<br>
 Example:
+
 ```bash
-export JAVA_OPTS_EXTRA="-Drequest.timeout=60000"
+export JAVA_OPTS_EXTRA="-Ddevice.management.request.timeout=60000"
 ``` 
 
 #### Building containers from scratch
+
 If you want to build containers from the code, you'll need to build the whole Kapua Project.
 
 From the project root directory, run:
+
 ```bash
 mvn clean install -Pdocker
 ```
 
 To build also the Admin Web Console container, which is excluded by default, add the `console` profile:
+
 ```bash
 mvn clean install -Pconsole,docker
 ```

--- a/deployment/minishift/README.md
+++ b/deployment/minishift/README.md
@@ -1,7 +1,6 @@
 # Kapua on Minishift
 
-To learn more on how to run Kapua in Minishift, please
-consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#minishift).
+To learn more on how to run Kapua in Minishift, please consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#minishift).
 
 The most recent version of the documentation can be viewed online at:
 
@@ -14,49 +13,37 @@ You are required to have _Docker_, _Minishift_ and _VirtualBox_ installed.<br>
 VirtualBox will be used as VM driver for Minishift.
 
 ### Fetching Docker images
-
 You'll need to have the images on your local Docker registry.<br>
 You can pull them from a Docker registry or build them from the code.
 
-If you choose to build them from the code please go
-to [Building containers from scratch](#Building-containers-from-scratch) section.
+If you choose to build them from the code please go to [Building containers from scratch](#Building-containers-from-scratch) section.
 
 If you want to pull them from a Docker registry, run:
-
 ```bash
 ./minishift-pull-images.sh
 ```
 
 ### Running
-
 First, you need the create and start the Minishift VM.<br>
 Run:
-
 ```bash
 ./minishift-initialize.sh
 ```
-
-This script will set _VirtualBox_ as VM driver of Minishift and start a Minishift VM with 6GB of RAM, 3 CPUs and 20GB of
-storage.
+This script will set _VirtualBox_ as VM driver of Minishift and start a Minishift VM with 6GB of RAM, 3 CPUs and 20GB of storage.
 
 After the Minishift VM has started you can deploy the Kapua components by running:
-
 ```bash
 ./minishift-deploy.sh
 ```
-
 This script will create new apps for each Kapua component.
 
 ### Accessing components
-
 After deployment and startup of containers, they can be accessed at the following endpoints
 
 | Application/Service | Endpoint                                         | User         | Password       | Others                            |
 |---------------------|--------------------------------------------------|--------------|----------------|-----------------------------------|
-| H2 SQL              | _None_                                           | _None_       | _
-None_         | This service is not exposed       |
-| Elasticsearch       | _None_                                           | _None_       | _
-None_         | This service is not exposed       |
+| H2 SQL              | _None_                                           | _None_       | _None_         | This service is not exposed       |
+| Elasticsearch       | _None_                                           | _None_       | _None_         | This service is not exposed       |
 | Broker              | broker-eclipse-kapua.192.168.99.100.nip.io:31883 | kapua-broker | kapua-password |                                   |
 | Admin WEB Console   | console-eclipse-kapua.192.168.99.100.nip.io:80   | kapua-sys    | kapua-password |                                   |
 | REST API endpoint   | api-eclipse-kapua.192.168.99.100.nip.io:80       | kapua-sys    | kapua-password | API KEY: `12345678kapua-password` |
@@ -64,29 +51,21 @@ None_         | This service is not exposed       |
 Please note that endpoints are available only from the host machine.
 
 ### Checking
-
-You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web
-Console.
+You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web Console.
 
 To access the OpenShift Web Console you can run:
-
 ```bash
 minishift dashboard
 ```
 
 ### Tear down
-
 To stop and remove the Eclipse Kapua project from OpenShift, run:
-
 ```bash
 ./minishift-undeploy.sh
 ```
-
-This command can take a while to be executed. Even if the `Eclipse Kapua` project has disappeared, processing still
-going on underneath.
+This command can take a while to be executed. Even if the `Eclipse Kapua` project has disappeared, processing still going on underneath.
 
 To destroy the Minishift VM, runL
-
 ```bash
 ./minishift-destroy.sh
 ```
@@ -94,40 +73,32 @@ To destroy the Minishift VM, runL
 ### Advanced options
 
 #### Setting the Kapua version
-
 Other than the default deployment it is possible to run other versions of Kapua.
 
-By default the `latest` version of Kapua will be brought up. You can change the version of Kapua by exporting the
-environment variable `IMAGE_VERSION`.
+By default the `latest` version of Kapua will be brought up.
+You can change the version of Kapua by exporting the environment variable `IMAGE_VERSION`.
 
 Example:
-
 ```bash
 export IMAGE_VERSION=1.0.0
 ``` 
 
 #### Passing additional JAVA_OPTS
-
-If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment
-variable.<br>
+If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment variable.<br>
 Example:
-
 ```bash
 export JAVA_OPTS_EXTRA="-Ddevice.management.request.timeout=60000"
 ``` 
 
 #### Building containers from scratch
-
 If you want to build containers from the code, you'll need to build the whole Kapua Project.
 
 From the project root directory, run:
-
 ```bash
 mvn clean install -Pdocker
 ```
 
 To build also the Admin Web Console container, which is excluded by default, add the `console` profile:
-
 ```bash
 mvn clean install -Pconsole,docker
 ```

--- a/deployment/openshift/README.md
+++ b/deployment/openshift/README.md
@@ -1,7 +1,6 @@
 # Kapua on OpenShift
 
-To learn more on how to run Kapua in Openshift, please
-consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#openshift).
+To learn more on how to run Kapua in Openshift, please consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#openshift).
 
 The most recent version of the documentation can be viewed online at:
 
@@ -11,104 +10,82 @@ The most recent version of the documentation can be viewed online at:
 ## How to run Kapua on OpenShift.
 
 You are required to have OpenShift Origin installed.<br>
-If you are running on MacOS or Windows machine, please go to the _Minishift_ deployment. OpenShift Origin is supported
-only on Linux OSs.
+If you are running on MacOS or Windows machine, please go to the _Minishift_ deployment.
+OpenShift Origin is supported only on Linux OSs.
 
 ### Running
-
 First, you need the OpenShift client and a OpenShift Origin cluster running.<br>
 Just run:
-
 ```bash
 ./openshift-start.sh
 ```
-
 This script will download the OpenShift Client and start the OpenShift cluster.
 
 Then you need to initialize the OpenShift Cluster by running:
-
 ```bash
 ./openshift-initialize.sh
 ```
-
 This script will create a new project into OpenShift.
 
 Final step of the deployment, is the deployment of the Docker images themself.<br>
 Run:
-
 ```bash
 ./openshift-deploy.sh
 ```
-
 This script will create new apps for each Kapua component.
 
 ### Accessing components
-
 After deployment and startup of containers, they can be accessed at the following endpoints
 
 | Application/Service | Endpoint                                              | User         | Password       | Others                            |
 |---------------------|-------------------------------------------------------|--------------|----------------|-----------------------------------|
-| H2 SQL              | _None_                                                | _None_       | _
-None_         | This service is not exposed       |
-| Elasticsearch       | _None_                                                | _None_       | _
-None_         | This service is not exposed       |
+| H2 SQL              | _None_                                                | _None_       | _None_         | This service is not exposed       |
+| Elasticsearch       | _None_                                                | _None_       | _None_         | This service is not exposed       |
 | Broker              | broker-eclipse-kapua.<openshift-default-domain>:31883 | kapua-broker | kapua-password |                                   |
 | Admin WEB Console   | console-eclipse-kapua.<openshift-default-domain>:80   | kapua-sys    | kapua-password |                                   |
 | REST API endpoint   | api-eclipse-kapua.<openshift-default-domain>:80       | kapua-sys    | kapua-password | API KEY: `12345678kapua-password` |
 
 ### Checking
+You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web Console.
 
-You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web
-Console.
 
 ### Tear down
-
 To stop and remove the Eclipse Kapua project from OpenShift, run:
-
 ```bash
 ./openshift-destroy.sh
 ```
-
 After this command, you'll need to run again `./openshift-initialize.sh` if you want to deploy again Kapua.
 
 ### Advanced options
 
 #### Setting the Kapua version
-
 Other than the default deployment it is possible to run other versions of Kapua.
 
-By default the `latest` version of Kapua will be brought up. You can change the version of Kapua by exporting the
-environment variable `IMAGE_VERSION`.
+By default the `latest` version of Kapua will be brought up.
+You can change the version of Kapua by exporting the environment variable `IMAGE_VERSION`.
 
 Example:
-
 ```bash
 export IMAGE_VERSION=1.0.0
 ``` 
 
 #### Passing additional JAVA_OPTS
-
-If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment
-variable.<br>
+If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment variable.<br>
 Example:
-
 ```bash
 export JAVA_OPTS_EXTRA="-Ddevice.management.request.timeout=60000"
 ``` 
 
 #### Building containers from scratch
-
 If you want to build containers from the code, you'll need to build the whole Kapua Project.
 
 From the project root directory, run:
-
 ```bash
 mvn clean install -f external/pom.xml
 mvn clean install -Pdocker
 ```
 
 To build also the Admin Web Console container, which is excluded by default, add the `console` profile:
-
 ```bash
 mvn clean install -f external/pom.xml
 mvn clean install -Pconsole,docker

--- a/deployment/openshift/README.md
+++ b/deployment/openshift/README.md
@@ -1,6 +1,7 @@
 # Kapua on OpenShift
 
-To learn more on how to run Kapua in Openshift, please consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#openshift).
+To learn more on how to run Kapua in Openshift, please
+consult [developer manual](https://github.com/eclipse/kapua/blob/develop/docs/developer-guide/en/running.md#openshift).
 
 The most recent version of the documentation can be viewed online at:
 
@@ -10,82 +11,104 @@ The most recent version of the documentation can be viewed online at:
 ## How to run Kapua on OpenShift.
 
 You are required to have OpenShift Origin installed.<br>
-If you are running on MacOS or Windows machine, please go to the _Minishift_ deployment.
-OpenShift Origin is supported only on Linux OSs.
+If you are running on MacOS or Windows machine, please go to the _Minishift_ deployment. OpenShift Origin is supported
+only on Linux OSs.
 
 ### Running
+
 First, you need the OpenShift client and a OpenShift Origin cluster running.<br>
 Just run:
+
 ```bash
 ./openshift-start.sh
 ```
+
 This script will download the OpenShift Client and start the OpenShift cluster.
 
 Then you need to initialize the OpenShift Cluster by running:
+
 ```bash
 ./openshift-initialize.sh
 ```
+
 This script will create a new project into OpenShift.
 
 Final step of the deployment, is the deployment of the Docker images themself.<br>
 Run:
+
 ```bash
 ./openshift-deploy.sh
 ```
+
 This script will create new apps for each Kapua component.
 
 ### Accessing components
+
 After deployment and startup of containers, they can be accessed at the following endpoints
 
 | Application/Service | Endpoint                                              | User         | Password       | Others                            |
 |---------------------|-------------------------------------------------------|--------------|----------------|-----------------------------------|
-| H2 SQL              | _None_                                                | _None_       | _None_         | This service is not exposed       |
-| Elasticsearch       | _None_                                                | _None_       | _None_         | This service is not exposed       |
+| H2 SQL              | _None_                                                | _None_       | _
+None_         | This service is not exposed       |
+| Elasticsearch       | _None_                                                | _None_       | _
+None_         | This service is not exposed       |
 | Broker              | broker-eclipse-kapua.<openshift-default-domain>:31883 | kapua-broker | kapua-password |                                   |
 | Admin WEB Console   | console-eclipse-kapua.<openshift-default-domain>:80   | kapua-sys    | kapua-password |                                   |
 | REST API endpoint   | api-eclipse-kapua.<openshift-default-domain>:80       | kapua-sys    | kapua-password | API KEY: `12345678kapua-password` |
 
 ### Checking
-You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web Console.
 
+You can check the status of the pods using the OpenShift Client from the command line or accessing the OpenShift Web
+Console.
 
 ### Tear down
+
 To stop and remove the Eclipse Kapua project from OpenShift, run:
+
 ```bash
 ./openshift-destroy.sh
 ```
+
 After this command, you'll need to run again `./openshift-initialize.sh` if you want to deploy again Kapua.
 
 ### Advanced options
 
 #### Setting the Kapua version
+
 Other than the default deployment it is possible to run other versions of Kapua.
 
-By default the `latest` version of Kapua will be brought up. 
-You can change the version of Kapua by exporting the environment variable `IMAGE_VERSION`.
+By default the `latest` version of Kapua will be brought up. You can change the version of Kapua by exporting the
+environment variable `IMAGE_VERSION`.
 
 Example:
+
 ```bash
 export IMAGE_VERSION=1.0.0
 ``` 
 
 #### Passing additional JAVA_OPTS
-If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment variable.<br>
+
+If you want to pass to the JVM additional optional parameters you can set the `JAVA_OPTS_EXTRA` environment
+variable.<br>
 Example:
+
 ```bash
-export JAVA_OPTS_EXTRA="-Drequest.timeout=60000"
+export JAVA_OPTS_EXTRA="-Ddevice.management.request.timeout=60000"
 ``` 
 
 #### Building containers from scratch
+
 If you want to build containers from the code, you'll need to build the whole Kapua Project.
 
 From the project root directory, run:
+
 ```bash
 mvn clean install -f external/pom.xml
 mvn clean install -Pdocker
 ```
 
 To build also the Admin Web Console container, which is excluded by default, add the `console` profile:
+
 ```bash
 mvn clean install -f external/pom.xml
 mvn clean install -Pconsole,docker

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfo.java
@@ -12,22 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.core.exception.model;
 
-import java.io.PrintWriter;
-import java.io.StringWriter;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiSetting;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiSettingKeys;
 
 import javax.ws.rs.core.Response.Status;
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlElement;
 import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlTransient;
-
-import org.eclipse.kapua.app.api.core.settings.KapuaApiSetting;
-import org.eclipse.kapua.app.api.core.settings.KapuaApiSettingKeys;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 
 @XmlRootElement(name = "throwableInfo")
 @XmlAccessorType(XmlAccessType.FIELD)
 public class ThrowableInfo {
+
+    private static final boolean SHOW_STACKTRACE = KapuaApiSetting.getInstance().getBoolean(KapuaApiSettingKeys.API_EXCEPTION_STACKTRACE_SHOW, false);
 
     @XmlElement(name = "httpErrorCode")
     private int httpErrorCode;
@@ -38,9 +38,6 @@ public class ThrowableInfo {
     @XmlElement(name = "stackTrace")
     private String stackTrace;
 
-    @XmlTransient
-    private final boolean showStacktrace = KapuaApiSetting.getInstance().getBoolean(KapuaApiSettingKeys.API_EXCEPTION_STACKTRACE_SHOW, false);
-
     protected ThrowableInfo() {
         super();
     }
@@ -49,7 +46,7 @@ public class ThrowableInfo {
         this.httpErrorCode = httpStatus.getStatusCode();
         this.message = throwable.getMessage();
         // Print stack trace
-        if (showStacktrace) {
+        if (SHOW_STACKTRACE) {
             StringWriter stringWriter = new StringWriter();
             throwable.printStackTrace(new PrintWriter(stringWriter));
             setStackTrace(stringWriter.toString());

--- a/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
+++ b/service/device/api/src/main/java/org/eclipse/kapua/service/device/management/message/response/KapuaResponsePayload.java
@@ -33,9 +33,9 @@ public interface KapuaResponsePayload extends KapuaPayload {
     /**
      * Set the exception message (if present)
      *
-     * @param setExecptionMessage
+     * @param exceptionMessage
      */
-    void setExceptionMessage(String setExecptionMessage);
+    void setExceptionMessage(String exceptionMessage);
 
     /**
      * Get the exception stack trace (if present)

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/response/KapuaResponsePayloadImpl.java
@@ -29,8 +29,8 @@ public class KapuaResponsePayloadImpl extends KapuaPayloadImpl implements KapuaR
     }
 
     @Override
-    public void setExceptionMessage(String setExecptionMessage) {
-        getMetrics().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue(), setExecptionMessage);
+    public void setExceptionMessage(String exceptionMessage) {
+        getMetrics().put(ResponseProperties.RESP_PROPERTY_EXCEPTION_MESSAGE.getValue(), exceptionMessage);
     }
 
     @Override

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -33,7 +33,7 @@ public enum DeviceManagementSettingKey implements SettingKey {
      *
      * @since 1.0.0
      */
-    REQUEST_TIMEOUT("request.timeout"),
+    REQUEST_TIMEOUT("device.management.request.timeout"),
 
     /**
      * Request timeout.

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -26,7 +26,7 @@ public enum DeviceManagementSettingKey implements SettingKey {
      *
      * @since 1.0.0
      */
-    CHAR_ENCODING("character.encoding"),
+    CHAR_ENCODING("device.management.character.encoding"),
 
     /**
      * Request timeout.

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/setting/DeviceManagementSettingKey.java
@@ -15,31 +15,43 @@ package org.eclipse.kapua.service.device.management.commons.setting;
 import org.eclipse.kapua.commons.setting.SettingKey;
 
 /**
- * Available settings key for device management service
+ * Device Management {@link SettingKey}s for {@link DeviceManagementSetting}.
  *
- * @since 1.0
- *
+ * @since 1.0.0
  */
 public enum DeviceManagementSettingKey implements SettingKey {
 
     /**
-     * Character encoding
+     * Character encoding.
+     *
+     * @since 1.0.0
      */
     CHAR_ENCODING("character.encoding"),
 
     /**
-     * Request timeout
+     * Request timeout.
+     *
+     * @since 1.0.0
      */
-    REQUEST_TIMEOUT("request.timeout");
-
-    private String key;
+    REQUEST_TIMEOUT("request.timeout"),
 
     /**
-     * Constructor
+     * Request timeout.
      *
-     * @param key
+     * @since 1.0.0
      */
-    private DeviceManagementSettingKey(String key) {
+    SHOW_STACKTRACE("device.management.response.stacktrace.show"),
+    ;
+
+    private final String key;
+
+    /**
+     * Constructor.
+     *
+     * @param key The value of the {@link DeviceManagementSettingKey}.
+     * @since 1.0.0
+     */
+    DeviceManagementSettingKey(String key) {
         this.key = key;
     }
 

--- a/service/device/commons/src/main/resources/device-management-setting.properties
+++ b/service/device/commons/src/main/resources/device-management-setting.properties
@@ -13,6 +13,6 @@
 ###############################################################################
 character.encoding=UTF-8
 
-request.timeout=30000
+device.management.request.timeout=30000
 
 device.management.response.stacktrace.show=false

--- a/service/device/commons/src/main/resources/device-management-setting.properties
+++ b/service/device/commons/src/main/resources/device-management-setting.properties
@@ -15,3 +15,4 @@ character.encoding=UTF-8
 
 request.timeout=30000
 
+device.management.response.stacktrace.show=false

--- a/service/device/commons/src/main/resources/device-management-setting.properties
+++ b/service/device/commons/src/main/resources/device-management-setting.properties
@@ -11,7 +11,7 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-character.encoding=UTF-8
+device.management.character.encoding=UTF-8
 
 device.management.request.timeout=30000
 

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetRequestPayload.java
@@ -35,8 +35,8 @@ import java.io.UnsupportedEncodingException;
 public class AssetRequestPayload extends KapuaPayloadImpl implements KapuaRequestPayload {
 
     private static final DeviceAssetFactory DEVICE_ASSET_FACTORY = KapuaLocator.getInstance().getFactory(DeviceAssetFactory.class);
-    private static final DeviceManagementSetting CONFIG = DeviceManagementSetting.getInstance();
-    private static final String CHAR_ENCODING = CONFIG.getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
     public DeviceAssets getDeviceAssets() throws JAXBException, XMLStreamException, FactoryConfigurationError, SAXException, UnsupportedEncodingException {
         DeviceAssets deviceAssets = DEVICE_ASSET_FACTORY.newAssetListResult();

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponseChannel.java
@@ -12,14 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset.message.internal;
 
+import org.eclipse.kapua.service.device.management.asset.internal.DeviceAssetAppProperties;
 import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Device bundle information response channel.
+ * Asset {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class AssetResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor
+     *
+     * @since 1.5.0
+     */
+    public AssetResponseChannel() {
+        setAppName(DeviceAssetAppProperties.APP_NAME);
+        setVersion(DeviceAssetAppProperties.APP_VERSION);
+    }
 }

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/message/internal/AssetResponsePayload.java
@@ -35,8 +35,8 @@ import java.io.UnsupportedEncodingException;
 public class AssetResponsePayload extends KapuaResponsePayloadImpl implements KapuaResponsePayload {
 
     private static final DeviceAssetFactory DEVICE_ASSET_FACTORY = KapuaLocator.getInstance().getFactory(DeviceAssetFactory.class);
-    private static final DeviceManagementSetting CONFIG = DeviceManagementSetting.getInstance();
-    private static final String CHAR_ENCODING = CONFIG.getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
     public DeviceAssets getDeviceAssets() throws JAXBException, XMLStreamException, FactoryConfigurationError, SAXException, UnsupportedEncodingException {
         DeviceAssets deviceAssets = DEVICE_ASSET_FACTORY.newAssetListResult();

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -50,6 +50,8 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
     private static final String SCOPE_ID = "scopeId";
     private static final String DEVICE_ID = "deviceId";
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     @Override
     public DeviceBundles get(KapuaId scopeId, KapuaId deviceId, Long timeout)
             throws KapuaException {
@@ -92,17 +94,14 @@ public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementS
         if (responseMessage.getResponseCode().isAccepted()) {
             BundleResponsePayload responsePayload = responseMessage.getPayload();
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
-            String body = null;
+            String body;
             try {
-                body = new String(responsePayload.getBody(), charEncoding);
+                body = new String(responsePayload.getBody(), CHAR_ENCODING);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, responsePayload.getBody());
             }
 
-            DeviceBundles deviceBundleList = null;
+            DeviceBundles deviceBundleList;
             try {
                 deviceBundleList = XmlUtil.unmarshal(body, DeviceBundlesImpl.class);
             } catch (Exception e) {

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/message/internal/BundleResponseChannel.java
@@ -12,14 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.bundle.message.internal;
 
+import org.eclipse.kapua.service.device.management.bundle.internal.DeviceBundleAppProperties;
 import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Device bundle information response channel.
+ * Bundle {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class BundleResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public BundleResponseChannel() {
+        setAppName(DeviceBundleAppProperties.APP_NAME);
+        setVersion(DeviceBundleAppProperties.APP_VERSION);
+    }
 }

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/message/internal/CommandResponseChannel.java
@@ -12,14 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command.message.internal;
 
+import org.eclipse.kapua.service.device.management.command.internal.CommandAppProperties;
 import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Device command response channel.
+ * Command {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class CommandResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public CommandResponseChannel() {
+        setAppName(CommandAppProperties.APP_NAME);
+        setVersion(CommandAppProperties.APP_VERSION);
+    }
 }

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -55,6 +55,8 @@ import java.util.Date;
 @KapuaProvider
 public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceConfigurationManagementService {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     private static final DeviceConfigurationFactory DEVICE_CONFIGURATION_FACTORY = LOCATOR.getFactory(DeviceConfigurationFactory.class);
 
     private static final String SCOPE_ID = "scopeId";
@@ -104,14 +106,11 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
         if (responseMessage.getResponseCode().isAccepted()) {
             ConfigurationResponsePayload responsePayload = responseMessage.getPayload();
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             DeviceConfiguration deviceConfiguration = null;
             if (responsePayload.hasBody()) {
                 String body = null;
                 try {
-                    body = new String(responsePayload.getBody(), charEncoding);
+                    body = new String(responsePayload.getBody(), CHAR_ENCODING);
                 } catch (Exception e) {
                     throw new DeviceManagementResponseException(e, responsePayload.getBody());
                 }
@@ -160,12 +159,9 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
             DeviceConfiguration deviceConfiguration = DEVICE_CONFIGURATION_FACTORY.newConfigurationInstance();
             deviceConfiguration.getComponentConfigurations().add(deviceComponentConfiguration);
 
-            DeviceManagementSetting deviceManagementConfig = DeviceManagementSetting.getInstance();
-            String charEncoding = deviceManagementConfig.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             StringWriter sw = new StringWriter();
             XmlUtil.marshal(deviceConfiguration, sw);
-            byte[] requestBody = sw.toString().getBytes(charEncoding);
+            byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
             configurationRequestPayload.setBody(requestBody);
         } catch (Exception e) {
@@ -234,12 +230,9 @@ public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceMana
         ConfigurationRequestPayload configurationRequestPayload = new ConfigurationRequestPayload();
 
         try {
-            DeviceManagementSetting deviceManagementConfig = DeviceManagementSetting.getInstance();
-            String charEncoding = deviceManagementConfig.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             StringWriter sw = new StringWriter();
             XmlUtil.marshal(deviceConfiguration, sw);
-            byte[] requestBody = sw.toString().getBytes(charEncoding);
+            byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
             configurationRequestPayload.setBody(requestBody);
         } catch (Exception e) {

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/message/internal/ConfigurationResponseChannel.java
@@ -13,13 +13,23 @@
 package org.eclipse.kapua.service.device.management.configuration.message.internal;
 
 import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationAppProperties;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Device configuration response channel.
+ * Configuration {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class ConfigurationResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public ConfigurationResponseChannel() {
+        setAppName(DeviceConfigurationAppProperties.APP_NAME);
+        setVersion(DeviceConfigurationAppProperties.APP_VERSION);
+    }
 }

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -46,6 +46,8 @@ import java.util.Date;
 @KapuaProvider
 public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceSnapshotManagementService {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     @Override
     public DeviceSnapshots get(KapuaId scopeId, KapuaId deviceId, Long timeout)
             throws KapuaException {
@@ -88,17 +90,14 @@ public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagemen
         if (responseMessage.getResponseCode().isAccepted()) {
             SnapshotResponsePayload responsePayload = responseMessage.getPayload();
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
-            String body = null;
+            String body;
             try {
-                body = new String(responsePayload.getBody(), charEncoding);
+                body = new String(responsePayload.getBody(), CHAR_ENCODING);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, (Object) responsePayload.getBody());
             }
 
-            DeviceSnapshots deviceSnapshots = null;
+            DeviceSnapshots deviceSnapshots;
             try {
                 deviceSnapshots = XmlUtil.unmarshal(body, DeviceSnapshotsImpl.class);
             } catch (Exception e) {

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/message/internal/SnapshotResponseChannel.java
@@ -13,13 +13,23 @@
 package org.eclipse.kapua.service.device.management.snapshot.message.internal;
 
 import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChannelImpl;
+import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationAppProperties;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Device snapshot response channel.
+ * Snapshot {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class SnapshotResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public SnapshotResponseChannel() {
+        setAppName(DeviceConfigurationAppProperties.APP_NAME);
+        setVersion(DeviceConfigurationAppProperties.APP_VERSION);
+    }
 }

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -74,9 +74,11 @@ import java.util.Date;
 @KapuaProvider
 public class DevicePackageManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DevicePackageManagementService {
 
-    private static final DevicePackageFactory DEVICE_PACKAGE_FACTORY = LOCATOR.getFactory(DevicePackageFactory.class);
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
     private static final PackageManagementServiceSetting PACKAGE_MANAGEMENT_SERVICE_SETTING = PackageManagementServiceSetting.getInstance();
+
+    private static final DevicePackageFactory DEVICE_PACKAGE_FACTORY = LOCATOR.getFactory(DevicePackageFactory.class);
 
     private static final String SCOPE_ID = "scopeId";
     private static final String DEVICE_ID = "deviceId";
@@ -129,12 +131,10 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
 
             DevicePackages devicePackages;
             if (responsePayload.hasBody()) {
-                DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-                String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
                 String body;
                 try {
-                    body = new String(responsePayload.getBody(), charEncoding);
+                    body = new String(responsePayload.getBody(), CHAR_ENCODING);
                 } catch (Exception e) {
                     throw new DeviceManagementResponseException(e, responsePayload.getBody());
                 }
@@ -143,8 +143,8 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
                     devicePackages = XmlUtil.unmarshal(body, DevicePackagesImpl.class);
                 } catch (Exception e) {
                     throw new DeviceManagementResponseException(e, body);
-
                 }
+
             } else {
                 devicePackages = new DevicePackagesImpl();
             }
@@ -487,12 +487,9 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         if (responseMessage.getResponseCode().isAccepted()) {
             PackageResponsePayload responsePayload = responseMessage.getPayload();
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             String body;
             try {
-                body = new String(responsePayload.getBody(), charEncoding);
+                body = new String(responsePayload.getBody(), CHAR_ENCODING);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, responsePayload.getBody());
 
@@ -503,7 +500,6 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
                 installOperation = XmlUtil.unmarshal(body, DevicePackageInstallOperationImpl.class);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, body);
-
             }
 
             return installOperation;
@@ -639,15 +635,11 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
         if (responseMessage.getResponseCode().isAccepted()) {
             PackageResponsePayload responsePayload = responseMessage.getPayload();
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             String body;
             try {
-                body = new String(responsePayload.getBody(), charEncoding);
+                body = new String(responsePayload.getBody(), CHAR_ENCODING);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, responsePayload.getBody());
-
             }
 
             DevicePackageUninstallOperation uninstallOperation;
@@ -655,7 +647,6 @@ public class DevicePackageManagementServiceImpl extends AbstractDeviceManagement
                 uninstallOperation = XmlUtil.unmarshal(body, DevicePackageUninstallOperationImpl.class);
             } catch (Exception e) {
                 throw new DeviceManagementResponseException(e, body);
-
             }
 
             return uninstallOperation;

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/message/internal/PackageResponseChannel.java
@@ -16,10 +16,19 @@ import org.eclipse.kapua.service.device.management.commons.message.KapuaAppChann
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseChannel;
 
 /**
- * Package response message channel.
+ * Package {@link KapuaResponseChannel}.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class PackageResponseChannel extends KapuaAppChannelImpl implements KapuaResponseChannel {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public PackageResponseChannel() {
+        setAppName(PackageAppProperties.APP_NAME);
+        setVersion(PackageAppProperties.APP_VERSION);
+    }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/MethodDictionaryKuraKapua.java
@@ -20,7 +20,7 @@ import java.util.EnumMap;
 import java.util.Map;
 
 /**
- * Dictionary class to define actions translations between {@link org.eclipse.kapua.service.device.call.kura.Kura} domain to Kapua domain.<br>
+ * Dictionary class to define actions translations between {@link org.eclipse.kapua.service.device.call.kura.Kura} domain to Kapua domain.
  *
  * @see KapuaMethod
  * @see KuraMethod
@@ -43,6 +43,11 @@ public class MethodDictionaryKuraKapua {
         DICTIONARY.put(KuraMethod.EXEC, KapuaMethod.EXECUTE);
     }
 
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
     private MethodDictionaryKuraKapua() {
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppAssetKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppAssetKuraKapua.java
@@ -28,7 +28,6 @@ import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannel;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannelMode;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
-import org.eclipse.kapua.service.device.management.asset.internal.DeviceAssetAppProperties;
 import org.eclipse.kapua.service.device.management.asset.message.internal.AssetResponseChannel;
 import org.eclipse.kapua.service.device.management.asset.message.internal.AssetResponseMessage;
 import org.eclipse.kapua.service.device.management.asset.message.internal.AssetResponsePayload;
@@ -47,7 +46,7 @@ public class TranslatorAppAssetKuraKapua extends AbstractSimpleTranslatorRespons
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppAssetKuraKapua() {
-        super(AssetResponseMessage.class);
+        super(AssetResponseMessage.class, AssetResponsePayload.class);
     }
 
     @Override
@@ -55,12 +54,7 @@ public class TranslatorAppAssetKuraKapua extends AbstractSimpleTranslatorRespons
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, AssetMetrics.APP_ID, AssetMetrics.APP_VERSION);
 
-            AssetResponseChannel assetResponseChannel = new AssetResponseChannel();
-            assetResponseChannel.setAppName(DeviceAssetAppProperties.APP_NAME);
-            assetResponseChannel.setVersion(DeviceAssetAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return assetResponseChannel;
+            return new AssetResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -68,11 +62,10 @@ public class TranslatorAppAssetKuraKapua extends AbstractSimpleTranslatorRespons
 
     @Override
     protected AssetResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
+        AssetResponsePayload assetResponsePayload = super.translatePayload(kuraResponsePayload);
+
         try {
             DeviceAssetFactory deviceAssetFactory = LOCATOR.getFactory(DeviceAssetFactory.class);
-
-            AssetResponsePayload assetResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new AssetResponsePayload());
-
             if (kuraResponsePayload.hasBody()) {
 
                 ObjectMapper mapper = new ObjectMapper();

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
@@ -24,7 +24,6 @@ import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraRespo
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
-import org.eclipse.kapua.service.device.management.bundle.internal.DeviceBundleAppProperties;
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleResponseChannel;
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleResponseMessage;
 import org.eclipse.kapua.service.device.management.bundle.message.internal.BundleResponsePayload;
@@ -51,7 +50,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppBundleKuraKapua() {
-        super(BundleResponseMessage.class);
+        super(BundleResponseMessage.class, BundleResponsePayload.class);
     }
 
     @Override
@@ -59,12 +58,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, BundleMetrics.APP_ID, BundleMetrics.APP_VERSION);
 
-            BundleResponseChannel bundleResponseChannel = new BundleResponseChannel();
-            bundleResponseChannel.setAppName(DeviceBundleAppProperties.APP_NAME);
-            bundleResponseChannel.setVersion(DeviceBundleAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return bundleResponseChannel;
+            return new BundleResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -72,11 +66,11 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
 
     @Override
     protected BundleResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
-        try {
-            BundleResponsePayload bundleResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new BundleResponsePayload());
+        BundleResponsePayload bundleResponsePayload = super.translatePayload(kuraResponsePayload);
 
+        try {
             if (kuraResponsePayload.hasBody()) {
-                KuraBundles kuraBundles = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraBundles.class);
+                KuraBundles kuraBundles = readXmlBodyAs(kuraResponsePayload.getBody(), KuraBundles.class);
 
                 translate(bundleResponsePayload, kuraBundles);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
@@ -77,14 +77,14 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
                 DeviceManagementSetting config = DeviceManagementSetting.getInstance();
                 String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
-                String body = null;
+                String body;
                 try {
                     body = new String(kuraResponsePayload.getBody(), charEncoding);
                 } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) kuraResponsePayload.getBody());
+                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, kuraResponsePayload.getBody());
                 }
 
-                KuraBundles kuraBundles = null;
+                KuraBundles kuraBundles;
                 try {
                     kuraBundles = XmlUtil.unmarshal(body, KuraBundles.class);
                 } catch (Exception e) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
@@ -46,6 +46,8 @@ import java.util.List;
  */
 public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<BundleResponseChannel, BundleResponsePayload, BundleResponseMessage> {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppBundleKuraKapua() {
@@ -74,12 +76,10 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
             BundleResponsePayload bundleResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new BundleResponsePayload());
 
             if (kuraResponsePayload.hasBody()) {
-                DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-                String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
                 String body;
                 try {
-                    body = new String(kuraResponsePayload.getBody(), charEncoding);
+                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
                 } catch (Exception e) {
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, kuraResponsePayload.getBody());
                 }
@@ -91,7 +91,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
                 }
 
-                translate(bundleResponsePayload, charEncoding, kuraBundles);
+                translate(bundleResponsePayload, kuraBundles);
             }
 
             // Return Kapua Payload
@@ -103,7 +103,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
         }
     }
 
-    private void translate(BundleResponsePayload bundleResponsePayload, String charEncoding, KuraBundles kuraBundles) throws KapuaException {
+    private void translate(BundleResponsePayload bundleResponsePayload, KuraBundles kuraBundles) throws KapuaException {
         try {
             DeviceBundleFactory deviceBundleFactory = LOCATOR.getFactory(DeviceBundleFactory.class);
 
@@ -121,7 +121,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
 
             StringWriter sw = new StringWriter();
             XmlUtil.marshal(deviceBundles, sw);
-            byte[] requestBody = sw.toString().getBytes(charEncoding);
+            byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
             bundleResponsePayload.setBody(requestBody);
         } catch (Exception e) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppBundleKuraKapua.java
@@ -76,20 +76,7 @@ public class TranslatorAppBundleKuraKapua extends AbstractSimpleTranslatorRespon
             BundleResponsePayload bundleResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new BundleResponsePayload());
 
             if (kuraResponsePayload.hasBody()) {
-
-                String body;
-                try {
-                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, kuraResponsePayload.getBody());
-                }
-
-                KuraBundles kuraBundles;
-                try {
-                    kuraBundles = XmlUtil.unmarshal(body, KuraBundles.class);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
-                }
+                KuraBundles kuraBundles = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraBundles.class);
 
                 translate(bundleResponsePayload, kuraBundles);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.service.device.call.kura.app.CommandMetrics;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseChannel;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseMessage;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
-import org.eclipse.kapua.service.device.management.command.internal.CommandAppProperties;
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponseChannel;
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponseMessage;
 import org.eclipse.kapua.service.device.management.command.message.internal.CommandResponsePayload;
@@ -34,7 +33,7 @@ import java.util.Map;
 public class TranslatorAppCommandKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<CommandResponseChannel, CommandResponsePayload, CommandResponseMessage> {
 
     public TranslatorAppCommandKuraKapua() {
-        super(CommandResponseMessage.class);
+        super(CommandResponseMessage.class, CommandResponsePayload.class);
     }
 
     @Override
@@ -42,12 +41,7 @@ public class TranslatorAppCommandKuraKapua extends AbstractSimpleTranslatorRespo
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, CommandMetrics.APP_ID, CommandMetrics.APP_VERSION);
 
-            CommandResponseChannel kapuaChannel = new CommandResponseChannel();
-            kapuaChannel.setAppName(CommandAppProperties.APP_NAME);
-            kapuaChannel.setVersion(CommandAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return kapuaChannel;
+            return new CommandResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -55,9 +49,9 @@ public class TranslatorAppCommandKuraKapua extends AbstractSimpleTranslatorRespo
 
     @Override
     protected CommandResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
-        try {
-            CommandResponsePayload commandResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new CommandResponsePayload());
+        CommandResponsePayload commandResponsePayload = super.translatePayload(kuraResponsePayload);
 
+        try {
             Map<String, Object> metrics = kuraResponsePayload.getMetrics();
             commandResponsePayload.setStderr((String) metrics.get(CommandMetrics.APP_METRIC_STDERR.getName()));
             commandResponsePayload.setStdout((String) metrics.get(CommandMetrics.APP_METRIC_STDOUT.getName()));

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppCommandKuraKapua.java
@@ -68,9 +68,6 @@ public class TranslatorAppCommandKuraKapua extends AbstractSimpleTranslatorRespo
                 commandResponsePayload.setTimedout(timedout);
             }
 
-            commandResponsePayload.setExceptionMessage(kuraResponsePayload.getExceptionMessage());
-            commandResponsePayload.setExceptionStack(kuraResponsePayload.getExceptionStack());
-
             // Return Kapua Payload
             return commandResponsePayload;
         } catch (Exception e) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
@@ -52,6 +52,8 @@ import java.util.Map;
  */
 public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<ConfigurationResponseChannel, ConfigurationResponsePayload, ConfigurationResponseMessage> {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     public TranslatorAppConfigurationKuraKapua() {
         super(ConfigurationResponseMessage.class);
     }
@@ -77,13 +79,10 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
         try {
             ConfigurationResponsePayload configurationResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new ConfigurationResponsePayload());
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             if (kuraResponsePayload.hasBody()) {
                 String body;
                 try {
-                    body = new String(kuraResponsePayload.getBody(), charEncoding);
+                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
                 } catch (Exception e) {
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) configurationResponsePayload.getBody());
                 }
@@ -95,7 +94,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
                 }
 
-                translateBody(configurationResponsePayload, charEncoding, kuraDeviceConfiguration);
+                translateBody(configurationResponsePayload, kuraDeviceConfiguration);
             }
 
             // Return Kapua Payload
@@ -107,7 +106,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
         }
     }
 
-    private void translateBody(ConfigurationResponsePayload configurationResponsePayload, String charEncoding, KuraDeviceConfiguration kuraDeviceConfiguration)
+    private void translateBody(ConfigurationResponsePayload configurationResponsePayload, KuraDeviceConfiguration kuraDeviceConfiguration)
             throws TranslatorException {
         try {
             DeviceConfigurationImpl deviceConfiguration = new DeviceConfigurationImpl();
@@ -129,7 +128,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
             StringWriter sw = new StringWriter();
 
             XmlUtil.marshal(deviceConfiguration, sw);
-            byte[] requestBody = sw.toString().getBytes(charEncoding);
+            byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
             configurationResponsePayload.setBody(requestBody);
         } catch (Exception e) {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
@@ -80,19 +80,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
             ConfigurationResponsePayload configurationResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new ConfigurationResponsePayload());
 
             if (kuraResponsePayload.hasBody()) {
-                String body;
-                try {
-                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) configurationResponsePayload.getBody());
-                }
-
-                KuraDeviceConfiguration kuraDeviceConfiguration = null;
-                try {
-                    kuraDeviceConfiguration = XmlUtil.unmarshal(body, KuraDeviceConfiguration.class);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
-                }
+                KuraDeviceConfiguration kuraDeviceConfiguration = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraDeviceConfiguration.class);
 
                 translateBody(configurationResponsePayload, kuraDeviceConfiguration);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppConfigurationKuraKapua.java
@@ -31,7 +31,6 @@ import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraRespo
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.configuration.internal.DeviceComponentConfigurationImpl;
-import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationAppProperties;
 import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationImpl;
 import org.eclipse.kapua.service.device.management.configuration.message.internal.ConfigurationResponseChannel;
 import org.eclipse.kapua.service.device.management.configuration.message.internal.ConfigurationResponseMessage;
@@ -55,7 +54,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
     private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
     public TranslatorAppConfigurationKuraKapua() {
-        super(ConfigurationResponseMessage.class);
+        super(ConfigurationResponseMessage.class, ConfigurationResponsePayload.class);
     }
 
     @Override
@@ -63,12 +62,7 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, ConfigurationMetrics.APP_ID, ConfigurationMetrics.APP_VERSION);
 
-            ConfigurationResponseChannel configurationResponseChannel = new ConfigurationResponseChannel();
-            configurationResponseChannel.setAppName(DeviceConfigurationAppProperties.APP_NAME);
-            configurationResponseChannel.setVersion(DeviceConfigurationAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return configurationResponseChannel;
+            return new ConfigurationResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -76,11 +70,11 @@ public class TranslatorAppConfigurationKuraKapua extends AbstractSimpleTranslato
 
     @Override
     protected ConfigurationResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
-        try {
-            ConfigurationResponsePayload configurationResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new ConfigurationResponsePayload());
+        ConfigurationResponsePayload configurationResponsePayload = super.translatePayload(kuraResponsePayload);
 
+        try {
             if (kuraResponsePayload.hasBody()) {
-                KuraDeviceConfiguration kuraDeviceConfiguration = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraDeviceConfiguration.class);
+                KuraDeviceConfiguration kuraDeviceConfiguration = readXmlBodyAs(kuraResponsePayload.getBody(), KuraDeviceConfiguration.class);
 
                 translateBody(configurationResponsePayload, kuraDeviceConfiguration);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
@@ -53,6 +53,8 @@ import java.util.Map;
  */
 public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<PackageResponseChannel, PackageResponsePayload, PackageResponseMessage> {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppPackageKuraKapua() {
@@ -116,22 +118,20 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
 
                 String body;
                 if (kuraResponsePayload.hasBody()) {
-                    DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-                    String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
 
                     try {
-                        body = new String(kuraResponsePayload.getBody(), charEncoding);
+                        body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
                     } catch (Exception e) {
                         throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) kuraResponsePayload.getBody());
                     }
 
-                    KuraDeploymentPackages kuraDeploymentPackages = null;
+                    KuraDeploymentPackages kuraDeploymentPackages;
                     try {
                         kuraDeploymentPackages = XmlUtil.unmarshal(body, KuraDeploymentPackages.class);
                     } catch (Exception e) {
                         throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
                     }
-                    translate(responsePayload, charEncoding, kuraDeploymentPackages);
+                    translate(responsePayload, kuraDeploymentPackages);
                 }
             } else {
                 if (kuraResponsePayload.hasBody()) {
@@ -150,7 +150,7 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
         }
     }
 
-    private void translate(PackageResponsePayload packageResponsePayload, String charEncoding, KuraDeploymentPackages kuraDeploymentPackages) throws KapuaException {
+    private void translate(PackageResponsePayload packageResponsePayload, KuraDeploymentPackages kuraDeploymentPackages) throws KapuaException {
         try {
             DevicePackageFactory devicePackageFactory = LOCATOR.getFactory(DevicePackageFactory.class);
 
@@ -180,7 +180,7 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
 
                 StringWriter sw = new StringWriter();
                 XmlUtil.marshal(deviceDeploymentPackages, sw);
-                byte[] requestBody = sw.toString().getBytes(charEncoding);
+                byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
                 packageResponsePayload.setBody(requestBody);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
@@ -116,21 +116,9 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
                     responsePayload.setPackageDownloadOperationStatus(DevicePackageDownloadStatus.NONE);
                 }
 
-                String body;
                 if (kuraResponsePayload.hasBody()) {
+                    KuraDeploymentPackages kuraDeploymentPackages = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraDeploymentPackages.class);
 
-                    try {
-                        body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
-                    } catch (Exception e) {
-                        throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) kuraResponsePayload.getBody());
-                    }
-
-                    KuraDeploymentPackages kuraDeploymentPackages;
-                    try {
-                        kuraDeploymentPackages = XmlUtil.unmarshal(body, KuraDeploymentPackages.class);
-                    } catch (Exception e) {
-                        throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
-                    }
                     translate(responsePayload, kuraDeploymentPackages);
                 }
             } else {

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppPackageKuraKapua.java
@@ -28,7 +28,6 @@ import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraRespo
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageFactory;
-import org.eclipse.kapua.service.device.management.packages.message.internal.PackageAppProperties;
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageResponseChannel;
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageResponseMessage;
 import org.eclipse.kapua.service.device.management.packages.message.internal.PackageResponsePayload;
@@ -58,7 +57,7 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppPackageKuraKapua() {
-        super(PackageResponseMessage.class);
+        super(PackageResponseMessage.class, PackageResponsePayload.class);
     }
 
     @Override
@@ -66,12 +65,7 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, PackageMetrics.APP_ID, PackageMetrics.APP_VERSION);
 
-            PackageResponseChannel responseChannel = new PackageResponseChannel();
-            responseChannel.setAppName(PackageAppProperties.APP_NAME);
-            responseChannel.setVersion(PackageAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return responseChannel;
+            return new PackageResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -79,9 +73,9 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
 
     @Override
     protected PackageResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
-        try {
-            PackageResponsePayload responsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new PackageResponsePayload());
+        PackageResponsePayload responsePayload = super.translatePayload(kuraResponsePayload);
 
+        try {
             KuraResponseCode responseCode = kuraResponsePayload.getResponseCode();
 
             Map<String, Object> metrics = kuraResponsePayload.getMetrics();
@@ -117,7 +111,7 @@ public class TranslatorAppPackageKuraKapua extends AbstractSimpleTranslatorRespo
                 }
 
                 if (kuraResponsePayload.hasBody()) {
-                    KuraDeploymentPackages kuraDeploymentPackages = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraDeploymentPackages.class);
+                    KuraDeploymentPackages kuraDeploymentPackages = readXmlBodyAs(kuraResponsePayload.getBody(), KuraDeploymentPackages.class);
 
                     translate(responsePayload, kuraDeploymentPackages);
                 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppResponseKuraKapua.java
@@ -66,18 +66,18 @@ public class TranslatorAppResponseKuraKapua extends AbstractSimpleTranslatorResp
     }
 
     @Override
-    protected GenericResponsePayload translatePayload(KuraResponsePayload kuraPayload) throws InvalidPayloadException {
+    protected GenericResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
         try {
             GenericRequestFactory genericRequestFactory = LOCATOR.getFactory(GenericRequestFactory.class);
 
-            GenericResponsePayload genericResponsePayload = genericRequestFactory.newResponsePayload();
-            genericResponsePayload.setBody(kuraPayload.getBody());
-            genericResponsePayload.setMetrics(kuraPayload.getMetrics());
-            genericResponsePayload.setExceptionMessage(kuraPayload.getExceptionMessage());
-            genericResponsePayload.setExceptionStack(kuraPayload.getExceptionStack());
+            GenericResponsePayload genericResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, genericRequestFactory.newResponsePayload());
+
+            genericResponsePayload.setBody(kuraResponsePayload.getBody());
+            genericResponsePayload.setMetrics(kuraResponsePayload.getMetrics());
+
             return genericResponsePayload;
         } catch (Exception e) {
-            throw new InvalidPayloadException(e, kuraPayload);
+            throw new InvalidPayloadException(e, kuraResponsePayload);
         }
     }
 }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppResponseKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppResponseKuraKapua.java
@@ -35,20 +35,20 @@ public class TranslatorAppResponseKuraKapua extends AbstractSimpleTranslatorResp
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppResponseKuraKapua() {
-        super(GenericResponseMessage.class);
+        super(GenericResponseMessage.class, GenericResponsePayload.class);
     }
 
     @Override
-    protected GenericResponseChannel translateChannel(KuraResponseChannel kuraChannel) throws InvalidChannelException {
+    protected GenericResponseChannel translateChannel(KuraResponseChannel kuraResponseChannel) throws InvalidChannelException {
         try {
             GenericRequestFactory genericRequestFactory = LOCATOR.getFactory(GenericRequestFactory.class);
 
-            if (!getControlMessageClassifier().equals(kuraChannel.getMessageClassification())) {
-                throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER, null, kuraChannel.getMessageClassification());
+            if (!getControlMessageClassifier().equals(kuraResponseChannel.getMessageClassification())) {
+                throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_CLASSIFIER, null, kuraResponseChannel.getMessageClassification());
             }
 
             GenericResponseChannel genericResponseChannel = genericRequestFactory.newResponseChannel();
-            String[] appIdTokens = kuraChannel.getAppId().split("-");
+            String[] appIdTokens = kuraResponseChannel.getAppId().split("-");
 
             if (appIdTokens.length < 1) {
                 throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_APP_NAME, null, (Object) appIdTokens);
@@ -61,17 +61,15 @@ public class TranslatorAppResponseKuraKapua extends AbstractSimpleTranslatorResp
 
             return genericResponseChannel;
         } catch (Exception e) {
-            throw new InvalidChannelException(e, kuraChannel);
+            throw new InvalidChannelException(e, kuraResponseChannel);
         }
     }
 
     @Override
     protected GenericResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
+        GenericResponsePayload genericResponsePayload = super.translatePayload(kuraResponsePayload);
+
         try {
-            GenericRequestFactory genericRequestFactory = LOCATOR.getFactory(GenericRequestFactory.class);
-
-            GenericResponsePayload genericResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, genericRequestFactory.newResponsePayload());
-
             genericResponsePayload.setBody(kuraResponsePayload.getBody());
             genericResponsePayload.setMetrics(kuraResponsePayload.getMetrics());
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -44,6 +44,8 @@ import java.util.List;
  */
 public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResponseKuraKapua<SnapshotResponseChannel, SnapshotResponsePayload, SnapshotResponseMessage> {
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
+
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppSnapshotKuraKapua() {
@@ -71,14 +73,12 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
         try {
             SnapshotResponsePayload snapshotResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new SnapshotResponsePayload());
 
-            DeviceManagementSetting config = DeviceManagementSetting.getInstance();
-            String charEncoding = config.getString(DeviceManagementSettingKey.CHAR_ENCODING);
-
             KuraSnapshotIds snapshotIdResult = null;
             if (kuraResponsePayload.hasBody()) {
-                String body = null;
+
+                String body;
                 try {
-                    body = new String(kuraResponsePayload.getBody(), charEncoding);
+                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
                 } catch (Exception e) {
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) snapshotResponsePayload.getBody());
                 }
@@ -90,7 +90,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
                 }
             }
 
-            translateBody(snapshotResponsePayload, charEncoding, snapshotIdResult);
+            translateBody(snapshotResponsePayload, snapshotIdResult);
 
             // Return Kapua Payload
             return snapshotResponsePayload;
@@ -101,7 +101,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
         }
     }
 
-    private void translateBody(SnapshotResponsePayload snapshotResponsePayload, String charEncoding, KuraSnapshotIds kuraSnapshotIdResult) throws TranslatorException {
+    private void translateBody(SnapshotResponsePayload snapshotResponsePayload, KuraSnapshotIds kuraSnapshotIdResult) throws TranslatorException {
         try {
             DeviceSnapshotFactory deviceSnapshotFactory = LOCATOR.getFactory(DeviceSnapshotFactory.class);
 
@@ -118,7 +118,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
 
                 StringWriter sw = new StringWriter();
                 XmlUtil.marshal(deviceSnapshots, sw);
-                byte[] requestBody = sw.toString().getBytes(charEncoding);
+                byte[] requestBody = sw.toString().getBytes(CHAR_ENCODING);
 
                 snapshotResponsePayload.setBody(requestBody);
             }

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -89,6 +89,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
                     throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
                 }
             }
+
             translateBody(snapshotResponsePayload, charEncoding, snapshotIdResult);
 
             // Return Kapua Payload

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -22,7 +22,6 @@ import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraRespo
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
 import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
-import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationAppProperties;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
@@ -49,7 +48,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
     public TranslatorAppSnapshotKuraKapua() {
-        super(SnapshotResponseMessage.class);
+        super(SnapshotResponseMessage.class, SnapshotResponsePayload.class);
     }
 
     @Override
@@ -57,12 +56,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
         try {
             TranslatorKuraKapuaUtils.validateKuraResponseChannel(kuraResponseChannel, SnapshotMetrics.APP_ID, SnapshotMetrics.APP_VERSION);
 
-            SnapshotResponseChannel snapshotResponseChannel = new SnapshotResponseChannel();
-            snapshotResponseChannel.setAppName(DeviceConfigurationAppProperties.APP_NAME);
-            snapshotResponseChannel.setVersion(DeviceConfigurationAppProperties.APP_VERSION);
-
-            // Return Kapua Channel
-            return snapshotResponseChannel;
+            return new SnapshotResponseChannel();
         } catch (Exception e) {
             throw new InvalidChannelException(e, kuraResponseChannel);
         }
@@ -70,12 +64,12 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
 
     @Override
     protected SnapshotResponsePayload translatePayload(KuraResponsePayload kuraResponsePayload) throws InvalidPayloadException {
-        try {
-            SnapshotResponsePayload snapshotResponsePayload = TranslatorKuraKapuaUtils.buildBaseResponsePayload(kuraResponsePayload, new SnapshotResponsePayload());
+        SnapshotResponsePayload snapshotResponsePayload = super.translatePayload(kuraResponsePayload);
 
+        try {
             KuraSnapshotIds snapshotIdResult = null;
             if (kuraResponsePayload.hasBody()) {
-                snapshotIdResult = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraSnapshotIds.class);
+                snapshotIdResult = readXmlBodyAs(kuraResponsePayload.getBody(), KuraSnapshotIds.class);
             }
 
             translateBody(snapshotResponsePayload, snapshotIdResult);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorAppSnapshotKuraKapua.java
@@ -75,19 +75,7 @@ public class TranslatorAppSnapshotKuraKapua extends AbstractSimpleTranslatorResp
 
             KuraSnapshotIds snapshotIdResult = null;
             if (kuraResponsePayload.hasBody()) {
-
-                String body;
-                try {
-                    body = new String(kuraResponsePayload.getBody(), CHAR_ENCODING);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) snapshotResponsePayload.getBody());
-                }
-
-                try {
-                    snapshotIdResult = XmlUtil.unmarshal(body, KuraSnapshotIds.class);
-                } catch (Exception e) {
-                    throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
-                }
+                snapshotIdResult = TranslatorKuraKapuaUtils.readBodyAs(kuraResponsePayload.getBody(), KuraSnapshotIds.class);
             }
 
             translateBody(snapshotResponsePayload, snapshotIdResult);

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
@@ -15,7 +15,6 @@ package org.eclipse.kapua.translator.kura.kapua;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
-import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPosition;
@@ -23,12 +22,7 @@ import org.eclipse.kapua.service.device.call.message.DevicePosition;
 import org.eclipse.kapua.service.device.call.message.app.DeviceAppMetrics;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseChannel;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseCode;
-import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseMetrics;
-import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
-import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
-import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseCode;
-import org.eclipse.kapua.service.device.management.message.response.KapuaResponsePayload;
 import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
 import org.eclipse.kapua.translator.exception.TranslatorException;
 
@@ -43,10 +37,7 @@ public final class TranslatorKuraKapuaUtils {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     private static final KapuaMessageFactory KAPUA_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaMessageFactory.class);
 
-    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
     private static final String CONTROL_MESSAGE_CLASSIFIER = SystemSetting.getInstance().getMessageClassifier();
-
-    private static final boolean SHOW_STACKTRACE = DeviceManagementSetting.getInstance().getBoolean(DeviceManagementSettingKey.SHOW_STACKTRACE, false);
 
     private TranslatorKuraKapuaUtils() {
     }
@@ -86,50 +77,6 @@ public final class TranslatorKuraKapuaUtils {
         if (!appVersion.getName().equals(appIdTokens[1])) {
             throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_APP_VERSION, null, appIdTokens[1]);
         }
-    }
-
-    /**
-     * Reads the given {@code byte[]} as the requested {@code returnAs} parameter.
-     *
-     * @param bytesToRead The {@link KapuaResponsePayload#getBody()}
-     * @param returnAs    The {@link Class} to read as.
-     * @param <T>         The type of the retrun.
-     * @return Returns the given {@code byte[]} as the given {@link Class}
-     * @throws TranslatorException If the {@code byte[]} is not uspported or the {@code byte[]} cannot be read as the given {@link Class}
-     * @since 1.5.0
-     */
-    public static <T> T readBodyAs(byte[] bytesToRead, Class<T> returnAs) throws TranslatorException {
-        String body;
-        try {
-            body = new String(bytesToRead, CHAR_ENCODING);
-        } catch (Exception e) {
-            throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) bytesToRead);
-        }
-
-        try {
-            return XmlUtil.unmarshal(body, returnAs);
-        } catch (Exception e) {
-            throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
-        }
-    }
-
-    /**
-     * Builds the {@link KapuaResponsePayload} with commons property in {@link KuraResponsePayload}
-     *
-     * @param kuraResponsePayload The {@link KuraResponsePayload}.
-     * @param appResponsePayload  The application specific {@link KapuaResponsePayload}.
-     * @param <P>                 The application specific {@link KapuaResponsePayload} type.
-     * @return The built base application specific {@link KapuaResponsePayload}}
-     */
-    public static <P extends KapuaResponsePayload> P buildBaseResponsePayload(KuraResponsePayload kuraResponsePayload, P appResponsePayload) {
-        appResponsePayload.setExceptionMessage(kuraResponsePayload.getExceptionMessage());
-
-        if (SHOW_STACKTRACE) {
-            appResponsePayload.setExceptionStack(kuraResponsePayload.getExceptionStack());
-            kuraResponsePayload.getMetrics().remove(KuraResponseMetrics.EXCEPTION_STACK.getName());
-        }
-
-        return appResponsePayload;
     }
 
     /**

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
@@ -22,7 +22,10 @@ import org.eclipse.kapua.service.device.call.message.DevicePosition;
 import org.eclipse.kapua.service.device.call.message.app.DeviceAppMetrics;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseChannel;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseCode;
+import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponseMetrics;
 import org.eclipse.kapua.service.device.call.message.kura.app.response.KuraResponsePayload;
+import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSetting;
+import org.eclipse.kapua.service.device.management.commons.setting.DeviceManagementSettingKey;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponseCode;
 import org.eclipse.kapua.service.device.management.message.response.KapuaResponsePayload;
 import org.eclipse.kapua.translator.exception.TranslatorErrorCodes;
@@ -40,6 +43,7 @@ public final class TranslatorKuraKapuaUtils {
     private static final KapuaMessageFactory KAPUA_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaMessageFactory.class);
 
     private static final String CONTROL_MESSAGE_CLASSIFIER = SystemSetting.getInstance().getMessageClassifier();
+    private static final boolean SHOW_STACKTRACE = DeviceManagementSetting.getInstance().getBoolean(DeviceManagementSettingKey.SHOW_STACKTRACE, false);
 
     private TranslatorKuraKapuaUtils() {
     }
@@ -91,7 +95,12 @@ public final class TranslatorKuraKapuaUtils {
      */
     public static <P extends KapuaResponsePayload> P buildBaseResponsePayload(KuraResponsePayload kuraResponsePayload, P appResponsePayload) {
         appResponsePayload.setExceptionMessage(kuraResponsePayload.getExceptionMessage());
-        appResponsePayload.setExceptionStack(kuraResponsePayload.getExceptionStack());
+
+        if (SHOW_STACKTRACE) {
+            appResponsePayload.setExceptionStack(kuraResponsePayload.getExceptionStack());
+            kuraResponsePayload.getMetrics().remove(KuraResponseMetrics.EXCEPTION_STACK.getName());
+        }
+
         return appResponsePayload;
     }
 

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/TranslatorKuraKapuaUtils.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.translator.kura.kapua;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.util.xml.XmlUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPosition;
@@ -42,7 +43,9 @@ public final class TranslatorKuraKapuaUtils {
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
     private static final KapuaMessageFactory KAPUA_MESSAGE_FACTORY = LOCATOR.getFactory(KapuaMessageFactory.class);
 
+    private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);
     private static final String CONTROL_MESSAGE_CLASSIFIER = SystemSetting.getInstance().getMessageClassifier();
+
     private static final boolean SHOW_STACKTRACE = DeviceManagementSetting.getInstance().getBoolean(DeviceManagementSettingKey.SHOW_STACKTRACE, false);
 
     private TranslatorKuraKapuaUtils() {
@@ -82,6 +85,31 @@ public final class TranslatorKuraKapuaUtils {
 
         if (!appVersion.getName().equals(appIdTokens[1])) {
             throw new TranslatorException(TranslatorErrorCodes.INVALID_CHANNEL_APP_VERSION, null, appIdTokens[1]);
+        }
+    }
+
+    /**
+     * Reads the given {@code byte[]} as the requested {@code returnAs} parameter.
+     *
+     * @param bytesToRead The {@link KapuaResponsePayload#getBody()}
+     * @param returnAs    The {@link Class} to read as.
+     * @param <T>         The type of the retrun.
+     * @return Returns the given {@code byte[]} as the given {@link Class}
+     * @throws TranslatorException If the {@code byte[]} is not uspported or the {@code byte[]} cannot be read as the given {@link Class}
+     * @since 1.5.0
+     */
+    public static <T> T readBodyAs(byte[] bytesToRead, Class<T> returnAs) throws TranslatorException {
+        String body;
+        try {
+            body = new String(bytesToRead, CHAR_ENCODING);
+        } catch (Exception e) {
+            throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, (Object) bytesToRead);
+        }
+
+        try {
+            return XmlUtil.unmarshal(body, returnAs);
+        } catch (Exception e) {
+            throw new TranslatorException(TranslatorErrorCodes.INVALID_PAYLOAD, e, body);
         }
     }
 


### PR DESCRIPTION
This PR introduces an option to show/hide the stacktrace coming as response from a device durein a device management operation.

This improves security since the stacktrace can show sensible data.

**Related Issue**
_None_

**Description of the solution adopted**
Added a setting `device.management.response.stacktrace.show` which is checked when translating the message.
Default option is false

**Screenshots**
_None_

**Any side note on the changes made**
I've renamed `request.timeout` and `character.encoding` prepending `device.management` to avoid collision with other setting values coming from other modules.