### PR TITLE
Added JUnit tests for AccessPermission and AccessRole classes

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionImplTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionImplTest.java
@@ -1,0 +1,257 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.commons.model.id.KapuaEid;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionImpl;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessPermissionImplTest extends Assert {
+
+    AccessPermissionImpl accessPermissionImpl1, accessPermissionImpl2, accessPermissionImpl;
+    AccessPermission accessPermission;
+    PermissionImpl permission1, permission2;
+    Permission newPermission;
+    Date createdOn;
+
+    @Before
+    public void initialize() {
+        accessPermissionImpl1 = new AccessPermissionImpl(KapuaId.ONE);
+        accessPermissionImpl2 = new AccessPermissionImpl(KapuaId.ONE);
+        accessPermission = Mockito.mock(AccessPermission.class);
+        permission1 = Mockito.mock(PermissionImpl.class);
+        permission2 = Mockito.mock(PermissionImpl.class);
+        newPermission = Mockito.mock(Permission.class);
+        createdOn = new Date();
+
+        Mockito.when(accessPermission.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessPermission.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessPermission.getCreatedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessPermission.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessPermission.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessPermission.getPermission()).thenReturn(permission1);
+        Mockito.when(permission1.getDomain()).thenReturn("domain");
+        Mockito.when(permission1.getAction()).thenReturn(Actions.connect);
+        Mockito.when(permission1.getTargetScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(permission1.getGroupId()).thenReturn(KapuaId.ANY);
+
+        accessPermissionImpl = new AccessPermissionImpl(accessPermission);
+    }
+
+    @Test
+    public void accessPermissionImplWithoutParametersTest() throws Exception {
+        Constructor<AccessPermissionImpl> accessPermissionImplWithoutParameters = AccessPermissionImpl.class.getDeclaredConstructor();
+        accessPermissionImplWithoutParameters.setAccessible(true);
+        accessPermissionImplWithoutParameters.newInstance();
+        assertTrue("True expected.", Modifier.isProtected(accessPermissionImplWithoutParameters.getModifiers()));
+    }
+
+    @Test
+    public void accessPermissionImplScopeIdParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionImpl1.getScopeId());
+        assertNull("Null expected", accessPermissionImpl1.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermissionImpl1.getPermission().toString());
+        assertNull("Null expected", accessPermissionImpl1.getPermission().getDomain());
+        assertNull("Null expected", accessPermissionImpl1.getPermission().getAction());
+        assertNull("Null expected", accessPermissionImpl1.getPermission().getTargetScopeId());
+        assertNull("Null expected", accessPermissionImpl1.getPermission().getGroupId());
+    }
+
+    @Test
+    public void accessPermissionImplNullScopeIdParameterTest() {
+        AccessPermissionImpl accessPermission = new AccessPermissionImpl((KapuaId) null);
+
+        assertNull("Null expected", accessPermission.getScopeId());
+        assertNull("Null expected", accessPermission.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermission.getPermission().toString());
+        assertNull("Null expected", accessPermission.getPermission().getDomain());
+        assertNull("Null expected", accessPermission.getPermission().getAction());
+        assertNull("Null expected", accessPermission.getPermission().getTargetScopeId());
+        assertNull("Null expected", accessPermission.getPermission().getGroupId());
+    }
+
+    @Test
+    public void accessPermissionImplAccessPermissionParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessPermissionImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessPermissionImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, accessPermissionImpl.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionImpl.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", permission1, accessPermissionImpl.getPermission());
+        assertEquals("Expected and actual values should be the same.", "domain", accessPermissionImpl.getPermission().getDomain());
+        assertEquals("Expected and actual values should be the same.", Actions.connect, accessPermissionImpl.getPermission().getAction());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionImpl.getPermission().getTargetScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessPermissionImpl.getPermission().getGroupId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessPermissionImplNullAccessPermissionParameterTest() {
+        new AccessPermissionImpl((AccessPermission) null);
+    }
+
+    @Test
+    public void setAndGetAccessInfoIdTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ANY);
+        assertEquals("Expected and actual values should be the same.", new KapuaEid(KapuaId.ANY), accessPermissionImpl1.getAccessInfoId());
+        accessPermissionImpl1.setAccessInfoId(new KapuaEid(KapuaId.ANY));
+        assertEquals("Expected and actual values should be the same.", new KapuaEid(KapuaId.ANY), accessPermissionImpl1.getAccessInfoId());
+        accessPermissionImpl1.setAccessInfoId(null);
+        assertNull("Null expected.", accessPermissionImpl1.getAccessInfoId());
+
+        accessPermissionImpl.setAccessInfoId(KapuaId.ANY);
+        assertEquals("Expected and actual values should be the same.", new KapuaEid(KapuaId.ANY), accessPermissionImpl.getAccessInfoId());
+        accessPermissionImpl.setAccessInfoId(new KapuaEid(KapuaId.ANY));
+        assertEquals("Expected and actual values should be the same.", new KapuaEid(KapuaId.ANY), accessPermissionImpl.getAccessInfoId());
+        accessPermissionImpl.setAccessInfoId(null);
+        assertNull("Null expected.", accessPermissionImpl.getAccessInfoId());
+
+    }
+
+    @Test
+    public void setAndGetPermissionTest() {
+        accessPermissionImpl1.setPermission(permission1);
+        assertEquals("Expected and actual values should be the same.", permission1, accessPermissionImpl1.getPermission());
+        accessPermissionImpl1.setPermission(null);
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermissionImpl1.getPermission().toString());
+        accessPermissionImpl1.setPermission(newPermission);
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermissionImpl1.getPermission().toString());
+
+        accessPermissionImpl.setPermission(permission2);
+        assertEquals("Expected and actual values should be the same.", permission2, accessPermissionImpl.getPermission());
+        accessPermissionImpl.setPermission(null);
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermissionImpl.getPermission().toString());
+        accessPermissionImpl.setPermission(newPermission);
+        assertEquals("Expected and actual values should be the same.", "*:*:*:*", accessPermissionImpl.getPermission().toString());
+    }
+
+    @Test
+    public void hashCodeNullAccessInfoIdNullPermissionTest() {
+        assertEquals("Expected and actual values should be the same.", 961, accessPermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullPermissionTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", 1953, accessPermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullAccessInfoIdTest() {
+        Permission permission = Mockito.mock(Permission.class);
+        Mockito.when(permission.getDomain()).thenReturn(null);
+        Mockito.when(permission.getAction()).thenReturn(null);
+        Mockito.when(permission.getTargetScopeId()).thenReturn(null);
+        Mockito.when(permission.getGroupId()).thenReturn(null);
+        PermissionImpl permissionImpl = new PermissionImpl(permission);
+        accessPermissionImpl1.setPermission(permissionImpl);
+        assertEquals("Expected and actual values should be the same.", 924482, accessPermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        Permission permission = Mockito.mock(Permission.class);
+        Mockito.when(permission.getDomain()).thenReturn(null);
+        Mockito.when(permission.getAction()).thenReturn(null);
+        Mockito.when(permission.getTargetScopeId()).thenReturn(null);
+        Mockito.when(permission.getGroupId()).thenReturn(null);
+        PermissionImpl permissionImpl = new PermissionImpl(permission);
+        accessPermissionImpl1.setPermission(permissionImpl);
+        assertEquals("Expected and actual values should be the same.", 925474, accessPermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        assertTrue("True expected.", accessPermissionImpl1.equals(accessPermissionImpl1));
+    }
+
+    @Test
+    public void equalsNullObjectTest() {
+        assertFalse("False expected.", accessPermissionImpl1.equals(null));
+    }
+
+    @Test
+    public void equalsObjectTest() {
+        assertFalse("False expected.", accessPermissionImpl1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNullBothAccessInfoIdsNullPermissionsTest() {
+        assertTrue("True expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsNullBothAccessInfoIdsEqualPermissionsTest() {
+        accessPermissionImpl1.setPermission(permission2);
+        accessPermissionImpl2.setPermission(permission2);
+        assertTrue("True expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsNullBothAccessInfoIdsDifferentPermissionsTest() {
+        accessPermissionImpl1.setPermission(permission2);
+        assertFalse("False expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsNullAccessInfoIdTest() {
+        accessPermissionImpl2.setAccessInfoId(KapuaId.ANY);
+        assertFalse("False expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsDifferentAccessInfoIdsTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl2.setAccessInfoId(KapuaId.ANY);
+        assertFalse("False expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsNullPermissionsTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl2.setAccessInfoId(KapuaId.ONE);
+        assertTrue("True expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsEqualPermissionsTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl2.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl1.setPermission(permission2);
+        accessPermissionImpl2.setPermission(permission2);
+        assertTrue("True expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsDifferentPermissionsTest() {
+        accessPermissionImpl1.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl2.setAccessInfoId(KapuaId.ONE);
+        accessPermissionImpl1.setPermission(Mockito.mock(PermissionImpl.class));
+        assertFalse("False expected.", accessPermissionImpl1.equals(accessPermissionImpl2));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCacheFactoryTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AccessPermissionCacheFactoryTest extends Assert {
+
+    @Test
+    public void accessPermissionCacheFactoryTest() throws Exception {
+        Constructor<AccessPermissionCacheFactory> accessPermissionCacheFactory = AccessPermissionCacheFactory.class.getDeclaredConstructor();
+        accessPermissionCacheFactory.setAccessible(true);
+        accessPermissionCacheFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(accessPermissionCacheFactory.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", AccessPermissionCacheFactory.getInstance() instanceof AccessPermissionCacheFactory);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionCreatorImplTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AccessPermissionCreatorImplTest extends Assert {
+
+    @Test
+    public void accessPermissionCreatorImplTest() {
+        AccessPermissionCreatorImpl accessPermissionCreatorImpl = new AccessPermissionCreatorImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionCreatorImpl.getScopeId());
+    }
+
+    @Test
+    public void accessPermissionCreatorImplNullTest() {
+        AccessPermissionCreatorImpl accessPermissionCreatorImpl = new AccessPermissionCreatorImpl(null);
+        assertNull("Null expected.", accessPermissionCreatorImpl.getScopeId());
+    }
+
+    @Test
+    public void setAndGetAccessInfoIdTest() {
+        AccessPermissionCreatorImpl accessPermissionCreatorImpl = new AccessPermissionCreatorImpl(KapuaId.ONE);
+
+        assertNull("Null expected.", accessPermissionCreatorImpl.getAccessInfoId());
+        accessPermissionCreatorImpl.setAccessInfoId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionCreatorImpl.getAccessInfoId());
+        accessPermissionCreatorImpl.setAccessInfoId(null);
+        assertNull("Null expected.", accessPermissionCreatorImpl.getAccessInfoId());
+    }
+
+    @Test
+    public void setAndGetPermissionTest() {
+        AccessPermissionCreatorImpl accessPermissionCreatorImpl = new AccessPermissionCreatorImpl(KapuaId.ONE);
+        Permission permission = Mockito.mock(Permission.class);
+
+        assertNull("Null expected.", accessPermissionCreatorImpl.getPermission());
+        accessPermissionCreatorImpl.setPermission(permission);
+        assertEquals("Expected and actual values should be the same.", permission, accessPermissionCreatorImpl.getPermission());
+        accessPermissionCreatorImpl.setPermission(null);
+        assertNull("Null expected.", accessPermissionCreatorImpl.getPermission());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImplTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class AccessPermissionFactoryImplTest extends Assert {
+
+    AccessPermissionFactoryImpl accessPermissionFactoryImpl;
+    KapuaId[] scopeIds;
+
+    @Before
+    public void initialize() {
+        accessPermissionFactoryImpl = new AccessPermissionFactoryImpl();
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+    }
+
+    @Test
+    public void newEntityTest() {
+        for (KapuaId scopeId : scopeIds) {
+            assertTrue("True expected.", accessPermissionFactoryImpl.newEntity(scopeId) instanceof AccessPermission);
+        }
+    }
+
+    @Test
+    public void newCreatorTest() {
+        for (KapuaId scopeId : scopeIds) {
+            assertTrue("True expected.", accessPermissionFactoryImpl.newCreator(scopeId) instanceof AccessPermissionCreator);
+        }
+    }
+
+    @Test
+    public void newQueryTest() {
+        for (KapuaId scopeId : scopeIds) {
+            assertTrue("True expected.", accessPermissionFactoryImpl.newQuery(scopeId) instanceof AccessPermissionQuery);
+        }
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("True expected.", accessPermissionFactoryImpl.newListResult() instanceof AccessPermissionListResult);
+    }
+
+    @Test
+    public void cloneTest() {
+        AccessPermission accessPermission = Mockito.mock(AccessPermission.class);
+        assertTrue("True expected.", accessPermissionFactoryImpl.clone(accessPermission) instanceof AccessPermission);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cloneNullTest() {
+        accessPermissionFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AccessPermissionQueryImplTest extends Assert {
+
+    @Test
+    public void accessPermissionQueryImplWithoutParametersTest() {
+        AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl();
+        assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void accessPermissionQueryImplScopeIdParameterTest() {
+        AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void accessPermissionQueryImplNullScopeIdParameterTest() {
+        AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(null);
+        assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AccessRoleCacheFactoryTest extends Assert {
+
+    @Test
+    public void accessRoleCacheFactoryTest() throws Exception {
+        Constructor<AccessRoleCacheFactory> accessRoleCacheFactory = AccessRoleCacheFactory.class.getDeclaredConstructor();
+        accessRoleCacheFactory.setAccessible(true);
+        accessRoleCacheFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(accessRoleCacheFactory.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", AccessRoleCacheFactory.getInstance() instanceof AccessRoleCacheFactory);
+        assertEquals("Expected and actual values should be the same.", "AccessRoleId", AccessRoleCacheFactory.getInstance().getEntityIdCacheName());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImplTest.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AccessRoleCreatorImplTest extends Assert {
+
+    AccessRoleCreatorImpl accessRoleCreatorImpl;
+
+    @Before
+    public void initialize() {
+        accessRoleCreatorImpl = new AccessRoleCreatorImpl(KapuaId.ONE);
+    }
+
+    @Test
+    public void accessRoleCreatorImplTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getScopeId());
+        assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
+        assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
+    }
+
+    @Test
+    public void accessRoleCreatorImplNullTest() {
+        AccessRoleCreatorImpl accessRoleCreatorImplNullId = new AccessRoleCreatorImpl(null);
+        assertNull("Null expected.", accessRoleCreatorImplNullId.getScopeId());
+        assertNull("Null expected.", accessRoleCreatorImplNullId.getAccessInfoId());
+        assertNull("Null expected.", accessRoleCreatorImplNullId.getRoleId());
+    }
+
+    @Test
+    public void setAndGetAccessInfoIdTest() {
+        accessRoleCreatorImpl.setAccessInfoId(KapuaId.ANY);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleCreatorImpl.getAccessInfoId());
+
+        accessRoleCreatorImpl.setAccessInfoId(null);
+        assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
+    }
+
+    @Test
+    public void setAndGetRoleIdTest() {
+        accessRoleCreatorImpl.setRoleId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getRoleId());
+
+        accessRoleCreatorImpl.setRoleId(null);
+        assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImplTest.java
@@ -1,0 +1,110 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
+import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
+import org.eclipse.kapua.service.authorization.access.AccessRoleQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessRoleFactoryImplTest extends Assert {
+
+    AccessRoleFactoryImpl accessRoleFactoryImpl;
+    AccessRole accessRole;
+    Date createdOn;
+
+    @Before
+    public void initialize() {
+        accessRoleFactoryImpl = new AccessRoleFactoryImpl();
+        accessRole = Mockito.mock(AccessRole.class);
+        createdOn = new Date();
+
+        Mockito.when(accessRole.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessRole.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRole.getCreatedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessRole.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessRole.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRole.getRoleId()).thenReturn(KapuaId.ANY);
+    }
+
+    @Test
+    public void newEntityTest() {
+        AccessRole accessRole = accessRoleFactoryImpl.newEntity(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRole.getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        AccessRole accessRole = accessRoleFactoryImpl.newEntity(null);
+        assertNull("Null expected.", accessRole.getScopeId());
+    }
+
+    @Test
+    public void newCreatorTest() {
+        AccessRoleCreator accessRoleCreator = accessRoleFactoryImpl.newCreator(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreator.getScopeId());
+    }
+
+    @Test
+    public void newCreatorNullTest() {
+        AccessRoleCreator accessRoleCreator = accessRoleFactoryImpl.newCreator(null);
+        assertNull("Null expected.", accessRoleCreator.getScopeId());
+    }
+
+    @Test
+    public void newQueryTest() {
+        AccessRoleQuery accessRoleQuery = accessRoleFactoryImpl.newQuery(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQuery.getScopeId());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        AccessRoleQuery accessRoleQuery = accessRoleFactoryImpl.newQuery(null);
+        assertNull("Null expected.", accessRoleQuery.getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        AccessRoleListResult accessRoleListResult = accessRoleFactoryImpl.newListResult();
+        assertTrue("True expected.", accessRoleListResult.isEmpty());
+    }
+
+    @Test
+    public void cloneTest() {
+        accessRoleFactoryImpl.clone(accessRole);
+
+        AccessRole resultAccessRole = accessRoleFactoryImpl.clone(accessRole);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultAccessRole.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getRoleId());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        accessRoleFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImplTest.java
@@ -1,0 +1,211 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class AccessRoleImplTest extends Assert {
+
+    AccessRoleImpl accessRoleImpl1, accessRoleImpl2, accessRoleImpl;
+    AccessRole accessRole;
+    Date createdOn;
+
+    @Before
+    public void initialize() throws KapuaException {
+        accessRoleImpl1 = new AccessRoleImpl();
+        accessRoleImpl2 = new AccessRoleImpl(KapuaId.ONE);
+        accessRole = Mockito.mock(AccessRole.class);
+        createdOn = new Date();
+
+        Mockito.when(accessRole.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessRole.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRole.getCreatedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(accessRole.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(accessRole.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRole.getRoleId()).thenReturn(KapuaId.ANY);
+
+        accessRoleImpl = new AccessRoleImpl(accessRole);
+    }
+
+    @Test
+    public void accessRoleImplWithoutParametersTest() {
+        assertNull("Null expected.", accessRoleImpl1.getScopeId());
+        assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
+        assertNull("Null expected.", accessRoleImpl1.getRoleId());
+    }
+
+    @Test
+    public void accessRoleImplScopeIdParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl2.getScopeId());
+        assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
+        assertNull("Null expected.", accessRoleImpl2.getRoleId());
+    }
+
+    @Test
+    public void accessRoleImplNullScopeIdParameterTest() {
+        AccessRoleImpl accessRoleImplNullScopeId = new AccessRoleImpl((KapuaId) null);
+        assertNull("Null expected.", accessRoleImplNullScopeId.getScopeId());
+        assertNull("Null expected.", accessRoleImplNullScopeId.getAccessInfoId());
+        assertNull("Null expected.", accessRoleImplNullScopeId.getRoleId());
+    }
+
+    @Test
+    public void accessRoleImplAccessRoleParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, accessRoleImpl.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void accessRoleImplNullAccessRoleParameterTest() throws KapuaException {
+        new AccessRoleImpl((AccessRole) null);
+    }
+
+    @Test
+    public void setAndGetAccessInfoIdTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ANY);
+        accessRoleImpl2.setAccessInfoId(KapuaId.ANY);
+        accessRoleImpl.setAccessInfoId(KapuaId.ANY);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getAccessInfoId());
+
+        accessRoleImpl1.setAccessInfoId(null);
+        accessRoleImpl2.setAccessInfoId(null);
+        accessRoleImpl.setAccessInfoId(null);
+        assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
+        assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
+        assertNull("Null expected.", accessRoleImpl.getAccessInfoId());
+    }
+
+    @Test
+    public void setAndGetRoleIdTest() {
+        accessRoleImpl1.setRoleId(KapuaId.ANY);
+        accessRoleImpl2.setRoleId(KapuaId.ANY);
+        accessRoleImpl.setRoleId(KapuaId.ANY);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getRoleId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getRoleId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
+
+        accessRoleImpl1.setRoleId(null);
+        accessRoleImpl2.setRoleId(null);
+        accessRoleImpl.setRoleId(null);
+        assertNull("Null expected.", accessRoleImpl1.getRoleId());
+        assertNull("Null expected.", accessRoleImpl2.getRoleId());
+        assertNull("Null expected.", accessRoleImpl.getRoleId());
+    }
+
+    @Test
+    public void hashCodeNullAccessInfoIdNullRoleIdTest() {
+        assertEquals("Expected and actual values should be the same.", 961, accessRoleImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullRoleIdTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", 1953, accessRoleImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullAccessInfoIdTest() {
+        accessRoleImpl1.setRoleId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", 993, accessRoleImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl1.setRoleId(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", 1985, accessRoleImpl1.hashCode());
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl1));
+    }
+
+    @Test
+    public void equalsNullObjectTest() {
+        assertFalse("False expected.", accessRoleImpl1.equals(null));
+    }
+
+    @Test
+    public void equalsObjectTest() {
+        assertFalse("False expected.", accessRoleImpl1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNullAccessInfoIdsNullRoleIdsTest() {
+        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsNullThisAccessInfoIdNullRoleIdsTest() {
+        accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
+        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsNullAccessInfoIdsNullThisRoleIdTest() {
+        accessRoleImpl2.setRoleId(KapuaId.ANY);
+        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsDifferentAccessInfoIdsTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl1.setAccessInfoId(KapuaId.ANY);
+        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsNullRoleIdsTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
+        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsDifferentRoleIdsTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl1.setRoleId(KapuaId.ANY);
+        accessRoleImpl2.setRoleId(KapuaId.ONE);
+
+        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+
+    @Test
+    public void equalsEqualAccessInfoIdsEqualRoleIdsTest() {
+        accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
+        accessRoleImpl1.setRoleId(KapuaId.ONE);
+        accessRoleImpl2.setRoleId(KapuaId.ONE);
+
+        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.access.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class AccessRoleQueryImplTest extends Assert {
+
+    @Test
+    public void accessRoleQueryImplWithoutParametersTest() {
+        AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl();
+        assertNull("Null expected.", accessRoleQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", accessRoleQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void accessRoleQueryImplScopeIdParameterTest() {
+        AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", accessRoleQueryImpl.getSortCriteria());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in authorization/access/shiro package:

 - AccessPermissionImpl class
 - AccessPermissionCacheFactory class
 - AccessPermissionCreatorImpl class
 - AccessPermissionFactoryImpl class
 - AccessPermissionQueryImpl class

 - AccessRoleCacheFactory class
 - AccessRoleCreatorImpl class
 - AccessRoleFactoryImpl class
 - AccessRoleImpl class
 - AccessRoleQueryImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
