### PR TITLE
Added JUnit tests for domain classes

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DomainDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DomainDAOTest.java
@@ -1,0 +1,438 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainCreator;
+import org.eclipse.kapua.service.authorization.domain.DomainListResult;
+import org.eclipse.kapua.service.authorization.domain.shiro.DomainDAO;
+import org.eclipse.kapua.service.authorization.domain.shiro.DomainImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.NonUniqueResultException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+
+import javax.persistence.criteria.ParameterExpression;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Selection;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class DomainDAOTest extends Assert {
+
+    EntityManager entityManager;
+    DomainCreator domainCreator;
+    Set<Actions> actions;
+    KapuaId scopeId, domainId;
+    DomainImpl entityToFindOrDelete;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        domainCreator = Mockito.mock(DomainCreator.class);
+        actions = new HashSet<>();
+        actions.add(Actions.connect);
+        scopeId = KapuaId.ONE;
+        domainId = KapuaId.ANY;
+        entityToFindOrDelete = Mockito.mock(DomainImpl.class);
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+
+        assertTrue("True expected.", DomainDAO.create(entityManager, domainCreator) instanceof Domain);
+        assertEquals("Expected and actual values should be the same.", "name", DomainDAO.create(entityManager, domainCreator).getName());
+        assertTrue("True expected.", DomainDAO.create(entityManager, domainCreator).getGroupable());
+        assertEquals("Expected and actual values should be the same.", actions, DomainDAO.create(entityManager, domainCreator).getActions());
+    }
+
+    @Test
+    public void createNullActionsTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(null);
+
+        assertTrue("True expected.", DomainDAO.create(entityManager, domainCreator) instanceof Domain);
+        assertEquals("Expected and actual values should be the same.", "name", DomainDAO.create(entityManager, domainCreator).getName());
+        assertTrue("True expected.", DomainDAO.create(entityManager, domainCreator).getGroupable());
+        assertNull("Null expected.", DomainDAO.create(entityManager, domainCreator).getActions());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        DomainDAO.create(entityManager, domainCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        DomainDAO.create(entityManager, domainCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithNotSQLCauseTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        DomainDAO.create(entityManager, domainCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        DomainDAO.create(entityManager, domainCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+
+        DomainDAO.create(null, domainCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullDomainCreatorTest() {
+        Mockito.when(domainCreator.getName()).thenReturn("name");
+        Mockito.when(domainCreator.getGroupable()).thenReturn(true);
+        Mockito.when(domainCreator.getActions()).thenReturn(actions);
+
+        DomainDAO.create(entityManager, (DomainCreator) null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", DomainDAO.find(entityManager, scopeId, domainId) instanceof Domain);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, DomainDAO.find(entityManager, scopeId, domainId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", DomainDAO.find(entityManager, scopeId, domainId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(null);
+
+        assertNull("Null expected.", DomainDAO.find(entityManager, scopeId, domainId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", DomainDAO.find(entityManager, scopeId, domainId) instanceof Domain);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        DomainDAO.find(null, scopeId, domainId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", DomainDAO.find(entityManager, null, domainId) instanceof Domain);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, DomainDAO.find(entityManager, null, domainId).getScopeId());
+    }
+
+    @Test
+    public void findNullDomainIdTest() {
+        Mockito.when(entityManager.find(DomainImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", DomainDAO.find(entityManager, scopeId, null) instanceof Domain);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, DomainDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<DomainImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<DomainImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", DomainDAO.query(entityManager, kapuaQuery) instanceof DomainListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        DomainDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<DomainImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<DomainImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        DomainDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, DomainDAO.count(entityManager, kapuaQuery));
+            assertNull("Null expected.", kapuaQuery.getScopeId());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        DomainDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        DomainDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", DomainDAO.delete(entityManager, scopeId, domainId) instanceof Domain);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        DomainDAO.delete(null, scopeId, domainId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", DomainDAO.delete(entityManager, null, domainId) instanceof Domain);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullDomainIdTest() throws KapuaEntityNotFoundException {
+        DomainDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(null);
+
+        DomainDAO.delete(entityManager, scopeId, domainId);
+    }
+
+    @Test
+    public void findByNameEmptyListTest() {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        ParameterExpression<String> parameterExpressionName = Mockito.mock(ParameterExpression.class);
+        Predicate namePredicate = Mockito.mock(Predicate.class);
+        List<DomainImpl> list = new ArrayList<>();
+        TypedQuery<DomainImpl> query1 = Mockito.mock(TypedQuery.class);
+        TypedQuery<DomainImpl> query2 = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaBuilder.parameter(String.class, KapuaNamedEntityAttributes.NAME)).thenReturn(parameterExpressionName);
+        Mockito.when(criteriaBuilder.equal(entityRoot.get(KapuaNamedEntityAttributes.NAME), parameterExpressionName)).thenReturn(namePredicate);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query1);
+        Mockito.when(query1.setParameter(parameterExpressionName.getName(), "name")).thenReturn(query2);
+        Mockito.when(query1.getResultList()).thenReturn(list);
+
+        assertNull("Null expected.", DomainDAO.findByName(entityManager, "name"));
+    }
+
+    @Test
+    public void findByNameTest() {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        ParameterExpression<String> parameterExpressionName = Mockito.mock(ParameterExpression.class);
+        Predicate namePredicate = Mockito.mock(Predicate.class);
+        List<DomainImpl> list = new ArrayList<>();
+        list.add(Mockito.mock(DomainImpl.class));
+        TypedQuery<DomainImpl> query1 = Mockito.mock(TypedQuery.class);
+        TypedQuery<DomainImpl> query2 = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaBuilder.parameter(String.class, KapuaNamedEntityAttributes.NAME)).thenReturn(parameterExpressionName);
+        Mockito.when(criteriaBuilder.equal(entityRoot.get(KapuaNamedEntityAttributes.NAME), parameterExpressionName)).thenReturn(namePredicate);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query1);
+        Mockito.when(query1.setParameter(parameterExpressionName.getName(), "name")).thenReturn(query2);
+        Mockito.when(query1.getResultList()).thenReturn(list);
+
+        assertTrue("True expected.", DomainDAO.findByName(entityManager, "name") instanceof Domain);
+        assertNotNull("NotNull expected.", DomainDAO.findByName(entityManager, "name"));
+    }
+
+    @Test(expected = NonUniqueResultException.class)
+    public void findByNameNonUniqueResultTest() {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        ParameterExpression<String> parameterExpressionName = Mockito.mock(ParameterExpression.class);
+        Predicate namePredicate = Mockito.mock(Predicate.class);
+        List<DomainImpl> list = new ArrayList<>();
+        list.add(Mockito.mock(DomainImpl.class));
+        list.add(Mockito.mock(DomainImpl.class));
+        TypedQuery<DomainImpl> query1 = Mockito.mock(TypedQuery.class);
+        TypedQuery<DomainImpl> query2 = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaBuilder.parameter(String.class, KapuaNamedEntityAttributes.NAME)).thenReturn(parameterExpressionName);
+        Mockito.when(criteriaBuilder.equal(entityRoot.get(KapuaNamedEntityAttributes.NAME), parameterExpressionName)).thenReturn(namePredicate);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query1);
+        Mockito.when(query1.setParameter(parameterExpressionName.getName(), "name")).thenReturn(query2);
+        Mockito.when(query1.getResultList()).thenReturn(list);
+
+        DomainDAO.findByName(entityManager, "name");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findByNameNullEntityManagerTest() {
+        DomainDAO.findByName(null, "name");
+    }
+
+    @Test
+    public void findByNameNullNameTest() {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<DomainImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<DomainImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<DomainImpl> entityRoot = Mockito.mock(Root.class);
+        ParameterExpression<String> parameterExpressionName = Mockito.mock(ParameterExpression.class);
+        Predicate namePredicate = Mockito.mock(Predicate.class);
+        List<DomainImpl> list = new ArrayList<>();
+        list.add(Mockito.mock(DomainImpl.class));
+        TypedQuery<DomainImpl> query1 = Mockito.mock(TypedQuery.class);
+        TypedQuery<DomainImpl> query2 = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(DomainImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(DomainImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaBuilder.parameter(String.class, KapuaNamedEntityAttributes.NAME)).thenReturn(parameterExpressionName);
+        Mockito.when(criteriaBuilder.equal(entityRoot.get(KapuaNamedEntityAttributes.NAME), parameterExpressionName)).thenReturn(namePredicate);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query1);
+        Mockito.when(query1.setParameter(parameterExpressionName.getName(), null)).thenReturn(query2);
+        Mockito.when(query1.getResultList()).thenReturn(list);
+
+        assertTrue("True expected.", DomainDAO.findByName(entityManager, null) instanceof Domain);
+        assertNotNull("NotNull expected.", DomainDAO.findByName(entityManager, null));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImplTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.domain.shiro;
+
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class DomainCreatorImplTest extends Assert {
+
+    @Test
+    public void domainCreatorImplTest() {
+        String[] names = {"", "  na123)(&*^&NAME  <>", "Na-,,..,,Me name ---", "-&^454536 na___,,12 NAME name    ", "! 2#@ na     meNEMA 2323", "12&^%4   ,,,. '|<>*(", "       ,,123name;;'", "12#name--765   ,.aaa!!#$%^<> "};
+
+        for (String name : names) {
+            DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl(name);
+            assertNull("Null expected.", domainCreatorImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", name, domainCreatorImpl.getName());
+            assertNull("Null expected.", domainCreatorImpl.getActions());
+            assertFalse("False expected.", domainCreatorImpl.getGroupable());
+        }
+    }
+
+    @Test
+    public void domainCreatorImplNullTest() {
+        DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl(null);
+        assertNull("Null expected.", domainCreatorImpl.getScopeId());
+        assertNull("Null expected.", domainCreatorImpl.getName());
+        assertNull("Null expected.", domainCreatorImpl.getActions());
+        assertFalse("False expected.", domainCreatorImpl.getGroupable());
+    }
+
+    @Test
+    public void setAndGetNameTest() {
+        String[] newNames = {"", "  na123)(&*^&NAME NEWname  <>", "newNa-,,..,,Me name NEW NEW---", "-&^454536 na___,,12 NAME New    name    ", "! 2#@ na     meNewNAME 23NeW23", "12&^%4   ,,,. '|<new name>*(", "       ,,123name;;'", "12#name-new-name765   ,.aaa!!#$%^<> "};
+
+        DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl("name");
+        for (String newName : newNames) {
+            domainCreatorImpl.setName(newName);
+            assertEquals("Expected and actual values should be the same.", newName, domainCreatorImpl.getName());
+        }
+        domainCreatorImpl.setName(null);
+        assertNull("Null expected.", domainCreatorImpl.getName());
+    }
+
+    @Test
+    public void setAndGetActionsTest() {
+        Set<Actions> actions = new HashSet<>();
+        DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl("name");
+
+        domainCreatorImpl.setActions(actions);
+        assertTrue("True expected", domainCreatorImpl.getActions().isEmpty());
+
+        actions.add(Actions.read);
+        actions.add(Actions.delete);
+        actions.add(Actions.connect);
+        actions.add(Actions.execute);
+        actions.add(Actions.write);
+        domainCreatorImpl.setActions(actions);
+        assertEquals("Expected and actual values should be the same.", 5, domainCreatorImpl.getActions().size());
+
+        domainCreatorImpl.setActions(null);
+        assertNull("Null expected.", domainCreatorImpl.getActions());
+    }
+
+    @Test
+    public void setAndGetGroupableTest() {
+        boolean[] groupables = {true, false};
+        DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl("name");
+
+        for (boolean groupable : groupables) {
+            domainCreatorImpl.setGroupable(groupable);
+            assertEquals("Expected and actual values should be the same.", groupable, domainCreatorImpl.getGroupable());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
@@ -1,0 +1,131 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.domain.shiro;
+
+import org.apache.commons.lang.NotImplementedException;
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.service.authorization.domain.DomainCreator;
+import org.eclipse.kapua.service.authorization.domain.DomainListResult;
+import org.eclipse.kapua.service.authorization.domain.DomainQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class DomainFactoryImplTest extends Assert {
+
+    DomainFactoryImpl domainFactoryImpl;
+
+    @Before
+    public void initialize() {
+        domainFactoryImpl = new DomainFactoryImpl();
+    }
+
+    @Test
+    public void newCreatorNameParameterTest() {
+        String[] names = {"", "  na123)(&*^&NAME  <>", "Na-,,..,,Me name ---", "-&^454536 na___,,12 NAME name    ", "! 2#@ na     meNEMA 2323", "12&^%4   ,,,. '|<>*(", "       ,,123name;;'", "12#name--765   ,.aaa!!#$%^<> "};
+
+        for (String name : names) {
+            DomainCreator domainCreator = domainFactoryImpl.newCreator(name);
+            assertEquals("Expected and actual values should be the same.", name, domainCreator.getName());
+            assertNull("Null expected.", domainCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorNullNameParameterTest() {
+        DomainCreator domainCreator = domainFactoryImpl.newCreator((String) null);
+        assertNull("Null expected.", domainCreator.getName());
+        assertNull("Null expected.", domainCreator.getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        DomainListResult domainListResult = domainFactoryImpl.newListResult();
+        assertTrue("True expected.", domainListResult.isEmpty());
+    }
+
+    @Test
+    public void newQueryTest() {
+        DomainQuery domainQuery = domainFactoryImpl.newQuery(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQuery.getScopeId());
+        assertNotNull("NotNull expected.", domainQuery.getSortCriteria());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        DomainQuery domainQuery = domainFactoryImpl.newQuery(null);
+        assertNull("Null expected.", domainQuery.getScopeId());
+        assertNotNull("NotNull expected.", domainQuery.getSortCriteria());
+    }
+
+    @Test
+    public void newEntityTest() {
+        Domain domain = domainFactoryImpl.newEntity(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domain.getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        Domain domain = domainFactoryImpl.newEntity(null);
+        assertNull("Null expected.", domain.getScopeId());
+    }
+
+    @Test(expected = NotImplementedException.class)
+    public void newCreatorScopeIdParameterTest() {
+        domainFactoryImpl.newCreator(KapuaId.ONE);
+    }
+
+    @Test(expected = NotImplementedException.class)
+    public void newCreatorNullScopeIdParameterTest() {
+        domainFactoryImpl.newCreator((KapuaId) null);
+    }
+
+    @Test
+    public void cloneTest() {
+        Domain domain = Mockito.mock(Domain.class);
+        Set<Actions> actions = new HashSet<>();
+        Date createdOn = new Date();
+
+        Mockito.when(domain.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(domain.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(domain.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(domain.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(domain.getName()).thenReturn("name");
+        Mockito.when(domain.getActions()).thenReturn(actions);
+        Mockito.when(domain.getGroupable()).thenReturn(true);
+
+        Domain resultDomain = domainFactoryImpl.clone(domain);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultDomain.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultDomain.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", "name", resultDomain.getName());
+        assertEquals("Expected and actual values should be the same.", actions, resultDomain.getActions());
+        assertEquals("Expected and actual values should be the same.", true, resultDomain.getGroupable());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cloneNullTest() {
+        domainFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImplTest.java
@@ -1,0 +1,283 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.domain.shiro;
+
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authorization.domain.Domain;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class DomainImplTest extends Assert {
+
+    Domain domain;
+    Date createdOn;
+    Set<Actions> actions;
+    DomainImpl domainImpl1, domainImpl2, domainImpl3;
+
+    @Before
+    public void initialize() {
+        domain = Mockito.mock(Domain.class);
+        createdOn = new Date();
+        actions = new HashSet<>();
+
+        Mockito.when(domain.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(domain.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(domain.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(domain.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(domain.getName()).thenReturn("name");
+        Mockito.when(domain.getActions()).thenReturn(actions);
+        Mockito.when(domain.getGroupable()).thenReturn(true);
+
+        domainImpl1 = new DomainImpl();
+        domainImpl2 = new DomainImpl(KapuaId.ONE);
+        domainImpl3 = new DomainImpl(domain);
+    }
+
+    @Test
+    public void domainImplWithoutParametersTest() {
+        assertNull("Null expected.", domainImpl1.getScopeId());
+        assertNull("Null expected.", domainImpl1.getName());
+        assertNull("Null expected.", domainImpl1.getActions());
+        assertFalse("False expected.", domainImpl1.getGroupable());
+    }
+
+    @Test
+    public void domainImplScopeIdParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl2.getScopeId());
+        assertNull("Null expected.", domainImpl2.getName());
+        assertNull("Null expected.", domainImpl2.getActions());
+        assertFalse("False expected.", domainImpl2.getGroupable());
+    }
+
+    @Test
+    public void domainImplNullScopeIdParameterTest() {
+        DomainImpl domainImpl = new DomainImpl((KapuaId) null);
+        assertNull("Null expected.", domainImpl.getScopeId());
+        assertNull("Null expected.", domainImpl.getName());
+        assertNull("Null expected.", domainImpl.getActions());
+        assertFalse("False expected.", domainImpl.getGroupable());
+    }
+
+    @Test
+    public void domainImplDomainParameterTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, domainImpl3.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, domainImpl3.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", "name", domainImpl3.getName());
+        assertEquals("Expected and actual values should be the same.", actions, domainImpl3.getActions());
+        assertTrue("True expected.", domainImpl3.getGroupable());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void domainImplNullDomainParameterTest() {
+        new DomainImpl((Domain) null);
+    }
+
+    @Test
+    public void setAndGetName() {
+        String[] newNames = {"", "  na123)(&*^&NAME NEWname  <>", "newNa-,,..,,Me name NEW NEW---", "-&^454536 na___,,12 NAME New    name    ", "! 2#@ na     meNewNAME 23NeW23", "12&^%4   ,,,. '|<new name>*(", "       ,,123name;;'", "12#name-new-name765   ,.aaa!!#$%^<> "};
+
+        for (String newName : newNames) {
+            domainImpl1.setName(newName);
+            domainImpl2.setName(newName);
+            domainImpl3.setName(newName);
+            assertEquals("Expected and actual values should be the same.", newName, domainImpl1.getName());
+            assertEquals("Expected and actual values should be the same.", newName, domainImpl2.getName());
+            assertEquals("Expected and actual values should be the same.", newName, domainImpl3.getName());
+        }
+
+        domainImpl1.setName(null);
+        domainImpl2.setName(null);
+        domainImpl3.setName(null);
+        assertNull("Null expected.", domainImpl1.getName());
+        assertNull("Null expected.", domainImpl2.getName());
+        assertNull("Null expected.", domainImpl3.getName());
+    }
+
+    @Test
+    public void setAndGetActionsTest() {
+        Set<Actions> newActions = new HashSet<>();
+
+        domainImpl1.setActions(newActions);
+        domainImpl2.setActions(newActions);
+        domainImpl3.setActions(newActions);
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
+        assertTrue("True expected", domainImpl1.getActions().isEmpty());
+        assertTrue("True expected", domainImpl2.getActions().isEmpty());
+        assertTrue("True expected", domainImpl3.getActions().isEmpty());
+
+        newActions.add(Actions.read);
+        newActions.add(Actions.delete);
+        newActions.add(Actions.connect);
+        newActions.add(Actions.execute);
+        newActions.add(Actions.write);
+        domainImpl1.setActions(newActions);
+        domainImpl2.setActions(newActions);
+        domainImpl3.setActions(newActions);
+
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
+        assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
+        assertEquals("Expected and actual values should be the same.", 5, domainImpl1.getActions().size());
+        assertEquals("Expected and actual values should be the same.", 5, domainImpl2.getActions().size());
+        assertEquals("Expected and actual values should be the same.", 5, domainImpl3.getActions().size());
+
+        domainImpl1.setActions(null);
+        domainImpl2.setActions(null);
+        domainImpl3.setActions(null);
+        assertNull("Null expected.", domainImpl1.getActions());
+        assertNull("Null expected.", domainImpl2.getActions());
+        assertNull("Null expected.", domainImpl3.getActions());
+    }
+
+    @Test
+    public void setAndGetGroupableTest() {
+        boolean[] groupables = {true, false};
+
+        for (boolean groupable : groupables) {
+            domainImpl1.setGroupable(groupable);
+            domainImpl2.setGroupable(groupable);
+            domainImpl3.setGroupable(groupable);
+
+            assertEquals("Expected and actual values should be the same.", groupable, domainImpl1.getGroupable());
+            assertEquals("Expected and actual values should be the same.", groupable, domainImpl2.getGroupable());
+            assertEquals("Expected and actual values should be the same.", groupable, domainImpl3.getGroupable());
+        }
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        assertTrue("True expected.", domainImpl1.equals(domainImpl1));
+    }
+
+    @Test
+    public void equalsNullTest() {
+        assertFalse("False expected.", domainImpl1.equals(null));
+    }
+
+    @Test
+    public void equalsObjectTest() {
+        assertFalse("False expected.", domainImpl1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsTrueTest() {
+        domainImpl1.setGroupable(true);
+        domainImpl2.setGroupable(true);
+        domainImpl1.setName("name");
+        domainImpl2.setName("name");
+        domainImpl1.setActions(actions);
+        domainImpl2.setActions(actions);
+
+        assertTrue("True expected.", domainImpl1.equals(domainImpl2));
+    }
+
+    @Test
+    public void equalsDifferentGroupableTest() {
+        domainImpl1.setGroupable(true);
+        domainImpl2.setGroupable(false);
+        domainImpl1.setName("name");
+        domainImpl2.setName("name");
+        domainImpl1.setActions(actions);
+        domainImpl2.setActions(actions);
+
+        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+    }
+
+    @Test
+    public void equalsDifferentNamesTest() {
+        domainImpl1.setGroupable(true);
+        domainImpl2.setGroupable(true);
+        domainImpl1.setName("name");
+        domainImpl2.setName("different name");
+        domainImpl1.setActions(actions);
+        domainImpl2.setActions(actions);
+
+        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+    }
+
+    @Test
+    public void equalsDifferentActionsTest() {
+        domainImpl1.setGroupable(true);
+        domainImpl2.setGroupable(true);
+        domainImpl1.setName("name");
+        domainImpl2.setName("name");
+        actions.add(Actions.delete);
+        domainImpl1.setActions(actions);
+        domainImpl2.setActions(new HashSet<>());
+
+        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+    }
+
+    @Test
+    public void hashCodeTest() {
+        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNameTest() {
+        domainImpl1.setName("name");
+        assertEquals("Expected and actual values should be the same.", -1052803841, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeEmptyActionsTest() {
+        domainImpl1.setActions(actions);
+        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeActionsTest() {
+        actions.add(Actions.read);
+        actions.add(Actions.delete);
+        actions.add(Actions.connect);
+        actions.add(Actions.execute);
+        actions.add(Actions.write);
+        domainImpl1.setActions(actions);
+
+        assertEquals("Expected and actual values should be the same.", 31 * actions.hashCode() + 31028, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeGroupableTrueTest() {
+        domainImpl1.setGroupable(true);
+        assertEquals("Expected and actual values should be the same.", 31022, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeGroupableFalseTest() {
+        domainImpl1.setGroupable(false);
+        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNameActionsGroupableTest() {
+        domainImpl1.setName("name");
+        domainImpl1.setActions(actions);
+        domainImpl1.setGroupable(true);
+        assertEquals("Expected and actual values should be the same.", -1052803847, domainImpl1.hashCode());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImplTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.domain.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DomainQueryImplTest extends Assert {
+
+    @Test
+    public void domainQueryImplWithoutParametersTest() {
+        DomainQueryImpl domainQueryImpl = new DomainQueryImpl();
+        assertNull("Null expected.", domainQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void domainQueryImplScopeIdParameterTest() {
+        DomainQueryImpl domainQueryImpl = new DomainQueryImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQueryImpl.getScopeId());
+    }
+
+    @Test
+    public void domainQueryImplNullScopeIdParameterTest() {
+        DomainQueryImpl domainQueryImpl = new DomainQueryImpl(null);
+        assertNull("Null expected.", domainQueryImpl.getScopeId());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in shiro module in authorization/domain/shiro package:
 - DomainDAO class
 - DomainCreatorImpl class
 - DomainFactoryImpl class
 - DomainImpl class
 - DomainQueryImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
