### PR TITLE
Improved AuthenticationServiceShiro validation of credentials

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImpl.java
@@ -14,13 +14,16 @@ package org.eclipse.kapua.service.authentication.shiro;
 
 import org.apache.shiro.authc.AuthenticationToken;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
-import org.eclipse.kapua.service.authentication.AuthenticationCredentials;
+
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 
 /**
- * Access token {@link AuthenticationCredentials} implementation.
+ * {@link AccessTokenCredentials} implementation.
+ * <p>
+ * This implements also {@link AuthenticationToken} to allow usage in Shiro.
  *
- * @since 1.0
- *
+ * @since 1.0.0
  */
 public class AccessTokenCredentialsImpl implements AccessTokenCredentials, AuthenticationToken {
 
@@ -28,24 +31,32 @@ public class AccessTokenCredentialsImpl implements AccessTokenCredentials, Authe
 
     private String tokenId;
 
-    private AccessTokenCredentialsImpl() {
-        super();
+    /**
+     * Constructor.
+     *
+     * @param tokenId The credential TokenId
+     * @since 1.0.0
+     */
+    public AccessTokenCredentialsImpl(@NotNull String tokenId) {
+        setTokenId(tokenId);
     }
 
     /**
-     * Constructor
+     * Clone constructor.
      *
-     * @param tokenId
+     * @param accessTokenCredentials The {@link AccessTokenCredentials} to clone.
+     * @since 1.5.0
      */
-    public AccessTokenCredentialsImpl(String tokenId) {
-        this();
-        this.tokenId = tokenId;
+    public AccessTokenCredentialsImpl(@NotNull AccessTokenCredentials accessTokenCredentials) {
+        setTokenId(accessTokenCredentials.getTokenId());
     }
 
+    @Override
     public String getTokenId() {
         return tokenId;
     }
 
+    @Override
     public void setTokenId(String tokenId) {
         this.tokenId = tokenId;
     }
@@ -59,4 +70,20 @@ public class AccessTokenCredentialsImpl implements AccessTokenCredentials, Authe
     public Object getCredentials() {
         return getTokenId();
     }
+
+    /**
+     * Parses a {@link AccessTokenCredentials} into a {@link AccessTokenCredentialsImpl}.
+     *
+     * @param accessTokenCredentials The {@link AccessTokenCredentials} to parse.
+     * @return A instance of {@link AccessTokenCredentialsImpl}.
+     * @since 1.5.0
+     */
+    public static AccessTokenCredentialsImpl parse(@Nullable AccessTokenCredentials accessTokenCredentials) {
+        return accessTokenCredentials != null ?
+                (accessTokenCredentials instanceof AccessTokenCredentialsImpl ?
+                        (AccessTokenCredentialsImpl) accessTokenCredentials :
+                        new AccessTokenCredentialsImpl(accessTokenCredentials))
+                : null;
+    }
 }
+

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImpl.java
@@ -15,14 +15,40 @@ package org.eclipse.kapua.service.authentication.shiro;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * {@link ApiKeyCredentials} implementation.
+ * <p>
+ * This implements also {@link AuthenticationToken} to allow usage in Shiro.
+ *
+ * @since 1.0.0
+ */
 public class ApiKeyCredentialsImpl implements ApiKeyCredentials, AuthenticationToken {
 
     private static final long serialVersionUID = -5920944517814926028L;
 
     private String apiKey;
 
+    /**
+     * Constructor.
+     *
+     * @param apiKey The crential key.
+     * @since 1.0.0
+     */
     public ApiKeyCredentialsImpl(String apiKey) {
         setApiKey(apiKey);
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param apiKeyCredentials The {@link ApiKeyCredentials} to clone.
+     * @since 1.5.0
+     */
+    public ApiKeyCredentialsImpl(@NotNull ApiKeyCredentials apiKeyCredentials) {
+        setApiKey(apiKeyCredentials.getApiKey());
     }
 
     @Override
@@ -43,6 +69,21 @@ public class ApiKeyCredentialsImpl implements ApiKeyCredentials, AuthenticationT
     @Override
     public Object getCredentials() {
         return getApiKey();
+    }
+
+    /**
+     * Parses a {@link ApiKeyCredentials} into a {@link ApiKeyCredentialsImpl}.
+     *
+     * @param apiKeyCredentials The {@link ApiKeyCredentials} to parse.
+     * @return A instance of {@link ApiKeyCredentialsImpl}.
+     * @since 1.5.0
+     */
+    public static ApiKeyCredentialsImpl parse(@Nullable ApiKeyCredentials apiKeyCredentials) {
+        return apiKeyCredentials != null ?
+                (apiKeyCredentials instanceof ApiKeyCredentialsImpl ?
+                        (ApiKeyCredentialsImpl) apiKeyCredentials :
+                        new ApiKeyCredentialsImpl(apiKeyCredentials))
+                : null;
     }
 
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
@@ -15,6 +15,16 @@ package org.eclipse.kapua.service.authentication.shiro;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
+/**
+ * {@link JwtCredentials} implementation.
+ * <p>
+ * This implements also {@link AuthenticationToken} to allow usage in Shiro.
+ *
+ * @since 1.0.0
+ */
 public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
 
     private static final long serialVersionUID = -5920944517814926028L;
@@ -22,9 +32,27 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
     private String jwt;
     private String idToken;
 
+    /**
+     * Constructor.
+     *
+     * @param jwt     The credential JWT.
+     * @param idToken The credential token.
+     * @since 1.4.0
+     */
     public JwtCredentialsImpl(String jwt, String idToken) {
         setJwt(jwt);
         setIdToken(idToken);
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param jwtCredentials The {@link JwtCredentials} to clone
+     * @since 1.5.0
+     */
+    public JwtCredentialsImpl(@NotNull JwtCredentials jwtCredentials) {
+        setJwt(jwtCredentials.getJwt());
+        setIdToken(jwtCredentials.getIdToken());
     }
 
     @Override
@@ -55,5 +83,20 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
     @Override
     public Object getCredentials() {
         return getJwt();
+    }
+
+    /**
+     * Parses a {@link JwtCredentials} into a {@link JwtCredentialsImpl}.
+     *
+     * @param jwtCredentials The {@link JwtCredentials} to parse.
+     * @return A instance of {@link JwtCredentialsImpl}.
+     * @since 1.5.0
+     */
+    public static JwtCredentialsImpl parse(@Nullable JwtCredentials jwtCredentials) {
+        return jwtCredentials != null ?
+                (jwtCredentials instanceof JwtCredentialsImpl ?
+                        (JwtCredentialsImpl) jwtCredentials :
+                        new JwtCredentialsImpl(jwtCredentials))
+                : null;
     }
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -13,14 +13,17 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.apache.shiro.authc.AuthenticationToken;
-import org.eclipse.kapua.service.authentication.AuthenticationCredentials;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 
+import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
+
 /**
- * Username and password {@link AuthenticationCredentials} implementation.
+ * {@link UsernamePasswordCredentials} implementation.
+ * <p>
+ * This implements also {@link AuthenticationToken} to allow usage in Shiro.
  *
- * @since 1.0
- *
+ * @since 1.0.0
  */
 public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredentials, AuthenticationToken {
 
@@ -32,13 +35,29 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
     private String trustKey;
 
     /**
-     * Constructor
-     *  @param username
-     * @param password
+     * Constructor.
+     *
+     * @param username The credential username.
+     * @param password The credential password.
+     * @since 1.0.0
      */
-    public UsernamePasswordCredentialsImpl(String username, String password) {
-        this.username = username;
-        this.password = password;
+    public UsernamePasswordCredentialsImpl(@NotNull String username, @NotNull String password) {
+        setUsername(username);
+        setPassword(password);
+    }
+
+
+    /**
+     * Clone constructor.
+     *
+     * @param usernamePasswordCredentials The {@link UsernamePasswordCredentials} to clone.
+     * @since 1.5.0
+     */
+    public UsernamePasswordCredentialsImpl(@NotNull UsernamePasswordCredentials usernamePasswordCredentials) {
+        setUsername(usernamePasswordCredentials.getUsername());
+        setPassword(usernamePasswordCredentials.getPassword());
+        setAuthenticationCode(usernamePasswordCredentials.getAuthenticationCode());
+        setTrustKey(usernamePasswordCredentials.getTrustKey());
     }
 
     @Override
@@ -89,5 +108,20 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
     @Override
     public void setTrustKey(String trustKey) {
         this.trustKey = trustKey;
+    }
+
+    /**
+     * Parses a {@link UsernamePasswordCredentials} into a {@link UsernamePasswordCredentialsImpl}.
+     *
+     * @param usernamePasswordCredentials The {@link UsernamePasswordCredentials} to parse.
+     * @return A instance of {@link UsernamePasswordCredentialsImpl}.
+     * @since 1.5.0
+     */
+    public static UsernamePasswordCredentialsImpl parse(@Nullable UsernamePasswordCredentials usernamePasswordCredentials) {
+        return usernamePasswordCredentials != null ?
+                (usernamePasswordCredentials instanceof UsernamePasswordCredentialsImpl ?
+                        (UsernamePasswordCredentialsImpl) usernamePasswordCredentials :
+                        new UsernamePasswordCredentialsImpl(usernamePasswordCredentials))
+                : null;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
@@ -22,59 +22,58 @@ import org.junit.experimental.categories.Category;
 public class AccessTokenCredentialsImplTest extends Assert {
 
     @Test(expected = NullPointerException.class)
-    public void accessTokenCredentialImplCloneConstructorNull() {
+    public void accessTokenCredentialsImplCloneConstructorNullTest() {
         new AccessTokenCredentialsImpl((AccessTokenCredentials) null);
     }
 
     @Test
-    public void accessTokenCredentialImplCloneConstructorImpl() {
+    public void accessTokenCredentialsImplCloneConstructorImplTest() {
         AccessTokenCredentialsImpl first = new AccessTokenCredentialsImpl("anAccessToken");
 
         AccessTokenCredentialsImpl second = new AccessTokenCredentialsImpl(first);
 
         assertNotEquals("AccessTokenCredentialImpl", first, second);
-        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+        assertEquals("AccessTokenCredential.tokenId", first.getTokenId(), second.getTokenId());
     }
 
     @Test
-    public void accessTokenCredentialImplParseImpl() {
+    public void accessTokenCredentialsImplCloneConstructorAnotherTest() {
+        AccessTokenCredentials first = new AccessTokenCredentialAnother("anAccessToken");
+
+        AccessTokenCredentialsImpl second = new AccessTokenCredentialsImpl(first);
+
+        assertNotEquals("AccessTokenCredentialImpl", first, second);
+        assertEquals("AccessTokenCredential.tokenId", first.getTokenId(), second.getTokenId());
+    }
+
+    @Test
+    public void accessTokenCredentialsImplParseNullTest() {
         AccessTokenCredentialsImpl first = null;
 
         AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(null);
 
+        assertNull("Parsed AccessTokenCredentialsImpl", second);
         assertEquals("AccessTokenCredentialImpl", first, second);
     }
 
     @Test
-    public void accessTokenCredentialImplParseNull() {
+    public void accessTokenCredentialsImplParseImplTest() {
         AccessTokenCredentialsImpl first = new AccessTokenCredentialsImpl("anAccessToken");
 
         AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(first);
 
         assertEquals("AccessTokenCredentialImpl", first, second);
-        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+        assertEquals("AccessTokenCredential.tokenId", first.getTokenId(), second.getTokenId());
     }
 
     @Test
-    public void accessTokenCredentialImplParseAnother() {
-        AccessTokenCredentials first = new AccessTokenCredentials() {
-            private String tokenId = "anAccessToken";
-
-            @Override
-            public String getTokenId() {
-                return tokenId;
-            }
-
-            @Override
-            public void setTokenId(String tokenId) {
-                this.tokenId = tokenId;
-            }
-        };
+    public void accessTokenCredentialsImplParseAnotherTest() {
+        AccessTokenCredentials first = new AccessTokenCredentialAnother("anAccessToken");
 
         AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(first);
 
         assertNotEquals("AccessTokenCredentialImpl", first, second);
-        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+        assertEquals("AccessTokenCredential.tokenId", first.getTokenId(), second.getTokenId());
     }
 
 
@@ -101,5 +100,23 @@ public class AccessTokenCredentialsImplTest extends Assert {
             assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenCredentialsImpl.getPrincipal());
             assertEquals("Expected and actual values should be the same.", newTokenId, accessTokenCredentialsImpl.getCredentials());
         }
+    }
+}
+
+class AccessTokenCredentialAnother implements AccessTokenCredentials {
+    private String tokenId;
+
+    public AccessTokenCredentialAnother(String tokenId) {
+        this.tokenId = tokenId;
+    }
+
+    @Override
+    public String getTokenId() {
+        return tokenId;
+    }
+
+    @Override
+    public void setTokenId(String tokenId) {
+        this.tokenId = tokenId;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
@@ -13,12 +13,70 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(JUnitTests.class)
 public class AccessTokenCredentialsImplTest extends Assert {
+
+    @Test(expected = NullPointerException.class)
+    public void accessTokenCredentialImplCloneConstructorNull() {
+        new AccessTokenCredentialsImpl((AccessTokenCredentials) null);
+    }
+
+    @Test
+    public void accessTokenCredentialImplCloneConstructorImpl() {
+        AccessTokenCredentialsImpl first = new AccessTokenCredentialsImpl("anAccessToken");
+
+        AccessTokenCredentialsImpl second = new AccessTokenCredentialsImpl(first);
+
+        assertNotEquals("AccessTokenCredentialImpl", first, second);
+        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+    }
+
+    @Test
+    public void accessTokenCredentialImplParseImpl() {
+        AccessTokenCredentialsImpl first = null;
+
+        AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(null);
+
+        assertEquals("AccessTokenCredentialImpl", first, second);
+    }
+
+    @Test
+    public void accessTokenCredentialImplParseNull() {
+        AccessTokenCredentialsImpl first = new AccessTokenCredentialsImpl("anAccessToken");
+
+        AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(first);
+
+        assertEquals("AccessTokenCredentialImpl", first, second);
+        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+    }
+
+    @Test
+    public void accessTokenCredentialImplParseAnother() {
+        AccessTokenCredentials first = new AccessTokenCredentials() {
+            private String tokenId = "anAccessToken";
+
+            @Override
+            public String getTokenId() {
+                return tokenId;
+            }
+
+            @Override
+            public void setTokenId(String tokenId) {
+                this.tokenId = tokenId;
+            }
+        };
+
+        AccessTokenCredentialsImpl second = AccessTokenCredentialsImpl.parse(first);
+
+        assertNotEquals("AccessTokenCredentialImpl", first, second);
+        assertEquals("AccessTokenCredential.tokenIn", first.getTokenId(), second.getTokenId());
+    }
+
 
     @Test
     public void accessTokenCredentialsImplTokenIdParameterTest() {

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/AccessTokenCredentialsImplTest.java
@@ -17,19 +17,8 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import java.lang.reflect.Constructor;
-import java.lang.reflect.Modifier;
-
 @Category(JUnitTests.class)
 public class AccessTokenCredentialsImplTest extends Assert {
-
-    @Test
-    public void accessTokenCredentialsImplWithoutParametersTest() throws Exception {
-        Constructor<AccessTokenCredentialsImpl> accessTokenCredentialsImpl = AccessTokenCredentialsImpl.class.getDeclaredConstructor();
-        accessTokenCredentialsImpl.setAccessible(true);
-        accessTokenCredentialsImpl.newInstance();
-        assertTrue("True expected.", Modifier.isPrivate(accessTokenCredentialsImpl.getModifiers()));
-    }
 
     @Test
     public void accessTokenCredentialsImplTokenIdParameterTest() {

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/ApiKeyCredentialsImplTest.java
@@ -13,12 +13,68 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 @Category(JUnitTests.class)
 public class ApiKeyCredentialsImplTest extends Assert {
+
+    @Test(expected = NullPointerException.class)
+    public void apiKeyCredentialsImplCloneConstructorNullTest() {
+        new ApiKeyCredentialsImpl((ApiKeyCredentials) null);
+    }
+
+    @Test
+    public void apiKeyCredentialsImplCloneConstructorImplTest() {
+        ApiKeyCredentialsImpl first = new ApiKeyCredentialsImpl("anApiKey");
+
+        ApiKeyCredentialsImpl second = new ApiKeyCredentialsImpl(first);
+
+        assertNotEquals("ApiKeyCredentialImpl", first, second);
+        assertEquals("ApiKeyCredential.apiKey", first.getApiKey(), second.getApiKey());
+    }
+
+    @Test
+    public void apiKeyCredentialsImplCloneConstructorAnotherTest() {
+        ApiKeyCredentials first = new ApiKwyCredentialsAnother("anApiKey");
+
+        ApiKeyCredentialsImpl second = new ApiKeyCredentialsImpl(first);
+
+        assertNotEquals("ApiKeyCredentialImpl", first, second);
+        assertEquals("ApiKeyCredential.apiKey", first.getApiKey(), second.getApiKey());
+    }
+
+    @Test
+    public void apiKeyCredentialsImplParseNullTest() {
+        ApiKeyCredentialsImpl first = null;
+
+        ApiKeyCredentialsImpl second = ApiKeyCredentialsImpl.parse(null);
+
+        assertNull("Parsed ApiKeyCredentialsImpl", second);
+        assertEquals("ApiKeyCredentialImpl", first, second);
+    }
+
+    @Test
+    public void apiKeyCredentialsImplParseImplTest() {
+        ApiKeyCredentialsImpl first = new ApiKeyCredentialsImpl("anApiKey");
+
+        ApiKeyCredentialsImpl second = ApiKeyCredentialsImpl.parse(first);
+
+        assertEquals("ApiKeyCredentialImpl", first, second);
+        assertEquals("ApiKeyCredential.apiKey", first.getApiKey(), second.getApiKey());
+    }
+
+    @Test
+    public void apiKeyCredentialsImplParseAnotherTest() {
+        ApiKeyCredentials first = new ApiKwyCredentialsAnother("anApiKey");
+
+        ApiKeyCredentialsImpl second = ApiKeyCredentialsImpl.parse(first);
+
+        assertNotEquals("ApiKeyCredentialImpl", first, second);
+        assertEquals("ApiKeyCredential.apiKey", first.getApiKey(), second.getApiKey());
+    }
 
     @Test
     public void apiKeyCredentialsImplTest() {
@@ -43,5 +99,23 @@ public class ApiKeyCredentialsImplTest extends Assert {
             assertEquals("Expected and actual values should be the same.", newApiKey, apiKeyCredentialsImpl.getPrincipal());
             assertEquals("Expected and actual values should be the same.", newApiKey, apiKeyCredentialsImpl.getCredentials());
         }
+    }
+}
+
+class ApiKwyCredentialsAnother implements ApiKeyCredentials {
+    private String apiKey;
+
+    public ApiKwyCredentialsAnother(String apiKey) {
+        this.apiKey = apiKey;
+    }
+
+    @Override
+    public String getApiKey() {
+        return apiKey;
+    }
+
+    @Override
+    public void setApiKey(String apiKey) {
+        this.apiKey = apiKey;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.JwtCredentials;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -32,6 +33,66 @@ public class JwtCredentialsTest extends Assert {
         newJwts = new String[]{null, "", "new_Jwt1122#$%", "   JWT)(..,,new", "NEW_jwt ./??)_)*", "<> 1111      ", "jwttt&^$$##Z||'", "%%%KEY NEW-JWT11"};
         newIdsToken = new String[]{null, "", "NEW tokenID0000@!!,,,#", "!@#00tokenID new.", " new id TOK --EN-44<>", "pA_ss0###woE**9()", "    tokenID new tokenID  12344*&^%"};
     }
+
+    @Test(expected = NullPointerException.class)
+    public void jwtCredentialsImplCloneConstructorNullTest() {
+        new JwtCredentialsImpl(null);
+    }
+
+    @Test
+    public void jwtCredentialsImplCloneConstructorImplTest() {
+        JwtCredentialsImpl first = new JwtCredentialsImpl("aJwt", "anIdToken");
+
+        JwtCredentialsImpl second = new JwtCredentialsImpl(first);
+
+        assertNotEquals("JwtCredentialImpl", first, second);
+        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
+    }
+
+    @Test
+    public void jwtCredentialsImplCloneConstructorAnotherTest() {
+        JwtCredentials first = new JwtCredentialsAnother("aJwt", "anIdToken");
+
+        JwtCredentialsImpl second = new JwtCredentialsImpl(first);
+
+        assertNotEquals("JwtCredentialImpl", first, second);
+        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
+    }
+
+    @Test
+    public void jwtCredentialsImplParseNullTest() {
+        JwtCredentialsImpl first = null;
+
+        JwtCredentialsImpl second = JwtCredentialsImpl.parse(null);
+
+        assertNull("Parsed JwtCredentialsImpl", second);
+        assertEquals("JwtCredentialImpl", first, second);
+    }
+
+    @Test
+    public void jwtCredentialsImplParseImplTest() {
+        JwtCredentialsImpl first = new JwtCredentialsImpl("aJwt", "anIdToken");
+
+        JwtCredentialsImpl second = JwtCredentialsImpl.parse(first);
+
+        assertEquals("JwtCredentialImpl", first, second);
+        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
+    }
+
+    @Test
+    public void jwtCredentialsImplParseAnotherTest() {
+        JwtCredentials first = new JwtCredentialsAnother("aJwt", "anIdToken");
+
+        JwtCredentialsImpl second = JwtCredentialsImpl.parse(first);
+
+        assertNotEquals("JwtCredentialImpl", first, second);
+        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
+    }
+
 
     @Test
     public void jwtCredentialsImplTest() {
@@ -62,5 +123,35 @@ public class JwtCredentialsTest extends Assert {
             jwtCredentialsImpl.setIdToken(newIdToken);
             assertEquals("Expected and actual values should be the same.", newIdToken, jwtCredentialsImpl.getIdToken());
         }
+    }
+}
+
+class JwtCredentialsAnother implements JwtCredentials {
+    private String jwt;
+    private String idToken;
+
+    public JwtCredentialsAnother(String jwt, String idToken) {
+        this.jwt = jwt;
+        this.idToken = idToken;
+    }
+
+    @Override
+    public String getJwt() {
+        return jwt;
+    }
+
+    @Override
+    public void setJwt(String jwt) {
+        this.jwt = jwt;
+    }
+
+    @Override
+    public String getIdToken() {
+        return idToken;
+    }
+
+    @Override
+    public void setIdToken(String idToken) {
+        this.idToken = idToken;
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImplTest.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -33,6 +34,82 @@ public class UsernamePasswordCredentialsImplTest extends Assert {
         trustKeys = new String[]{null, "", "!!trust key-1", "#1(TRUST KEY.,/trust key)9--99", "!$$ 1-2 KEY//", "trust 99key(....)<00>"};
         authenticationCodes = new String[]{null, "", "  authentication@#$%Code=t110.,<> code", "(!!)432j&^authenti)(&%cation-Code$#3t", "##<>/.CODE    ", "__J!#W(-8T    ", "authenticatioN&* 99code0t  ", "jwt987)_=;'''     .", "jwt CODE-123"};
         usernamePasswordCredentialsImpl = new UsernamePasswordCredentialsImpl("username", "password");
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void usernamePasswordCredentialsImplCloneConstructorNullTest() {
+        new UsernamePasswordCredentialsImpl(null);
+    }
+
+    @Test
+    public void usernamePasswordCredentialsImplCloneConstructorImplTest() {
+        UsernamePasswordCredentialsImpl first = new UsernamePasswordCredentialsImpl("aUsername", "aPassword");
+        first.setTrustKey("aTrustKey");
+        first.setAuthenticationCode("aAuthCode");
+
+        UsernamePasswordCredentialsImpl second = new UsernamePasswordCredentialsImpl(first);
+
+        assertNotEquals("UsernamePasswordCredentialImpl", first, second);
+        assertEquals("UsernamePasswordCredential.username", first.getUsername(), second.getUsername());
+        assertEquals("UsernamePasswordCredential.password", first.getPassword(), second.getPassword());
+        assertEquals("UsernamePasswordCredential.trustKey", first.getTrustKey(), second.getTrustKey());
+        assertEquals("UsernamePasswordCredential.authenticationCode", first.getAuthenticationCode(), second.getAuthenticationCode());
+
+    }
+
+    @Test
+    public void usernamePasswordCredentialsImplCloneConstructorAnotherTest() {
+        UsernamePasswordCredentials first = new UsernamePasswordCredentialsAnother("aUsername", "aPassword");
+        first.setTrustKey("aTrustKey");
+        first.setAuthenticationCode("aAuthCode");
+
+        UsernamePasswordCredentialsImpl second = new UsernamePasswordCredentialsImpl(first);
+
+        assertNotEquals("UsernamePasswordCredentialImpl", first, second);
+        assertEquals("UsernamePasswordCredential.username", first.getUsername(), second.getUsername());
+        assertEquals("UsernamePasswordCredential.password", first.getPassword(), second.getPassword());
+        assertEquals("UsernamePasswordCredential.trustKey", first.getTrustKey(), second.getTrustKey());
+        assertEquals("UsernamePasswordCredential.authenticationCode", first.getAuthenticationCode(), second.getAuthenticationCode());
+    }
+
+    @Test
+    public void usernamePasswordCredentialsImplParseNullTest() {
+        UsernamePasswordCredentialsImpl first = null;
+
+        UsernamePasswordCredentialsImpl second = UsernamePasswordCredentialsImpl.parse(null);
+
+        assertNull("Parsed UsernamePasswordCredentialsImpl", second);
+        assertEquals("UsernamePasswordCredentialImpl", first, second);
+    }
+
+    @Test
+    public void usernamePasswordCredentialsImplParseImplTest() {
+        UsernamePasswordCredentialsImpl first = new UsernamePasswordCredentialsImpl("aUsername", "aPassword");
+        first.setTrustKey("aTrustKey");
+        first.setAuthenticationCode("aAuthCode");
+
+        UsernamePasswordCredentialsImpl second = UsernamePasswordCredentialsImpl.parse(first);
+
+        assertEquals("UsernamePasswordCredentialImpl", first, second);
+        assertEquals("UsernamePasswordCredential.username", first.getUsername(), second.getUsername());
+        assertEquals("UsernamePasswordCredential.password", first.getPassword(), second.getPassword());
+        assertEquals("UsernamePasswordCredential.trustKey", first.getTrustKey(), second.getTrustKey());
+        assertEquals("UsernamePasswordCredential.authenticationCode", first.getAuthenticationCode(), second.getAuthenticationCode());
+    }
+
+    @Test
+    public void usernamePasswordCredentiaslImplParseAnotherTest() {
+        UsernamePasswordCredentials first = new UsernamePasswordCredentialsAnother("aUsername", "aPassword");
+        first.setTrustKey("aTrustKey");
+        first.setAuthenticationCode("aAuthCode");
+
+        UsernamePasswordCredentialsImpl second = UsernamePasswordCredentialsImpl.parse(first);
+
+        assertNotEquals("UsernamePasswordCredentialImpl", first, second);
+        assertEquals("UsernamePasswordCredential.username", first.getUsername(), second.getUsername());
+        assertEquals("UsernamePasswordCredential.password", first.getPassword(), second.getPassword());
+        assertEquals("UsernamePasswordCredential.trustKey", first.getTrustKey(), second.getTrustKey());
+        assertEquals("UsernamePasswordCredential.authenticationCode", first.getAuthenticationCode(), second.getAuthenticationCode());
     }
 
     @Test
@@ -82,5 +159,58 @@ public class UsernamePasswordCredentialsImplTest extends Assert {
             usernamePasswordCredentialsImpl.setTrustKey(trustKey);
             assertEquals("Expected and actual values should be the same.", trustKey, usernamePasswordCredentialsImpl.getTrustKey());
         }
+    }
+}
+
+class UsernamePasswordCredentialsAnother implements UsernamePasswordCredentials {
+
+    private String username;
+    private String password;
+    private String trustKey;
+    private String authenticationCode;
+
+    public UsernamePasswordCredentialsAnother(String username, String password) {
+        this.username = username;
+        this.password = password;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public void setUsername(String username) {
+        this.username = username;
+    }
+
+    @Override
+    public String getPassword() {
+        return password;
+    }
+
+    @Override
+    public void setPassword(String password) {
+        this.password = password;
+    }
+
+    @Override
+    public String getTrustKey() {
+        return trustKey;
+    }
+
+    @Override
+    public void setTrustKey(String trustKey) {
+        this.trustKey = trustKey;
+    }
+
+    @Override
+    public String getAuthenticationCode() {
+        return authenticationCode;
+    }
+
+    @Override
+    public void setAuthenticationCode(String authenticationCode) {
+        this.authenticationCode = authenticationCode;
     }
 }


### PR DESCRIPTION
This PR improves the validation of the `LoginCredentials` and `SessionCredential` to avoid that `null` values reach the Realms logic. 
If a credential is `null`, we can immediately return an AuthenticationException for invalid credentials. 

**Related Issue**
_None_

**Description of the solution adopted**
Added checks in `AuthenticationService.login(LoginCredentials)` and `AuthenticationService.authenticate(SessionCredentials)` according to the Credentials type. 
Improved the parsing of the object to avoid instantiation of `new` objects if the credentials are of the correct type.

**Screenshots**
_None_

**Any side note on the changes made**
_None_