### PR TITLE
Added JUnit tests for shiro/authorization/group/shiro package

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessRoleDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessRoleDAOTest.java
@@ -1,0 +1,303 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
+import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleDAO;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class AccessRoleDAOTest extends Assert {
+
+    EntityManager entityManager;
+    AccessRoleCreator accessRoleCreator;
+    KapuaId scopeId, accessRoleId;
+    AccessRoleImpl entityToFindOrDelete;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        accessRoleCreator = Mockito.mock(AccessRoleCreator.class);
+        scopeId = KapuaId.ONE;
+        accessRoleId = KapuaId.ANY;
+        entityToFindOrDelete = Mockito.mock(AccessRoleImpl.class);
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessRoleDAO.create(entityManager, accessRoleCreator) instanceof AccessRole);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.create(entityManager, accessRoleCreator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.create(entityManager, accessRoleCreator).getAccessInfoId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.create(entityManager, accessRoleCreator).getRoleId());
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        AccessRoleDAO.create(entityManager, accessRoleCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        AccessRoleDAO.create(entityManager, accessRoleCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithNotSQLCauseTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        AccessRoleDAO.create(entityManager, accessRoleCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        AccessRoleDAO.create(entityManager, accessRoleCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+
+        AccessRoleDAO.create(null, accessRoleCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullAccessRoleCreatorTest() throws KapuaException {
+        Mockito.when(accessRoleCreator.getScopeId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getAccessInfoId()).thenReturn(KapuaId.ONE);
+        Mockito.when(accessRoleCreator.getRoleId()).thenReturn(KapuaId.ONE);
+
+        AccessRoleDAO.create(entityManager, (AccessRoleCreator) null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessRoleDAO.find(entityManager, scopeId, accessRoleId) instanceof AccessRole);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.find(entityManager, scopeId, accessRoleId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", AccessRoleDAO.find(entityManager, scopeId, accessRoleId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(null);
+
+        assertNull("Null expected.", AccessRoleDAO.find(entityManager, scopeId, accessRoleId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", AccessRoleDAO.find(entityManager, scopeId, accessRoleId) instanceof AccessRole);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        AccessRoleDAO.find(null, scopeId, accessRoleId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessRoleDAO.find(entityManager, null, accessRoleId) instanceof AccessRole);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.find(entityManager, null, accessRoleId).getScopeId());
+    }
+
+    @Test
+    public void findNullAccessRoleIdTest() {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", AccessRoleDAO.find(entityManager, scopeId, null) instanceof AccessRole);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, AccessRoleDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessRoleImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessRoleImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<AccessRoleImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessRoleImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessRoleImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", AccessRoleDAO.query(entityManager, kapuaQuery) instanceof AccessRoleListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        AccessRoleDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<AccessRoleImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessRoleImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<AccessRoleImpl> entityType = Mockito.mock(EntityType.class);
+        TypedQuery<AccessRoleImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(AccessRoleImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessRoleImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        AccessRoleDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<AccessRoleImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(AccessRoleImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, AccessRoleDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        AccessRoleDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        AccessRoleDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessRoleDAO.delete(entityManager, scopeId, accessRoleId) instanceof AccessRole);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        AccessRoleDAO.delete(null, scopeId, accessRoleId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+
+        assertTrue("True expected.", AccessRoleDAO.delete(entityManager, null, accessRoleId) instanceof AccessRole);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullAccessRoleIdTest() throws KapuaEntityNotFoundException {
+        AccessRoleDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(null);
+
+        AccessRoleDAO.delete(entityManager, scopeId, accessRoleId);
+    }
+} 

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/GroupDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/GroupDAOTest.java
@@ -1,0 +1,338 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.eclipse.kapua.KapuaEntityExistsException;
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupCreator;
+import org.eclipse.kapua.service.authorization.group.GroupListResult;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupDAO;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupImpl;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.persistence.EntityExistsException;
+import javax.persistence.PersistenceException;
+import javax.persistence.TypedQuery;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
+import java.sql.SQLException;
+import java.util.ArrayList;
+import java.util.Date;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class GroupDAOTest extends Assert {
+
+    EntityManager entityManager;
+    GroupCreator groupCreator;
+    GroupImpl group, entityToFindOrDelete;
+    Date createdOn;
+    KapuaId createdBy, scopeId, groupId;
+    KapuaQuery kapuaQuery;
+
+    @Before
+    public void initialize() {
+        entityManager = Mockito.mock(EntityManager.class);
+        groupCreator = Mockito.mock(GroupCreator.class);
+        group = Mockito.mock(GroupImpl.class);
+        entityToFindOrDelete = Mockito.mock(GroupImpl.class);
+        createdOn = new Date();
+        createdBy = KapuaId.ONE;
+        scopeId = KapuaId.ONE;
+        groupId = KapuaId.ANY;
+        kapuaQuery = Mockito.mock(KapuaQuery.class);
+    }
+
+    @Test
+    public void createTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+
+        assertTrue("True expected.", GroupDAO.create(entityManager, groupCreator) instanceof Group);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, GroupDAO.create(entityManager, groupCreator).getScopeId());
+        assertEquals("Expected and actual values should be the same.", "name", GroupDAO.create(entityManager, groupCreator).getName());
+        assertEquals("Expected and actual values should be the same.", "description", GroupDAO.create(entityManager, groupCreator).getDescription());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullEntityManagerTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+
+        GroupDAO.create(null, groupCreator);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void createNullGroupCreatorTest() throws KapuaException {
+        GroupDAO.create(entityManager, (GroupCreator) null);
+    }
+
+    @Test(expected = KapuaEntityExistsException.class)
+    public void createEntityExistsExceptionTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+        Mockito.doThrow(new EntityExistsException()).when(entityManager).flush();
+
+        GroupDAO.create(entityManager, groupCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+        Mockito.doThrow(new PersistenceException()).when(entityManager).flush();
+
+        GroupDAO.create(entityManager, groupCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithNotSQLCauseTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+        Mockito.doThrow(new PersistenceException(new Exception(new Exception()))).when(entityManager).flush();
+
+        GroupDAO.create(entityManager, groupCreator);
+    }
+
+    @Test(expected = PersistenceException.class)
+    public void createPersistenceExceptionWithSQLCauseTest() throws KapuaException {
+        Mockito.when(groupCreator.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(groupCreator.getName()).thenReturn("name");
+        Mockito.when(groupCreator.getDescription()).thenReturn("description");
+        Mockito.doThrow(new PersistenceException(new SQLException("reason", "23505", new Exception()))).when(entityManager).flush();
+
+        GroupDAO.create(entityManager, groupCreator);
+    }
+
+    @Test
+    public void updateTest() throws KapuaEntityNotFoundException {
+        Mockito.when(group.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(entityManager.find(GroupImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        assertTrue("True expected.", GroupDAO.update(entityManager, group) instanceof Group);
+        assertEquals("Expected and actual values should be the same.", createdBy, GroupDAO.update(entityManager, group).getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, GroupDAO.update(entityManager, group).getCreatedOn());
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void updateEntityNotFoundExceptionTest() throws KapuaEntityNotFoundException {
+        Mockito.when(group.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(entityManager.find(GroupImpl.class, KapuaId.ONE)).thenReturn(null);
+
+        GroupDAO.update(entityManager, group);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        Mockito.when(group.getId()).thenReturn(KapuaId.ONE);
+
+        GroupDAO.update(null, group);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void updateNullGroupTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(GroupImpl.class, KapuaId.ONE)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(entityToFindOrDelete.getCreatedBy()).thenReturn(createdBy);
+
+        GroupDAO.update(entityManager, null);
+    }
+
+    @Test
+    public void findSameScopeIdsTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", GroupDAO.find(entityManager, scopeId, groupId) instanceof Group);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, GroupDAO.find(entityManager, scopeId, groupId).getScopeId());
+    }
+
+    @Test
+    public void findDifferentScopeIdsTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ANY);
+
+        assertNull("Null expected.", GroupDAO.find(entityManager, scopeId, groupId));
+    }
+
+    @Test
+    public void findNullEntityToFindTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(null);
+
+        assertNull("Null expected.", GroupDAO.find(entityManager, scopeId, groupId));
+    }
+
+    @Test
+    public void findNullEntityToFindScopeIdTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
+
+        assertTrue("True expected.", GroupDAO.find(entityManager, scopeId, groupId) instanceof Group);
+        assertNull("Null expected.", GroupDAO.find(entityManager, scopeId, groupId).getScopeId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void findNullEntityManagerTest() {
+        GroupDAO.find(null, scopeId, groupId);
+    }
+
+    @Test
+    public void findNullScopeIdTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", GroupDAO.find(entityManager, null, groupId) instanceof Group);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, GroupDAO.find(entityManager, scopeId, groupId).getScopeId());
+    }
+
+    @Test
+    public void findNullGroupIdTest() {
+        Mockito.when(entityManager.find(GroupImpl.class, null)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
+        assertTrue("True expected.", GroupDAO.find(entityManager, scopeId, null) instanceof Group);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, GroupDAO.find(entityManager, scopeId, null).getScopeId());
+    }
+
+    @Test
+    public void queryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<GroupImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<GroupImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<GroupImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<GroupImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<GroupImpl> entityType = Mockito.mock(EntityType.class);
+        List<String> list = new ArrayList<>();
+        TypedQuery<GroupImpl> query = Mockito.mock(TypedQuery.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(GroupImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(GroupImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+        Mockito.when(kapuaQuery.getFetchAttributes()).thenReturn(list);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+
+        assertTrue("True expected.", GroupDAO.query(entityManager, kapuaQuery) instanceof GroupListResult);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullEntityManagerTest() throws KapuaException {
+        GroupDAO.query(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void queryNullKapuaQueryTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<GroupImpl> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<GroupImpl> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<GroupImpl> criteriaQuery3 = Mockito.mock(CriteriaQuery.class);
+        Root<GroupImpl> entityRoot = Mockito.mock(Root.class);
+        EntityType<GroupImpl> entityType = Mockito.mock(EntityType.class);
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(GroupImpl.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(GroupImpl.class)).thenReturn(entityRoot);
+        Mockito.when(entityRoot.getModel()).thenReturn(entityType);
+        Mockito.when(criteriaQuery1.select(entityRoot)).thenReturn(criteriaQuery2);
+        Mockito.when(criteriaQuery2.distinct(true)).thenReturn(criteriaQuery3);
+
+        GroupDAO.query(entityManager, null);
+    }
+
+    @Test
+    public void countTest() throws KapuaException {
+        CriteriaBuilder criteriaBuilder = Mockito.mock(CriteriaBuilder.class);
+        CriteriaQuery<Long> criteriaQuery1 = Mockito.mock(CriteriaQuery.class);
+        CriteriaQuery<Long> criteriaQuery2 = Mockito.mock(CriteriaQuery.class);
+        Root<GroupImpl> entityRoot = Mockito.mock(Root.class);
+        TypedQuery<Long> query = Mockito.mock(TypedQuery.class);
+        Selection<Long> selection = Mockito.mock(Selection.class);
+        Expression<Long> expression = Mockito.mock(Expression.class);
+        long[] longNumberList = {0L, 10L, 100L, 1000000L, 9223372036854775807L, -100L, -9223372036854775808L};
+
+        Mockito.when(entityManager.getCriteriaBuilder()).thenReturn(criteriaBuilder);
+        Mockito.when(criteriaBuilder.createQuery(Long.class)).thenReturn(criteriaQuery1);
+        Mockito.when(criteriaQuery1.from(GroupImpl.class)).thenReturn(entityRoot);
+        Mockito.when(criteriaBuilder.countDistinct(entityRoot)).thenReturn(expression);
+        Mockito.when(criteriaQuery1.select(selection)).thenReturn(criteriaQuery2);
+        Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
+        for (long number : longNumberList) {
+            Mockito.doReturn(number).when(query).getSingleResult();
+
+            assertEquals("Expected and actual values should be the same.", number, GroupDAO.count(entityManager, kapuaQuery));
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullEntityManagerTest() throws KapuaException {
+        GroupDAO.count(null, kapuaQuery);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void countNullKapuaQueryTest() throws KapuaException {
+        GroupDAO.count(entityManager, null);
+    }
+
+    @Test
+    public void deleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        assertTrue("True expected.", GroupDAO.delete(entityManager, scopeId, groupId) instanceof Group);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullEntityManagerTest() throws KapuaEntityNotFoundException {
+        GroupDAO.delete(null, scopeId, groupId);
+    }
+
+    @Test
+    public void deleteNullScopeIdTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        assertTrue("True expected.", GroupDAO.delete(entityManager, null, groupId) instanceof Group);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void deleteNullGroupIdIdTest() throws KapuaEntityNotFoundException {
+        GroupDAO.delete(entityManager, scopeId, null);
+    }
+
+    @Test(expected = KapuaEntityNotFoundException.class)
+    public void deleteNullEntityToDeleteTest() throws KapuaEntityNotFoundException {
+        Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(null);
+
+        GroupDAO.delete(entityManager, scopeId, groupId);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImplTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class GroupCreatorImplTest extends Assert {
+
+    String[] names;
+    KapuaId scopeId;
+
+    @Before
+    public void initialize() {
+        names = new String[]{"", "  na123)(&*^&NAME  <>", "Na-,,..,,Me name ---", "-&^454536 na___,,12 NAME name    ", "! 2#@ na     meNEMA 2323", "12&^%4   ,,,. '|<>*(", "       ,,123name;;'", "12#name--765   ,.aaa!!#$%^<> "};
+        scopeId = KapuaId.ONE;
+    }
+
+    @Test
+    public void groupCreatorImplScopeIdNameParametersTest() {
+        for (String name : names) {
+            GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId, name);
+            assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
+        }
+    }
+
+    @Test
+    public void groupCreatorImplNullScopeIdNameParametersTest() {
+        for (String name : names) {
+            GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null, name);
+            assertNull("Null expected.", groupCreatorImpl.getScopeId());
+            assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
+        }
+    }
+
+    @Test
+    public void groupCreatorImplScopeIdNullNameParametersTest() {
+        GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId, null);
+        assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+        assertNull("Null expected.", groupCreatorImpl.getName());
+    }
+
+    @Test
+    public void groupCreatorImplNullScopeIdNullNameParametersTest() {
+        GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null, null);
+        assertNull("Null expected.", groupCreatorImpl.getScopeId());
+        assertNull("Null expected.", groupCreatorImpl.getName());
+    }
+
+    @Test
+    public void groupCreatorImplScopeIdParameterTest() {
+        GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId);
+        assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+        assertNull("Null expected.", groupCreatorImpl.getName());
+    }
+
+    @Test
+    public void groupCreatorImplNullScopeIdParameterTest() {
+        GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null);
+        assertNull("Null expected.", groupCreatorImpl.getScopeId());
+        assertNull("Null expected.", groupCreatorImpl.getName());
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImplTest.java
@@ -1,0 +1,144 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.KapuaEntityCloneException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.group.GroupCreator;
+import org.eclipse.kapua.service.authorization.group.GroupListResult;
+import org.eclipse.kapua.service.authorization.group.GroupQuery;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class GroupFactoryImplTest extends Assert {
+
+    GroupFactoryImpl groupFactoryImpl;
+    KapuaId scopeId;
+    String[] names;
+    Group group;
+    Date createdOn, modifiedOn;
+
+    @Before
+    public void initialize() {
+        groupFactoryImpl = new GroupFactoryImpl();
+        scopeId = KapuaId.ONE;
+        names = new String[]{"", "  na123)(&*^&NAME  <>", "Na-,,..,,Me name ---", "-&^454536 na___,,12 NAME name    ", "! 2#@ na     meNEMA 2323", "12&^%4   ,,,. '|<>*(", "       ,,123name;;'", "12#name--765   ,.aaa!!#$%^<> "};
+        group = Mockito.mock(Group.class);
+        createdOn = new Date();
+        modifiedOn = new Date();
+
+        Mockito.when(group.getName()).thenReturn("group name");
+        Mockito.when(group.getDescription()).thenReturn("description");
+        Mockito.when(group.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(group.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(group.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(group.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(group.getModifiedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(group.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(group.getOptlock()).thenReturn(11);
+    }
+
+    @Test
+    public void newCreatorScopeIdNameParametersTest() {
+        for (String name : names) {
+            GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId, name);
+            assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
+            assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorNullScopeIdNameParametersTest() {
+        for (String name : names) {
+            GroupCreator groupCreator = groupFactoryImpl.newCreator(null, name);
+            assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
+            assertNull("Null expected.", groupCreator.getScopeId());
+        }
+    }
+
+    @Test
+    public void newCreatorScopeIdNullNameParametersTest() {
+        GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId, null);
+        assertNull("Null expected.", groupCreator.getName());
+        assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+    }
+
+    @Test
+    public void newEntityTest() {
+        Group group = groupFactoryImpl.newEntity(scopeId);
+        assertEquals("Expected and actual values should be the same.", scopeId, group.getScopeId());
+    }
+
+    @Test
+    public void newEntityNullTest() {
+        Group group = groupFactoryImpl.newEntity(null);
+        assertNull("Null expected.", group.getScopeId());
+    }
+
+    @Test
+    public void newListResultTest() {
+        GroupListResult groupListResult = groupFactoryImpl.newListResult();
+        assertTrue("True expected.", groupListResult.isEmpty());
+    }
+
+    @Test
+    public void newQueryTest() {
+        GroupQuery groupQuery = groupFactoryImpl.newQuery(scopeId);
+        assertEquals("Expected and actual values should be the same.", scopeId, groupQuery.getScopeId());
+    }
+
+    @Test
+    public void newQueryNullTest() {
+        GroupQuery groupQuery = groupFactoryImpl.newQuery(null);
+        assertNull("Null expected.", groupQuery.getScopeId());
+    }
+
+    @Test
+    public void newCreatorTest() {
+        GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId);
+        assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+    }
+
+    @Test
+    public void newCreatorNullTest() {
+        GroupCreator groupCreator = groupFactoryImpl.newCreator(null);
+        assertNull("Null expected.", groupCreator.getScopeId());
+    }
+
+    @Test
+    public void cloneTest() {
+        Group resultGroup = groupFactoryImpl.clone(group);
+        assertEquals("Expected and actual values should be the same.", "group name", resultGroup.getName());
+        assertEquals("Expected and actual values should be the same.", "description", resultGroup.getDescription());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, resultGroup.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, resultGroup.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 11, resultGroup.getOptlock());
+    }
+
+    @Test(expected = KapuaEntityCloneException.class)
+    public void cloneNullTest() {
+        groupFactoryImpl.clone(null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImplTest.java
@@ -1,0 +1,79 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class GroupImplTest extends Assert {
+
+    @Test
+    public void groupImplWithoutParametersTest() {
+        GroupImpl groupImpl = new GroupImpl();
+        assertNull("Null expected.", groupImpl.getScopeId());
+    }
+
+    @Test
+    public void groupImplScopeIdParameterTest() {
+        GroupImpl groupImpl = new GroupImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getScopeId());
+    }
+
+    @Test
+    public void groupImplNullScopeIdParameterTest() {
+        GroupImpl groupImpl = new GroupImpl((KapuaId) null);
+        assertNull("Null expected.", groupImpl.getScopeId());
+    }
+
+    @Test
+    public void groupImplGroupParameterTest() throws KapuaException {
+        Group group = Mockito.mock(Group.class);
+        Date createdOn = new Date();
+        Date modifiedOn = new Date();
+
+        Mockito.when(group.getName()).thenReturn("group name");
+        Mockito.when(group.getDescription()).thenReturn("description");
+        Mockito.when(group.getId()).thenReturn(KapuaId.ONE);
+        Mockito.when(group.getScopeId()).thenReturn(KapuaId.ANY);
+        Mockito.when(group.getCreatedBy()).thenReturn(KapuaId.ONE);
+        Mockito.when(group.getCreatedOn()).thenReturn(createdOn);
+        Mockito.when(group.getModifiedBy()).thenReturn(KapuaId.ANY);
+        Mockito.when(group.getModifiedOn()).thenReturn(modifiedOn);
+        Mockito.when(group.getOptlock()).thenReturn(11);
+
+        GroupImpl groupImpl = new GroupImpl(group);
+        assertEquals("Expected and actual values should be the same.", "group name", groupImpl.getName());
+        assertEquals("Expected and actual values should be the same.", "description", groupImpl.getDescription());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getCreatedBy());
+        assertEquals("Expected and actual values should be the same.", createdOn, groupImpl.getCreatedOn());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getModifiedBy());
+        assertEquals("Expected and actual values should be the same.", modifiedOn, groupImpl.getModifiedOn());
+        assertEquals("Expected and actual values should be the same.", 11, groupImpl.getOptlock());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void groupImplNullGroupParameterTest() throws KapuaException {
+        new GroupImpl((Group) null);
+    }
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.group.shiro;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class GroupQueryImplTest extends Assert {
+
+    @Test
+    public void groupQueryImplTest() {
+        GroupQueryImpl groupQueryImpl = new GroupQueryImpl(KapuaId.ONE);
+        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", groupQueryImpl.getSortCriteria());
+    }
+
+    @Test
+    public void groupQueryImplNullTest() {
+        GroupQueryImpl groupQueryImpl = new GroupQueryImpl(null);
+        assertNull("Null expected.", groupQueryImpl.getScopeId());
+        assertNotNull("NotNull expected.", groupQueryImpl.getSortCriteria());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in shiro/authorization/group/shiro package:
 - GroupDAO class
 - GroupCreatorImpl class
 - GroupFactoryImpl class
 - GroupImpl class
 - GroupQueryImpl class

Also, it contains JUnit tests for AccessRoleDAO class from access/shiro package

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
