### PR TITLE
Bump Apache HTTP Client to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>
         <guice.version>4.1.0</guice.version>
         <h2.version>1.4.199</h2.version>
-        <httpcomponents.version>4.5.2</httpcomponents.version>
+        <httpcomponents.version>4.5.13</httpcomponents.version>
         <jackson.version>2.10.1</jackson.version>
         <javassist.version>3.19.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>


### PR DESCRIPTION
Update `org.apache.httpcomponents:httpclient` version to 4.5.13

**Related Issue**
[CVE-2020-13956](https://nvd.nist.gov/vuln/detail/CVE-2020-13956)
