### PR TITLE
Fixed Jobs and TriggerServices tests errors on GitHub Actions

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -39,7 +39,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -60,7 +60,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -81,7 +81,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -102,7 +102,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -123,7 +123,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -144,7 +144,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -165,7 +165,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -186,7 +186,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -207,7 +207,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -228,7 +228,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -249,7 +249,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -270,7 +270,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -291,7 +291,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -312,7 +312,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -333,7 +333,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -354,7 +354,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -375,7 +375,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error
@@ -396,7 +396,7 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: nick-invision/retry@v2
+      - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 30
           retry_on: error

--- a/ci-output.sh
+++ b/ci-output.sh
@@ -8,15 +8,15 @@ export OUTPUT=build.txt
 touch $OUTPUT
 
 tail_log() {
-   echo 'The last 1000 lines of build output:'
-   tail -1000 $OUTPUT
+   echo "The last $1 lines of build output:"
+   tail "$1" $OUTPUT
 }
 
 ### Build error handler
 
 on_error() {
   echo ERROR: An error was encountered with the build.
-  tail_log
+  tail_log -5000
   exit 1
 }
 trap 'on_error' ERR
@@ -29,7 +29,7 @@ HEARTBEAT_PROCESS_PID=$!
 ### Run
 
 "$@" >> $OUTPUT 2>&1
-tail_log
+tail_log -1000
 
 ### Cleaning up heartbeat process
 

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexCustomPrefixTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexCustomPrefixTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
                 "json:target/DatastoreNewIndex_cucumber.json"},
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "commons.settings.hotswap", value = "true")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "127.0.0.1:9200")
 @CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreNewIndexTest.java
@@ -31,7 +31,6 @@ import org.junit.runner.RunWith;
                 "json:target/DatastoreNewIndex_cucumber.json"},
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "commons.settings.hotswap", value = "true")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "127.0.0.1:9200")
 @CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreTransportI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/datastore/RunDatastoreTransportI9nTest.java
@@ -30,7 +30,6 @@ import org.junit.runner.RunWith;
                 "json:target/DatastoreTransportI9n_cucumber.json"},
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "commons.settings.hotswap", value = "true")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "127.0.0.1:9300")
 @CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.transport.TransportElasticsearchClientProvider")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLDeviceManageI9nTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key = "commons.db.connection.host", value = "")
 @CucumberProperty(key = "commons.db.connection.port", value = "")
 @CucumberProperty(key = "commons.eventbus.url", value = "")
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "certificate.jwt.private.key", value = "")
 @CucumberProperty(key = "certificate.jwt.certificate", value = "")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunBrokerACLI9nTest.java
@@ -40,7 +40,6 @@ import org.junit.runner.RunWith;
 @CucumberProperty(key = "commons.db.connection.host", value = "")
 @CucumberProperty(key = "commons.db.connection.port", value = "")
 @CucumberProperty(key = "commons.eventbus.url", value = "")
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "certificate.jwt.private.key", value = "")
 @CucumberProperty(key = "certificate.jwt.certificate", value = "")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpSysEnvI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceBrokerIpSysEnvI9nTest.java
@@ -33,6 +33,5 @@ import org.junit.runner.RunWith;
                  },
         strict = true,
         monochrome = true )
-@CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
 public class RunDeviceBrokerIpSysEnvI9nTest {}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceDataI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceDataI9nTest.java
@@ -34,7 +34,6 @@ import org.junit.runner.RunWith;
         },
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "127.0.0.1")
 @CucumberProperty(key = "kapua.config.url", value = "")
 public class RunDeviceDataI9nTest {

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/device/RunDeviceI9nTest.java
@@ -34,6 +34,5 @@ import cucumber.api.CucumberOptions;
                  },
         strict = true,
         monochrome = true )
-@CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
 public class RunDeviceI9nTest {}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunLockoutExpirationI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunLockoutExpirationI9nTest.java
@@ -31,6 +31,5 @@ import org.junit.runner.RunWith;
                  },
         strict = true,
         monochrome = true)
-@CucumberProperty(key="broker.ip", value="192.168.33.10")
 @CucumberProperty(key="kapua.config.url", value="")
 public class RunLockoutExpirationI9nTest {}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserRoleI9nTests.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserRoleI9nTests.java
@@ -39,7 +39,6 @@ import org.junit.runner.RunWith;
         },
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "kapua.config.url", value = "")
 @CucumberProperty(key = "datastore.elasticsearch.nodes", value = "127.0.0.1")
 @CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider")

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
@@ -38,7 +38,6 @@ import org.junit.runner.RunWith;
         },
         strict = true,
         monochrome = true)
-@CucumberProperty(key = "broker.ip", value = "192.168.33.10")
 @CucumberProperty(key = "kapua.config.url", value = "")
 @CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClient")
 @CucumberProperty(key = "org.eclipse.kapua.qa.datastore.extraStartupDelay", value = "5")


### PR DESCRIPTION
This PR fixes test failures in `Jobs` and `TriggerServices` tests on the GitHub Actions environment.

**Related Issue**
This PR fixes #3224 

**Description of the solution adopted**
Apparently the Cucumber property `@CucumberProperty(key = "broker.ip", value = "192.168.33.10")` used in some test Runners had a negative impact on some specific tests. Even if `Jobs` and `TriggerServices` tests were not triggered by those runners, the `@CucumberProperty` annotation was working for some reason. 

Note that this broker IP was not used at all (maybe it was in the past), thus it didn't make any sense to use it.

**Screenshots**
_n/a_

**Any side note on the changes made**
This PR also updates the GitHub action `retry` to the latest version, and extend the test log in case of errors to 5000 lines.
