### PR TITLE
Upgraded docker-deploy.sh script, added REST API tests

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -25,6 +25,28 @@ jobs:
       - run: mvn -v
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
+  test-restApi:
+    needs: build-kapua
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-java@v1
+        with:
+          java-version: '8'
+      - uses: actions/cache@v2
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+          restore-keys: |
+            ${{ runner.os }}-maven-
+      # deploying docker containers because Rest Api calls need real endpoints
+      - run: ./deployment/docker/unix/docker-deploy.sh -xe
+      - uses: actions/checkout@master
+      - uses: matt-ball/newman-action@master
+        with:
+          collection: rest-api/test/KapuaApiTestingPostman_collection.json
+      - run: ./deployment/docker/unix/docker-undeploy.sh -xe
+      - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build-kapua
     runs-on: ubuntu-latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,10 +28,24 @@ env:
 
 jobs:
   include:
-  - stage: build
+  - stage: Build
     script:
     - mvn -v
     - mvn -B ${BUILD_OPTS} -DskipTests clean install
+  - stage: REST API Tests
+      language: node_js
+      node_js: "12.0"
+      install:
+        - npm install newman
+      before_script:
+        - ./deployment/docker/unix/docker-deploy.sh
+        - docker ps -a
+        - node --version
+        - npm --version
+        - node_modules/.bin/newman --version
+      script:
+        - node_modules/.bin/newman run rest-api/test/KapuaApiTestingPostman_collection.json
+        - ./deployment/docker/unix/docker-undeploy.sh
   - stage: test
     script:
     - ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.options="--tags @brokerAcl" verify

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -5,7 +5,7 @@ services:
     image: kapua/kapua-sql:${IMAGE_VERSION}
     ports:
       - 8181:8181
-      - 3306:3306
+      - 3307:3307
   es:
     image: docker.elastic.co/elasticsearch/elasticsearch:6.8.7
     ports:

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -62,6 +62,20 @@ docker_compose || {
     echo "Deploying Eclipse Kapua... ERROR!"
     exit 1
 }
+
+container=1
+while ((container)); do
+    echo "waiting for containers to start..."
+    docker logs compose_kapua-api_1 >& docker-log.log
+    if grep -q "org.eclipse.jetty.server.Server - Started" docker-log.log ; then
+        container=0  
+    else
+        sleep 5s
+    fi
+done
+echo "Docker containers are up and running!"
+rm docker-log.log
+
 echo "Deploying Eclipse Kapua... DONE!"
 
 if [[ -z "$1" ]]; then

--- a/rest-api/test/KapuaApiTestingPostman_collection.json
+++ b/rest-api/test/KapuaApiTestingPostman_collection.json
@@ -1,0 +1,510 @@
+{
+	"info": {
+		"_postman_id": "90847948-be9c-41c5-b13c-0564b836422e",
+		"name": "kapua-api-tests",
+		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json"
+	},
+	"item": [
+		{
+			"name": "Login - Username and password",
+			"item": [
+				{
+					"name": "Login with correct username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "16102ddb-cc37-4410-978e-ad5da17accf1",
+								"exec": [
+									"pm.test(\"Status code is 200\", function () {\r",
+									"    pm.response.to.have.status(200);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"id\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"scopeId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"createdBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"modifiedBy\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"optlock\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"tokenId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"userId\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"expiresOn\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"refreshToken\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"refreshExpiresOn\");\r",
+									"\r",
+									"});\r",
+									"\r",
+									"var jsonData = JSON.parse(responseBody);\r",
+									"pm.globals.set(\"jwttoken\", jsonData.tokenId);\r",
+									""
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"auth": {
+							"type": "noauth"
+						},
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with wrong username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "2c6db04b-146e-4e21-86a6-52c6460c56c3",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"protocolProfileBehavior": {
+						"strictSSL": true
+					},
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"message\": \"string\",\r\n  \"kapuaErrorCode\": \"string\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with correct username and wrong password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "e3f06466-34ab-421f-a0ed-66b1b7ac1c92",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"wrong-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with wrong username and correct password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "b89edcba-14b3-4bb1-93b9-045ec4ac8921",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-username\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with empty username and correct password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "80d32002-659c-4144-ac6d-914631acd9b7",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"\",\r\n  \"password\": \"kapua-password\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with correct username and empty password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "f6f16bc6-eab4-45f3-a6e9-f2e5cc33dd90",
+								"exec": [
+									"pm.test(\"Status code is 401\", function () {\r",
+									"    pm.response.to.have.status(401);\r",
+									"});"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"kapua-sys\",\r\n  \"password\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Login with empty username and password",
+					"event": [
+						{
+							"listen": "test",
+							"script": {
+								"id": "4efd4479-6b9a-4e0e-a531-959bb59d78d6",
+								"exec": [
+									"pm.test(\"Status code is 500\", function () {\r",
+									"    pm.response.to.have.status(500);\r",
+									"});\r",
+									"pm.test(\"Body matches string\", function () {\r",
+									"    pm.expect(pm.response.text()).to.include(\"type\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"httpErrorCode\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"message\");\r",
+									"    pm.expect(pm.response.text()).to.include(\"kapuaErrorCode\");\r",
+									"});\r",
+									"\r",
+									"var jsonData = pm.response.json(); \r",
+									"\r",
+									"    pm.test(\"Verify type\", function () { \r",
+									"        pm.expect(jsonData.type).is.to.equal(\"exceptionInfo\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify httpErrorCode\", function () { \r",
+									"        pm.expect(jsonData.httpErrorCode).is.to.equal(500); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify message\", function () { \r",
+									"        pm.expect(jsonData.message).is.to.equal(\"An internal error occurred: org.apache.shiro.ShiroException: Error while find user!.\"); \r",
+									"    });\r",
+									"\r",
+									"    pm.test(\"Verify kapuaErrorCode\", function () { \r",
+									"        pm.expect(jsonData.kapuaErrorCode).is.to.equal(\"INTERNAL_ERROR\"); \r",
+									"    });"
+								],
+								"type": "text/javascript"
+							}
+						}
+					],
+					"request": {
+						"method": "POST",
+						"header": [],
+						"body": {
+							"mode": "raw",
+							"raw": "{\r\n  \"username\": \"\",\r\n  \"password\": \"\"\r\n}",
+							"options": {
+								"raw": {
+									"language": "json"
+								}
+							}
+						},
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/user",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"user"
+							]
+						}
+					},
+					"response": []
+				},
+				{
+					"name": "Logout",
+					"request": {
+						"auth": {
+							"type": "bearer",
+							"bearer": [
+								{
+									"key": "token",
+									"value": "{{jwttoken}}",
+									"type": "string"
+								}
+							]
+						},
+						"method": "POST",
+						"header": [],
+						"url": {
+							"raw": "http://localhost:8081/v1/authentication/logout",
+							"protocol": "http",
+							"host": [
+								"localhost"
+							],
+							"port": "8081",
+							"path": [
+								"v1",
+								"authentication",
+								"logout"
+							]
+						}
+					},
+					"response": []
+				}
+			],
+			"auth": {
+				"type": "noauth"
+			},
+			"event": [
+				{
+					"listen": "prerequest",
+					"script": {
+						"id": "95f728bc-5cd2-4dff-ab74-1d9c3a947514",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				},
+				{
+					"listen": "test",
+					"script": {
+						"id": "a443a496-b4fe-4ee4-a1d9-267fe349e248",
+						"type": "text/javascript",
+						"exec": [
+							""
+						]
+					}
+				}
+			],
+			"protocolProfileBehavior": {}
+		}
+	],
+	"auth": {
+		"type": "bearer",
+		"bearer": [
+			{
+				"key": "token",
+				"value": "eyJhbGciOiJSUzI1NiJ9.eyJpc3MiOiJodHRwczovL3d3dy5lY2xpcHNlLm9yZy9rYXB1YSIsImlhdCI6MTU5NDIxMjgzMSwiZXhwIjoxNTk0MjE0NjMxLCJzdWIiOiJBUSIsInNJZCI6IkFRIn0.fre_rsuvan7MqPo1sAfcGxR9sxVCedT_KPi-sm2VijunOItXNSDVFW1dtzGHzyIZwWyXk6LxuV5YS5eVfKfDyz_HrNBfN-w4Mt-cMV4uSTyDPMRLzqCCavKwd_Un8P14h1PmJ0VkqX45xAdkOlxNUydbofkfZkY9vCnvYfppjfJHR4TdfE4zeTOKsa1CbyIH6_b1SE06ke8TPZfTqIGQIP8LyGpIACn80tBSoIVLJgpB5-XBOydx5e0T4ejZej9Cp9ajweOewSJUUoEqw4WGq0duHz76MLbmT4GsGB1wU31O_uVpNIzEtyjk7w2KepZXf2bO9xpNcrYYhg8kK9orPIyfTu2uvontBingZQkskToGPv4aWA5V2GxpBstvHqgzGfbV9IgZe6O4GWJqGYZtWrMBzwX-MdnjZfnVZgriONdpCPL7iUu6fS3rEV_K9iSl6H_PXm4127ErZyupIsUqjOK13PrYYqRHtLJdMM4JJVS2UsWpXRAzw29Dvdbnyh97EtftU2CYOXMttoGTw_0IdbilkedF1unYaOQqmjnxBaM3-nCH6aYhvEWT4TAbGPLzbRm9UaMgXa2h1PN-Urg89gZKJf3RBcjZaOAJo3yetrX-EZiENkTr6jVfDG6FPN8bnC9dPthWvzCh7R8qXNZKLXYlPXMXCfDVcF8s6huEGWE",
+				"type": "string"
+			}
+		]
+	},
+	"event": [
+		{
+			"listen": "prerequest",
+			"script": {
+				"id": "644908d8-421f-4c66-9726-76a151522bab",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		},
+		{
+			"listen": "test",
+			"script": {
+				"id": "42ae9b46-d55f-4da8-9f20-8bd80a9ea366",
+				"type": "text/javascript",
+				"exec": [
+					""
+				]
+			}
+		}
+	],
+	"protocolProfileBehavior": {}
+}


### PR DESCRIPTION
This PR introduces framework for REST API testing. 
The PR consists of three parts:
 - Adding Newman runner for running tests in CI (GHA and Travis - this tool is available in GitHub Marketplace)
 - Enhancing docker-deploy.sh script
 - Adding JSON file with Rest Api tests

The idea is this: We will write tests in Postman, as this is much faster that adding tests via Rest Assured or something else (it is also a much better collaboration tool than any others, so we can divide testing team into smaller fragments and also check the progress of others, etc.). After we add some tests, we will export this to a file "KapuaApiTestingPostman_collection.json", which is located in rest-api/test/ folder. 

The tests will be run after every push and PR (I added a test-restApi stage into GHA yml file), but they can also be run locally:
1. If you don't have Newman on you machine yet, install it with `npm install -g newman`
2. In terminal go to rest-api/test folder
3. Run command `newman run KapuaApiTestingPostman_collection.json`

Output should be something like this: 
<img width="720" alt="Screenshot 2021-02-11 at 13 47 09" src="https://user-images.githubusercontent.com/15121999/107638503-f6a35100-6c6f-11eb-86b5-910e7d0e1d1b.png">

 Although Travis is becoming obsolete I have upgraded Travis.yml file, so the rest-api tests will be run also there. 
There are just a couple of tests added in the JSON file, becasue rest-api tests tend to get very long (a lot of lines) and I wanted to avoid CQ.

**Related Issue**
This PR is not related to any specific issue, but is rather a initial commit, which sets up the framework for rest api testing. 

**Description of the solution adopted:**
/

**Screenshots**
/

**Any side note on the changes made**
I have added a "smart" timeout to the docker-deploy.sh script because there were some trobules wtih running Rest API tests.
The problem is, that once you run this script, docker containers get status "Running" although they are not properly started just yet - they need a minute or so to properly start. Without this addition, the Rest API tests will start as soon the docker-deploy.sh scripts completes and the tests will fail, because API container is not deployed. 
Therefore this timeout checks API container log for a certain string every 5 seconds (when this string appears the container is up and running), to see if the container is properly running or not. I have tested this and it works fine.

Signed-off-by: Leonardo Gaube <leonardo.gaube@endava.com>