### PR TITLE
Added JUnit tests for mfa and realm packages

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenAuthenticationRealmTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenAuthenticationRealmTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.AccessTokenCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AccessTokenAuthenticationRealmTest extends Assert {
+
+    AccessTokenAuthenticatingRealm accessTokenAuthenticatingRealm;
+
+    @Before
+    public void initialize() throws KapuaException {
+        accessTokenAuthenticatingRealm = new AccessTokenAuthenticatingRealm();
+    }
+
+    @Test
+    public void accessTokenAuthenticatingRealmTest() {
+        assertEquals("Expected and actual values should be the same.", "accessTokenAuthenticatingRealm", accessTokenAuthenticatingRealm.getName());
+        assertNotNull("NotNull expected.", accessTokenAuthenticatingRealm.getCredentialsMatcher());
+    }
+
+    @Test
+    public void supportsTrueTest() {
+        AccessTokenCredentialsImpl authenticationToken = new AccessTokenCredentialsImpl("token id");
+        assertTrue("True expected.", accessTokenAuthenticatingRealm.supports(authenticationToken));
+    }
+
+    @Test
+    public void supportsFalseTest() {
+        AuthenticationToken authenticationToken = Mockito.mock(AuthenticationToken.class);
+        assertFalse("False expected.", accessTokenAuthenticatingRealm.supports(authenticationToken));
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenCredentialsMatcherTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenCredentialsMatcherTest.java
@@ -1,0 +1,59 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenCredentialsMatcher;
+import org.eclipse.kapua.service.authentication.shiro.realm.SessionAuthenticationInfo;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AccessTokenCredentialsMatcherTest extends Assert {
+
+    AuthenticationToken authenticationToken;
+    SessionAuthenticationInfo authenticationInfo;
+    String jwt;
+    AccessToken accessToken;
+    AccessTokenCredentialsMatcher accessTokenCredentialsMatcher;
+
+    @Before
+    public void initialize() {
+        authenticationToken = Mockito.mock(AuthenticationToken.class);
+        authenticationInfo = Mockito.mock(SessionAuthenticationInfo.class);
+        jwt = "jwt";
+        accessToken = Mockito.mock(AccessToken.class);
+        accessTokenCredentialsMatcher = new AccessTokenCredentialsMatcher();
+    }
+
+    @Test
+    public void doCredentialsMatchDifferentCredentialsTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn(jwt);
+        Mockito.when(authenticationInfo.getAccessToken()).thenReturn(accessToken);
+        Mockito.when(accessToken.getTokenId()).thenReturn("token id");
+        assertFalse("False expected.", accessTokenCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchEqualCredentialsErrorJWTValidationTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn(jwt);
+        Mockito.when(authenticationInfo.getAccessToken()).thenReturn(accessToken);
+        Mockito.when(accessToken.getTokenId()).thenReturn(jwt);
+        assertFalse("False expected.", accessTokenCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ApiKeyAuthenticatingRealmTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ApiKeyAuthenticatingRealmTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.ApiKeyCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.realm.ApiKeyAuthenticatingRealm;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class ApiKeyAuthenticatingRealmTest extends Assert {
+
+    ApiKeyAuthenticatingRealm apiKeyAuthenticatingRealm;
+
+    @Before
+    public void initialize() throws KapuaException {
+        apiKeyAuthenticatingRealm = new ApiKeyAuthenticatingRealm();
+    }
+
+    @Test
+    public void apiKeyAuthenticatingRealmTest() {
+        assertEquals("Expected and actual values should be the same.", "apiKeyAuthenticatingRealm", apiKeyAuthenticatingRealm.getName());
+        assertNotNull("Null not expected", apiKeyAuthenticatingRealm.getCredentialsMatcher());
+    }
+
+    @Test
+    public void supportsTrueTest() {
+        ApiKeyCredentialsImpl authenticationToken = new ApiKeyCredentialsImpl("api key");
+        assertTrue("True expected.", apiKeyAuthenticatingRealm.supports(authenticationToken));
+    }
+
+    @Test
+    public void supportsFalseTest() {
+        AuthenticationToken authenticationToken = Mockito.mock(AuthenticationToken.class);
+        assertFalse("False expected.", apiKeyAuthenticatingRealm.supports(authenticationToken));
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/JwtAuthenticatingRealmTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/JwtAuthenticatingRealmTest.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class JwtAuthenticatingRealmTest extends Assert {
+
+    JwtAuthenticatingRealm jwtAuthenticatingRealm;
+
+    @Before
+    public void initialize() throws KapuaException {
+        jwtAuthenticatingRealm = new JwtAuthenticatingRealm();
+    }
+
+    @Test
+    public void jwtAuthenticatingRealmTest() {
+        assertEquals("Expected and actual values should be the same.", "jwtAuthenticatingRealm", jwtAuthenticatingRealm.getName());
+    }
+
+    @Test
+    public void destroyNullJwtProcessorTest() throws Exception {
+        try {
+            jwtAuthenticatingRealm.destroy();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void supportsTrueTest() {
+        JwtCredentialsImpl authenticationToken = new JwtCredentialsImpl("jwt", "token id");
+        assertTrue("True expected.", jwtAuthenticatingRealm.supports(authenticationToken));
+    }
+
+    @Test
+    public void supportsFalseTest() {
+        AuthenticationToken authenticationToken = Mockito.mock(AuthenticationToken.class);
+        assertFalse("False expected.", jwtAuthenticatingRealm.supports(authenticationToken));
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/UserPassAuthenticatingRealmTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/UserPassAuthenticatingRealmTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.UsernamePasswordCredentialsImpl;
+import org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class UserPassAuthenticatingRealmTest extends Assert {
+
+    UserPassAuthenticatingRealm userPassAuthenticatingRealm;
+
+    @Before
+    public void initialize() throws KapuaException {
+        userPassAuthenticatingRealm = new UserPassAuthenticatingRealm();
+    }
+
+    @Test
+    public void userPassAuthenticatingRealmTest() {
+        assertEquals("Expected and actual values should be the same.", "userPassAuthenticatingRealm", userPassAuthenticatingRealm.getName());
+        assertNotNull("Null expected.", userPassAuthenticatingRealm.getCredentialsMatcher());
+    }
+
+    @Test
+    public void supportsTrueTest() {
+        UsernamePasswordCredentialsImpl authenticationToken = new UsernamePasswordCredentialsImpl("username", "password");
+        assertTrue("True expected.", userPassAuthenticatingRealm.supports(authenticationToken));
+    }
+
+    @Test
+    public void supportsFalseTest() {
+        AuthenticationToken authenticationToken = Mockito.mock(AuthenticationToken.class);
+        assertFalse("False expected.", userPassAuthenticatingRealm.supports(authenticationToken));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorImplTest.java
@@ -1,0 +1,107 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.mfa;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
+import org.eclipse.kapua.service.authentication.shiro.utils.CryptAlgorithm;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class MfaAuthenticatorImplTest extends Assert {
+
+    MfaAuthenticatorImpl mfaAuthenticatorImpl;
+    String[] encryptedSecrets, hashedScratchCodes, stringVerificationCodes;
+    int[] verificationCodes;
+
+    @Before
+    public void initialize() throws KapuaException {
+        mfaAuthenticatorImpl = new MfaAuthenticatorImpl();
+        encryptedSecrets = new String[]{AuthenticationUtils.encryptAes("value to encrypt"), AuthenticationUtils.encryptAes("value@#$ en-999crypt"), AuthenticationUtils.encryptAes("!<>v87a-lue to encrypt"),
+                AuthenticationUtils.encryptAes("value_to$#encr-0y()pt"), AuthenticationUtils.encryptAes("va09l-ue|,,,.to00encrypt")};
+        verificationCodes = new int[]{-2147483648, -100000, -100, -1, 0, 1, 100, 100000, 2147483647};
+        hashedScratchCodes = new String[]{AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "val-ue99_<11>"), AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "   !@#$v66a0l-ueee"),
+                AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "val  *&^%087,...ueee   "), AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, "_877V.A;;LUE")};
+        stringVerificationCodes = new String[]{"-2147483648", "-100000", "-100", "-1", "0", " 1", "100", "100000", "2147483647"};
+    }
+
+    @Test
+    public void isEnabledTest() {
+        assertTrue("True expected.", mfaAuthenticatorImpl.isEnabled());
+    }
+
+    @Test
+    public void authorizeEncryptedSecretVerificationCodeParametersTest() {
+        for (String encryptedSecret : encryptedSecrets) {
+            for (int verificationCode : verificationCodes) {
+                assertFalse("False expected.", mfaAuthenticatorImpl.authorize(encryptedSecret, verificationCode));
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void authorizeNullEncryptedSecretVerificationCodeParametersTest() {
+        for (int verificationCode : verificationCodes) {
+            assertFalse("False expected.", mfaAuthenticatorImpl.authorize(null, verificationCode));
+        }
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void authorizeEncryptedSecretNullVerificationCodeParametersTest() {
+        for (String encryptedSecret : encryptedSecrets) {
+            assertFalse("False expected.", mfaAuthenticatorImpl.authorize(encryptedSecret, null));
+        }
+    }
+
+    @Test
+    public void authorizeHasedScratchCodeVerificationCodeParametersFalseTest() {
+        for (String hasedScratchCode : hashedScratchCodes) {
+            for (String stringVerificationCode : stringVerificationCodes) {
+                assertFalse("False expected.", mfaAuthenticatorImpl.authorize(hasedScratchCode, stringVerificationCode));
+            }
+        }
+    }
+
+    @Test
+    public void authorizeHasedScratchCodeVerificationCodeParametersTrueTest() {
+        assertTrue("True expected.", mfaAuthenticatorImpl.authorize("$2a$12$2AZYOAvilJyNvG8b6rBDaOSIcM3mKc6iyNQUYIXOF4ZFEAYdzM7Jm", "plainValue"));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void authorizeNullHasedScratchCodeVerificationCodeParametersTest() {
+        for (String stringVerificationCode : stringVerificationCodes) {
+            mfaAuthenticatorImpl.authorize(null, stringVerificationCode);
+        }
+    }
+
+    @Test
+    public void authorizeHasedScratchCodeVerificationNullCodeParametersTest() {
+        for (String hasedScratchCode : hashedScratchCodes) {
+            assertFalse("False expected.", mfaAuthenticatorImpl.authorize(hasedScratchCode, null));
+        }
+    }
+
+    @Test
+    public void generateKeyTest() {
+        assertEquals("Expected and actual values should be the same.", 32, mfaAuthenticatorImpl.generateKey().length());
+    }
+
+    @Test
+    public void generateCodesTest() {
+        assertEquals("Expected and actual values should be the same.", 5, mfaAuthenticatorImpl.generateCodes().size());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorServiceLocatorTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorServiceLocatorTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.mfa;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticator;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class MfaAuthenticatorServiceLocatorTest extends Assert {
+
+    @Test
+    public void mfaAuthenticatorServiceLocatorTest() throws Exception {
+        Constructor<MfaAuthenticatorServiceLocator> mfaAuthenticatorServiceLocator = MfaAuthenticatorServiceLocator.class.getDeclaredConstructor();
+        mfaAuthenticatorServiceLocator.setAccessible(true);
+        mfaAuthenticatorServiceLocator.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(mfaAuthenticatorServiceLocator.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceNullLocatorTest() {
+        assertTrue("True expected.", MfaAuthenticatorServiceLocator.getInstance() instanceof MfaAuthenticatorServiceLocator);
+    }
+
+    @Test
+    public void getInstanceTest() {
+        MfaAuthenticatorServiceLocator.getInstance();
+        assertTrue("True expected.", MfaAuthenticatorServiceLocator.getInstance() instanceof MfaAuthenticatorServiceLocator);
+    }
+
+    @Test
+    public void getMfaAuthenticatorTest() {
+        assertTrue("True expected.", MfaAuthenticatorServiceLocator.getInstance().getMfaAuthenticator() instanceof MfaAuthenticator);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcherTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcherTest.java
@@ -1,0 +1,91 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialType;
+import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class ApiKeyCredentialsMatcherTest extends Assert {
+
+    ApiKeyCredentialsMatcher apiKeyCredentialsMatcher;
+    JwtCredentialsImpl authenticationToken;
+    LoginAuthenticationInfo authenticationInfo;
+    Credential credential;
+
+    @Before
+    public void initialize() {
+        apiKeyCredentialsMatcher = new ApiKeyCredentialsMatcher();
+        authenticationToken = Mockito.mock(JwtCredentialsImpl.class);
+        authenticationInfo = Mockito.mock(LoginAuthenticationInfo.class);
+        credential = Mockito.mock(Credential.class);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void doCredentialsMatchNullAuthenticationTokenTest() {
+        apiKeyCredentialsMatcher.doCredentialsMatch(null, authenticationInfo);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void doCredentialsMatchNullAuthenticationInfoTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn("tokenApiFullKey");
+
+        apiKeyCredentialsMatcher.doCredentialsMatch(authenticationToken, null);
+    }
+
+    @Test
+    public void doCredentialsMatchDifferentCredentialTypesTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn("tokenApiFullKey");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialType()).thenReturn(CredentialType.PASSWORD);
+
+        assertFalse("False expected.", apiKeyCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchDifferentTokenAndInfoPreTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn("tokenApiFullKey");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialType()).thenReturn(CredentialType.API_KEY);
+        Mockito.when(credential.getCredentialKey()).thenReturn("FullApiK:Credential");
+
+        assertFalse("False expected.", apiKeyCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchEqualTokenAndInfoPreFalseCheckPwTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn("FullApiKCredential");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialType()).thenReturn(CredentialType.API_KEY);
+        Mockito.when(credential.getCredentialKey()).thenReturn("FullApiK:$2a$12$2AZYOAvilJyNvG8b6rBDaOSIcM3mKc6iyNQUYIXOF4ZFEAYdzM7Jm");
+
+        assertFalse("False expected.", apiKeyCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchTest() {
+        Mockito.when(authenticationToken.getCredentials()).thenReturn("FullApiKplainValue");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialType()).thenReturn(CredentialType.API_KEY);
+        Mockito.when(credential.getCredentialKey()).thenReturn("FullApiK:$2a$12$2AZYOAvilJyNvG8b6rBDaOSIcM3mKc6iyNQUYIXOF4ZFEAYdzM7Jm");
+
+        assertTrue("True expected.", apiKeyCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcherTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcherTest.java
@@ -1,0 +1,125 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.apache.shiro.authc.AuthenticationInfo;
+import org.eclipse.kapua.plugin.sso.openid.JwtProcessor;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.shiro.JwtCredentialsImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class JwtCredentialsMatcherTest extends Assert {
+
+    JwtProcessor jwtProcessor;
+    JwtCredentialsImpl authenticationToken;
+    AuthenticationInfo authenticationInfo;
+    Credential credential;
+    JwtCredentialsMatcher jwtCredentialsMatcher;
+
+    @Before
+    public void initialize() {
+        jwtProcessor = Mockito.mock(JwtProcessor.class);
+        authenticationToken = Mockito.mock(JwtCredentialsImpl.class);
+        authenticationInfo = Mockito.mock(AuthenticationInfo.class);
+        credential = Mockito.mock(Credential.class);
+        jwtCredentialsMatcher = new JwtCredentialsMatcher(jwtProcessor);
+    }
+
+    @Test
+    public void jwtCredentialsMatcherNullTest() {
+        try {
+            new JwtCredentialsMatcher(null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void doCredentialsMatchNullAuthenticationTokenTest() {
+        jwtCredentialsMatcher.doCredentialsMatch(null, authenticationInfo);
+    }
+
+    @Test
+    public void doCredentialsMatchNullAuthenticationInfoNullJwtTest() {
+        Mockito.when(authenticationToken.getJwt()).thenReturn(null);
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, null));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void doCredentialsMatchNullAuthenticationInfoTest() {
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, null);
+    }
+
+    @Test
+    public void doCredentialsMatchNullJwtTest() {
+        Mockito.when(authenticationToken.getJwt()).thenReturn(null);
+
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchStringCredentialTest() {
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn("credential");
+
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchDifferentKeysTest() {
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialKey()).thenReturn("credential key");
+
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchEqualKeysFalseTest() throws OpenIDException {
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
+        Mockito.when(jwtProcessor.validate("jwt")).thenReturn(false);
+
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchEqualKeysTrueTest() throws OpenIDException {
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
+        Mockito.when(jwtProcessor.validate("jwt")).thenReturn(true);
+
+        assertTrue("True expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+
+    @Test
+    public void doCredentialsMatchEqualKeysOpenIDExceptionTest() throws OpenIDException {
+        JwtCredentialsMatcher jwtCredentialsMatcher = new JwtCredentialsMatcher(jwtProcessor);
+        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
+        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
+        Mockito.when(jwtProcessor.validate("jwt")).thenThrow(Mockito.mock(OpenIDException.class));
+
+        assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfoTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/LoginAuthenticationInfoTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.user.User;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class LoginAuthenticationInfoTest extends Assert {
+
+    String[] realmNames;
+    Account account;
+    User user;
+    Credential credentials;
+    Map<String, Object> credentialServiceConfig;
+
+    @Before
+    public void initialize() {
+        realmNames = new String[]{"", "!!realm NAME-1", "#1(REALM.,/name realm)9--99", "!$$ 1-2 name//", "RE_ALM naME(....)<00>", "na_me=223RE   65ALM     "};
+        account = Mockito.mock(Account.class);
+        user = Mockito.mock(User.class);
+        credentials = Mockito.mock(Credential.class);
+        credentialServiceConfig = new HashMap<>();
+    }
+
+    @Test
+    public void loginAuthenticationInfoTest() {
+        for (String realmName : realmNames) {
+            LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(realmName, account, user, credentials, credentialServiceConfig);
+            assertEquals("Expected and actual values should be the same.", user, loginAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, loginAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, loginAuthenticationInfo.getRealmName());
+            assertFalse("False expected.", loginAuthenticationInfo.getPrincipals().isEmpty());
+            assertEquals("Expected and actual values should be the same.", credentials, loginAuthenticationInfo.getCredentials());
+            assertEquals("Expected and actual values should be the same.", credentialServiceConfig, loginAuthenticationInfo.getCredentialServiceConfig());
+        }
+    }
+
+    @Test
+    public void loginAuthenticationInfoNullNameTest() {
+        LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(null, account, user, credentials, credentialServiceConfig);
+        assertEquals("Expected and actual values should be the same.", user, loginAuthenticationInfo.getUser());
+        assertEquals("Expected and actual values should be the same.", account, loginAuthenticationInfo.getAccount());
+        assertNull("Null expected.", loginAuthenticationInfo.getRealmName());
+        assertEquals("Expected and actual values should be the same.", credentials, loginAuthenticationInfo.getCredentials());
+        assertEquals("Expected and actual values should be the same.", credentialServiceConfig, loginAuthenticationInfo.getCredentialServiceConfig());
+        try {
+            loginAuthenticationInfo.getPrincipals();
+            fail("IllegalArgumentException expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException("realmName argument cannot be null.").toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void loginAuthenticationInfoNullAccountTest() {
+        for (String realmName : realmNames) {
+            LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(realmName, null, user, credentials, credentialServiceConfig);
+            assertEquals("Expected and actual values should be the same.", user, loginAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", realmName, loginAuthenticationInfo.getRealmName());
+            assertNull("Null expected.", loginAuthenticationInfo.getAccount());
+            assertFalse("False expected.", loginAuthenticationInfo.getPrincipals().isEmpty());
+            assertEquals("Expected and actual values should be the same.", credentials, loginAuthenticationInfo.getCredentials());
+            assertEquals("Expected and actual values should be the same.", credentialServiceConfig, loginAuthenticationInfo.getCredentialServiceConfig());
+        }
+    }
+
+    @Test
+    public void loginAuthenticationInfoNullUserTest() {
+        for (String realmName : realmNames) {
+            LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(realmName, account, null, credentials, credentialServiceConfig);
+            assertNull("Null expected.", loginAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, loginAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, loginAuthenticationInfo.getRealmName());
+            assertEquals("Expected and actual values should be the same.", credentials, loginAuthenticationInfo.getCredentials());
+            assertEquals("Expected and actual values should be the same.", credentialServiceConfig, loginAuthenticationInfo.getCredentialServiceConfig());
+            try {
+                loginAuthenticationInfo.getPrincipals();
+                fail("IllegalArgumentException expected.");
+            } catch (Exception e) {
+                assertEquals("Expected and actual values should be the same.", new NullPointerException("principal argument cannot be null.").toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void loginAuthenticationInfoNullCredentialsTest() {
+        for (String realmName : realmNames) {
+            LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(realmName, account, user, null, credentialServiceConfig);
+            assertEquals("Expected and actual values should be the same.", user, loginAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, loginAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, loginAuthenticationInfo.getRealmName());
+            assertFalse("False expected.", loginAuthenticationInfo.getPrincipals().isEmpty());
+            assertNull("Null expected.", loginAuthenticationInfo.getCredentials());
+            assertEquals("Expected and actual values should be the same.", credentialServiceConfig, loginAuthenticationInfo.getCredentialServiceConfig());
+        }
+    }
+
+    @Test
+    public void loginAuthenticationInfoNullCredentialServiceConfigTest() {
+        for (String realmName : realmNames) {
+            LoginAuthenticationInfo loginAuthenticationInfo = new LoginAuthenticationInfo(realmName, account, user, credentials, null);
+            assertEquals("Expected and actual values should be the same.", user, loginAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, loginAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, loginAuthenticationInfo.getRealmName());
+            assertFalse("False expected.", loginAuthenticationInfo.getPrincipals().isEmpty());
+            assertEquals("Expected and actual values should be the same.", credentials, loginAuthenticationInfo.getCredentials());
+            assertNull("Null expected.", loginAuthenticationInfo.getCredentialServiceConfig());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfoTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/SessionAuthenticationInfoTest.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro.realm;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.user.User;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class SessionAuthenticationInfoTest extends Assert {
+
+    String[] realmNames;
+    Account account;
+    User user;
+    AccessToken accessToken;
+
+    @Before
+    public void initialize() {
+        realmNames = new String[]{"", "!!realm NAME-1", "#1(REALM.,/name realm)9--99", "!$$ 1-2 name//", "RE_ALM naME(....)<00>", "na_me=223RE   65ALM     "};
+        account = Mockito.mock(Account.class);
+        user = Mockito.mock(User.class);
+        accessToken = Mockito.mock(AccessToken.class);
+    }
+
+    @Test
+    public void sessionAuthenticationInfoTest() {
+        for (String realmName : realmNames) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, user, accessToken);
+            assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getAccessToken());
+            assertFalse("False expected.", sessionAuthenticationInfo.getPrincipals().isEmpty());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getCredentials());
+        }
+    }
+
+    @Test
+    public void sessionAuthenticationInfoNullNameTest() {
+        SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(null, account, user, accessToken);
+        assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
+        assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
+        assertNull("Null expected.", sessionAuthenticationInfo.getRealmName());
+        assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getAccessToken());
+        assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getCredentials());
+        try {
+            sessionAuthenticationInfo.getPrincipals();
+            fail("IllegalArgumentException expected.");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException("realmName argument cannot be null.").toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void sessionAuthenticationInfoNullAccountTest() {
+        for (String realmName : realmNames) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, null, user, accessToken);
+            assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
+            assertNull("Null expected.", sessionAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getAccessToken());
+            assertFalse("False expected.", sessionAuthenticationInfo.getPrincipals().isEmpty());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getCredentials());
+        }
+    }
+
+    @Test
+    public void sessionAuthenticationInfoNullUserTest() {
+        for (String realmName : realmNames) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, null, accessToken);
+            assertNull("Null expected.", sessionAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getAccessToken());
+            assertEquals("Expected and actual values should be the same.", accessToken, sessionAuthenticationInfo.getCredentials());
+            try {
+                sessionAuthenticationInfo.getPrincipals();
+                fail("IllegalArgumentException expected.");
+            } catch (Exception e) {
+                assertEquals("Expected and actual values should be the same.", new NullPointerException("principal argument cannot be null.").toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void sessionAuthenticationInfoNullAccessTokenTest() {
+        for (String realmName : realmNames) {
+            SessionAuthenticationInfo sessionAuthenticationInfo = new SessionAuthenticationInfo(realmName, account, user, null);
+            assertEquals("Expected and actual values should be the same.", user, sessionAuthenticationInfo.getUser());
+            assertEquals("Expected and actual values should be the same.", account, sessionAuthenticationInfo.getAccount());
+            assertEquals("Expected and actual values should be the same.", realmName, sessionAuthenticationInfo.getRealmName());
+            assertNull("Null expected.", sessionAuthenticationInfo.getAccessToken());
+            assertFalse("False expected.", sessionAuthenticationInfo.getPrincipals().isEmpty());
+            assertNull("Null expected.", sessionAuthenticationInfo.getCredentials());
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in:

-shiro/authentication/shiro/mfa package:
 - MfaAuthenticatorImpl class
 - MfaAuthenticatorServiceLocator class

-shiro/authentication/shiro/realm package:
 - AccessTokenAuthenticationRealm class
 - AccessTokenCredentialsMatcher class
 - ApiKeyAuthenticatingRealm class
 - ApiKeyCredentialsMatcher class
 - JwtAuthenticatingRealm class
 - JwtCredentialsMatcher class
 - LoginAuthenticationInfo class
 - SessionAuthenticationInfo class
 - UserPassAuthenticatingRealm class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
