### PR TITLE
Fix openIDidToken variable on AuthenticationServiceShiroImpl

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -164,8 +164,9 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             shiroAuthenticationToken = apiKeyCredentials;
         } else if (loginCredentials instanceof JwtCredentials) {
             JwtCredentialsImpl jwtCredentials = JwtCredentialsImpl.parse((JwtCredentials) loginCredentials);
+            openIDidToken = jwtCredentials.getIdToken();
 
-            if (Strings.isNullOrEmpty(jwtCredentials.getIdToken())) {
+            if (Strings.isNullOrEmpty(openIDidToken)) {
                 throw new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS);
             }
 


### PR DESCRIPTION
This PR restores the `openIDidToken` variable on `AuthenticationServiceShiroImpl`, which was removed in PR #3242 , but caused the SSO logout not working anymore.

**Related Issue**
_n/a_

**Description of the solution adopted**
`openIDidToken` is stored as before.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_
