### PR TITLE
Added JUnit tests for exceptions, registration, setting, utils packages

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationRuntimeExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/AuthenticationRuntimeExceptionTest.java
@@ -1,0 +1,137 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaAuthenticationErrorCodes;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AuthenticationRuntimeExceptionTest extends Assert {
+
+    KapuaAuthenticationErrorCodes[] kapuaAuthenticationErrorCodes;
+    Object stringArgument, intArgument, booleanArgument;
+    Throwable[] throwables;
+    String errorMessageWithoutArguments, errorMessageWithArguments;
+
+    @Before
+    public void initialize() {
+        kapuaAuthenticationErrorCodes = new KapuaAuthenticationErrorCodes[]{KapuaAuthenticationErrorCodes.SUBJECT_ALREADY_LOGGED, KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED,
+                KapuaAuthenticationErrorCodes.AUTHENTICATION_ERROR, KapuaAuthenticationErrorCodes.CREDENTIAL_CRYPT_ERROR, KapuaAuthenticationErrorCodes.UNKNOWN_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS,
+                KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.UNKNOWN_SESSION_CREDENTIAL,
+                KapuaAuthenticationErrorCodes.INVALID_SESSION_CREDENTIALS, KapuaAuthenticationErrorCodes.EXPIRED_SESSION_CREDENTIALS, KapuaAuthenticationErrorCodes.LOCKED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_SESSION_CREDENTIAL,
+                KapuaAuthenticationErrorCodes.JWK_FILE_ERROR, KapuaAuthenticationErrorCodes.REFRESH_ERROR, KapuaAuthenticationErrorCodes.JWK_GENERATION_ERROR, KapuaAuthenticationErrorCodes.JWT_CERTIFICATE_NOT_FOUND,
+                KapuaAuthenticationErrorCodes.PASSWORD_CANNOT_BE_CHANGED};
+        stringArgument = "String argument";
+        intArgument = 20;
+        booleanArgument = true;
+        throwables = new Throwable[]{null, new Throwable(), new Throwable(new Exception()), new Throwable("message")};
+        errorMessageWithoutArguments = "Error: ";
+        errorMessageWithArguments = "Error: " + stringArgument + ", " + intArgument + ", " + booleanArgument;
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionCodeParameterTest() {
+        for (KapuaAuthenticationErrorCodes kapuaAuthenticationErrorCode : kapuaAuthenticationErrorCodes) {
+            AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(kapuaAuthenticationErrorCode);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, authenticationRuntimeException.getCode());
+            assertEquals("Expected and actual values should be the same.", errorMessageWithoutArguments, authenticationRuntimeException.getMessage());
+            assertNull("Null expected.", authenticationRuntimeException.getCause());
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionNullCodeParameterTest() {
+        AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(null);
+        assertNull("Null expected.", authenticationRuntimeException.getCode());
+        assertNull("Null expected.", authenticationRuntimeException.getCause());
+        try {
+            authenticationRuntimeException.getMessage();
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionCodeArgumentParametersTest() {
+        for (KapuaAuthenticationErrorCodes kapuaAuthenticationErrorCode : kapuaAuthenticationErrorCodes) {
+            AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(kapuaAuthenticationErrorCode, stringArgument, intArgument, booleanArgument);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, authenticationRuntimeException.getCode());
+            assertEquals("Expected and actual values should be the same.", errorMessageWithArguments, authenticationRuntimeException.getMessage());
+            assertNull("Null expected.", authenticationRuntimeException.getCause());
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionNullCodeArgumentParametersTest() {
+        AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(null, stringArgument, intArgument, booleanArgument);
+        assertNull("Null expected.", authenticationRuntimeException.getCode());
+        assertNull("Null expected.", authenticationRuntimeException.getCause());
+        try {
+            authenticationRuntimeException.getMessage();
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionCodeNullArgumentParametersTest() {
+        for (KapuaAuthenticationErrorCodes kapuaAuthenticationErrorCode : kapuaAuthenticationErrorCodes) {
+            AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(kapuaAuthenticationErrorCode, null);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, authenticationRuntimeException.getCode());
+            assertEquals("Expected and actual values should be the same.", errorMessageWithoutArguments, authenticationRuntimeException.getMessage());
+            assertNull("Null expected.", authenticationRuntimeException.getCause());
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionCodeCauseArgumentsParametersTest() {
+        for (KapuaAuthenticationErrorCodes kapuaAuthenticationErrorCode : kapuaAuthenticationErrorCodes) {
+            for (Throwable throwable : throwables) {
+                AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(kapuaAuthenticationErrorCode, throwable, stringArgument, intArgument, booleanArgument);
+                assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, authenticationRuntimeException.getCode());
+                assertEquals("Expected and actual values should be the same.", errorMessageWithArguments, authenticationRuntimeException.getMessage());
+                assertEquals("Expected and actual values should be the same.", throwable, authenticationRuntimeException.getCause());
+            }
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionNullCodeCauseArgumentsParametersTest() {
+        for (Throwable throwable : throwables) {
+            AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(null, throwable, stringArgument, intArgument, booleanArgument);
+            assertNull("Null expected.", authenticationRuntimeException.getCode());
+            assertEquals("Expected and actual values should be the same.", throwable, authenticationRuntimeException.getCause());
+            try {
+                authenticationRuntimeException.getMessage();
+            } catch (Exception e) {
+                assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void authenticationRuntimeExceptionCodeCauseNullArgumentsParametersTest() {
+        for (KapuaAuthenticationErrorCodes kapuaAuthenticationErrorCode : kapuaAuthenticationErrorCodes) {
+            for (Throwable throwable : throwables) {
+                AuthenticationRuntimeException authenticationRuntimeException = new AuthenticationRuntimeException(kapuaAuthenticationErrorCode, throwable, null);
+                assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, authenticationRuntimeException.getCode());
+                assertEquals("Expected and actual values should be the same.", errorMessageWithoutArguments, authenticationRuntimeException.getMessage());
+                assertEquals("Expected and actual values should be the same.", throwable, authenticationRuntimeException.getCause());
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/ExpiredAccountExceptionTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class ExpiredAccountExceptionTest extends Assert {
+
+    @Test
+    public void expiredAccountExceptionTest() {
+        Date[] dates = {new Date(), new Date(1L), new Date(9999999999999L)};
+        String[] expectedMessages = {"This credential has been locked out until " + DateTimeFormatter.ISO_INSTANT.format(dates[0].toInstant()), "This credential has been locked out until 1970-01-01T00:00:00.001Z", "This credential has been locked out until 2286-11-20T17:46:39.999Z"};
+
+        for (int i = 0; i < dates.length; i++) {
+            ExpiredAccountException expiredAccountException = new ExpiredAccountException(dates[i]);
+            assertEquals("Expected and actual values should be the same.", expectedMessages[i], expiredAccountException.getMessage());
+        }
+    }
+
+    @Test
+    public void expiredAccountExceptionNullTest() {
+        ExpiredAccountException expiredAccountException = new ExpiredAccountException(null);
+        assertEquals("Expected and actual values should be the same.", "This credential has been locked out until <null>", expiredAccountException.getMessage());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/JwtCertificateNotFoundExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/JwtCertificateNotFoundExceptionTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaAuthenticationErrorCodes;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class JwtCertificateNotFoundExceptionTest extends Assert {
+
+    @Test
+    public void jwtCertificateNotFoundExceptionTest() {
+        JwtCertificateNotFoundException jwtCertificateNotFoundException = new JwtCertificateNotFoundException();
+        assertEquals("Expected and actual values should be the same.", KapuaAuthenticationErrorCodes.JWT_CERTIFICATE_NOT_FOUND, jwtCertificateNotFoundException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: ", jwtCertificateNotFoundException.getMessage());
+        assertNull("Null expected.", jwtCertificateNotFoundException.getCause());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/MfaRequiredExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/MfaRequiredExceptionTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class MfaRequiredExceptionTest extends Assert {
+
+    @Test
+    public void mfaRequiredExceptionTest() {
+        MfaRequiredException mfaRequiredException = new MfaRequiredException();
+        assertEquals("Expected and actual values should be the same.", "This user requires Multi Factor Authentication.", mfaRequiredException.getMessage());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/exceptions/TemporaryLockedAccountExceptionTest.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.exceptions;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.time.format.DateTimeFormatter;
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class TemporaryLockedAccountExceptionTest extends Assert {
+
+    @Test
+    public void temporaryLockedAccountExceptionTest() {
+        Date[] dates = {new Date(), new Date(1L), new Date(9999999999999L)};
+        String[] expectedMessages = {"This credential has been locked out until " + DateTimeFormatter.ISO_INSTANT.format(dates[0].toInstant()), "This credential has been locked out until 1970-01-01T00:00:00.001Z", "This credential has been locked out until 2286-11-20T17:46:39.999Z"};
+
+        for (int i = 0; i < dates.length; i++) {
+            TemporaryLockedAccountException temporaryLockedAccountException = new TemporaryLockedAccountException(dates[i]);
+            assertEquals("Expected and actual values should be the same.", expectedMessages[i], temporaryLockedAccountException.getMessage());
+        }
+    }
+
+    @Test
+    public void temporaryLockedAccountExceptionNullTest() {
+        TemporaryLockedAccountException temporaryLockedAccountException = new TemporaryLockedAccountException(null);
+        assertEquals("Expected and actual values should be the same.", "This credential has been locked out until <null>", temporaryLockedAccountException.getMessage());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImplTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.registration;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.JwtCredentials;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class RegistrationServiceImplTest extends Assert {
+
+    @Test
+    public void registrationServiceImplTest() {
+        try {
+            new RegistrationServiceImpl();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void closeTest() throws Exception {
+        RegistrationServiceImpl registrationServiceImpl = new RegistrationServiceImpl();
+        try {
+            registrationServiceImpl.close();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void isAccountCreationEnabledTrueEmptyProcessorsTest() throws KapuaException {
+        System.setProperty("authentication.registration.service.enabled", "true");
+        RegistrationServiceImpl registrationService = new RegistrationServiceImpl();
+        assertFalse("False expected.", registrationService.isAccountCreationEnabled());
+    }
+
+    @Test
+    public void isAccountCreationEnabledFalseTest() throws KapuaException {
+        System.setProperty("authentication.registration.service.enabled", "false");
+        RegistrationServiceImpl registrationService = new RegistrationServiceImpl();
+        assertFalse("False expected.", registrationService.isAccountCreationEnabled());
+    }
+
+    @Test
+    public void createAccountCreationNotEnabledTest() throws KapuaException {
+        JwtCredentials jwtCredentials = Mockito.mock(JwtCredentials.class);
+        assertFalse("False expected.", new RegistrationServiceImpl().createAccount(jwtCredentials));
+    }
+
+    @Test
+    public void createAccountNullTest() throws KapuaException {
+        assertFalse("False expected.", new RegistrationServiceImpl().createAccount(null));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeysTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingKeysTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaAuthenticationSettingKeysTest extends Assert {
+
+    @Test
+    public void keyTest() {
+        assertEquals("Expected and actual values should be the same.", "authentication.key", KapuaAuthenticationSettingKeys.AUTHENTICATION_KEY.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.token.expire.after", KapuaAuthenticationSettingKeys.AUTHENTICATION_TOKEN_EXPIRE_AFTER.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.refresh.token.expire.after", KapuaAuthenticationSettingKeys.AUTHENTICATION_REFRESH_TOKEN_EXPIRE_AFTER.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.session.jwt.issuer", KapuaAuthenticationSettingKeys.AUTHENTICATION_SESSION_JWT_ISSUER.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.session.jwt.cache.enabled", KapuaAuthenticationSettingKeys.AUTHENTICATION_SESSION_JWT_CACHE_ENABLE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.session.jwt.cache.ttl", KapuaAuthenticationSettingKeys.AUTHENTICATION_SESSION_JWT_CACHE_CACHE_TTL.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.userpass.cache.enabled", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_USERPASS_CACHE_ENABLE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.userpass.cache.ttl", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_USERPASS_CACHE_CACHE_TTL.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.userpass.password.minlength", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_USERPASS_PASSWORD_MINLENGTH.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.jwt.audience.allowed", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_AUDIENCE_ALLOWED.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.jwt.cache.enabled", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_JWT_CACHE_ENABLE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.jwt.cache.ttl", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_JWT_CACHE_CACHE_TTL.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.jwt.issuer.allowed", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_ISSUER_ALLOWED.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.apiKey.pre.length", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.apiKey.pre.separator", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_SEPARATOR.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.apiKey.key.length", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_KEY_LENGTH.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.apiKey.cache.enabled", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_CACHE_ENABLE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.credential.apiKey.cache.ttl", KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_CACHE_TTL.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.eventAddress", KapuaAuthenticationSettingKeys.AUTHENTICATION_EVENT_ADDRESS.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.registration.service.enabled", KapuaAuthenticationSettingKeys.AUTHENTICATION_REGISTRATION_SERVICE_ENABLED.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.mfa.time.step.size", KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_TIME_STEP_SIZE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.mfa.window.size", KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_WINDOW_SIZE.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.mfa.scratch.codes.number", KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_SCRATCH_CODES_NUMBER.key());
+        assertEquals("Expected and actual values should be the same.", "authentication.mfa.code.digits.number", KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_CODE_DIGITS_NUMBER.key());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaAuthenticationSettingTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class KapuaAuthenticationSettingTest extends Assert {
+
+    @Test
+    public void kapuaAuthenticationSettingTest() throws Exception {
+        Constructor<KapuaAuthenticationSetting> kapuaAuthenticationSetting = KapuaAuthenticationSetting.class.getDeclaredConstructor();
+        kapuaAuthenticationSetting.setAccessible(true);
+        kapuaAuthenticationSetting.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(kapuaAuthenticationSetting.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", KapuaAuthenticationSetting.getInstance() instanceof KapuaAuthenticationSetting);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeysTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingKeysTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaCryptoSettingKeysTest extends Assert {
+
+    @Test
+    public void keyTest() {
+        assertEquals("Expected and actual values should be the same.", "crypto.key", KapuaCryptoSettingKeys.CRYPTO_KEY.key());
+        assertEquals("Expected and actual values should be the same.", "crypto.bCrypt.logRounds", KapuaCryptoSettingKeys.CRYPTO_BCRYPT_LOG_ROUNDS.key());
+        assertEquals("Expected and actual values should be the same.", "crypto.sha.algorithm", KapuaCryptoSettingKeys.CRYPTO_SHA_ALGORITHM.key());
+        assertEquals("Expected and actual values should be the same.", "crypto.sha.salt.length", KapuaCryptoSettingKeys.CRYPTO_SHA_SALT_LENGTH.key());
+        assertEquals("Expected and actual values should be the same.", "cipher.key", KapuaCryptoSettingKeys.CIPHER_KEY.key());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/setting/KapuaCryptoSettingTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class KapuaCryptoSettingTest extends Assert {
+
+    @Test
+    public void kapuaCryptoSettingTest() throws Exception {
+        Constructor<KapuaCryptoSetting> kapuaCryptoSetting = KapuaCryptoSetting.class.getDeclaredConstructor();
+        kapuaCryptoSetting.setAccessible(true);
+        kapuaCryptoSetting.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(kapuaCryptoSetting.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", KapuaCryptoSetting.getInstance() instanceof KapuaCryptoSetting);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtilsTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/utils/AuthenticationUtilsTest.java
@@ -1,0 +1,173 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.utils;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AuthenticationUtilsTest extends Assert {
+
+    String[] plainValues, encryptedValues;
+
+    @Before
+    public void initialize() {
+        plainValues = new String[]{"plain_..val9&^%ue123!!", "   value#999 ?><,,..;''a  ", "valu   e plain*&^%     $#45", "value,,,,va?><  ", "... s_er%%67nsaa4356&^%   a *(me"};
+        encryptedValues = new String[]{"2c3mAagxwaEuAhmR1UzyafpKdA8R-poaS2upJPj4kzE", "QprB8vCeyft4pU8AJdxSWlIFL1b02s-UqTQwirKj9Dw", "RrRtzYPLFDgVdmKo9kOipZv723WBs2J3IxSoPwSJM7g",
+                "gcGjWNELoVl9R-71-Nm8aAoNgf3lxr5FziYhj8dmML0", "lCysXXE00k64hm_FzQ8aK1GlVMFqR6So3knfnb5R_CQKDYH95ca-Rc4mIY_HZjC9"};
+    }
+
+    @Test
+    public void authenticationUtilsTest() throws Exception {
+        Constructor<AuthenticationUtils> authenticationUtils = AuthenticationUtils.class.getDeclaredConstructor();
+        authenticationUtils.setAccessible(true);
+        authenticationUtils.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(authenticationUtils.getModifiers()));
+    }
+
+    @Test
+    public void cryptCredentialBCRYPTAlgorithmTest() throws KapuaException {
+        for (String plainValue : plainValues) {
+            assertTrue("True expected.", AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, plainValue).startsWith("$2a$12$"));
+            assertEquals("Expected and actual values should be the same.", 60, AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "plain value").length());
+        }
+    }
+
+    @Test
+    public void cryptCredentialSHAAlgorithmTest() throws KapuaException {
+        String[] shaAlgorithm = {"SHA256", "SHA512", "algorithm", ""};
+        int[] expectedLength = {77, 141, 141, 141};
+
+        for (int i = 0; i < shaAlgorithm.length; i++) {
+            System.setProperty("crypto.sha.algorithm", shaAlgorithm[i]);
+            for (String plainValue : plainValues) {
+                assertTrue("True expected.", AuthenticationUtils.cryptCredential(CryptAlgorithm.SHA, plainValue).contains("=:"));
+                assertEquals("Expected and actual values should be the same.", expectedLength[i], AuthenticationUtils.cryptCredential(CryptAlgorithm.SHA, plainValue).length());
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cryptCredentialNullAlgorithmTest() throws KapuaException {
+        AuthenticationUtils.cryptCredential(null, "plain value");
+    }
+
+    @Test(expected = KapuaIllegalNullArgumentException.class)
+    public void cryptCredentialNullPlainValueTest() throws KapuaException {
+        AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, null);
+    }
+
+    @Test(expected = KapuaIllegalNullArgumentException.class)
+    public void cryptCredentialEmptyPlainValueTest() throws KapuaException {
+        AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "");
+    }
+
+    @Test
+    public void encryptAesTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        for (String plainValue : plainValues) {
+            try {
+                AuthenticationUtils.encryptAes(plainValue);
+            } catch (Exception e) {
+                fail("Exception not expected.");
+            }
+        }
+    }
+
+    @Test(expected = KapuaRuntimeException.class)
+    public void encryptAesIncorrectKeyTest() {
+        System.setProperty("cipher.key", "rv;ipse32918@#");
+        for (String plainValue : plainValues) {
+            AuthenticationUtils.encryptAes(plainValue);
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void encryptAesNullTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        AuthenticationUtils.encryptAes(null);
+    }
+
+    @Test
+    public void encryptAesEmptyValueTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        try {
+            AuthenticationUtils.encryptAes("");
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void encryptAesEmptyKeyTest() {
+        System.setProperty("cipher.key", "");
+        AuthenticationUtils.encryptAes("plain value");
+    }
+
+    @Test
+    public void decryptAesTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        for (String encryptedValue : encryptedValues) {
+            try {
+                AuthenticationUtils.decryptAes(encryptedValue);
+            } catch (Exception e) {
+                fail("Exception not expected.");
+            }
+        }
+    }
+
+    @Test(expected = KapuaRuntimeException.class)
+    public void decryptAesIncorrectKeyTest() {
+        System.setProperty("cipher.key", "rv;ipse32918@#");
+        for (String encryptedValue : encryptedValues) {
+            AuthenticationUtils.decryptAes(encryptedValue);
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void decryptAesNullTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        AuthenticationUtils.decryptAes(null);
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decryptAesNllTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        AuthenticationUtils.decryptAes("value");
+    }
+
+    @Test
+    public void decryptAesEmptyValueTest() {
+        System.setProperty("cipher.key", "rv;ipse329183!@#");
+        try {
+            AuthenticationUtils.decryptAes("");
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decryptAesEmptyKeyTest() {
+        System.setProperty("cipher.key", "");
+        AuthenticationUtils.decryptAes("2c3mAagxwaEuAhmR1UzyafpKdA8R-poaS2upJPj4kzE");
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/utils/JwtProcessorsTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/utils/JwtProcessorsTest.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.utils;
+
+import org.eclipse.kapua.plugin.sso.openid.JwtProcessor;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class JwtProcessorsTest extends Assert {
+
+    @Test
+    public void jwtProcessorsTest() throws Exception {
+        Constructor<JwtProcessors> jwtProcessors = JwtProcessors.class.getDeclaredConstructor();
+        jwtProcessors.setAccessible(true);
+        jwtProcessors.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(jwtProcessors.getModifiers()));
+    }
+
+    @Test
+    public void createDefaultTest() throws OpenIDException {
+        assertTrue("True expected.", JwtProcessors.createDefault() instanceof JwtProcessor);
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in shiro module in packages:

 - exceptions
     AuthenticationRuntimeException class
     ExpiredAccountException class
     JwtCertificateNotFoundException class
     MfaRequiredException class
     TemporaryLockedAccountException class

 - registration
    RegistrationServiceImpl class

 - setting
    KapuaAuthenticationSettingKeys class
    KapuaAuthenticationSetting class
    KapuaCryptoSettingKeys class
    KapuaCryptoSetting class

 - utils
    AuthenticationUtils class
    JwtProcessors class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/
**Screenshots**
/

**Any side note on the changes made**
/
