### PR TITLE
Added JUnit tests for authorization/role/shiro package

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionFactoryTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionFactoryTest.java
@@ -1,0 +1,115 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.eclipse.kapua.service.authorization.role.RolePermissionCreator;
+import org.eclipse.kapua.service.authorization.role.RolePermissionListResult;
+import org.eclipse.kapua.service.authorization.role.RolePermissionQuery;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionFactoryImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class RolePermissionFactoryTest extends Assert {
+
+    RolePermissionFactoryImpl rolePermissionFactoryImpl;
+    KapuaId scopeId;
+    RolePermission rolePermission;
+    Date createdOn, modifiedOn;
+    PermissionImpl permission;
+
+    @Before
+    public void initialize() {
+        rolePermissionFactoryImpl = new RolePermissionFactoryImpl();
+        scopeId = KapuaId.ONE;
+        createdOn = new Date();
+        modifiedOn = new Date();
+        rolePermission = Mockito.mock(RolePermission.class);
+        permission = Mockito.mock(PermissionImpl.class);
+
+        Mockito.when(rolePermission.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(rolePermission.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.when(rolePermission.getPermission()).thenReturn(permission);
+        Mockito.when(rolePermission.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(rolePermission.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(rolePermission.getCreatedOn()).thenReturn(createdOn);
+    }
+
+    @Test
+    public void newEntityTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newEntity(scopeId) instanceof RolePermission);
+        assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionFactoryImpl.newEntity(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newEntity(null) instanceof RolePermission);
+        assertNull("Null expected.", rolePermissionFactoryImpl.newEntity(null).getScopeId());
+    }
+
+    @Test
+    public void newCreatorTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newCreator(scopeId) instanceof RolePermissionCreator);
+        assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionFactoryImpl.newCreator(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newCreatorNullTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newCreator(null) instanceof RolePermissionCreator);
+        assertNull("Null expected.", rolePermissionFactoryImpl.newCreator(null).getScopeId());
+    }
+
+    @Test
+    public void newQueryTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newQuery(scopeId) instanceof RolePermissionQuery);
+        assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionFactoryImpl.newQuery(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newQuery(null) instanceof RolePermissionQuery);
+        assertNull("Null expected.", rolePermissionFactoryImpl.newQuery(null).getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("True expected.", rolePermissionFactoryImpl.newListResult() instanceof RolePermissionListResult);
+        assertTrue("True expected.", rolePermissionFactoryImpl.newListResult().isEmpty());
+    }
+
+    @Test
+    public void cloneTest() {
+        RolePermission resultRolePermission = rolePermissionFactoryImpl.clone(rolePermission);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRolePermission.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRolePermission.getRoleId());
+        assertEquals("Expected and actual values should be the same.", permission, resultRolePermission.getPermission());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRolePermission.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRolePermission.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultRolePermission.getCreatedOn());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void cloneNullTest() {
+        rolePermissionFactoryImpl.clone(null);
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionImplTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionImplTest.java
@@ -1,0 +1,241 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class RolePermissionImplTest extends Assert {
+
+    KapuaId[] scopeIds;
+    Permission permission1, permission2;
+    RolePermissionImpl rolePermissionImpl1, rolePermissionImpl2;
+    RolePermission rolePermission;
+    Date createdOn;
+
+    @Before
+    public void initialize() {
+        scopeIds = new KapuaId[]{null, KapuaId.ONE};
+        permission1 = Mockito.mock(Permission.class);
+        permission2 = Mockito.mock(PermissionImpl.class);
+        rolePermissionImpl1 = new RolePermissionImpl(KapuaId.ONE);
+        rolePermissionImpl2 = new RolePermissionImpl(KapuaId.ANY);
+        rolePermission = Mockito.mock(RolePermission.class);
+        createdOn = new Date();
+
+        Mockito.when(rolePermission.getId()).thenReturn(KapuaId.ANY);
+        Mockito.when(rolePermission.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.when(rolePermission.getPermission()).thenReturn(permission2);
+        Mockito.when(rolePermission.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(rolePermission.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(rolePermission.getCreatedOn()).thenReturn(createdOn);
+    }
+
+    @Test
+    public void rolePermissionImplWithoutParametersTest() throws Exception {
+        Constructor<RolePermissionImpl> rolePermissionImpl = RolePermissionImpl.class.getDeclaredConstructor();
+        rolePermissionImpl.setAccessible(true);
+        rolePermissionImpl.newInstance();
+        assertTrue("True expected.", Modifier.isProtected(rolePermissionImpl.getModifiers()));
+    }
+
+    @Test
+    public void rolePermissionImpScopeIdTest() {
+        for (KapuaId scopeId : scopeIds) {
+            RolePermissionImpl rolePermissionImpl = new RolePermissionImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", new PermissionImpl(null, null, null, null), rolePermissionImpl.getPermission());
+            assertNull("Null expected.", rolePermissionImpl.getRoleId());
+        }
+    }
+
+    @Test
+    public void rolePermissionImplScopeIdPermissionTest() {
+        for (KapuaId scopeId : scopeIds) {
+            RolePermissionImpl rolePermissionImpl = new RolePermissionImpl(scopeId, permission2);
+            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", permission2, rolePermissionImpl.getPermission());
+            assertNull("Null expected.", rolePermissionImpl.getRoleId());
+        }
+    }
+
+    @Test
+    public void rolePermissionImplScopeIdNullPermissionTest() {
+        for (KapuaId scopeId : scopeIds) {
+            RolePermissionImpl rolePermissionImpl = new RolePermissionImpl(scopeId, null);
+            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", new PermissionImpl(null, null, null, null), rolePermissionImpl.getPermission());
+        }
+    }
+
+    @Test
+    public void rolePermissionImplRolePermissionTest() {
+        RolePermissionImpl rolePermissionImpl = new RolePermissionImpl(rolePermission);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, rolePermissionImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, rolePermissionImpl.getRoleId());
+        assertEquals("Expected and actual values should be the same.", permission2, rolePermissionImpl.getPermission());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, rolePermissionImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, rolePermissionImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, rolePermissionImpl.getCreatedOn());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void rolePermissionImplNullRolePermissionTest() {
+        new RolePermissionImpl((RolePermission) null);
+    }
+
+    @Test
+    public void setAndGetRoleIdTest() {
+        KapuaId[] roleIds = {null, KapuaId.ONE};
+
+        RolePermissionImpl rolePermissionImpl1 = new RolePermissionImpl(KapuaId.ONE);
+        RolePermissionImpl rolePermissionImpl2 = new RolePermissionImpl(KapuaId.ANY, permission2);
+        RolePermissionImpl rolePermissionImpl3 = new RolePermissionImpl(rolePermission);
+
+        for (KapuaId roleId : roleIds) {
+            rolePermissionImpl1.setRoleId(roleId);
+            assertEquals("Expected and actual values should be the same.", roleId, rolePermissionImpl1.getRoleId());
+
+            rolePermissionImpl2.setRoleId(roleId);
+            assertEquals("Expected and actual values should be the same.", roleId, rolePermissionImpl2.getRoleId());
+
+            rolePermissionImpl3.setRoleId(roleId);
+            assertEquals("Expected and actual values should be the same.", roleId, rolePermissionImpl3.getRoleId());
+        }
+    }
+
+    @Test
+    public void setAndGetPermissionToStringTest() {
+        RolePermissionImpl rolePermissionImpl1 = new RolePermissionImpl(KapuaId.ONE);
+        RolePermissionImpl rolePermissionImpl2 = new RolePermissionImpl(KapuaId.ANY, permission2);
+        RolePermissionImpl rolePermissionImpl3 = new RolePermissionImpl(rolePermission);
+        Permission[] permissions = {null, permission1, permission2};
+        Permission[] expectedPermissions = {new PermissionImpl(null, null, null, null), new PermissionImpl(null, null, null, null), permission2};
+
+        for (int i = 0; i < permissions.length; i++) {
+            rolePermissionImpl1.setPermission(permissions[i]);
+            assertEquals("Expected and actual values should be the same.", expectedPermissions[i], rolePermissionImpl1.getPermission());
+            assertEquals("Expected and actual values should be the same.", expectedPermissions[i].toString(), rolePermissionImpl1.toString());
+
+            rolePermissionImpl2.setPermission(permissions[i]);
+            assertEquals("Expected and actual values should be the same.", expectedPermissions[i].toString(), rolePermissionImpl2.toString());
+
+            rolePermissionImpl3.setPermission(permissions[i]);
+            assertEquals("Expected and actual values should be the same.", expectedPermissions[i].toString(), rolePermissionImpl3.toString());
+        }
+
+    }
+
+    @Test
+    public void hashCodeNullRoleIdNullPermissionTest() {
+        assertEquals("Expected and actual values should be the same.", 961, rolePermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullPermissionTest() {
+        rolePermissionImpl1.setRoleId(KapuaId.ONE);
+
+        assertEquals("Expected and actual values should be the same.", 993, rolePermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeNullRoleIdTest() {
+        rolePermissionImpl1.setPermission(permission1);
+
+        assertEquals("Expected and actual values should be the same.", 28630112, rolePermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void hashCodeTest() {
+        rolePermissionImpl1.setRoleId(KapuaId.ONE);
+        rolePermissionImpl1.setPermission(Mockito.mock(Permission.class));
+
+        assertEquals("Expected and actual values should be the same.", 28630144, rolePermissionImpl1.hashCode());
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        assertTrue("True expected.", rolePermissionImpl1.equals(rolePermissionImpl1));
+    }
+
+    @Test
+    public void equalsNullObjectTest() {
+        assertFalse("False expected.", rolePermissionImpl1.equals(null));
+    }
+
+    @Test
+    public void equalsObjectTest() {
+        assertFalse("False expected.", rolePermissionImpl1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNullBothRoleIdsTest() {
+        assertTrue("True expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+
+    @Test
+    public void equalsNullBothRoleIdsDifferentPermissionsTest() {
+        rolePermissionImpl1.setPermission(permission1);
+        rolePermissionImpl2.setPermission(permission2);
+
+        assertFalse("False expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+
+    @Test
+    public void equalsNullRoleIdTest() {
+        rolePermissionImpl2.setRoleId(KapuaId.ONE);
+
+        assertFalse("False expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+
+    @Test
+    public void equalsDifferentRoleIdsTest() {
+        rolePermissionImpl1.setRoleId(KapuaId.ONE);
+        rolePermissionImpl2.setRoleId(KapuaId.ANY);
+
+        assertFalse("False expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+
+    @Test
+    public void equalsSameRoleIdsTest() {
+        rolePermissionImpl1.setRoleId(KapuaId.ONE);
+        rolePermissionImpl2.setRoleId(KapuaId.ONE);
+
+        assertTrue("True expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+
+    @Test
+    public void equalsSameRoleIdsDifferentPermissionsTest() {
+        rolePermissionImpl1.setRoleId(KapuaId.ONE);
+        rolePermissionImpl1.setPermission(permission1);
+        rolePermissionImpl2.setRoleId(KapuaId.ONE);
+        rolePermissionImpl2.setPermission(permission2);
+
+        assertFalse("False expected.", rolePermissionImpl1.equals(rolePermissionImpl2));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class RoleCacheFactoryTest extends Assert {
+
+    @Test
+    public void roleCacheFactoryTest() throws Exception {
+        Constructor<RoleCacheFactory> roleCacheFactory = RoleCacheFactory.class.getDeclaredConstructor();
+        roleCacheFactory.setAccessible(true);
+        roleCacheFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(roleCacheFactory.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", RoleCacheFactory.getInstance() instanceof RoleCacheFactory);
+        assertEquals("Expected and actual values should be the same.", "RoleId", RoleCacheFactory.getInstance().getEntityIdCacheName());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImplTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashSet;
+import java.util.Set;
+
+@Category(JUnitTests.class)
+public class RoleCreatorImplTest extends Assert {
+
+    RoleCreatorImpl roleCreatorImpl;
+    Set<Permission> permissions;
+    Permission permission1, permission2;
+
+    @Before
+    public void initialize() {
+        roleCreatorImpl = new RoleCreatorImpl(KapuaId.ONE);
+        permissions = new HashSet<>();
+        permission1 = Mockito.mock(Permission.class);
+        permission2 = Mockito.mock(Permission.class);
+    }
+
+    @Test
+    public void roleCreatorImplTest() {
+        KapuaId[] scopeIds = {KapuaId.ONE, null};
+        for (KapuaId scopeId : scopeIds) {
+            RoleCreatorImpl roleCreatorImpl = new RoleCreatorImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, roleCreatorImpl.getScopeId());
+            assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+        }
+    }
+
+    @Test
+    public void setAndGetEmptyPermissionsTest() {
+        roleCreatorImpl.setPermissions(permissions);
+        assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+    }
+
+    @Test
+    public void setAndGetPermissionsTest() {
+        permissions.add(permission1);
+        permissions.add(permission2);
+        permissions.add(null);
+
+        roleCreatorImpl.setPermissions(permissions);
+        assertFalse("False expected.", roleCreatorImpl.getPermissions().isEmpty());
+        assertEquals("Expected and actual values should be the same.", permissions, roleCreatorImpl.getPermissions());
+        assertEquals("Expected and actual values should be the same.", 3, roleCreatorImpl.getPermissions().size());
+    }
+
+    @Test
+    public void setAndGetNullPermissionsTest() {
+        roleCreatorImpl.setPermissions(null);
+        assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImplTest.java
@@ -1,0 +1,127 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.authorization.role.RoleCreator;
+import org.eclipse.kapua.service.authorization.role.RoleQuery;
+import org.eclipse.kapua.service.authorization.role.RoleListResult;
+import org.eclipse.kapua.service.authorization.role.RolePermission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class RoleFactoryImplTest extends Assert {
+
+    RoleFactoryImpl roleFactoryImpl;
+    KapuaId scopeId;
+    Role role;
+    Date createdOn, modifiedOn;
+
+    @Before
+    public void initialize() {
+        roleFactoryImpl = new RoleFactoryImpl();
+        scopeId = KapuaId.ONE;
+        createdOn = new Date();
+        modifiedOn = new Date();
+        role = Mockito.mock(Role.class);
+
+        Mockito.when(role.getName()).thenReturn("role name");
+        Mockito.when(role.getDescription()).thenReturn("role description");
+        Mockito.when(role.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(role.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(role.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(role.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(role.getModifiedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(role.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(role.getOptlock()).thenReturn(11);
+    }
+
+    @Test
+    public void newEntityTest() {
+        assertTrue("True expected.", roleFactoryImpl.newEntity(scopeId) instanceof Role);
+        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newEntity(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        assertTrue("True expected.", roleFactoryImpl.newEntity(null) instanceof Role);
+        assertNull("Null expected.", roleFactoryImpl.newEntity(null).getScopeId());
+    }
+
+    @Test
+    public void newCreatorTest() {
+        assertTrue("True expected.", roleFactoryImpl.newCreator(scopeId) instanceof RoleCreator);
+        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newCreator(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newCreatorNullTest() {
+        assertTrue("True expected.", roleFactoryImpl.newCreator(null) instanceof RoleCreator);
+        assertNull("Null expected.", roleFactoryImpl.newCreator(null).getScopeId());
+    }
+
+    @Test
+    public void newQueryTest() {
+        assertTrue("True expected.", roleFactoryImpl.newQuery(scopeId) instanceof RoleQuery);
+        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newQuery(scopeId).getScopeId());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        assertTrue("True expected.", roleFactoryImpl.newQuery(null) instanceof RoleQuery);
+        assertNull("Null expected.", roleFactoryImpl.newQuery(null).getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        assertTrue("True expected.", roleFactoryImpl.newListResult() instanceof RoleListResult);
+        assertTrue("True expected.", roleFactoryImpl.newListResult().isEmpty());
+    }
+
+    @Test
+    public void newRolePermissionTest() {
+        assertTrue("True expected.", roleFactoryImpl.newRolePermission() instanceof RolePermission);
+    }
+
+    @Test
+    public void cloneTest() {
+        Role resultRole = roleFactoryImpl.clone(role);
+
+        assertEquals("Expected and actual values should be the same.", "role name", resultRole.getName());
+        assertEquals("Expected and actual values should be the same.", "role description", resultRole.getDescription());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultRole.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, resultRole.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 11, resultRole.getOptlock());
+    }
+
+    @Test
+    public void cloneNullTest() {
+        try {
+            roleFactoryImpl.clone(null);
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same", "org.eclipse.kapua.KapuaEntityCloneException: Severe error while cloning: role", e.toString());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImplTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class RoleImplTest extends Assert {
+
+    RoleImpl role1, role2;
+
+    @Before
+    public void initialize() {
+        role1 = new RoleImpl();
+        role2 = new RoleImpl();
+    }
+
+    @Test
+    public void roleImplWithoutParametersTest() {
+        RoleImpl roleImpl = new RoleImpl();
+        assertNull("Null expected.", roleImpl.getScopeId());
+        assertNull("Null expected.", roleImpl.getName());
+        assertNull("Null expected.", roleImpl.getDescription());
+    }
+
+    @Test
+    public void roleImplScopeIdTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ONE};
+
+        for (KapuaId scopeId : scopeIds) {
+            RoleImpl roleImpl = new RoleImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, roleImpl.getScopeId());
+            assertNull("Null expected.", roleImpl.getName());
+            assertNull("Null expected.", roleImpl.getDescription());
+        }
+    }
+
+    @Test
+    public void roleImplRoleTest() throws KapuaException {
+        Role role = Mockito.mock(Role.class);
+        Date createdOn = new Date();
+        Date modifiedOn = new Date();
+
+        Mockito.when(role.getName()).thenReturn("role name");
+        Mockito.when(role.getDescription()).thenReturn("role description");
+        Mockito.when(role.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(role.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(role.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(role.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(role.getModifiedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(role.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(role.getOptlock()).thenReturn(11);
+
+        RoleImpl roleImpl = new RoleImpl(role);
+        assertEquals("Expected and actual values should be the same.", "role name", roleImpl.getName());
+        assertEquals("Expected and actual values should be the same.", "role description", roleImpl.getDescription());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, roleImpl.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, roleImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 11, roleImpl.getOptlock());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void roleImplNullRoleTest() throws KapuaException {
+        new RoleImpl((Role) null);
+    }
+
+    @Test
+    public void hashCodeNullNameTest() {
+        RoleImpl role = new RoleImpl();
+        assertEquals("Expected and actual values should be the same.", 31, role.hashCode());
+    }
+
+    @Test
+    public void hashCodeWithNameTest() {
+        RoleImpl role = new RoleImpl();
+        String[] names = {"", "  na123)(&*^&NAME  <>", "Na-,,..,,Me name ---", "-&^454536 na___,,12 NAME name    ", "! 2#@ na     meNEMA 2323", "12&^%4   ,,,. '|<>*(", "       ,,123name;;'", "12#name--765   ,.aaa!!#$%^<> "};
+        int[] expectedResult = {31, 467704822, -586547515, -576050570, 589188417, -894904038, -1874261591, 12362811};
+        for (int i = 0; i < names.length; i++) {
+            role.setName(names[i]);
+            assertEquals("Expected and actual values should be the same.", expectedResult[i], role.hashCode());
+        }
+    }
+
+    @Test
+    public void equalsSameObjectTest() {
+        assertTrue("True expected.", role1.equals(role1));
+    }
+
+    @Test
+    public void equalsNullObjectTest() {
+        assertFalse("False expected.", role1.equals(null));
+    }
+
+    @Test
+    public void equalsObjectTest() {
+        assertFalse("False expected.", role1.equals(new Object()));
+    }
+
+    @Test
+    public void equalsNullBothNamesTest() {
+        assertTrue("True expected.", role1.equals(role2));
+    }
+
+    @Test
+    public void equalsNullNameTest() {
+        role2.setName("name2");
+        assertFalse("False expected.", role1.equals(role2));
+    }
+
+    @Test
+    public void equalsDifferentNamesTest() {
+        role1.setName("name1");
+        role2.setName("name2");
+        assertFalse("False expected.", role1.equals(role2));
+    }
+
+    @Test
+    public void equalsSameNamesTest() {
+        role1.setName("name");
+        role2.setName("name");
+        assertTrue("True expected.", role1.equals(role2));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactoryTest.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class RolePermissionCacheFactoryTest extends Assert {
+
+    @Test
+    public void rolePermissionCacheFactoryTest() throws Exception {
+        Constructor<RolePermissionCacheFactory> rolePermissionCacheFactory = RolePermissionCacheFactory.class.getDeclaredConstructor();
+        rolePermissionCacheFactory.setAccessible(true);
+        rolePermissionCacheFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(rolePermissionCacheFactory.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", RolePermissionCacheFactory.getInstance() instanceof RolePermissionCacheFactory);
+        assertEquals("Expected and actual values should be the same.", "RolePermissionId", RolePermissionCacheFactory.getInstance().getEntityIdCacheName());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImplTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class RolePermissionCreatorImplTest extends Assert {
+
+    @Test
+    public void rolePermissionCreatorImplTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ANY};
+        for (KapuaId scopeId : scopeIds) {
+            RolePermissionCreatorImpl rolePermissionCreatorImpl = new RolePermissionCreatorImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionCreatorImpl.getScopeId());
+            assertNull("Null expected.", rolePermissionCreatorImpl.getRoleId());
+            assertNull("Null expected.", rolePermissionCreatorImpl.getPermission());
+        }
+    }
+
+    @Test
+    public void setAndGetRoleIdTest() {
+        KapuaId[] roleIds = {null, KapuaId.ONE};
+        RolePermissionCreatorImpl rolePermissionCreatorImpl = new RolePermissionCreatorImpl(KapuaId.ONE);
+
+        for (KapuaId roleId : roleIds) {
+            rolePermissionCreatorImpl.setRoleId(roleId);
+            assertEquals("Expected and actual values should be the same.", roleId, rolePermissionCreatorImpl.getRoleId());
+        }
+    }
+
+    @Test
+    public void setAndGetPermissionTest() {
+        Permission[] permissions = {null, Mockito.mock(Permission.class)};
+        RolePermissionCreatorImpl rolePermissionCreatorImpl = new RolePermissionCreatorImpl(KapuaId.ONE);
+
+        for (Permission permission : permissions) {
+            rolePermissionCreatorImpl.setPermission(permission);
+            assertEquals("Expected and actual values should be the same.", permission, rolePermissionCreatorImpl.getPermission());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class RolePermissionQueryImplTest extends Assert {
+
+    @Test
+    public void rolePermissionQueryImplWithoutParametersTest() {
+        RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl();
+        assertNull("Null expected.", rolePermissionQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", rolePermissionQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void rolePermissionQueryImpScopeIdTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ANY};
+
+        for (KapuaId scopeId : scopeIds) {
+            RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionQueryImpl.getScopeId());
+            assertNotNull("NotNull expected.", rolePermissionQueryImpl.getSortCriteria());
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
@@ -1,0 +1,41 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.role.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class RoleQueryImplTest extends Assert {
+
+    @Test
+    public void rolePermissionQueryImplWithoutParametersTest() {
+        RoleQueryImpl roleQueryImpl = new RoleQueryImpl();
+        assertNull("Null expected.", roleQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", roleQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void rolePermissionQueryImpScopeIdTest() {
+        KapuaId[] scopeIds = {null, KapuaId.ANY};
+
+        for (KapuaId scopeId : scopeIds) {
+            RoleQueryImpl roleQueryImpl = new RoleQueryImpl(scopeId);
+            assertEquals("Expected and actual values should be the same.", scopeId, roleQueryImpl.getScopeId());
+            assertNotNull("NotNull expected.", roleQueryImpl.getSortCriteria());
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in authorization/role/shiro package from
shiro module:

 - RoleCacheFactory class
 - RoleCreatorImpl class
 - RoleFactoryImpl class
 - RoleImpl class
 - RolePermissionCacheFactory class
 - RolePermissionCreatorImpl class
 - RolePermissionQueryImpl class
 - RolePermissionFactory class
 - RolePermissionImpl class
 - RoleQueryImpl class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
