### PR TITLE
Added isValid check before enabling Submit button on ActionDialog

### DIFF
--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/dialog/ActionDialog.java
@@ -35,7 +35,6 @@ import com.google.gwt.user.client.Event;
 import com.google.gwt.user.client.Timer;
 import com.google.gwt.user.client.Window;
 import com.google.gwt.user.client.rpc.AsyncCallback;
-
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
@@ -243,7 +242,7 @@ public abstract class ActionDialog extends KapuaDialog {
 
     public void setSubmitButtonState() {
         if (submitButton != null) {
-            if (formPanel.isDirty() || dateValueNotNull) {
+            if ((formPanel.isDirty() || dateValueNotNull) && formPanel.isValid(true)) {
                 submitButton.enable();
             } else {
                 submitButton.disable();


### PR DESCRIPTION
This PR add a missing check on the enable/disable control of the `SubmitButton` in the `ActionDialog`, which caused the `SubmitButton` to be enabled even if the form contained erros.

**Related Issue**
_None_

**Description of the solution adopted**
Added  `formPanel.isValid()` to the `if` statements that handles the enablement.

**Screenshots**
_None_

**Any side note on the changes made**
_None_