### PR TITLE
Forbid modifying JobSteps if Job has started at least once

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -86,11 +86,12 @@
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
         <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
 
+        <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>
+        <api>org.eclipse.kapua.service.job.execution.JobExecutionFactory</api>
         <api>org.eclipse.kapua.service.job.step.JobStepService</api>
         <api>org.eclipse.kapua.service.job.step.JobStepFactory</api>
-
         <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService</api>
-
+        <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory</api>
         <api>org.eclipse.kapua.service.job.targets.JobTargetService</api>
         <api>org.eclipse.kapua.service.job.targets.JobTargetFactory</api>
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
@@ -64,10 +64,10 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
                 gwtJobStepDefinitionList.add(gwtJobStepDefinition);
             }
 
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            return new BaseListLoadResult<GwtJobStepDefinition>(gwtJobStepDefinitionList);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-        return new BaseListLoadResult<GwtJobStepDefinition>(gwtJobStepDefinitionList);
     }
 
     @Override
@@ -82,11 +82,10 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
 
                 setEnumOnJobStepProperty(gwtJobStepDefinition.getStepProperties());
             }
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            return gwtJobStepDefinition;
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-
-        return gwtJobStepDefinition;
     }
 
     @Override

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -75,11 +75,10 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
                 gwtJobStepList.add(gwtJobStep);
             }
 
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+            return new BasePagingLoadResult<GwtJobStep>(gwtJobStepList, loadConfig.getOffset(), totalLength);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-
-        return new BasePagingLoadResult<GwtJobStep>(gwtJobStepList, loadConfig.getOffset(), totalLength);
     }
 
     @Override
@@ -115,13 +114,13 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
             gwtJobStep = KapuaGwtJobModelConverter.convertJobStep(jobStep);
 
             setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
-        }
 
-        //
-        // Return result
-        return gwtJobStep;
+            //
+            // Return result
+            return gwtJobStep;
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
+        }
     }
 
     @Override
@@ -133,8 +132,8 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
 
         try {
             JOB_STEP_SERVICE.delete(scopeId, jobTargetId);
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
     }
 
@@ -153,8 +152,8 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
 
                 setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
             }
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
 
         return gwtJobStep;
@@ -193,10 +192,11 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
 
                 setEnumOnJobStepProperty(gwtJobStep.getStepProperties());
             }
-        } catch (Throwable t) {
-            KapuaExceptionHandler.handle(t);
+
+            return gwtJobStepUpdated;
+        } catch (Exception e) {
+            throw KapuaExceptionHandler.buildExceptionFromError(e);
         }
-        return gwtJobStepUpdated;
     }
 
     /**

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -103,22 +103,17 @@
 
         <api>org.eclipse.kapua.service.job.JobService</api>
         <api>org.eclipse.kapua.service.job.JobFactory</api>
-
         <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>
         <api>org.eclipse.kapua.service.job.execution.JobExecutionFactory</api>
-
         <api>org.eclipse.kapua.service.job.step.JobStepService</api>
         <api>org.eclipse.kapua.service.job.step.JobStepFactory</api>
-
         <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService</api>
         <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory</api>
-
         <api>org.eclipse.kapua.service.job.targets.JobTargetService</api>
         <api>org.eclipse.kapua.service.job.targets.JobTargetFactory</api>
 
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -107,16 +107,12 @@
 
         <api>org.eclipse.kapua.service.job.JobService</api>
         <api>org.eclipse.kapua.service.job.JobFactory</api>
-
         <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>
         <api>org.eclipse.kapua.service.job.execution.JobExecutionFactory</api>
-
         <api>org.eclipse.kapua.service.job.step.JobStepService</api>
         <api>org.eclipse.kapua.service.job.step.JobStepFactory</api>
-
         <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService</api>
         <api>org.eclipse.kapua.service.job.step.definition.JobStepDefinitionFactory</api>
-
         <api>org.eclipse.kapua.service.job.targets.JobTargetService</api>
         <api>org.eclipse.kapua.service.job.targets.JobTargetFactory</api>
 
@@ -125,7 +121,6 @@
 
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/CannotModifyJobStepsException.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/CannotModifyJobStepsException.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.exception;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.job.step.JobStep;
+
+/**
+ * {@link JobServiceException} to throw when trying to modify {@link JobStep}s of a {@link Job} that already started once.
+ *
+ * @since 1.5.0
+ */
+public class CannotModifyJobStepsException extends JobServiceException {
+
+    private final KapuaId jobId;
+
+    /**
+     * Constructor.
+     *
+     * @param jobId The {@link Job#getId()}.
+     * @since 1.5.0
+     */
+    public CannotModifyJobStepsException(KapuaId jobId) {
+        super(JobServiceErrorCodes.CANNOT_MODIFY_JOB_STEPS, jobId);
+
+        this.jobId = jobId;
+    }
+
+    /**
+     * Gets the {@link Job#getId()}.
+     *
+     * @return The {@link Job#getId()}.
+     * @since 1.5.0
+     */
+    public KapuaId getJobId() {
+        return jobId;
+    }
+}

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/JobServiceErrorCodes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/JobServiceErrorCodes.java
@@ -1,0 +1,30 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.exception;
+
+import org.eclipse.kapua.KapuaErrorCode;
+
+/**
+ * {@link KapuaErrorCode}s for {@link JobServiceException}
+ *
+ * @since 1.5.0
+ */
+public enum JobServiceErrorCodes implements KapuaErrorCode {
+
+    /**
+     * See {@link CannotModifyJobStepsException}.
+     *
+     * @since 1.5.0
+     */
+    CANNOT_MODIFY_JOB_STEPS,
+}

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/JobServiceException.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/exception/JobServiceException.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.job.exception;
+
+import org.eclipse.kapua.KapuaException;
+
+/**
+ * {@link KapuaException} base for Scheduler Service {@link Exception}s
+ *
+ * @since 1.5.0
+ */
+public abstract class JobServiceException extends KapuaException {
+
+    private static final String KAPUA_ERROR_MESSAGES = "job-service-error-messages";
+
+    /**
+     * Constructor.
+     *
+     * @param code The {@link JobServiceErrorCodes}.
+     * @since 1.5.0
+     */
+    public JobServiceException(JobServiceErrorCodes code) {
+        super(code);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param code      The {@link JobServiceErrorCodes}.
+     * @param arguments Additional argument associated with the {@link JobServiceException}.
+     * @since 1.5.0
+     */
+    public JobServiceException(JobServiceErrorCodes code, Object... arguments) {
+        super(code, arguments);
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param code      The {@link JobServiceErrorCodes}.
+     * @param cause     The root {@link Throwable} of this {@link JobServiceException}.
+     * @param arguments Additional argument associated with the {@link JobServiceException}.
+     * @since 1.5.0
+     */
+    public JobServiceException(JobServiceErrorCodes code, Throwable cause, Object... arguments) {
+        super(code, cause, arguments);
+    }
+
+    @Override
+    protected String getKapuaErrorMessagesBundle() {
+        return KAPUA_ERROR_MESSAGES;
+    }
+}

--- a/service/job/api/src/main/resources/job-service-error-messages.properties
+++ b/service/job/api/src/main/resources/job-service-error-messages.properties
@@ -1,0 +1,14 @@
+###############################################################################
+# Copyright (c) 2021 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+CANNOT_MODIFY_JOB_STEPS=Cannot modify JobSteps of Job {0} because it has already started once.


### PR DESCRIPTION
This PR add a check when modifying JobStep data for a Job.

Modifying JobSteps after the job has started once can mess up the JobTarted.stepIndex references and process tracking. 

Now you can only edit/modify JobStep data only if the Job has never been executed

**Related Issue**
_None_

**Description of the solution adopted**
Added a check on JobExecutions before performing changes.

**Screenshots**
_None_

**Any side note on the changes made**
_None_