### PR TITLE
Introduced usage of ConfigurationPrinter in some classes

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/router/EndPointContainer.java
@@ -12,14 +12,13 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core.router;
 
-import java.util.ArrayList;
-import java.util.List;
-
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlAnyElement;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
+import java.util.ArrayList;
+import java.util.List;
 
 @XmlRootElement(name = "endPoints")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -31,11 +30,14 @@ public class EndPointContainer {
     private List<EndPoint> endPoints;
 
     public EndPointContainer() {
-        endPoints = new ArrayList<>();
     }
 
     @XmlAnyElement
     public List<EndPoint> getEndPoints() {
+        if (endPoints == null) {
+            endPoints = new ArrayList<>();
+        }
+
         return endPoints;
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -124,17 +124,16 @@ public class KapuaLiquibaseClient {
                 .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                 .withTitle("KapuaLiquibaseClient Configuration")
                 .addParameter("Liquibase Version", currentLiquibaseVersionString)
-                .addHeader("DB connection info")
-                .increaseIndentation()
+                .openSection("DB connection info")
                 .addParameter("JDBC URL", jdbcUrl)
                 .addParameter("Username", username)
                 .addParameter("Password", "******")
                 .addParameter("Schema", schema)
-                .decreaseIndentation()
-                .addHeader("Timestamp(3) fix info (eclipse/kapua#2889)")
-                .increaseIndentation()
+                .closeSection()
+                .openSection("Timestamp(3) fix info (eclipse/kapua#2889)")
                 .addParameter("Force timestamp fix", forceTimestampFix)
                 .addParameter("Apply timestamp fix", runTimestampsFix)
+                .closeSection()
                 .printLog();
     }
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/log/ConfigurationPrinter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/log/ConfigurationPrinter.java
@@ -243,6 +243,34 @@ public class ConfigurationPrinter {
     }
 
     /**
+     * Shortcut method for:
+     * <pre>
+     *      addHeader(name);
+     *      increaseIndentation();
+     * </pre>
+     *
+     * @param name The name of the {@link ConfigurationHeader}
+     * @return Itself, to chain method invocation.
+     * @since 1.5.0
+     */
+    public ConfigurationPrinter openSection(@NotNull String name) {
+        addHeader(name);
+        increaseIndentation();
+        return this;
+    }
+
+    /**
+     * Same as {@link #decreaseIndentation()} but to be used in combination with {@link #openSection(String)}
+     *
+     * @return Itself, to chain method invocation.
+     * @since 1.5.0
+     */
+    public ConfigurationPrinter closeSection() {
+        decreaseIndentation();
+        return this;
+    }
+
+    /**
      * Increases the indentation of the printed configuration.
      * <p>
      * It prints a {@code \t} for each indentation added.

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
@@ -13,8 +13,8 @@
 package org.eclipse.kapua.app.console.core.servlet;
 
 import org.apache.http.client.utils.URIBuilder;
-import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.app.console.core.server.util.SsoHelper;
+import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
 import org.eclipse.kapua.plugin.sso.openid.OpenIDLocator;
 import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDAccessTokenException;
@@ -64,15 +64,17 @@ public class SsoCallbackServlet extends HttpServlet {
                         .withLogger(logger)
                         .withLogLevel(ConfigurationPrinter.LogLevel.DEBUG)
                         .withTitle("SSO Servlet Log")
-                        .addHeader("SSO servlet request:")
-                        .increaseIndentation()
+                        .openSection("SSO servlet request")
                         .addParameter("Request URL", req.getRequestURL())
                         .addParameter("AuthCode", HIDDEN_SECRET)
-                        .decreaseIndentation();
+                        .closeSection();
         try {
             homeUri = SsoHelper.getHomeUri();
-            httpReqLogger.addHeader("SSO servlet response:");
-            httpReqLogger.increaseIndentation().addParameter("Response URI", homeUri);
+
+            httpReqLogger
+                    .openSection("SSO servlet response")
+                    .addParameter("Response URI", homeUri);
+
             final URIBuilder redirect = new URIBuilder(homeUri);
 
             if (authCode != null) {

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClientProvider.java
@@ -106,40 +106,45 @@ public class RestElasticsearchClientProvider implements ElasticsearchClientProvi
                             .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                             .withTitle("Elasticsearch REST Provider Configuration")
                             .addParameter("Module Name", getClientConfiguration().getModuleName())
-                            .addParameter("Cluster Name", getClientConfiguration().getClusterName())
-                            .addHeader("Nodes")
-                            .increaseIndentation();
+                            .addParameter("Cluster Name", getClientConfiguration().getClusterName());
 
-            int nodesIndex = 1;
-            for (ElasticsearchNode node : getClientConfiguration().getNodes()) {
-                configurationPrinter
-                        .addHeader("# " + nodesIndex++)
-                        .increaseIndentation()
-                        .addParameter("Host", node.getAddress())
-                        .addParameter("Port", node.getPort())
-                        .decreaseIndentation();
+            try {
+                configurationPrinter.openSection("Nodes");
+
+                int nodesIndex = 1;
+                for (ElasticsearchNode node : getClientConfiguration().getNodes()) {
+                    configurationPrinter
+                            .openSection("# " + nodesIndex++)
+                            .addParameter("Host", node.getAddress())
+                            .addParameter("Port", node.getPort())
+                            .closeSection();
+                }
+            } finally {
+                configurationPrinter.closeSection();
             }
 
             // SSL Configuration
-            configurationPrinter
-                    .decreaseIndentation()
-                    .addHeader("SSL Layer")
-                    .increaseIndentation()
-                    .addParameter("Is Enabled", getClientSslConfiguration().isEnabled());
-
-            if (getClientSslConfiguration().isEnabled()) {
+            try {
                 configurationPrinter
-                        .addParameter("Key Store Path", getClientSslConfiguration().getKeyStorePath())
-                        .addParameter("Key Store Type", getClientSslConfiguration().getKeyStoreType())
-                        .addParameter("Key Store Password", Strings.isNullOrEmpty(getClientSslConfiguration().getKeyStorePassword()) ? "No" : "Yes")
-                        .addParameter("Trust Server Certificate", getClientSslConfiguration().isTrustServiceCertificate())
-                        .addParameter("Trust Store Path", getClientSslConfiguration().getTrustStorePath())
-                        .addParameter("Trust Store Password", Strings.isNullOrEmpty(getClientSslConfiguration().getTrustStorePassword()) ? "No" : "Yes");
+                        .openSection("SSL Layer")
+                        .addParameter("Is Enabled", getClientSslConfiguration().isEnabled());
+
+                if (getClientSslConfiguration().isEnabled()) {
+                    configurationPrinter
+                            .addParameter("Key Store Path", getClientSslConfiguration().getKeyStorePath())
+                            .addParameter("Key Store Type", getClientSslConfiguration().getKeyStoreType())
+                            .addParameter("Key Store Password", Strings.isNullOrEmpty(getClientSslConfiguration().getKeyStorePassword()) ? "No" : "Yes")
+                            .addParameter("Trust Server Certificate", getClientSslConfiguration().isTrustServiceCertificate())
+                            .addParameter("Trust Store Path", getClientSslConfiguration().getTrustStorePath())
+                            .addParameter("Trust Store Password", Strings.isNullOrEmpty(getClientSslConfiguration().getTrustStorePassword()) ? "No" : "Yes");
+                }
+
+            } finally {
+                configurationPrinter.closeSection();
             }
 
             // Other configurations
             configurationPrinter
-                    .decreaseIndentation()
                     .addParameter("Model Context", modelContext)
                     .addParameter("Model Converter", modelConverter)
                     .printLog();

--- a/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
+++ b/service/commons/elasticsearch/client-transport/src/main/java/org/eclipse/kapua/service/elasticsearch/client/transport/TransportElasticsearchClientProvider.java
@@ -76,22 +76,25 @@ public class TransportElasticsearchClientProvider implements ElasticsearchClient
                             .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                             .withTitle("Elasticsearch Transport Provider Configuration")
                             .addParameter("Module Name", getClientConfiguration().getModuleName())
-                            .addParameter("Cluster Name", getClientConfiguration().getClusterName())
-                            .addHeader("Nodes")
-                            .increaseIndentation();
+                            .addParameter("Cluster Name", getClientConfiguration().getClusterName());
 
-            int nodesIndex = 1;
-            for (ElasticsearchNode node : getClientConfiguration().getNodes()) {
-                configurationPrinter
-                        .addHeader("# " + nodesIndex++)
-                        .increaseIndentation()
-                        .addParameter("Host", node.getAddress())
-                        .addParameter("Port", node.getPort())
-                        .decreaseIndentation();
+            try {
+                configurationPrinter.openSection("Nodes");
+
+                int nodesIndex = 1;
+                for (ElasticsearchNode node : getClientConfiguration().getNodes()) {
+                    configurationPrinter
+                            .openSection("# " + nodesIndex++)
+                            .addParameter("Host", node.getAddress())
+                            .addParameter("Port", node.getPort())
+                            .closeSection();
+                }
+            } finally {
+                configurationPrinter.closeSection();
             }
+
             // Other configurations
             configurationPrinter
-                    .decreaseIndentation()
                     .addParameter("Model Context", modelContext)
                     .addParameter("Model Converter", modelConverter)
                     .printLog();

--- a/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
+++ b/service/commons/elasticsearch/server-embedded/src/main/java/org/eclipse/kapua/service/elasticsearch/server/embedded/EsEmbeddedEngine.java
@@ -87,15 +87,14 @@ public class EsEmbeddedEngine implements Closeable {
                             .withTitle("Elasticsearch Embedded Node Configuration")
                             .addParameter("Cluster name", clusterName)
                             .addParameter("Data Directory", defaultDataDirectory)
-                            .addHeader("Transport Endpoint")
-                            .increaseIndentation()
+                            .openSection("Transport Endpoint")
                             .addParameter("Host", transportTcpHost)
                             .addParameter("Port", transportTcpPort)
-                            .decreaseIndentation()
-                            .addHeader("REST Endpoint")
-                            .increaseIndentation()
+                            .closeSection()
+                            .openSection("REST Endpoint")
                             .addParameter("Host", restTcpHost)
                             .addParameter("Port", restTcpPort)
+                            .closeSection()
                             .printLog();
 
                     // ES 5.3 FIX


### PR DESCRIPTION
This PR introduces the usage of ConfigurationPrinter utility class to improve readability of the code and improve the component configuration in some classes.

**Related Issue**
_None_

**Description of the solution adopted**
Replaced invocation of `Logger.info` with a lot of `\n\t` with invocations to `ConfigurationPrinter` which embeds a lot of the formatting logics

**Screenshots**
_None_

**Any side note on the changes made**
Added try-with-resources in `CamelKapuaDefaultRouter`