### PR TITLE
Added JUnit tests for AccessInfo classes 

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoCreatorImplTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoCreatorImplTest.java
@@ -1,0 +1,139 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
+import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoCreatorImpl;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class AccessInfoCreatorImplTest extends Assert {
+
+    AccessInfoFactory accessInfoFactory;
+    AccessInfoCreator accessInfoCreator;
+    Set<KapuaId> roleId;
+    Set<Permission> setPermission;
+    AccessInfoCreatorImpl accessInfoCreatorImpl1, accessInfoCreatorImpl2;
+
+    @Before
+    public void initialize() {
+        accessInfoFactory = KapuaLocator.getInstance().getFactory(AccessInfoFactory.class);
+        accessInfoCreator = accessInfoFactory.newCreator(KapuaId.ONE);
+        roleId = new HashSet<>();
+        setPermission = new HashSet<>();
+        roleId.add(KapuaId.ANY);
+        setPermission.add(Mockito.mock(Permission.class));
+        accessInfoCreator.setScopeId(KapuaId.ONE);
+        accessInfoCreator.setUserId(KapuaId.ONE);
+        accessInfoCreator.setRoleIds(roleId);
+        accessInfoCreator.setPermissions(setPermission);
+
+        accessInfoCreatorImpl1 = new AccessInfoCreatorImpl(accessInfoCreator);
+        accessInfoCreatorImpl2 = new AccessInfoCreatorImpl(KapuaId.ONE);
+    }
+
+    @Test
+    public void accessInfoCreatorImplAccessInfoCreatorParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoCreatorImpl1.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoCreatorImpl1.getUserId());
+        assertEquals("Expected and actual values should be the same.", roleId, accessInfoCreatorImpl1.getRoleIds());
+        assertEquals("Expected and actual values should be the same.", setPermission, accessInfoCreatorImpl1.getPermissions());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessInfoCreatorImplNullAccessInfoCreatorParameterTest() {
+        accessInfoCreatorImpl1 = new AccessInfoCreatorImpl((AccessInfoCreator) null);
+    }
+
+    @Test
+    public void accessInfoCreatorScopeIdParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoCreatorImpl2.getScopeId());
+        assertNull("Null expected.", accessInfoCreatorImpl2.getUserId());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getRoleIds().isEmpty());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getPermissions().isEmpty());
+    }
+
+    @Test
+    public void accessInfoCreatorNullScopeIdParameterTest() {
+        accessInfoCreatorImpl2 = new AccessInfoCreatorImpl((KapuaId) null);
+
+        assertNull("Null expected.", accessInfoCreatorImpl2.getScopeId());
+        assertNull("Null expected.", accessInfoCreatorImpl2.getUserId());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getRoleIds().isEmpty());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getPermissions().isEmpty());
+    }
+
+    @Test
+    public void setAndGetUserIdTest() {
+        accessInfoCreatorImpl1.setUserId(KapuaId.ANY);
+        accessInfoCreatorImpl2.setUserId(KapuaId.ANY);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessInfoCreatorImpl1.getUserId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessInfoCreatorImpl2.getUserId());
+
+        accessInfoCreatorImpl1.setUserId(null);
+        accessInfoCreatorImpl2.setUserId(null);
+        assertNull("Null expected.", accessInfoCreatorImpl1.getUserId());
+        assertNull("Null expected.", accessInfoCreatorImpl2.getUserId());
+    }
+
+    @Test
+    public void setAndGetRoleIdsTest() {
+        Set<KapuaId> newRoleIds = new HashSet<>();
+        newRoleIds.add(KapuaId.ANY);
+        newRoleIds.add(KapuaId.ONE);
+
+        accessInfoCreatorImpl1.setRoleIds(newRoleIds);
+        accessInfoCreatorImpl2.setRoleIds(newRoleIds);
+
+        assertEquals("Expected and actual values should be the same.", newRoleIds, accessInfoCreatorImpl1.getRoleIds());
+        assertEquals("Expected and actual values should be the same.", newRoleIds, accessInfoCreatorImpl2.getRoleIds());
+
+        accessInfoCreatorImpl1.setRoleIds(null);
+        accessInfoCreatorImpl2.setRoleIds(null);
+        assertTrue("True expected.", accessInfoCreatorImpl1.getRoleIds().isEmpty());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getRoleIds().isEmpty());
+    }
+
+    @Test
+    public void setAndGetPermissionsTest() {
+        Set<Permission> newPermissions = new HashSet<>();
+        newPermissions.add(Mockito.mock(Permission.class));
+        newPermissions.add(Mockito.mock(Permission.class));
+
+        accessInfoCreatorImpl1.setPermissions(newPermissions);
+        accessInfoCreatorImpl2.setPermissions(newPermissions);
+
+        assertEquals("Expected and actual values should be the same.", newPermissions, accessInfoCreatorImpl1.getPermissions());
+        assertEquals("Expected and actual values should be the same.", newPermissions, accessInfoCreatorImpl2.getPermissions());
+
+        accessInfoCreatorImpl1.setPermissions(null);
+        accessInfoCreatorImpl2.setPermissions(null);
+        assertNotNull("NotNull expected.", accessInfoCreatorImpl1.getPermissions());
+        assertNotNull("NotNull expected.", accessInfoCreatorImpl2.getPermissions());
+        assertTrue("True expected.", accessInfoCreatorImpl1.getPermissions().isEmpty());
+        assertTrue("True expected.", accessInfoCreatorImpl2.getPermissions().isEmpty());
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoDAOTest.java
@@ -1,0 +1,295 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
+import org.eclipse.kapua.service.authorization.access.AccessInfoListResult;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoDAO;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class AccessInfoDAOTest extends Assert {
+
+    EntityManager entityManager;
+    AccessInfoCreator accessInfoCreator;
+   KapuaId scopeId, accessInfoId;
+    AccessInfoImpl entityToFindOrDelete;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        accessInfoCreator = Mockito.mock(AccessInfoCreator.class);
+        scopeId = KapuaId.ONE;
+        accessInfoId = KapuaId.ANY;
+        entityToFindOrDelete = Mockito.mock(AccessInfoImpl.class);
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessInfoDAO.create(entityManager, accessInfoCreator) instanceof AccessInfo);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessInfoDAO.create(entityManager, accessInfoCreator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessInfoDAO.create(entityManager, accessInfoCreator).getUserId());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        AccessInfoDAO.create(entityManager, accessInfoCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithoutCauseTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        AccessInfoDAO.create(entityManager, accessInfoCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithNotSQLCauseTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        AccessInfoDAO.create(entityManager, accessInfoCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        AccessInfoDAO.create(entityManager, accessInfoCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+
+        AccessInfoDAO.create(null, accessInfoCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullAccessInfoCreatorTest() throws KapuaException {
+        Mockito.when(accessInfoCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfoCreator.getUserId()).thenReturn(KapuaId.ONE);
+
+        AccessInfoDAO.create(entityManager, (AccessInfoCreator) null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessInfoDAO.find(entityManager, scopeId, accessInfoId) instanceof AccessInfo);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessInfoDAO.find(entityManager, scopeId, accessInfoId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", AccessInfoDAO.find(entityManager, scopeId, accessInfoId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(null);
+
+        assertNull("Null expected.", AccessInfoDAO.find(entityManager, scopeId, accessInfoId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", AccessInfoDAO.find(entityManager, scopeId, accessInfoId) instanceof AccessInfo);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        AccessInfoDAO.find(null, scopeId, accessInfoId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessInfoDAO.find(entityManager, null, accessInfoId) instanceof AccessInfo);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessInfoDAO.find(entityManager, null, accessInfoId).getScopeId());
+    }
+
+    @Test
+    public void findNullAccessInfoIdTest() {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessInfoDAO.find(entityManager, scopeId, null) instanceof AccessInfo);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessInfoDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessInfoImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessInfoImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<AccessInfoImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessInfoImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessInfoImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", AccessInfoDAO.query(entityManager, kapuaQuery) instanceof AccessInfoListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        AccessInfoDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessInfoImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessInfoImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessInfoImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<AccessInfoImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessInfoImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessInfoImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        AccessInfoDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessInfoImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessInfoImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, AccessInfoDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        AccessInfoDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        AccessInfoDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessInfoDAO.delete(entityManager, scopeId, accessInfoId) instanceof AccessInfo);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        AccessInfoDAO.delete(null, scopeId, accessInfoId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessInfoDAO.delete(entityManager, null, accessInfoId) instanceof AccessInfo);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullAccessInfoIdIdTest() throws KapuaEntityNotFoundException {
+        AccessInfoDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(null);
+
+        AccessInfoDAO.delete(entityManager, scopeId, accessInfoId);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheFactoryTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.commons.service.internal.cache.EntityCache;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AccessInfoCacheFactoryTest extends Assert {
+
+    AccessInfoCacheFactory accessInfoCacheFactory;
+
+    @Before
+    public void initialize() {
+        accessInfoCacheFactory = new AccessInfoCacheFactory();
+    }
+
+    @Test
+    public void accessInfoCacheFactoryTest() {
+        assertEquals("Expected and actual values should be the same.", "AccessInfoId", accessInfoCacheFactory.getEntityIdCacheName());
+    }
+
+    @Test
+    public void createCacheTest() {
+        assertTrue("True expected.", accessInfoCacheFactory.createCache() instanceof EntityCache);
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertEquals("Expected and actual values should be the same.", "AccessInfoId", AccessInfoCacheFactory.getInstance().getEntityIdCacheName());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoCacheTest.java
@@ -1,0 +1,162 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AccessInfoCacheTest extends Assert {
+
+    String[] idCacheNames, nameCacheNames;
+    AccessInfo kapuaEntity;
+
+    @Before
+    public void initialize() {
+        idCacheNames = new String[]{"", " id 123<> cache(*&% NAME", ")(87CASHE name ^%$id", "98ID <id>     name%$^#62522", ",, #@IDcacheNAME-09", "cache_ID 0998@#$", "C12_...cache==_NAME ID   "};
+        nameCacheNames = new String[]{"", "name &^5CACHE-name;'...,,,   ", "!@@@name123CACHE ;,.,,name", "cache--987name,*(NAME", "CACHE      32%$#$%^ name", "CaChE 098)  (name     "};
+        kapuaEntity = Mockito.mock(AccessInfo.class);
+    }
+
+    @Test
+    public void accessInfoCacheTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                assertNotNull("NotNull expected.", accessInfoCache.accessInfoByUserIdCache);
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessInfoCacheNullIdCacheNameTest() {
+        for (String nameCacheName : nameCacheNames) {
+            new AccessInfoCache(null, nameCacheName);
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessInfoCacheNullNameCacheNameTest() {
+        for (String idCacheName : idCacheNames) {
+            new AccessInfoCache(idCacheName, null);
+        }
+    }
+
+    @Test
+    public void getByUserIdTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                //COMMENT: This method always returns null, due to method get(Object key) in Cache.java which always returns null
+                assertNull("Null expected.", accessInfoCache.getByUserId(KapuaId.ONE, KapuaId.ONE));
+            }
+        }
+    }
+
+    @Test
+    public void getByUserIdNullScopeIdTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                //COMMENT: This method always returns null, due to method get(Object key) in Cache.java which always returns null
+                assertNull("Null expected.", accessInfoCache.getByUserId(null, KapuaId.ONE));
+            }
+        }
+    }
+
+    @Test
+    public void getByNullUserIdTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                assertNull("Null expected.", accessInfoCache.getByUserId(KapuaId.ONE, null));
+            }
+        }
+    }
+
+    @Test
+    public void putTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                try {
+                    accessInfoCache.put(kapuaEntity);
+                } catch (Exception e) {
+                    fail("Exception not expected.");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void putNullEntityTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                try {
+                    accessInfoCache.put(null);
+                } catch (Exception e) {
+                    fail("Exception not expected.");
+                }
+            }
+        }
+    }
+
+    @Test
+    public void removeTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                //COMMENT: kapuaEntity is always null(see method get(Object key) in Cache.java which always returns null)
+                // Due to that reason the following part of code could not be tested in AccessInfoCache.java:
+                //          if (kapuaEntity != null) {
+                //            accessInfoByUserIdCache.remove(((AccessInfo) kapuaEntity).getUserId());
+                //        }
+                //and this method always returns null
+                assertNull("Null expected.", accessInfoCache.remove(KapuaId.ONE, KapuaId.ONE));
+            }
+        }
+    }
+
+    @Test
+    public void removeNullScopeIdTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                //COMMENT: kapuaEntity is always null(see method get(Object key) in Cache.java which always returns null)
+                // Due to that reason the following part of code could not be tested in AccessInfoCache.java:
+                //          if (kapuaEntity != null) {
+                //            accessInfoByUserIdCache.remove(((AccessInfo) kapuaEntity).getUserId());
+                //        }
+                //and this method always returns null
+                assertNull("Null expected.", accessInfoCache.remove(null, KapuaId.ONE));
+            }
+        }
+    }
+
+    @Test
+    public void removeNullKapuaIdTest() {
+        for (String idCacheName : idCacheNames) {
+            for (String nameCacheName : nameCacheNames) {
+                AccessInfoCache accessInfoCache = new AccessInfoCache(idCacheName, nameCacheName);
+                assertNull("Null expected.", accessInfoCache.remove(KapuaId.ONE, (KapuaId) null));
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImplTest.java
@@ -1,0 +1,124 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
+import org.eclipse.kapua.service.authorization.access.AccessInfoListResult;
+import org.eclipse.kapua.service.authorization.access.AccessInfoQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessInfoFactoryImplTest extends Assert {
+
+    AccessInfoFactoryImpl accessInfoFactoryImpl;
+    KapuaId scopeId;
+    AccessInfo accessInfo;
+    Date createdOn,modifiedOn;
+
+
+    @Before
+    public void initialize() {
+        accessInfoFactoryImpl = new AccessInfoFactoryImpl();
+        scopeId = KapuaId.ONE;
+        accessInfo = Mockito.mock(AccessInfo.class);
+        createdOn = new Date();
+        modifiedOn = new Date();
+
+        Mockito.when(accessInfo.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfo.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessInfo.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfo.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessInfo.getModifiedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessInfo.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(accessInfo.getOptlock()).thenReturn(11);
+        Mockito.when(accessInfo.getUserId()).thenReturn(KapuaId.ANY);
+    }
+
+    @Test
+    public void newEntityTest() {
+        AccessInfo accessInfo = accessInfoFactoryImpl.newEntity(scopeId);
+
+        assertNull("Null expected.", accessInfo.getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        AccessInfo accessInfo = accessInfoFactoryImpl.newEntity(null);
+
+        assertNull("Null expected.", accessInfo.getScopeId());
+    }
+
+    @Test
+    public void newCreatorTest() {
+        AccessInfoCreator accessInfoCreator = accessInfoFactoryImpl.newCreator(scopeId);
+
+        assertEquals("Expected and actual values should be the same.", scopeId, accessInfoCreator.getScopeId());
+    }
+
+    @Test
+    public void newCreatorNullTest() {
+        AccessInfoCreator accessInfoCreator = accessInfoFactoryImpl.newCreator(null);
+
+        assertNull("Null expected.", accessInfoCreator.getScopeId());
+    }
+
+    @Test
+    public void newQueryTest() {
+        AccessInfoQuery accessInfoQuery = accessInfoFactoryImpl.newQuery(scopeId);
+
+        assertEquals("Expected and actual values should be the same.", scopeId, accessInfoQuery.getScopeId());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        AccessInfoQuery accessInfoQuery = accessInfoFactoryImpl.newQuery(null);
+
+        assertNull("Null expected.", accessInfoQuery.getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        AccessInfoListResult accessInfoListResult = accessInfoFactoryImpl.newListResult();
+
+        assertTrue("True expected.", accessInfoListResult.isEmpty());
+    }
+
+    @Test
+    public void cloneTest() {
+        AccessInfo resultAccessInfo = accessInfoFactoryImpl.clone(accessInfo);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessInfo.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessInfo.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessInfo.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultAccessInfo.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessInfo.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, resultAccessInfo.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 11, resultAccessInfo.getOptlock());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessInfo.getUserId());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        accessInfoFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoImplTest.java
@@ -1,0 +1,109 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessInfo;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessInfoImplTest extends Assert {
+
+    AccessInfo accessInfo;
+    Date modifiedOn, createdOn;
+
+    @Before
+    public void initialize() {
+        accessInfo = Mockito.mock(AccessInfo.class);
+        modifiedOn = new Date();
+        createdOn = new Date();
+
+        Mockito.when(accessInfo.getUserId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessInfo.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(accessInfo.getModifiedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfo.getOptlock()).thenReturn(10);
+        Mockito.when(accessInfo.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessInfo.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessInfo.getCreatedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessInfo.getCreatedOn()).thenReturn(createdOn);
+    }
+
+    @Test
+    public void accessInfoImplWithoutParametersTest() {
+        AccessInfoImpl accessInfoImpl = new AccessInfoImpl();
+
+        assertNull("Null expected.", accessInfoImpl.getScopeId());
+        assertNull("Null expected.", accessInfoImpl.getUserId());
+    }
+
+    @Test
+    public void accessInfoImplScopeIdParameterTest() {
+        AccessInfoImpl accessInfoImpl = new AccessInfoImpl(KapuaId.ONE);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoImpl.getScopeId());
+        assertNull("Null expected.", accessInfoImpl.getUserId());
+    }
+
+    @Test
+    public void accessInfoImplNullScopeIdParameterTest() {
+        AccessInfoImpl accessInfoImpl = new AccessInfoImpl((KapuaId) null);
+
+        assertNull("Null expected.", accessInfoImpl.getScopeId());
+        assertNull("Null expected.", accessInfoImpl.getUserId());
+    }
+
+    @Test
+    public void accessInfoImplAccessInfoParameterTest() throws KapuaException {
+        AccessInfoImpl accessInfoImpl = new AccessInfoImpl(accessInfo);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessInfoImpl.getUserId());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, accessInfoImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoImpl.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", 10, accessInfoImpl.getOptlock());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessInfoImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessInfoImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, accessInfoImpl.getCreatedOn());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessInfoImplNullAccessInfoParameterTest() throws KapuaException {
+        new AccessInfoImpl((AccessInfo) null);
+    }
+
+    @Test
+    public void setAndGetUserId() throws KapuaException {
+        KapuaId[] newUserIds = {null, KapuaId.ONE};
+        AccessInfoImpl accessInfoImpl1 = new AccessInfoImpl();
+        AccessInfoImpl accessInfoImpl2 = new AccessInfoImpl(KapuaId.ONE);
+        AccessInfoImpl accessInfoImpl3 = new AccessInfoImpl(accessInfo);
+
+        for (KapuaId newUserId : newUserIds) {
+            accessInfoImpl1.setUserId(newUserId);
+            accessInfoImpl2.setUserId(newUserId);
+            accessInfoImpl3.setUserId(newUserId);
+
+            assertEquals("Expected and actual values should be the same.", newUserId, accessInfoImpl1.getUserId());
+            assertEquals("Expected and actual values should be the same.", newUserId, accessInfoImpl2.getUserId());
+            assertEquals("Expected and actual values should be the same.", newUserId, accessInfoImpl3.getUserId());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImplTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AccessInfoQueryImplTest extends Assert {
+
+    @Test
+    public void accessInfoQueryImplWithoutParameterTest() {
+        AccessInfoQueryImpl accessInfoQueryImpl = new AccessInfoQueryImpl();
+
+        assertNull("Null expected.", accessInfoQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void accessInfoQueryImplScopeIdParameterTest() {
+        AccessInfoQueryImpl accessInfoQueryImpl = new AccessInfoQueryImpl(KapuaId.ONE);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessInfoQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void accessInfoQueryImplNullScopeIdParameterTest() {
+        AccessInfoQueryImpl accessInfoQueryImpl = new AccessInfoQueryImpl(null);
+
+        assertNull("Null expected.", accessInfoQueryImpl.getScopeId());
+    }
+}


### PR DESCRIPTION
Added JUnit tests for classes from shiro module in authorization/access/shiro package:
 - AccessInfoCacheFactory class
 - AccessInfoCache class
 - AccessInfoFactoryImpl class
 - AccessInfoImpl class
 - AccessInfoQueryImpl class
 - AccessInfoCreatorImpl class
 - AccessInfoDAO class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
