### PR TITLE
Added JUnit tests for authorization package in shiro module

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionDAOTest.java
@@ -1,0 +1,294 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessPermission;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionDAO;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionImpl;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class AccessPermissionDAOTest extends Assert {
+
+    EntityManager entityManager;
+    AccessPermissionCreator creator;
+    PermissionImpl permission;
+    AccessPermissionImpl accessPermission, entityToFindOrDelete;
+    KapuaId scopeId, accessPermissionId;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        creator = Mockito.mock(AccessPermissionCreator.class);
+        permission = Mockito.mock(PermissionImpl.class);
+        accessPermission = Mockito.mock(AccessPermissionImpl.class);
+        entityToFindOrDelete = Mockito.mock(AccessPermissionImpl.class);
+        scopeId = KapuaId.ONE;
+        accessPermissionId = KapuaId.ONE;
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+
+        assertTrue("True expected.", AccessPermissionDAO.create(entityManager, creator) instanceof AccessPermission);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessPermissionDAO.create(entityManager, creator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, AccessPermissionDAO.create(entityManager, creator).getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", permission, AccessPermissionDAO.create(entityManager, creator).getPermission());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        AccessPermissionDAO.create(entityManager, creator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        AccessPermissionDAO.create(entityManager, creator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithNotSQLCauseTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        AccessPermissionDAO.create(entityManager, creator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        AccessPermissionDAO.create(entityManager, creator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(creator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(creator.getAccessInfoId()).thenReturn(KapuaId.ANY);
+        Mockito.when(creator.getPermission()).thenReturn(permission);
+
+        AccessPermissionDAO.create(null, creator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullAccessPermissionCreatorTest() throws KapuaException {
+        AccessPermissionDAO.create(entityManager, (AccessPermissionCreator) null);
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", AccessPermissionDAO.find(entityManager, scopeId, accessPermissionId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(null);
+
+        assertNull("Null expected.", AccessPermissionDAO.find(entityManager, scopeId, accessPermissionId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", AccessPermissionDAO.find(entityManager, scopeId, accessPermissionId) instanceof AccessPermission);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        AccessPermissionDAO.find(null, scopeId, accessPermissionId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessPermissionDAO.find(entityManager, null, accessPermissionId) instanceof AccessPermission);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessPermissionDAO.find(entityManager, null, accessPermissionId).getScopeId());
+    }
+
+    @Test
+    public void findNullAccessPermissionIdTest() {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessPermissionDAO.find(entityManager, scopeId, null) instanceof AccessPermission);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessPermissionDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessPermissionImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessPermissionImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<AccessPermissionImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessPermissionImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessPermissionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", AccessPermissionDAO.query(entityManager, kapuaQuery) instanceof AccessPermissionListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        AccessPermissionDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessPermissionImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessPermissionImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessPermissionImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<AccessPermissionImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessPermissionImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessPermissionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        AccessPermissionDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessPermissionImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessPermissionImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, AccessPermissionDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        AccessPermissionDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        AccessPermissionDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessPermissionDAO.delete(entityManager, scopeId, accessPermissionId) instanceof AccessPermission);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        AccessPermissionDAO.delete(null, scopeId, accessPermissionId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessPermissionDAO.delete(entityManager, null, accessPermissionId) instanceof AccessPermission);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullAccessPermissionIdTest() throws KapuaEntityNotFoundException {
+        AccessPermissionDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(null);
+
+        AccessPermissionDAO.delete(entityManager, scopeId, accessPermissionId);
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AuthorizationEntityManagerFactoryTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AuthorizationEntityManagerFactoryTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerFactory;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class AuthorizationEntityManagerFactoryTest extends Assert {
+
+    @Test
+    public void authorizationEntityManagerFactoryTest() throws Exception {
+        Constructor<AuthorizationEntityManagerFactory> authorizationEntityManagerFactory = AuthorizationEntityManagerFactory.class.getDeclaredConstructor();
+        authorizationEntityManagerFactory.setAccessible(true);
+        authorizationEntityManagerFactory.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(authorizationEntityManagerFactory.getModifiers()));
+    }
+
+    @Test
+    public void getEntityManagerTest() throws KapuaException {
+        assertTrue("True expected.", AuthorizationEntityManagerFactory.getEntityManager() instanceof EntityManager);
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", AuthorizationEntityManagerFactory.getInstance() instanceof AuthorizationEntityManagerFactory);
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/PermissionFactoryImplTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/PermissionFactoryImplTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class PermissionFactoryImplTest {
+
+    @Test
+    public void newPermissionTest(){
+        PermissionFactoryImpl permissionFactoryImpl=new PermissionFactoryImpl();
+        System.out.println(permissionFactoryImpl.newPermission(null,null,null,null,true));
+    }
+}

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/PermissionImplTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/PermissionImplTest.java
@@ -1,0 +1,97 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class PermissionImplTest extends Assert {
+
+    @Test
+    public void permissionImplWithoutParametersTest() throws Exception {
+        Constructor<PermissionImpl> permissionImpl = PermissionImpl.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isProtected(permissionImpl.getModifiers()));
+        permissionImpl.setAccessible(true);
+        permissionImpl.newInstance();
+    }
+
+    @Test
+    public void permissionImplScopeIdParameterTest() {
+        Permission permission = Mockito.mock(Permission.class);
+
+        Mockito.when(permission.getDomain()).thenReturn("domain");
+        Mockito.when(permission.getAction()).thenReturn(Actions.connect);
+        Mockito.when(permission.getTargetScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(permission.getGroupId()).thenReturn(KapuaId.ANY);
+        Mockito.when(permission.getForwardable()).thenReturn(true);
+
+        PermissionImpl permissionImpl = new PermissionImpl(permission);
+        assertEquals("Expected and actual values should be the same.", "domain", permissionImpl.getDomain());
+        assertEquals("Expected and actual values should be the same.", Actions.connect, permissionImpl.getAction());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, permissionImpl.getTargetScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, permissionImpl.getGroupId());
+        assertTrue("True expected.", permissionImpl.getForwardable());
+    }
+
+    @Test
+    public void permissionDomainActionScopeIdGroupIdTest() {
+        String[] domains = {"domain 1 - 333  d>o,,,main.^%$      ", "do-ma)in 12^%$ ,. ///", "@#domain 123*&^,,  11", "-d)oM&^    ain", "D0O-ma  )in 123", "domain  domain 65%^8*7<>"};
+        Actions[] actions = {Actions.read, Actions.write, Actions.delete, Actions.connect, Actions.execute};
+        KapuaId targetScopeId = KapuaId.ANY;
+        KapuaId groupId = KapuaId.ONE;
+
+        for (String domain : domains) {
+            for (Actions action : actions) {
+                PermissionImpl permissionImpl = new PermissionImpl(domain, action, targetScopeId, groupId);
+                assertEquals("Expected and actual values should be the same.", domain, permissionImpl.getDomain());
+                assertEquals("Expected and actual values should be the same.", action, permissionImpl.getAction());
+                assertEquals("Expected and actual values should be the same.", KapuaId.ANY, permissionImpl.getTargetScopeId());
+                assertEquals("Expected and actual values should be the same.", KapuaId.ONE, permissionImpl.getGroupId());
+                assertFalse("False expected.", permissionImpl.getForwardable());
+            }
+        }
+    }
+
+    @Test
+    public void permissionDomainActionScopeIdGroupIdForwardableTest() {
+        String[] domains = {"domain 1 - 333  d>o,,,main.^%$      ", "do-ma)in 12^%$ ,. ///", "@#domain 123*&^,,  11", "-d)oM&^    ain", "D0O-ma  )in 123", "domain  domain 65%^8*7<>"};
+        Actions[] actions = {Actions.read, Actions.write, Actions.delete, Actions.connect, Actions.execute};
+        KapuaId targetScopeId = KapuaId.ANY;
+        KapuaId groupId = KapuaId.ONE;
+        boolean[] forwardables = {true, false};
+
+        for (String domain : domains) {
+            for (Actions action : actions) {
+                for (boolean forwardable : forwardables) {
+                    PermissionImpl permissionImpl = new PermissionImpl(domain, action, targetScopeId, groupId,forwardable);
+                    assertEquals("Expected and actual values should be the same.", domain, permissionImpl.getDomain());
+                    assertEquals("Expected and actual values should be the same.", action, permissionImpl.getAction());
+                    assertEquals("Expected and actual values should be the same.", KapuaId.ANY, permissionImpl.getTargetScopeId());
+                    assertEquals("Expected and actual values should be the same.", KapuaId.ONE, permissionImpl.getGroupId());
+                    assertEquals("Expected and actual values should be the same.", forwardable, permissionImpl.getForwardable());
+                }
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealmTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealmTest.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import org.apache.shiro.authc.AuthenticationToken;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class KapuaAuthorizingRealmTest extends Assert {
+
+    KapuaAuthorizingRealm kapuaAuthorizingRealm;
+    AuthenticationToken authenticationToken;
+
+    @Before
+    public void initialize() throws KapuaException {
+        kapuaAuthorizingRealm = new KapuaAuthorizingRealm();
+        authenticationToken = Mockito.mock(AuthenticationToken.class);
+    }
+
+    @Test
+    public void kapuaAuthorizingRealmTest() {
+        assertEquals("Expected and actual values should be the same.", "kapuaAuthorizingRealm", kapuaAuthorizingRealm.getName());
+    }
+
+    @Test
+    public void supportsTest() {
+        assertFalse("False expected.", kapuaAuthorizingRealm.supports(authenticationToken));
+    }
+
+    @Test
+    public void supportsNullTest() {
+        assertFalse("False expected.", kapuaAuthorizingRealm.supports(null));
+    }
+
+    @Test
+    public void doGetAuthenticationInfoTest() {
+        assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
+    }
+
+    @Test
+    public void doGetAuthenticationInfoNullTest() {
+        assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/InternalUserOnlyExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/InternalUserOnlyExceptionTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class InternalUserOnlyExceptionTest extends Assert {
+
+    @Test
+    public void internalUserOnlyExceptionTest() {
+        InternalUserOnlyException internalUserOnlyException = new InternalUserOnlyException();
+        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.INTERNAL_USER_ONLY, internalUserOnlyException.getCode());
+        assertNull("Null expected.", internalUserOnlyException.getCause());
+        assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyException.getMessage());
+        assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", internalUserOnlyException.getKapuaErrorMessagesBundle());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
@@ -1,0 +1,147 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaAuthorizationExceptionTest extends Assert {
+
+    KapuaAuthorizationErrorCodes[] kapuaAuthorizationErrorCodes;
+    Object stringArgument, intArgument, booleanArgument;
+    Throwable[] throwables;
+    String kapuaErrorMessage;
+    String[] errorMessagesWithoutArguments, errorMessagesWithArguments;
+
+    @Before
+    public void initialize() {
+        kapuaAuthorizationErrorCodes = new KapuaAuthorizationErrorCodes[]{KapuaAuthorizationErrorCodes.ENTITY_SCOPE_MISSMATCH, KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED,
+                KapuaAuthorizationErrorCodes.INVALID_STRING_PERMISSION};
+        stringArgument = "string argument";
+        intArgument = 10;
+        booleanArgument = true;
+        throwables = new Throwable[]{null, new Throwable(), new Throwable(new Exception()), new Throwable("message")};
+        kapuaErrorMessage = "kapua-service-error-messages";
+        errorMessagesWithoutArguments = new String[]{"Error: ", "User does not have permission to perform this action. Missing permission: {0}. Please perform a new login to refresh users permissions.", "Error: "};
+        errorMessagesWithArguments = new String[]{"Error: " + stringArgument + ", " + intArgument + ", " + booleanArgument, "User does not have permission to perform this action. Missing permission: " + stringArgument + ". Please perform a new login to refresh users permissions.", "Error: " + stringArgument + ", " + intArgument + ", " + booleanArgument};
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionCodeParameterTest() {
+        for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i]);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionNullCodeParameterTest() {
+        KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null);
+        assertNull("Null expected.", kapuaAuthorizationException.getCode());
+        assertNull("Null expected.", kapuaAuthorizationException.getCause());
+        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        try {
+            kapuaAuthorizationException.getMessage();
+            fail("NullPointerException expected");
+        } catch (Exception e) {
+            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionCodeArgumentsParametersTest() {
+        for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], stringArgument, intArgument, booleanArgument);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionNullCodeArgumentsParametersTest() {
+        for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, stringArgument, intArgument, booleanArgument);
+            assertNull("Null expected.", kapuaAuthorizationException.getCode());
+            assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            try {
+                kapuaAuthorizationException.getMessage();
+                fail("NullPointerException expected");
+            } catch (Exception e) {
+                assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionCodeNullArgumentsParametersTest() {
+        for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], null);
+            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionCodeCauseArgumentsParametersTest() {
+        for (Throwable throwable : throwables) {
+            for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+                KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], throwable, stringArgument, intArgument, booleanArgument);
+                assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+                assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+                assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
+                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            }
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionNullCodeCauseArgumentsParametersTest() {
+        for (Throwable throwable : throwables) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, throwable, stringArgument, intArgument, booleanArgument);
+            assertNull("Null expected.", kapuaAuthorizationException.getCode());
+            assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            try {
+                kapuaAuthorizationException.getMessage();
+                fail("NullPointerException expected");
+            } catch (Exception e) {
+                assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+            }
+        }
+    }
+
+    @Test
+    public void kapuaAuthorizationExceptionCodeCauseNullArgumentsParametersTest() {
+        for (Throwable throwable : throwables) {
+            for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
+                KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], throwable, null);
+                assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+                assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+                assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            }
+        }
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SelfManagedOnlyExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SelfManagedOnlyExceptionTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class SelfManagedOnlyExceptionTest extends Assert {
+
+    @Test
+    public void selfManagedOnlyExceptionTest() {
+        SelfManagedOnlyException selfManagedOnlyException = new SelfManagedOnlyException();
+        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SELF_MANAGED_ONLY, selfManagedOnlyException.getCode());
+        assertNull("Null expected.", selfManagedOnlyException.getCause());
+        assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyException.getMessage());
+        assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", selfManagedOnlyException.getKapuaErrorMessagesBundle());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedExceptionTest.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class SubjectUnauthorizedExceptionTest extends Assert {
+
+    Permission permission, newPermission;
+    SubjectUnauthorizedException subjectUnauthorizedException;
+    String kapuaErrorMessage;
+
+    @Before
+    public void initialize() {
+        permission = Mockito.mock(Permission.class);
+        newPermission = Mockito.mock(Permission.class);
+        subjectUnauthorizedException = new SubjectUnauthorizedException(permission);
+        kapuaErrorMessage = "kapua-service-error-messages";
+    }
+
+    @Test
+    public void subjectUnauthorizedExceptionTest() {
+        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
+        assertNull("Null expected.", subjectUnauthorizedException.getCause());
+        assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Missing permission: " + permission + ". Please perform a new login to refresh users permissions.", subjectUnauthorizedException.getMessage());
+        assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedException.getPermission());
+        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
+    }
+
+    @Test
+    public void subjectUnauthorizedExceptionNullTest() {
+        subjectUnauthorizedException = new SubjectUnauthorizedException(null);
+        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
+        assertNull("Null expected.", subjectUnauthorizedException.getCause());
+        assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Missing permission: null. Please perform a new login to refresh users permissions.", subjectUnauthorizedException.getMessage());
+        assertNull("Null expected.", subjectUnauthorizedException.getPermission());
+        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
+    }
+
+    @Test
+    public void setAndGetPermissionTest() {
+        subjectUnauthorizedException.setPermission(newPermission);
+        assertEquals("Expected and actual values should be the same.", newPermission, subjectUnauthorizedException.getPermission());
+
+        subjectUnauthorizedException.setPermission(null);
+        assertNull("Null expected.", subjectUnauthorizedException.getPermission());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeysTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeysTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaAuthorizationSettingKeysTest extends Assert {
+
+    @Test
+    public void keyTest() {
+        assertEquals("Expected and actual values should be the same.", "authorization.key", KapuaAuthorizationSettingKeys.AUTHORIZATION_KEY.key());
+        assertEquals("Expected and actual values should be the same.", "authorization.eventAddress", KapuaAuthorizationSettingKeys.AUTHORIZATION_EVENT_ADDRESS.key());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro.setting;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class KapuaAuthorizationSettingTest extends Assert {
+
+    @Test
+    public void kapuaAuthorizationSettingTest() throws Exception {
+        Constructor<KapuaAuthorizationSetting> kapuaAuthorizationSetting = KapuaAuthorizationSetting.class.getDeclaredConstructor();
+        assertTrue("True expected.", Modifier.isPrivate(kapuaAuthorizationSetting.getModifiers()));
+        kapuaAuthorizationSetting.setAccessible(true);
+        kapuaAuthorizationSetting.newInstance();
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", KapuaAuthorizationSetting.getInstance() instanceof KapuaAuthorizationSetting);
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes for authorization package in shiro module:

 - AuthorizationEntityManagerFactory class
 - AccessPermissionDAO class
 - KapuaAuthorizingRealm class

 - permission/shiro package:
    PermissionFactoryImpl class
    PermissionImpl class

 - exception package:
    InternalUserOnlyException class
    KapuaAuthorizationException class
    SelfManagedOnlyException class
    SubjectUnauthorizedException class

 - setting package:
    KapuaAuthorizationSettingKeys class
    KapuaAuthorizationSetting class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
