### PR TITLE
Added JUnit tests for core/exception/model package

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfoTest.java
@@ -1,0 +1,77 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class IllegalArgumentExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    KapuaIllegalArgumentException kapuaIllegalArgumentException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        kapuaIllegalArgumentException = new KapuaIllegalArgumentException("name", "value");
+    }
+
+    @Test
+    public void illegalArgumentExceptionInfoWithoutParametersTest() {
+        IllegalArgumentExceptionInfo illegalArgumentExceptionInfo = new IllegalArgumentExceptionInfo();
+
+        assertNull("Null expected.", illegalArgumentExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, illegalArgumentExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumenName());
+        assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumentValue());
+    }
+
+    @Test
+    public void illegalArgumentExceptionInfoWithParametersTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            IllegalArgumentExceptionInfo illegalArgumentExceptionInfo = new IllegalArgumentExceptionInfo(statusList[i], kapuaIllegalArgumentException);
+
+            assertEquals("Expected and actual values should be the same.", "ILLEGAL_ARGUMENT", illegalArgumentExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalArgumentExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", "name", illegalArgumentExceptionInfo.getArgumenName());
+            assertEquals("Expected and actual values should be the same.", "value", illegalArgumentExceptionInfo.getArgumentValue());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void illegalArgumentExceptionInfoNullStatusTest() {
+        new IllegalArgumentExceptionInfo(null, kapuaIllegalArgumentException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void illegalArgumentExceptionInfoNullExceptionTest() {
+        new IllegalArgumentExceptionInfo(Response.Status.ACCEPTED, null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfoTest.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class IllegalNullArgumentExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    KapuaIllegalNullArgumentException kapuaIllegalNullArgumentException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        kapuaIllegalNullArgumentException = new KapuaIllegalNullArgumentException("name");
+    }
+
+    @Test
+    public void illegalNullArgumentExceptionInfoWithoutParametersTest() {
+        IllegalNullArgumentExceptionInfo illegalNullArgumentExceptionInfo = new IllegalNullArgumentExceptionInfo();
+
+        assertNull("Null expected.", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, illegalNullArgumentExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", illegalNullArgumentExceptionInfo.getArgumenName());
+    }
+
+    @Test
+    public void illegalNullArgumentExceptionInfoWithParametersTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            IllegalNullArgumentExceptionInfo illegalNullArgumentExceptionInfo = new IllegalNullArgumentExceptionInfo(statusList[i], kapuaIllegalNullArgumentException);
+
+            assertEquals("Expected and actual values should be the same.", "ILLEGAL_NULL_ARGUMENT", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalNullArgumentExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", "name", illegalNullArgumentExceptionInfo.getArgumenName());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void illegalArgumentExceptionInfoNullStatusTest() {
+        new IllegalArgumentExceptionInfo(null, kapuaIllegalNullArgumentException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void illegalArgumentExceptionInfoNullExceptionTest() {
+        new IllegalArgumentExceptionInfo(Response.Status.OK, null);
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/InternalUserOnlyExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/InternalUserOnlyExceptionInfoTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.exception.InternalUserOnlyException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class InternalUserOnlyExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    InternalUserOnlyException internalUserOnlyException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        internalUserOnlyException = new InternalUserOnlyException();
+    }
+
+    @Test
+    public void internalUserOnlyExceptionInfoWithoutParametersTest() {
+        InternalUserOnlyExceptionInfo internalUserOnlyExceptionInfo = new InternalUserOnlyExceptionInfo();
+
+        assertNull("Null expected.", internalUserOnlyExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, internalUserOnlyExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", internalUserOnlyExceptionInfo.getMessage());
+    }
+
+    @Test
+    public void internalUserOnlyExceptionInfoStatusExceptionTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            InternalUserOnlyExceptionInfo internalUserOnlyExceptionInfo = new InternalUserOnlyExceptionInfo(statusList[i], internalUserOnlyException);
+            assertEquals("Expected and actual values should be the same.", "INTERNAL_USER_ONLY", internalUserOnlyExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], internalUserOnlyExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyExceptionInfo.getMessage());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void internalUserOnlyExceptionInfoNullStatusExceptionTest() {
+        new InternalUserOnlyExceptionInfo(null, internalUserOnlyException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void internalUserOnlyExceptionInfoStatusNullExceptionTest() {
+        new InternalUserOnlyExceptionInfo(Response.Status.OK, null);
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/MfaRequiredExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/MfaRequiredExceptionInfoTest.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaAuthenticationErrorCodes;
+import org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticationException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class MfaRequiredExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    KapuaAuthenticationErrorCodes[] errorCodes;
+    KapuaAuthenticationException kapuaException;
+    String[] expectedKapuaErrorCode;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        errorCodes = new KapuaAuthenticationErrorCodes[]{KapuaAuthenticationErrorCodes.SUBJECT_ALREADY_LOGGED, KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED,
+                KapuaAuthenticationErrorCodes.AUTHENTICATION_ERROR, KapuaAuthenticationErrorCodes.CREDENTIAL_CRYPT_ERROR, KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS,
+                KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL,
+                KapuaAuthenticationErrorCodes.UNKNOWN_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.INVALID_SESSION_CREDENTIALS, KapuaAuthenticationErrorCodes.EXPIRED_SESSION_CREDENTIALS,
+                KapuaAuthenticationErrorCodes.LOCKED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.JWK_FILE_ERROR,
+                KapuaAuthenticationErrorCodes.REFRESH_ERROR, KapuaAuthenticationErrorCodes.JWK_GENERATION_ERROR, KapuaAuthenticationErrorCodes.JWT_CERTIFICATE_NOT_FOUND,
+                KapuaAuthenticationErrorCodes.PASSWORD_CANNOT_BE_CHANGED, KapuaAuthenticationErrorCodes.REQUIRE_MFA_CREDENTIALS};
+        expectedKapuaErrorCode = new String[]{"SUBJECT_ALREADY_LOGGED", "INVALID_CREDENTIALS_TYPE_PROVIDED", "AUTHENTICATION_ERROR", "CREDENTIAL_CRYPT_ERROR", "INVALID_LOGIN_CREDENTIALS",
+                "EXPIRED_LOGIN_CREDENTIALS", "LOCKED_LOGIN_CREDENTIAL", "DISABLED_LOGIN_CREDENTIAL", "UNKNOWN_SESSION_CREDENTIAL", "INVALID_SESSION_CREDENTIALS", "EXPIRED_SESSION_CREDENTIALS",
+                "LOCKED_SESSION_CREDENTIAL", "DISABLED_SESSION_CREDENTIAL", "JWK_FILE_ERROR", "REFRESH_ERROR", "JWK_GENERATION_ERROR", "JWT_CERTIFICATE_NOT_FOUND",
+                "PASSWORD_CANNOT_BE_CHANGED", "REQUIRE_MFA_CREDENTIALS"};
+    }
+
+    @Test
+    public void mfaRequiredExceptionInfoWithoutParametersTest() {
+        MfaRequiredExceptionInfo mfaRequiredExceptionInfo = new MfaRequiredExceptionInfo();
+
+        assertNull("Null expected.", mfaRequiredExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, mfaRequiredExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", mfaRequiredExceptionInfo.getMessage());
+    }
+
+    @Test
+    public void mfaRequiredExceptionInfoStatusExceptionTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            for (int j = 0; j < errorCodes.length; j++) {
+                kapuaException = new KapuaAuthenticationException(errorCodes[j]);
+
+                MfaRequiredExceptionInfo mfaRequiredExceptionInfo = new MfaRequiredExceptionInfo(statusList[i], kapuaException);
+                assertEquals("Expected and actual values should be the same.", expectedKapuaErrorCode[j], mfaRequiredExceptionInfo.getKapuaErrorCode());
+                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], mfaRequiredExceptionInfo.getHttpErrorCode());
+                assertEquals("Expected and actual values should be the same.", "Error: ", mfaRequiredExceptionInfo.getMessage());
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mfaRequiredExceptionInfoNullStatusExceptionTest() {
+        kapuaException = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.SUBJECT_ALREADY_LOGGED);
+        new MfaRequiredExceptionInfo(null, kapuaException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void mfaRequiredExceptionInfoStatusNullExceptionTest() {
+        new MfaRequiredExceptionInfo(Response.Status.OK, null);
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SelfManagedOnlyExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SelfManagedOnlyExceptionInfoTest.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.exception.SelfManagedOnlyException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class SelfManagedOnlyExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    SelfManagedOnlyException selfManagedOnlyException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        selfManagedOnlyException = new SelfManagedOnlyException();
+    }
+
+    @Test
+    public void selfManagedOnlyExceptionInfoWithoutParametersTest() {
+        SelfManagedOnlyExceptionInfo selfManagedOnlyExceptionInfo = new SelfManagedOnlyExceptionInfo();
+
+        assertNull("Null expected.", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, selfManagedOnlyExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", selfManagedOnlyExceptionInfo.getMessage());
+    }
+
+    @Test
+    public void selfManagedOnlyExceptionInfoStatusExceptionTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            SelfManagedOnlyExceptionInfo selfManagedOnlyExceptionInfo = new SelfManagedOnlyExceptionInfo(statusList[i], selfManagedOnlyException);
+            assertEquals("Expected and actual values should be the same.", "SELF_MANAGED_ONLY", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], selfManagedOnlyExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyExceptionInfo.getMessage());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void selfManagedOnlyExceptionInfoNullStatusExceptionTest() {
+        new SelfManagedOnlyExceptionInfo(null, selfManagedOnlyException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void selfManagedOnlyExceptionInfStatusNullExceptionTest() {
+        new SelfManagedOnlyExceptionInfo(Response.Status.OK, null);
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfoTest.java
@@ -1,0 +1,98 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.shiro.exception.SubjectUnauthorizedException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class SubjectUnauthorizedExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    Permission permission;
+    SubjectUnauthorizedException subjectUnauthorizedException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        permission = Mockito.mock(Permission.class);
+        subjectUnauthorizedException = new SubjectUnauthorizedException(permission);
+    }
+
+    @Test
+    public void subjectUnauthorizedExceptionInfoWithoutParametersTest() {
+        SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo = new SubjectUnauthorizedExceptionInfo();
+
+        assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, subjectUnauthorizedExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getPermission());
+    }
+
+    @Test
+    public void subjectUnauthorizedExceptionInfoWithParametersTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo = new SubjectUnauthorizedExceptionInfo(statusList[i], subjectUnauthorizedException);
+
+            assertEquals("Expected and actual values should be the same.", "SUBJECT_UNAUTHORIZED", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], subjectUnauthorizedExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedExceptionInfo.getPermission());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void subjectUnauthorizedExceptionInfoNullStatusTest() {
+        new SubjectUnauthorizedExceptionInfo(null, subjectUnauthorizedException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void subjectUnauthorizedExceptionInfoNullExceptionTest() {
+        new SubjectUnauthorizedExceptionInfo(Response.Status.OK, null);
+    }
+
+    @Test
+    public void setAndGetPermission() {
+        Permission newPermission = Mockito.mock(Permission.class);
+        SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo1 = new SubjectUnauthorizedExceptionInfo();
+        SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo2 = new SubjectUnauthorizedExceptionInfo(Response.Status.OK, subjectUnauthorizedException);
+
+        subjectUnauthorizedExceptionInfo1.setPermission(newPermission);
+        subjectUnauthorizedExceptionInfo2.setPermission(newPermission);
+
+        assertEquals("Expected and actual values should be the same.", newPermission, subjectUnauthorizedExceptionInfo1.getPermission());
+        assertEquals("Expected and actual values should be the same.", newPermission, subjectUnauthorizedExceptionInfo2.getPermission());
+
+        subjectUnauthorizedExceptionInfo1.setPermission(null);
+        subjectUnauthorizedExceptionInfo2.setPermission(null);
+
+        assertNull("Null expected.", subjectUnauthorizedExceptionInfo1.getPermission());
+        assertNull("Null expected.", subjectUnauthorizedExceptionInfo2.getPermission());
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfoTest.java
@@ -1,0 +1,130 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class ThrowableInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    Throwable[] throwables;
+    String[] expectedMessage;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        throwables = new Throwable[]{new Throwable(), new Throwable("message")};
+        expectedMessage = new String[]{null, "message"};
+    }
+
+    @Test
+    public void throwableInfoWithoutParametersTest() {
+        ThrowableInfo throwableInfo = new ThrowableInfo();
+
+        assertEquals("Expected and actual values should be the same.", 0, throwableInfo.getHttpErrorCode());
+        assertNull("Null expected.", throwableInfo.getMessage());
+        assertNull("Null expected.", throwableInfo.getStackTrace());
+    }
+
+    @Test
+    public void throwableInfoWithParametersFalseStackTraceTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            for (int j = 0; j < throwables.length; j++) {
+                ThrowableInfo throwableInfo = new ThrowableInfo(statusList[i], throwables[j]);
+
+                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
+                assertEquals("Expected and actual values should be the same.", expectedMessage[j], throwableInfo.getMessage());
+                assertNull("Null expected.", throwableInfo.getStackTrace());
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void throwableInfoNullStatusTest() {
+        new ThrowableInfo(null, new Throwable());
+    }
+
+    @Test
+    public void throwableInfoNullThrowableTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            ThrowableInfo throwableInfo = new ThrowableInfo(statusList[i], null);
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
+            assertNull("Null expected.", throwableInfo.getMessage());
+            assertNull("Null expected.", throwableInfo.getStackTrace());
+        }
+    }
+
+    @Test
+    public void setAndGetHttpErrorCodeTest() {
+        ThrowableInfo throwableInfo1 = new ThrowableInfo();
+        ThrowableInfo throwableInfo2 = new ThrowableInfo(Response.Status.OK, new Throwable());
+
+        for (int i = 0; i < statusList.length; i++) {
+            throwableInfo1.setHttpErrorCode(statusList[i]);
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo1.getHttpErrorCode());
+        }
+
+        try {
+            throwableInfo1.setHttpErrorCode(null);
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        for (int i = 0; i < statusList.length; i++) {
+            throwableInfo2.setHttpErrorCode(statusList[i]);
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo2.getHttpErrorCode());
+        }
+
+        try {
+            throwableInfo2.setHttpErrorCode(null);
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void setAndGetMessageTest() {
+        ThrowableInfo throwableInfo1 = new ThrowableInfo();
+        ThrowableInfo throwableInfo2 = new ThrowableInfo(Response.Status.OK, new Throwable());
+        String[] messages = {null, "", "mess_age", "message#123", "@message-333", "message<9>,", "(1*2)m,."};
+
+        for (int i = 0; i < messages.length; i++) {
+            throwableInfo1.setMessage(messages[i]);
+            assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo1.getMessage());
+        }
+
+        for (int i = 0; i < messages.length; i++) {
+            throwableInfo2.setMessage(messages[i]);
+            assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo2.getMessage());
+        }
+    }
+} 


### PR DESCRIPTION
This PR contains JUnit tests for classes in exception/model package in
rest-api/core module:
 - IllegalArgumentExceptionInfo class
 - IllegalNullArgumentExceptionInfo class
 - InternalUserOnlyExceptionInfo class
 - MfaRequiredExceptionInfo class
 - SelfManagedOnlyExceptionInfo class
 - SubjectUnauthorizedExceptionInfo class
 - ThrowableInfo class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
