### PR TITLE
Removed  kapua-external module references from documentation

### DIFF
--- a/deployment/openshift/README.md
+++ b/deployment/openshift/README.md
@@ -66,7 +66,7 @@ You can change the version of Kapua by exporting the environment variable `IMAGE
 
 Example:
 ```bash
-export IMAGE_VERSION=1.0.0
+export IMAGE_VERSION=1.4.0
 ``` 
 
 #### Passing additional JAVA_OPTS
@@ -81,13 +81,11 @@ If you want to build containers from the code, you'll need to build the whole Ka
 
 From the project root directory, run:
 ```bash
-mvn clean install -f external/pom.xml
 mvn clean install -Pdocker
 ```
 
 To build also the Admin Web Console container, which is excluded by default, add the `console` profile:
 ```bash
-mvn clean install -f external/pom.xml
 mvn clean install -Pconsole,docker
 ```
 

--- a/docs/developer-guide/en/building.md
+++ b/docs/developer-guide/en/building.md
@@ -8,12 +8,7 @@ We use `gitbook` to build the documentation.
 
 Kapua is being compiled with Maven. 
 
-In order to perform a full build of Kapua first you have to build the external 
-resources of Kapua with the following command in the root of the Git repository:
-
-    mvn clean install -f external/pom.xml
-
-Than you can run the Kapua full build issuing the command:
+You can run the Kapua full build issuing the command:
 
     mvn clean install
 

--- a/docs/kuraKapuaDocs.md
+++ b/docs/kuraKapuaDocs.md
@@ -32,9 +32,8 @@ This part of the tutorial consists of several pieces. First you need to download
 
 1. Open OS Shell (Terminal) and go to home directory.
 2. Download Kapua project from [Github repository](https://github.com/eclipse/kapua.git) with command `git clone https://github.com/eclipse/kapua.git`
-3. Go to Kapua folder and run command `mvn clean install -f external/pom.xml` which will build some additional resources required by Kapua.
-4. Go to Kapua folder and run command `mvn clean install -DskipTests -Pconsole,docker` which will build the project with the Web Admin console.
-5. After build finishes run Docker deploy script in `deployment/docker`:
+3. Go to Kapua folder and run command `mvn clean install -DskipTests -Pconsole,docker` which will build the project with the Web Admin console.
+4. After build finishes run Docker deploy script in `deployment/docker`:
  
 ```
 ./docker-deploy.sh

--- a/pom.xml
+++ b/pom.xml
@@ -1894,14 +1894,6 @@
             </modules>
         </profile>
 
-        <!-- Profile used to exclude external dependency modules -->
-        <!-- <profile>
-            <id>external</id>
-            <modules>
-                <module>external</module>
-            </modules>
-        </profile> -->
-
         <!-- Profile used only during release process. -->
         <profile>
             <id>release</id>


### PR DESCRIPTION
This PR remove all references of `kapua-external` module from the documentation.
This was an old module that has been removed.

**Related Issue**
This PR closes #3196 

**Description of the solution adopted**
Just removed references.

**Screenshots**
_None_

**Any side note on the changes made**
_None_