### PR TITLE
Added JUnit tests for rest-api/core module

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
@@ -1,0 +1,152 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.integration.misc;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.config.Ini;
+import org.apache.shiro.config.IniSecurityManagerFactory;
+import org.apache.shiro.mgt.SecurityManager;
+import org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.servlet.FilterConfig;
+import javax.servlet.FilterChain;
+import javax.servlet.ServletResponse;
+import javax.servlet.ServletRequest;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+@Category(JUnitTests.class)
+public class KapuaSessionCleanupFilterTest extends Assert {
+
+    KapuaSessionCleanupFilter kapuaSessionCleanupFilter;
+    URL shiroIniUrl;
+    Ini shiroIni;
+    InputStream input;
+    SecurityManager securityManager;
+    ServletRequest request;
+    ServletResponse response;
+    FilterChain chain;
+    KapuaSession kapuaSession;
+
+    @Before
+    public void initialize() throws IOException {
+        kapuaSessionCleanupFilter = new KapuaSessionCleanupFilter();
+        shiroIniUrl = getClass().getResource("/shiro.ini");
+        shiroIni = new Ini();
+        input = shiroIniUrl.openStream();
+        shiroIni.load(input);
+        securityManager = new IniSecurityManagerFactory(shiroIni).getInstance();
+
+        request = Mockito.mock(ServletRequest.class);
+        response = Mockito.mock(ServletResponse.class);
+        chain = Mockito.mock(FilterChain.class);
+        kapuaSession = new KapuaSession();
+    }
+
+    //COMMENT: Method init(FilterConfig filterConfig) is empty
+    @Test
+    public void initTest() {
+        try {
+            kapuaSessionCleanupFilter.init(Mockito.mock(FilterConfig.class));
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void initNullTest() {
+        try {
+            kapuaSessionCleanupFilter.init(null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    //COMMENT: Method destroy() is empty
+    @Test
+    public void destroyTest() {
+        try {
+            kapuaSessionCleanupFilter.destroy();
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void doFilterTest() {
+        SecurityUtils.setSecurityManager(securityManager);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        try {
+            kapuaSessionCleanupFilter.doFilter(request, response, chain);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void doFilterNullRequestTest() {
+        SecurityUtils.setSecurityManager(securityManager);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        try {
+            kapuaSessionCleanupFilter.doFilter(null, response, chain);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void doFilterNullResponseTest() {
+        SecurityUtils.setSecurityManager(securityManager);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        try {
+            kapuaSessionCleanupFilter.doFilter(request, null, chain);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void doFilterNullChainTest() {
+        SecurityUtils.setSecurityManager(securityManager);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        try {
+            kapuaSessionCleanupFilter.doFilter(request, response, null);
+            fail("Exception expected.");
+        } catch (Exception e) {
+            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void doFilterNullSessionTest() {
+        SecurityUtils.setSecurityManager(securityManager);
+        try {
+            kapuaSessionCleanupFilter.doFilter(request, response, chain);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriterTest.java
@@ -1,0 +1,163 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core;
+
+import org.eclipse.kapua.KapuaSerializable;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+
+@Category(JUnitTests.class)
+public class KapuaSerializableBodyWriterTest extends Assert {
+
+    KapuaSerializableBodyWriter kapuaSerializableBodyWriter;
+    Annotation[] annotations;
+    MediaType mediaType;
+    KapuaSerializable kapuaSerializable;
+    Type genericType;
+    MultivaluedMap<String, Object> httpHeaders;
+    JAXBContext jaxbContext;
+    Marshaller marshaller;
+    OutputStream outputStream;
+
+    @Before
+    public void initialize() {
+        kapuaSerializableBodyWriter = new KapuaSerializableBodyWriter();
+        annotations = new Annotation[]{Mockito.mock(Annotation.class), Mockito.mock(Annotation.class)};
+        mediaType = MediaType.valueOf("some/text");
+        kapuaSerializable = Mockito.mock(KapuaSerializable.class);
+        genericType = Mockito.mock(Type.class);
+        httpHeaders = Mockito.mock(MultivaluedMap.class);
+        jaxbContext = Mockito.mock(JAXBContext.class);
+        marshaller = Mockito.mock(Marshaller.class);
+        outputStream = new OutputStream() {
+            @Override
+            public void write(int b) {
+            }
+        };
+    }
+
+    @Test
+    public void isWriteableTest() {
+        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullTypeTest() {
+        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(null, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullGenericTypeTest() {
+        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, null, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullAnnotationsTest() {
+        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, null, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullMediaTypeTest() {
+        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, null));
+    }
+
+    @Test
+    public void getSizeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullKapuaSerializableTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, null, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullGenericTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, null, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullAnnotationsTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, null, mediaType));
+    }
+
+    @Test
+    public void getSizeNullMediaTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, null));
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToNullProvidersTest() throws IOException {
+        kapuaSerializableBodyWriter.providers = null;
+
+        kapuaSerializableBodyWriter.writeTo(kapuaSerializable, String.class, genericType, annotations, mediaType, httpHeaders, outputStream);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToNullJaxbContextTest() throws IOException {
+        kapuaSerializableBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(null);
+
+        kapuaSerializableBodyWriter.writeTo(kapuaSerializable, String.class, genericType, annotations, mediaType, httpHeaders, outputStream);
+    }
+
+    @Test
+    public void writeToTest() throws Exception {
+        kapuaSerializableBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(jaxbContext);
+        Mockito.when(jaxbContext.createMarshaller()).thenReturn(marshaller);
+
+        try {
+            kapuaSerializableBodyWriter.writeTo(kapuaSerializable, String.class, genericType, annotations, mediaType, httpHeaders, outputStream);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToInternalServerErrorTest() throws Exception {
+        kapuaSerializableBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(kapuaSerializableBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(jaxbContext);
+        Mockito.when(jaxbContext.createMarshaller()).thenThrow(new JAXBException("message"));
+
+        kapuaSerializableBodyWriter.writeTo(kapuaSerializable, String.class, genericType, annotations, mediaType, httpHeaders, outputStream);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/ListBodyWriterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/ListBodyWriterTest.java
@@ -1,0 +1,164 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import javax.xml.bind.JAXBContext;
+import javax.xml.bind.JAXBException;
+import javax.xml.bind.Marshaller;
+import java.io.IOException;
+import java.io.OutputStream;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Type;
+import java.util.LinkedList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class ListBodyWriterTest extends Assert {
+
+    ListBodyWriter listBodyWriter;
+    Type genericType;
+    Annotation[] annotations;
+    MediaType mediaType;
+    List list;
+    MultivaluedMap<String, Object> httpHeaders;
+    JAXBContext jaxbContext;
+    Marshaller marshaller;
+    OutputStream outputStream;
+
+    @Before
+    public void initialize() {
+        listBodyWriter = new ListBodyWriter();
+        genericType = Mockito.mock(Type.class);
+        annotations = new Annotation[]{Mockito.mock(Annotation.class), Mockito.mock(Annotation.class)};
+        mediaType = MediaType.valueOf("some/text");
+        list = new LinkedList();
+        httpHeaders = Mockito.mock(MultivaluedMap.class);
+        jaxbContext = Mockito.mock(JAXBContext.class);
+        marshaller = Mockito.mock(Marshaller.class);
+        outputStream = new OutputStream() {
+            @Override
+            public void write(int b) {
+            }
+        };
+    }
+
+    @Test
+    public void isWriteableTest() {
+        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullTypeTest() {
+        assertTrue("True expected.", listBodyWriter.isWriteable(null, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullGenericTypeTest() {
+        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, null, annotations, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullAnnotationsTest() {
+        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, null, mediaType));
+    }
+
+    @Test
+    public void isWriteableNullMediaTypeTest() {
+        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, null));
+    }
+
+    @Test
+    public void getSizeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullListTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, null, genericType, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullGenericTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, null, annotations, mediaType));
+    }
+
+    @Test
+    public void getSizeNullAnnotationsTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, null, mediaType));
+    }
+
+    @Test
+    public void getSizeNullMediaTypeTest() {
+        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, null));
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToNullProvidersTest() throws IOException {
+        listBodyWriter.providers = null;
+
+        listBodyWriter.writeTo(list, String.class, Mockito.mock(Type.class), annotations, mediaType, httpHeaders, outputStream);
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToNullJaxbContextTest() throws IOException {
+        listBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(null);
+
+        listBodyWriter.writeTo(list, String.class, Mockito.mock(Type.class), annotations, mediaType, httpHeaders, outputStream);
+    }
+
+    @Test
+    public void writeToTest() throws Exception {
+        listBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(jaxbContext);
+        Mockito.when(jaxbContext.createMarshaller()).thenReturn(marshaller);
+
+        try {
+            listBodyWriter.writeTo(list, String.class, Mockito.mock(Type.class), annotations, mediaType, httpHeaders, outputStream);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test(expected = WebApplicationException.class)
+    public void writeToInternalServerErrorTest() throws Exception {
+        listBodyWriter.providers = Mockito.mock(Providers.class);
+
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(Mockito.mock(ContextResolver.class));
+        Mockito.when(listBodyWriter.providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE).getContext(JAXBContext.class)).thenReturn(jaxbContext);
+        Mockito.when(jaxbContext.createMarshaller()).thenThrow(new JAXBException("message"));
+
+        listBodyWriter.writeTo(list, String.class, Mockito.mock(Type.class), annotations, mediaType, httpHeaders, outputStream);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolverTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolverTest.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.glassfish.jersey.moxy.json.MoxyJsonConfig;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class MoxyJsonConfigContextResolverTest extends Assert {
+
+    @Test
+    public void moxyJsonConfigContextResolverTest() {
+        Class[] classes = {null, String.class, Integer.class, Short.class, Long.class, Character.class, Double.class, Float.class, String.class};
+        MoxyJsonConfigContextResolver moxyJsonConfigContextResolver = new MoxyJsonConfigContextResolver();
+
+        for (Class clazz : classes) {
+            assertTrue("True expected.", moxyJsonConfigContextResolver.getContext(clazz) instanceof MoxyJsonConfig);
+            assertEquals("Expected and actual values should be the same.", moxyJsonConfigContextResolver.config, moxyJsonConfigContextResolver.getContext(clazz));
+            assertEquals("Expected and actual values should be the same.", "{jaxb.formatted.output=false, eclipselink.json.namespace-separator=., eclipselink.json.include-root=false, eclipselink.json.wrapper-as-array-name=true, eclipselink.json.marshal-empty-collections=true}", moxyJsonConfigContextResolver.config.getMarshallerProperties().toString());
+        }
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilterTest.java
@@ -1,0 +1,63 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.auth;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+@Category(JUnitTests.class)
+public class KapuaTokenAuthenticationFilterTest extends Assert {
+
+    HttpServletRequest request;
+    HttpServletResponse response;
+    KapuaTokenAuthenticationFilter kapuaTokenAuthenticationFilter;
+    Object[] mappedValues;
+
+    @Before
+    public void initialize() {
+        request = Mockito.mock(HttpServletRequest.class);
+        response = Mockito.mock(HttpServletResponse.class);
+        kapuaTokenAuthenticationFilter = new KapuaTokenAuthenticationFilter();
+        mappedValues = new Object[]{new Object(), 0, 10, 100000, "String", 'c', -10, -1000000000, -100000000000L, 10L, 10.0f, null, 10.10d, true, false};
+    }
+
+    @Test
+    public void isAccessAllowedTrueTest() {
+        Mockito.when(request.getMethod()).thenReturn("OPTIONS");
+        for (Object mappedValue : mappedValues) {
+            assertTrue("True expected.", kapuaTokenAuthenticationFilter.isAccessAllowed(request, response, mappedValue));
+        }
+    }
+
+    @Test
+    public void onAccessDeniedTest() throws Exception {
+        assertFalse("False expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, response));
+    }
+
+    @Test
+    public void onAccessDeniedNullRequestTest() throws Exception {
+        assertFalse("False expected.", kapuaTokenAuthenticationFilter.onAccessDenied(null, response));
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void onAccessDeniedNullResponseTest() throws Exception {
+        assertFalse("False expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, null));
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeysTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeysTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.settings;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaApiCoreSettingKeysTest extends Assert {
+
+    @Test
+    public void kapuaApiCoreSettingKeysTest(){
+        assertEquals("Expected and actual values should be the same.","api.path.param.scopeId.wildcard",KapuaApiCoreSettingKeys.API_PATH_PARAM_SCOPEID_WILDCARD.key());
+        assertEquals("Expected and actual values should be the same.","api.exception.stacktrace.show",KapuaApiCoreSettingKeys.API_EXCEPTION_STACKTRACE_SHOW.key());
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingTest.java
@@ -1,0 +1,38 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.settings;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.lang.reflect.Constructor;
+import java.lang.reflect.Modifier;
+
+@Category(JUnitTests.class)
+public class KapuaApiCoreSettingTest extends Assert {
+
+    @Test
+    public void kapuaApiCoreSettingTest() throws Exception {
+        Constructor<KapuaApiCoreSetting> kapuaApiCoreSetting = KapuaApiCoreSetting.class.getDeclaredConstructor();
+        kapuaApiCoreSetting.setAccessible(true);
+        kapuaApiCoreSetting.newInstance();
+        assertTrue("True expected.", Modifier.isPrivate(kapuaApiCoreSetting.getModifiers()));
+    }
+
+    @Test
+    public void getInstanceTest() {
+        assertTrue("True expected.", KapuaApiCoreSetting.getInstance() instanceof KapuaApiCoreSetting);
+    }
+}


### PR DESCRIPTION
This PR contais JUnit tests for classes in rest-api/core module:

- KapuaSerializableBodyWriter class
- ListBodyWriter class
- MoxyJsonConfigContextResolver class

  - filter package:
- KapuaSessionCleanupFilter class

  - auth package:
- KapuaTokenAuthenticationFilter class

  - settings package:
- KapuaApiSettingKeys class
- KapuaApiSetting class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
