### PR TITLE
Added JUnit tests for token package

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenCreatorImplTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessTokenCreatorImplTest extends Assert {
+
+    AccessTokenCreatorImpl accessTokenCreatorImpl;
+
+    @Before
+    public void initialize() {
+        accessTokenCreatorImpl = new AccessTokenCreatorImpl(KapuaId.ONE);
+    }
+
+    @Test
+    public void accessTokenCreatorImplTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenCreatorImpl.getScopeId());
+    }
+
+    @Test
+    public void accessTokenCreatorImplNullTest() {
+        AccessTokenCreatorImpl accessTokenCreatorImpl = new AccessTokenCreatorImpl(null);
+        assertNull("Null expected.", accessTokenCreatorImpl.getScopeId());
+    }
+
+    @Test
+    public void setAndGetTokenIdTest() {
+        String[] tokenIds = {null, "", "!!tokenID-1", "#1(TOKEN.,/token id)9--99", "!$$ 1-2 ID//", "id_tokeN(....)<00>"};
+
+        assertNull("Null expected.", accessTokenCreatorImpl.getTokenId());
+        for (String tokenId : tokenIds) {
+            accessTokenCreatorImpl.setTokenId(tokenId);
+            assertEquals("Expected and actual values should be the same.", tokenId, accessTokenCreatorImpl.getTokenId());
+        }
+    }
+
+    @Test
+    public void setAndGetUserIdTest() {
+        KapuaId[] userIds = {null, KapuaId.ONE};
+
+        assertNull("Null expected.", accessTokenCreatorImpl.getUserId());
+        for (KapuaId userId : userIds) {
+            accessTokenCreatorImpl.setUserId(userId);
+            assertEquals("Expected and actual values should be the same.", userId, accessTokenCreatorImpl.getUserId());
+        }
+    }
+
+    @Test
+    public void setAndGetExpiresOnTest() {
+        Date[] expiresOnDates = {null, new Date(), new Date(1L), new Date(9999999999999L)};
+        assertNull("Null expected.", accessTokenCreatorImpl.getExpiresOn());
+        for (Date expiresOnDate : expiresOnDates) {
+            accessTokenCreatorImpl.setExpiresOn(expiresOnDate);
+            assertEquals("Expected and actual values should be the same.", expiresOnDate, accessTokenCreatorImpl.getExpiresOn());
+        }
+    }
+
+    @Test
+    public void setAndGetRefreshTokenTest() {
+        String[] refreshTokens = {null, "", "!!refreshToken-1", "#1(TOKEN.,/refresh token id)9--99", "!$$ 1-2 REFREsh//", "refresh_tokeN(....)<00>"};
+
+        assertNull("Null expected.", accessTokenCreatorImpl.getRefreshToken());
+        for (String refreshToken : refreshTokens) {
+            accessTokenCreatorImpl.setRefreshToken(refreshToken);
+            assertEquals("Expected and actual values should be the same.", refreshToken, accessTokenCreatorImpl.getRefreshToken());
+        }
+    }
+
+    @Test
+    public void setAndGetRefreshExpiresOnTest() {
+        Date[] refreshExpiresOnDates = {null, new Date(), new Date(1L), new Date(9999999999999L)};
+        assertNull("Null expected.", accessTokenCreatorImpl.getRefreshExpiresOn());
+        for (Date refreshExpiresOnDate : refreshExpiresOnDates) {
+            accessTokenCreatorImpl.setRefreshExpiresOn(refreshExpiresOnDate);
+            assertEquals("Expected and actual values should be the same.", refreshExpiresOnDate, accessTokenCreatorImpl.getRefreshExpiresOn());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenEntityManagerFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AccessTokenEntityManagerFactoryTest extends Assert {
+
+    @Test
+    public void accessTokenEntityManagerFactoryTest() throws Exception {
+        Constructor<AccessTokenEntityManagerFactory> accessTokenEntityManagerFactory = AccessTokenEntityManagerFactory.class.getDeclaredConstructor();
+        accessTokenEntityManagerFactory.setAccessible(true);
+        accessTokenEntityManagerFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(accessTokenEntityManagerFactory.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", AccessTokenEntityManagerFactory.getInstance() instanceof EntityManagerFactory);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImplTest.java
@@ -1,0 +1,151 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authentication.token.AccessTokenQuery;
+import org.eclipse.kapua.service.authentication.token.LoginInfo;
+import org.eclipse.kapua.service.authentication.token.AccessTokenListResult;
+import org.eclipse.kapua.service.authentication.token.AccessTokenCreator;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessTokenFactoryImplTest extends Assert {
+
+    AccessTokenFactoryImpl accessTokenFactoryImpl;
+    KapuaId[] scopeIds;
+    KapuaEid[] userIds;
+    String[] tokenIds, refreshTokens;
+    Date[] expiresOnDates, refreshExpiresOnDates;
+    AccessToken accessToken;
+    Date modifiedOn, createdOn, invalidatedOn;
+
+    @Before
+    public void initialize() {
+        accessTokenFactoryImpl = new AccessTokenFactoryImpl();
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        userIds = new KapuaEid[]{null, new KapuaEid()};
+        tokenIds = new String[]{null, "", "!!token id-1", "#1(token.,/tokenID)9--99", "!$$ 1-2 id//", "to_ken_id(....)<00>"};
+        refreshTokens = new String[]{null, "", "!!token refresh token-1", "#1(REfreSF.,/token_refresh)9--99", "!$$ 1-2 id//", "to_ken_refRESH token(....)<00>"};
+        expiresOnDates = new Date[]{null, new Date()};
+        refreshExpiresOnDates = new Date[]{null, new Date()};
+        accessToken = Mockito.mock(AccessToken.class);
+        modifiedOn = new Date();
+        createdOn = new Date();
+        invalidatedOn = new Date();
+    }
+
+    @Test
+    public void newCreatorMultipleParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaEid userId : userIds) {
+                for (String tokenId : tokenIds) {
+                    for (Date expiresOnDate : expiresOnDates) {
+                        for (String refreshToken : refreshTokens) {
+                            for (Date refreshExpiresOnDate : refreshExpiresOnDates) {
+                                AccessTokenCreatorImpl accessTokenCreatorImpl = accessTokenFactoryImpl.newCreator(scopeId, userId, tokenId, expiresOnDate, refreshToken, refreshExpiresOnDate);
+                                assertEquals("Expected and actual values should be the same.", scopeId, accessTokenCreatorImpl.getScopeId());
+                                assertEquals("Expected and actual values should be the same.", userId, accessTokenCreatorImpl.getUserId());
+                                assertEquals("Expected and actual values should be the same.", tokenId, accessTokenCreatorImpl.getTokenId());
+                                assertEquals("Expected and actual values should be the same.", expiresOnDate, accessTokenCreatorImpl.getExpiresOn());
+                                assertEquals("Expected and actual values should be the same.", refreshToken, accessTokenCreatorImpl.getRefreshToken());
+                                assertEquals("Expected and actual values should be the same.", refreshExpiresOnDate, accessTokenCreatorImpl.getRefreshExpiresOn());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void newEntityTest() {
+        for (KapuaId scopeId : scopeIds) {
+            AccessToken accessToken = accessTokenFactoryImpl.newEntity(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, accessToken.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            AccessTokenCreator accessTokenCreator = accessTokenFactoryImpl.newCreator(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, accessTokenCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void newQueryTest() {
+        for (KapuaId scopeId : scopeIds) {
+            AccessTokenQuery accessTokenQuery = accessTokenFactoryImpl.newQuery(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, accessTokenQuery.getScopeId());
+        }
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("True expected.", accessTokenFactoryImpl.newListResult() instanceof AccessTokenListResult);
+    }
+
+    @Test
+    public void cloneTest() {
+        Mockito.when(accessToken.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessToken.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getUserId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessToken.getTokenId()).thenReturn("token id");
+        Mockito.when(accessToken.getExpiresOn()).thenReturn(expiresOnDates[1]);
+        Mockito.when(accessToken.getRefreshToken()).thenReturn("refresh token");
+        Mockito.when(accessToken.getRefreshExpiresOn()).thenReturn(refreshExpiresOnDates[1]);
+        Mockito.when(accessToken.getInvalidatedOn()).thenReturn(invalidatedOn);
+        Mockito.when(accessToken.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(accessToken.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getOptlock()).thenReturn(10);
+
+        AccessToken accessTokenResult = accessTokenFactoryImpl.clone(accessToken);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenResult.getId());
+        assertEquals("Expected and actual values should be the same.", createdOn, accessTokenResult.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenResult.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenResult.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessTokenResult.getUserId());
+        assertEquals("Expected and actual values should be the same.", "token id", accessTokenResult.getTokenId());
+        assertEquals("Expected and actual values should be the same.", expiresOnDates[1], accessTokenResult.getExpiresOn());
+        assertEquals("Expected and actual values should be the same.", "refresh token", accessTokenResult.getRefreshToken());
+        assertEquals("Expected and actual values should be the same.", refreshExpiresOnDates[1], accessTokenResult.getRefreshExpiresOn());
+        assertEquals("Expected and actual values should be the same.", invalidatedOn, accessTokenResult.getInvalidatedOn());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, accessTokenResult.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenResult.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", 10, accessTokenResult.getOptlock());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        accessTokenFactoryImpl.clone(null);
+    }
+
+    @Test
+    public void newLoginInfoTest() {
+        assertTrue("True expected.", accessTokenFactoryImpl.newLoginInfo() instanceof LoginInfo);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenImplTest.java
@@ -1,0 +1,305 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessTokenImplTest extends Assert {
+
+    KapuaId[] scopeIds;
+    KapuaEid[] userIds;
+    String[] tokenIds, refreshTokens;
+    Date[] expiresOnDates, refreshExpiresOnDates;
+    AccessToken accessToken;
+    Date expiresOn, refreshExpiresOn, invalidatedOn, modifiedOn, createdOn;
+    AccessTokenImpl accessTokenImpl1, accessTokenImpl2, accessTokenImpl3, accessTokenImpl4;
+
+    @Before
+    public void initialize() throws KapuaException {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        userIds = new KapuaEid[]{null, new KapuaEid()};
+        tokenIds = new String[]{null, "", "!!tokenID-1", "#1(TOKEN.,/token id)9--99", "!$$ 1-2 ID//", "id_tokeN(....)<00>"};
+        expiresOnDates = new Date[]{null, new Date()};
+        refreshTokens = new String[]{null, "", "!!refreshToken-1", "#1(TOKEN.,/refresh token id)9--99", "!$$ 1-2 REFREsh//", "refresh_tokeN(....)<00>"};
+        refreshExpiresOnDates = new Date[]{null, new Date()};
+        accessToken = Mockito.mock(AccessToken.class);
+        expiresOn = new Date();
+        refreshExpiresOn = new Date();
+        invalidatedOn = new Date();
+        modifiedOn = new Date();
+        createdOn = new Date();
+
+        Mockito.when(accessToken.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessToken.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getUserId()).thenReturn(new KapuaEid(KapuaId.ONE));
+        Mockito.when(accessToken.getTokenId()).thenReturn("token id");
+        Mockito.when(accessToken.getExpiresOn()).thenReturn(expiresOn);
+        Mockito.when(accessToken.getRefreshToken()).thenReturn("refresh token");
+        Mockito.when(accessToken.getRefreshExpiresOn()).thenReturn(refreshExpiresOn);
+        Mockito.when(accessToken.getInvalidatedOn()).thenReturn(invalidatedOn);
+        Mockito.when(accessToken.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(accessToken.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessToken.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessToken.getOptlock()).thenReturn(10);
+
+        accessTokenImpl1 = new AccessTokenImpl();
+        accessTokenImpl2 = new AccessTokenImpl(KapuaId.ONE, new KapuaEid(KapuaId.ONE), "tokenId", expiresOn, "refreshToken", refreshExpiresOn);
+        accessTokenImpl3 = new AccessTokenImpl(KapuaId.ONE);
+        accessTokenImpl4 = new AccessTokenImpl(accessToken);
+    }
+
+    @Test
+    public void accessTokenImplWithoutParametersTest() {
+        AccessTokenImpl accessTokenImpl = new AccessTokenImpl();
+        assertNull("Null expected.", accessTokenImpl.getScopeId());
+        assertNull("Null expected.", accessTokenImpl.getUserId());
+        assertNull("Null expected.", accessTokenImpl.getTokenId());
+        assertNull("Null expected.", accessTokenImpl.getExpiresOn());
+        assertNull("Null expected.", accessTokenImpl.getRefreshToken());
+        assertNull("Null expected.", accessTokenImpl.getRefreshExpiresOn());
+    }
+
+    @Test
+    public void accessTokenImplMultipleParametersTest() {
+        for (KapuaId scopeId : scopeIds) {
+            for (KapuaId userId : userIds) {
+                for (String tokenId : tokenIds) {
+                    for (Date expiresOnDate : expiresOnDates) {
+                        for (String refreshToken : refreshTokens) {
+                            for (Date refreshExpiresOnDate : refreshExpiresOnDates) {
+                                AccessTokenImpl accessTokenImpl = new AccessTokenImpl(scopeId, userId, tokenId, expiresOnDate, refreshToken, refreshExpiresOnDate);
+                                assertEquals("Expected and actual values should be the same.", scopeId, accessTokenImpl.getScopeId());
+                                assertEquals("Expected and actual values should be the same.", userId, accessTokenImpl.getUserId());
+                                assertEquals("Expected and actual values should be the same.", tokenId, accessTokenImpl.getTokenId());
+                                assertEquals("Expected and actual values should be the same.", expiresOnDate, accessTokenImpl.getExpiresOn());
+                                assertEquals("Expected and actual values should be the same.", refreshToken, accessTokenImpl.getRefreshToken());
+                                assertEquals("Expected and actual values should be the same.", refreshExpiresOnDate, accessTokenImpl.getRefreshExpiresOn());
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    @Test
+    public void accessTokenImplScopeIdParameterTest() {
+        for (KapuaId scopeId : scopeIds) {
+            AccessTokenImpl accessTokenImpl = new AccessTokenImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, accessTokenImpl.getScopeId());
+            assertNull("Null expected.", accessTokenImpl.getUserId());
+            assertNull("Null expected.", accessTokenImpl.getTokenId());
+            assertNull("Null expected.", accessTokenImpl.getExpiresOn());
+            assertNull("Null expected.", accessTokenImpl.getRefreshToken());
+            assertNull("Null expected.", accessTokenImpl.getRefreshExpiresOn());
+        }
+    }
+
+    @Test
+    public void accessTokenImplAccessTokenParameterTest() throws KapuaException {
+        AccessTokenImpl accessTokenImpl = new AccessTokenImpl(accessToken);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", new KapuaEid(KapuaId.ONE), accessTokenImpl.getUserId());
+        assertEquals("Expected and actual values should be the same.", "token id", accessTokenImpl.getTokenId());
+        assertEquals("Expected and actual values should be the same.", expiresOn, accessTokenImpl.getExpiresOn());
+        assertEquals("Expected and actual values should be the same.", "refresh token", accessTokenImpl.getRefreshToken());
+        assertEquals("Expected and actual values should be the same.", refreshExpiresOn, accessTokenImpl.getRefreshExpiresOn());
+        assertEquals("Expected and actual values should be the same.", invalidatedOn, accessTokenImpl.getInvalidatedOn());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, accessTokenImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", 10, accessTokenImpl.getOptlock());
+    }
+
+    @Test
+    public void setAndGetUserIdTest() {
+        KapuaId[] newUserIds = {null, KapuaId.ANY};
+        for (KapuaId newUserId : newUserIds) {
+            accessTokenImpl1.setUserId(newUserId);
+            accessTokenImpl2.setUserId(newUserId);
+            accessTokenImpl3.setUserId(newUserId);
+            accessTokenImpl4.setUserId(newUserId);
+
+            assertEquals("Expected and actual values should be the same.", newUserId, accessTokenImpl1.getUserId());
+            assertEquals("Expected and actual values should be the same.", newUserId, accessTokenImpl2.getUserId());
+            assertEquals("Expected and actual values should be the same.", newUserId, accessTokenImpl3.getUserId());
+            assertEquals("Expected and actual values should be the same.", newUserId, accessTokenImpl4.getUserId());
+        }
+    }
+
+    @Test
+    public void setAndGetTokenIdTest() {
+        String[] newTokenIds = {null, "", "!!NEWtokenID-1", "#1(TOKEN.,/token NEW id)9--99", "!$$ 1-2 newID//", "id_tokeN(newID)<00>"};
+        for (String newTokenId : newTokenIds) {
+            accessTokenImpl1.setTokenId(newTokenId);
+            accessTokenImpl2.setTokenId(newTokenId);
+            accessTokenImpl3.setTokenId(newTokenId);
+            accessTokenImpl4.setTokenId(newTokenId);
+
+            assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenImpl1.getTokenId());
+            assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenImpl2.getTokenId());
+            assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenImpl3.getTokenId());
+            assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenImpl4.getTokenId());
+        }
+    }
+
+    @Test
+    public void setAndGetExpiresOnTest() {
+        Date[] newExpiresOnDates = {null, new Date()};
+        for (Date newExpiresOnDate : newExpiresOnDates) {
+            accessTokenImpl1.setExpiresOn(newExpiresOnDate);
+            accessTokenImpl2.setExpiresOn(newExpiresOnDate);
+            accessTokenImpl3.setExpiresOn(newExpiresOnDate);
+            accessTokenImpl4.setExpiresOn(newExpiresOnDate);
+
+            assertEquals("Expected and actual values should be the same.", newExpiresOnDate, accessTokenImpl1.getExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newExpiresOnDate, accessTokenImpl2.getExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newExpiresOnDate, accessTokenImpl3.getExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newExpiresOnDate, accessTokenImpl4.getExpiresOn());
+        }
+    }
+
+    @Test
+    public void prePersistsActionTest() {
+        accessTokenImpl1.setUserId(KapuaId.ANY);
+        assertNull("Null expected.", accessTokenImpl1.getId());
+        assertNull("Null expected.", accessTokenImpl1.getCreatedBy());
+        assertNull("Null expected.", accessTokenImpl1.getCreatedOn());
+        assertNull("Null expected.", accessTokenImpl1.getModifiedBy());
+        assertNull("Null expected.", accessTokenImpl1.getModifiedOn());
+
+        accessTokenImpl1.prePersistsAction();
+        assertNotNull("NotNull expected.", accessTokenImpl1.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessTokenImpl1.getCreatedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl1.getCreatedOn());
+        assertNotNull("NotNullExpected", accessTokenImpl1.getModifiedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl1.getModifiedOn());
+
+        accessTokenImpl2.setUserId(KapuaId.ANY);
+        assertNull("Null expected.", accessTokenImpl2.getId());
+        assertNull("Null expected.", accessTokenImpl2.getCreatedBy());
+        assertNull("Null expected.", accessTokenImpl2.getCreatedOn());
+        assertNull("Null expected.", accessTokenImpl2.getModifiedBy());
+        assertNull("Null expected.", accessTokenImpl2.getModifiedOn());
+
+        accessTokenImpl2.prePersistsAction();
+        assertNotNull("NotNull expected.", accessTokenImpl2.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessTokenImpl2.getCreatedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl2.getCreatedOn());
+        assertNotNull("NotNullExpected", accessTokenImpl2.getModifiedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl2.getModifiedOn());
+
+        accessTokenImpl3.setUserId(KapuaId.ANY);
+        assertNull("Null expected.", accessTokenImpl3.getId());
+        assertNull("Null expected.", accessTokenImpl3.getCreatedBy());
+        assertNull("Null expected.", accessTokenImpl3.getCreatedOn());
+        assertNull("Null expected.", accessTokenImpl3.getModifiedBy());
+        assertNull("Null expected.", accessTokenImpl3.getModifiedOn());
+
+        accessTokenImpl3.prePersistsAction();
+        assertNotNull("NotNull expected.", accessTokenImpl3.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessTokenImpl3.getCreatedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl3.getCreatedOn());
+        assertNotNull("NotNullExpected", accessTokenImpl3.getModifiedBy());
+        assertNotNull("NotNullExpected", accessTokenImpl3.getModifiedOn());
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessTokenImpl4.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl4.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, accessTokenImpl4.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl4.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, accessTokenImpl4.getModifiedOn());
+
+        accessTokenImpl4.prePersistsAction();
+        assertNotEquals("Expected and actual values should not be the same.", KapuaId.ANY, accessTokenImpl4.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl4.getCreatedBy());
+        assertNotEquals("Expected and actual values should not be the same.", createdOn, accessTokenImpl4.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenImpl4.getModifiedBy());
+        assertNotEquals("Expected and actual values should not be the same.", modifiedOn, accessTokenImpl4.getModifiedOn());
+    }
+
+    @Test
+    public void setAndGetRefreshTokenTest() {
+        String[] newRefreshTokens = {null, "", "!!NEW refresh token-1", "#1(TOKEN.REFRESH,/token NEW )9--99", "!$$ 1-2 newRefresh/TOKEN/", "id_tokeN(newrefresh)<00>"};
+        for (String newRefreshToken : newRefreshTokens) {
+            accessTokenImpl1.setRefreshToken(newRefreshToken);
+            accessTokenImpl2.setRefreshToken(newRefreshToken);
+            accessTokenImpl3.setRefreshToken(newRefreshToken);
+            accessTokenImpl4.setRefreshToken(newRefreshToken);
+
+            assertEquals("Expected and actual values should be the same.", newRefreshToken, accessTokenImpl1.getRefreshToken());
+            assertEquals("Expected and actual values should be the same.", newRefreshToken, accessTokenImpl2.getRefreshToken());
+            assertEquals("Expected and actual values should be the same.", newRefreshToken, accessTokenImpl3.getRefreshToken());
+            assertEquals("Expected and actual values should be the same.", newRefreshToken, accessTokenImpl4.getRefreshToken());
+        }
+    }
+
+    @Test
+    public void setAndGetRefreshExpiresOnTest() {
+        Date[] newRefreshExpiresOnDates = {null, new Date()};
+        for (Date newRefreshExpiresOnDate : newRefreshExpiresOnDates) {
+            accessTokenImpl1.setRefreshExpiresOn(newRefreshExpiresOnDate);
+            accessTokenImpl2.setRefreshExpiresOn(newRefreshExpiresOnDate);
+            accessTokenImpl3.setRefreshExpiresOn(newRefreshExpiresOnDate);
+            accessTokenImpl4.setRefreshExpiresOn(newRefreshExpiresOnDate);
+
+            assertEquals("Expected and actual values should be the same.", newRefreshExpiresOnDate, accessTokenImpl1.getRefreshExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newRefreshExpiresOnDate, accessTokenImpl2.getRefreshExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newRefreshExpiresOnDate, accessTokenImpl3.getRefreshExpiresOn());
+            assertEquals("Expected and actual values should be the same.", newRefreshExpiresOnDate, accessTokenImpl4.getRefreshExpiresOn());
+        }
+    }
+
+    @Test
+    public void setAndGetInvalidatedOnTest() {
+        Date[] newInvalidatedOnDates = {null, new Date()};
+        for (Date newInvalidatedOnDate : newInvalidatedOnDates) {
+            accessTokenImpl1.setInvalidatedOn(newInvalidatedOnDate);
+            accessTokenImpl2.setInvalidatedOn(newInvalidatedOnDate);
+            accessTokenImpl3.setInvalidatedOn(newInvalidatedOnDate);
+            accessTokenImpl4.setInvalidatedOn(newInvalidatedOnDate);
+
+            assertEquals("Expected and actual values should be the same.", newInvalidatedOnDate, accessTokenImpl1.getInvalidatedOn());
+            assertEquals("Expected and actual values should be the same.", newInvalidatedOnDate, accessTokenImpl2.getInvalidatedOn());
+            assertEquals("Expected and actual values should be the same.", newInvalidatedOnDate, accessTokenImpl3.getInvalidatedOn());
+            assertEquals("Expected and actual values should be the same.", newInvalidatedOnDate, accessTokenImpl4.getInvalidatedOn());
+        }
+    }
+
+    @Test
+    public void setAndGetTrustKeyTest() {
+        String[] newTrustKeys = {null, "", "!!NEW trust key-1", "#1(TRUST.key,/KEY NEW )9--99", "!$$ 1-2 newTrust/KEY/", "nEwTrUstKEY(0--trustkey)<00>"};
+        for (String newTrustKey : newTrustKeys) {
+            accessTokenImpl1.setTrustKey(newTrustKey);
+            accessTokenImpl2.setTrustKey(newTrustKey);
+            accessTokenImpl3.setTrustKey(newTrustKey);
+            accessTokenImpl4.setTrustKey(newTrustKey);
+
+            assertEquals("Expected and actual values should be the same.", newTrustKey, accessTokenImpl1.getTrustKey());
+            assertEquals("Expected and actual values should be the same.", newTrustKey, accessTokenImpl2.getTrustKey());
+            assertEquals("Expected and actual values should be the same.", newTrustKey, accessTokenImpl3.getTrustKey());
+            assertEquals("Expected and actual values should be the same.", newTrustKey, accessTokenImpl4.getTrustKey());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImplTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AccessTokenQueryImplTest extends Assert {
+
+    @Test
+    public void accessTokenQueryImplTest() throws Exception {
+        Constructor<AccessTokenQueryImpl> accessTokenQueryImpl = AccessTokenQueryImpl.class.getDeclaredConstructor();
+        accessTokenQueryImpl.setAccessible(true);
+        accessTokenQueryImpl.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(accessTokenQueryImpl.getModifiers()));
+    }
+
+    @Test
+    public void accessTokenQueryImplTestScopeIdParameterTest() {
+        AccessTokenQueryImpl accessTokenQueryImpl = new AccessTokenQueryImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessTokenQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void accessTokenQueryImplTestNullScopeIdParameterTest() {
+        AccessTokenQueryImpl accessTokenQueryImpl = new AccessTokenQueryImpl(null);
+        assertNull("Null expected.", accessTokenQueryImpl.getScopeId());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/LoginInfoImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/token/shiro/LoginInfoImplTest.java
@@ -1,0 +1,99 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.token.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class LoginInfoImplTest extends Assert {
+
+    LoginInfoImpl loginInfoImpl;
+    Set<RolePermission> rolePermissions;
+    Set<AccessPermission> accessPermissions;
+
+    @Before
+    public void initialize() {
+        loginInfoImpl = new LoginInfoImpl();
+        rolePermissions = new HashSet<>();
+        accessPermissions = new HashSet<>();
+    }
+
+    @Test
+    public void setAndGetAccessTokenTest() {
+        AccessToken[] accessTokens = {null, Mockito.mock(AccessToken.class)};
+        assertNull("Null expected.", loginInfoImpl.getAccessToken());
+        for (AccessToken accessToken : accessTokens) {
+            loginInfoImpl.setAccessToken(accessToken);
+            assertEquals("Expected and actual values should be the same.", accessToken, loginInfoImpl.getAccessToken());
+        }
+    }
+
+    @Test
+    public void setAndGetRolePermissionEmptySetTest() {
+        assertNull("Null expected.", loginInfoImpl.getRolePermission());
+        loginInfoImpl.setRolePermission(rolePermissions);
+        assertEquals("Expected and actual values should be the same.", rolePermissions, loginInfoImpl.getRolePermission());
+    }
+
+    @Test
+    public void setAndGetRolePermissionTest() {
+        rolePermissions.add(Mockito.mock(RolePermission.class));
+        rolePermissions.add(Mockito.mock(RolePermission.class));
+
+        assertNull("Null expected.", loginInfoImpl.getRolePermission());
+        loginInfoImpl.setRolePermission(rolePermissions);
+        assertEquals("Expected and actual values should be the same.", rolePermissions, loginInfoImpl.getRolePermission());
+    }
+
+    @Test
+    public void setAndGetRolePermissionNullTest() {
+        assertNull("Null expected.", loginInfoImpl.getRolePermission());
+        loginInfoImpl.setRolePermission(null);
+        assertNull("Null expected.", loginInfoImpl.getRolePermission());
+    }
+
+    @Test
+    public void setAndGetAccessPermissionEmptySetTest() {
+        assertNull("Null expected.", loginInfoImpl.getAccessPermission());
+        loginInfoImpl.setAccessPermission(accessPermissions);
+        assertEquals("Expected and actual values should be the same.", accessPermissions, loginInfoImpl.getAccessPermission());
+    }
+
+    @Test
+    public void setAndGetAccessPermissionTest() {
+        accessPermissions.add(Mockito.mock(AccessPermission.class));
+        accessPermissions.add(Mockito.mock(AccessPermission.class));
+
+        assertNull("Null expected.", loginInfoImpl.getAccessPermission());
+        loginInfoImpl.setAccessPermission(accessPermissions);
+        assertEquals("Expected and actual values should be the same.", accessPermissions, loginInfoImpl.getAccessPermission());
+    }
+
+    @Test
+    public void setAndGetAccessPermissionNullTest() {
+        assertNull("Null expected.", loginInfoImpl.getAccessPermission());
+        loginInfoImpl.setAccessPermission(null);
+        assertNull("Null expected.", loginInfoImpl.getAccessPermission());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in token package:
 - AccessTokenCreatorImpl class
 - AccessTokenEntityManagerFactory class
 - AccessTokenFactoryImpl class
 - AccessTokenImpl class
 - AccessTokenQueryImpl class
 - LoginInfoImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
