### PR TITLE
Added JUnit tests for rest-api/core/exception package

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/InternalUserOnlyExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/InternalUserOnlyExceptionMapperTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.exception.InternalUserOnlyException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class InternalUserOnlyExceptionMapperTest extends Assert {
+
+    InternalUserOnlyExceptionMapper internalUserOnlyExceptionMapper;
+    InternalUserOnlyException internalUserOnlyException;
+
+    @Before
+    public void initialize() {
+        internalUserOnlyExceptionMapper = new InternalUserOnlyExceptionMapper();
+        internalUserOnlyException = new InternalUserOnlyException();
+    }
+
+    @Test
+    public void toResponseTest() {
+        assertEquals("Expected and actual values should be the same.", 403, internalUserOnlyExceptionMapper.toResponse(internalUserOnlyException).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", internalUserOnlyExceptionMapper.toResponse(internalUserOnlyException).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        internalUserOnlyExceptionMapper.toResponse(null).getStatus();
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SelfManagedOnlyExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SelfManagedOnlyExceptionMapperTest.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.exception.SelfManagedOnlyException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class SelfManagedOnlyExceptionMapperTest extends Assert {
+
+    SelfManagedOnlyExceptionMapper selfManagedOnlyExceptionMapper;
+    SelfManagedOnlyException selfManagedOnlyException;
+
+    @Before
+    public void initialize() {
+        selfManagedOnlyExceptionMapper = new SelfManagedOnlyExceptionMapper();
+        selfManagedOnlyException = new SelfManagedOnlyException();
+    }
+
+    @Test
+    public void toResponseTest() {
+        assertEquals("Expected and actual values should be the same.", 403, selfManagedOnlyExceptionMapper.toResponse(selfManagedOnlyException).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", selfManagedOnlyExceptionMapper.toResponse(selfManagedOnlyException).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        selfManagedOnlyExceptionMapper.toResponse(null).getStatus();
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaAuthenticationExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaAuthenticationExceptionMapperTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authentication.KapuaAuthenticationErrorCodes;
+import org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticationException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaAuthenticationExceptionMapperTest extends Assert {
+
+    KapuaAuthenticationExceptionMapper kapuaAuthenticationExceptionMapper;
+
+    @Before
+    public void initialize() {
+        kapuaAuthenticationExceptionMapper = new KapuaAuthenticationExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        KapuaAuthenticationErrorCodes[] errorCodes = {KapuaAuthenticationErrorCodes.SUBJECT_ALREADY_LOGGED, KapuaAuthenticationErrorCodes.INVALID_CREDENTIALS_TYPE_PROVIDED,
+                KapuaAuthenticationErrorCodes.AUTHENTICATION_ERROR, KapuaAuthenticationErrorCodes.CREDENTIAL_CRYPT_ERROR, KapuaAuthenticationErrorCodes.INVALID_LOGIN_CREDENTIALS,
+                KapuaAuthenticationErrorCodes.EXPIRED_LOGIN_CREDENTIALS, KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL,
+                KapuaAuthenticationErrorCodes.UNKNOWN_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.INVALID_SESSION_CREDENTIALS, KapuaAuthenticationErrorCodes.EXPIRED_SESSION_CREDENTIALS,
+                KapuaAuthenticationErrorCodes.LOCKED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.JWK_FILE_ERROR,
+                KapuaAuthenticationErrorCodes.REFRESH_ERROR, KapuaAuthenticationErrorCodes.JWK_GENERATION_ERROR, KapuaAuthenticationErrorCodes.JWT_CERTIFICATE_NOT_FOUND,
+                KapuaAuthenticationErrorCodes.PASSWORD_CANNOT_BE_CHANGED};
+
+        for (KapuaAuthenticationErrorCodes code : errorCodes) {
+            KapuaAuthenticationException kapuaAuthenticationException = new KapuaAuthenticationException(code);
+
+            assertEquals("Expected and actual values should be the same.", 401, kapuaAuthenticationExceptionMapper.toResponse(kapuaAuthenticationException).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Unauthorized", kapuaAuthenticationExceptionMapper.toResponse(kapuaAuthenticationException).getStatusInfo().toString());
+        }
+    }
+
+    @Test
+    public void toResponseRequireMfaCredentialsTest() {
+        KapuaAuthenticationException kapuaAuthenticationException = new KapuaAuthenticationException(KapuaAuthenticationErrorCodes.REQUIRE_MFA_CREDENTIALS);
+
+        assertEquals("Expected and actual values should be the same.", 403, kapuaAuthenticationExceptionMapper.toResponse(kapuaAuthenticationException).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", kapuaAuthenticationExceptionMapper.toResponse(kapuaAuthenticationException).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullCodeTest() {
+        KapuaAuthenticationException kapuaAuthenticationException = new KapuaAuthenticationException(null);
+        kapuaAuthenticationExceptionMapper.toResponse(kapuaAuthenticationException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaAuthenticationExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaAuthorizationExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaAuthorizationExceptionMapperTest.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizationErrorCodes;
+import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizationException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaAuthorizationExceptionMapperTest extends Assert {
+
+    KapuaAuthorizationExceptionMapper kapuaAuthorizationExceptionMapper;
+
+    @Before
+    public void initialize() {
+        kapuaAuthorizationExceptionMapper = new KapuaAuthorizationExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        KapuaAuthorizationErrorCodes[] errorCodes = {KapuaAuthorizationErrorCodes.INVALID_STRING_PERMISSION,
+                KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, KapuaAuthorizationErrorCodes.ENTITY_SCOPE_MISSMATCH};
+
+        for (KapuaAuthorizationErrorCodes code : errorCodes) {
+            KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(code);
+
+            assertEquals("Expected and actual values should be the same.", 403, kapuaAuthorizationExceptionMapper.toResponse(kapuaAuthorizationException).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Forbidden", kapuaAuthorizationExceptionMapper.toResponse(kapuaAuthorizationException).getStatusInfo().toString());
+        }
+    }
+
+    @Test
+    public void toResponseNullCodeTest() {
+        KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null);
+        assertEquals("Expected and actual values should be the same.", 403, kapuaAuthorizationExceptionMapper.toResponse(kapuaAuthorizationException).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", kapuaAuthorizationExceptionMapper.toResponse(kapuaAuthorizationException).getStatusInfo().toString());
+    }
+
+    @Test
+    public void toResponseNullTest() {
+        assertEquals("Expected and actual values should be the same.", 403, kapuaAuthorizationExceptionMapper.toResponse(null).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", kapuaAuthorizationExceptionMapper.toResponse(null).getStatusInfo().toString());
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaEntityNotFoundExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaEntityNotFoundExceptionMapperTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaEntityNotFoundExceptionMapperTest extends Assert {
+
+    KapuaEntityNotFoundExceptionMapper kapuaEntityNotFoundExceptionMapper;
+
+    @Before
+    public void initialize() {
+        kapuaEntityNotFoundExceptionMapper = new KapuaEntityNotFoundExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        assertEquals("Expected and actual values should be the same.", 404, kapuaEntityNotFoundExceptionMapper.toResponse(new KapuaEntityNotFoundException("entity type", KapuaId.ANY)).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Not Found", kapuaEntityNotFoundExceptionMapper.toResponse(new KapuaEntityNotFoundException("entity type", KapuaId.ANY)).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaEntityNotFoundExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaExceptionMapperTest.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaExceptionMapperTest extends Assert {
+
+    KapuaExceptionMapper kapuaExceptionMapper;
+
+    @Before
+    public void initialize() {
+        kapuaExceptionMapper = new KapuaExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        assertEquals("Expected and actual values should be the same.", 500, kapuaExceptionMapper.toResponse(new KapuaException(KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR)).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Internal Server Error", kapuaExceptionMapper.toResponse(new KapuaException(KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR)).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaIllegalArgumentExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaIllegalArgumentExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaIllegalArgumentExceptionMapperTest extends Assert {
+
+    KapuaIllegalArgumentExceptionMapper kapuaIllegalArgumentExceptionMapper;
+    KapuaIllegalArgumentException[] kapuaIllegalArgumentException;
+
+    @Before
+    public void initialize() {
+        kapuaIllegalArgumentExceptionMapper = new KapuaIllegalArgumentExceptionMapper();
+        kapuaIllegalArgumentException = new KapuaIllegalArgumentException[]{new KapuaIllegalArgumentException("name", "value"), new KapuaIllegalArgumentException(null, "value"), new KapuaIllegalArgumentException("name", null), new KapuaIllegalArgumentException(null, null)};
+    }
+
+    @Test
+    public void toResponseTest() {
+        for (KapuaIllegalArgumentException kapuaException : kapuaIllegalArgumentException) {
+            assertEquals("Expected and actual values should be the same.", 400, kapuaIllegalArgumentExceptionMapper.toResponse(kapuaException).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Bad Request", kapuaIllegalArgumentExceptionMapper.toResponse(kapuaException).getStatusInfo().toString());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaIllegalArgumentExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaIllegalNullArgumentExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaIllegalNullArgumentExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaIllegalNullArgumentExceptionMapperTest extends Assert {
+
+    KapuaIllegalNullArgumentExceptionMapper kapuaIllegalNullArgumentExceptionMapper;
+    KapuaIllegalNullArgumentException[] kapuaIllegalNullArgumentException;
+
+    @Before
+    public void initialize() {
+        kapuaIllegalNullArgumentExceptionMapper = new KapuaIllegalNullArgumentExceptionMapper();
+        kapuaIllegalNullArgumentException = new KapuaIllegalNullArgumentException[]{new KapuaIllegalNullArgumentException("name"), new KapuaIllegalNullArgumentException(""), new KapuaIllegalNullArgumentException(null)};
+    }
+
+    @Test
+    public void toResponseTest() {
+        for (KapuaIllegalNullArgumentException kapuaException : kapuaIllegalNullArgumentException) {
+            assertEquals("Expected and actual values should be the same.", 400, kapuaIllegalNullArgumentExceptionMapper.toResponse(kapuaException).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Bad Request", kapuaIllegalNullArgumentExceptionMapper.toResponse(kapuaException).getStatusInfo().toString());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaIllegalNullArgumentExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaServiceDisabledExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaServiceDisabledExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class KapuaServiceDisabledExceptionMapperTest extends Assert {
+
+    KapuaServiceDisabledExceptionMapper kapuaServiceDisabledExceptionMapper;
+    KapuaServiceDisabledException[] kapuaServiceDisabledException;
+
+    @Before
+    public void initialize() {
+        kapuaServiceDisabledExceptionMapper = new KapuaServiceDisabledExceptionMapper();
+        kapuaServiceDisabledException = new KapuaServiceDisabledException[]{new KapuaServiceDisabledException("name"), new KapuaServiceDisabledException(""), new KapuaServiceDisabledException(null)};
+    }
+
+    @Test
+    public void toResponseTest() {
+        for (KapuaServiceDisabledException kapuaException : kapuaServiceDisabledException) {
+            assertEquals("Expected and actual values should be the same.", 404, kapuaServiceDisabledExceptionMapper.toResponse(kapuaException).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Not Found", kapuaServiceDisabledExceptionMapper.toResponse(kapuaException).getStatusInfo().toString());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        kapuaServiceDisabledExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/ParamExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/ParamExceptionMapperTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.glassfish.jersey.server.ParamException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ParamExceptionMapperTest extends Assert {
+
+    ParamExceptionMapper paramExceptionMapper;
+
+    @Before
+    public void initialize() {
+        paramExceptionMapper = new ParamExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        Throwable[] throwables = {new Throwable(), new Throwable("message"), new Throwable(new Exception()), new KapuaIllegalArgumentException("name", "value"), new KapuaIllegalArgumentException(null, "value"), new KapuaIllegalArgumentException("name", null), new KapuaIllegalArgumentException(null, null)};
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 400, paramExceptionMapper.toResponse(new ParamException.PathParamException(throwable, "name", "default value")).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Bad Request", paramExceptionMapper.toResponse(new ParamException.PathParamException(throwable, "name", "default value")).getStatusInfo().toString());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        paramExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/SubjectUnauthorizedExceptionMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/SubjectUnauthorizedExceptionMapperTest.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.permission.Permission;
+import org.eclipse.kapua.service.authorization.shiro.exception.SubjectUnauthorizedException;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category(JUnitTests.class)
+public class SubjectUnauthorizedExceptionMapperTest extends Assert {
+
+    SubjectUnauthorizedExceptionMapper subjectUnathorizedExceptionMapper;
+
+    @Before
+    public void initialize() {
+        subjectUnathorizedExceptionMapper = new SubjectUnauthorizedExceptionMapper();
+    }
+
+    @Test
+    public void toResponseTest() {
+        assertEquals("Expected and actual values should be the same.", 403, subjectUnathorizedExceptionMapper.toResponse(new SubjectUnauthorizedException(Mockito.mock(Permission.class))).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", subjectUnathorizedExceptionMapper.toResponse(new SubjectUnauthorizedException(Mockito.mock(Permission.class))).getStatusInfo().toString());
+    }
+
+    @Test
+    public void toResponseNullPermissionTest() {
+        assertEquals("Expected and actual values should be the same.", 403, subjectUnathorizedExceptionMapper.toResponse(new SubjectUnauthorizedException(null)).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Forbidden", subjectUnathorizedExceptionMapper.toResponse(new SubjectUnauthorizedException(null)).getStatusInfo().toString());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toResponseNullTest() {
+        subjectUnathorizedExceptionMapper.toResponse(null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/ThrowableMapperTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/mapper/ThrowableMapperTest.java
@@ -1,0 +1,46 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ThrowableMapperTest extends Assert {
+
+    ThrowableMapper throwableMapper;
+    Throwable[] throwables;
+
+    @Before
+    public void initialize() {
+        throwableMapper = new ThrowableMapper();
+        throwables = new Throwable[]{new Throwable(), new Throwable("message"), new Throwable(new Exception())};
+    }
+
+    @Test
+    public void toResponseTest() {
+        for (Throwable throwable : throwables) {
+            assertEquals("Expected and actual values should be the same.", 500, throwableMapper.toResponse(throwable).getStatus());
+            assertEquals("Expected and actual values should be the same.", "Internal Server Error", throwableMapper.toResponse(throwable).getStatusInfo().toString());
+        }
+    }
+
+    @Test
+    public void toResponseNullTest() {
+        assertEquals("Expected and actual values should be the same.", 500, throwableMapper.toResponse(null).getStatus());
+        assertEquals("Expected and actual values should be the same.", "Internal Server Error", throwableMapper.toResponse(null).getStatusInfo().toString());
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/EntityNotFoundExceptionInfoTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class EntityNotFoundExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    int[] expectedStatusCodes;
+    KapuaEntityNotFoundException kapuaEntityNotFoundException;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        kapuaEntityNotFoundException = new KapuaEntityNotFoundException("type", KapuaId.ONE);
+    }
+
+    @Test
+    public void entityNotFoundExceptionInfoWithoutParametersTest() {
+        EntityNotFoundExceptionInfo entityNotFoundExceptionInfo = new EntityNotFoundExceptionInfo();
+
+        assertNull("Null expected.", entityNotFoundExceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, entityNotFoundExceptionInfo.getHttpErrorCode());
+        assertNull("Null expected.", entityNotFoundExceptionInfo.getEntityType());
+        assertNull("Null expected.", entityNotFoundExceptionInfo.getEntityId());
+    }
+
+    @Test
+    public void entityNotFoundExceptionInfoWithParametersTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            EntityNotFoundExceptionInfo entityNotFoundExceptionInfo = new EntityNotFoundExceptionInfo(statusList[i], kapuaEntityNotFoundException);
+
+            assertEquals("Expected and actual values should be the same.", "ENTITY_NOT_FOUND", entityNotFoundExceptionInfo.getKapuaErrorCode());
+            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], entityNotFoundExceptionInfo.getHttpErrorCode());
+            assertEquals("Expected and actual values should be the same.", "type", entityNotFoundExceptionInfo.getEntityType());
+            assertEquals("Expected and actual values should be the same.", KapuaId.ONE, entityNotFoundExceptionInfo.getEntityId());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void entityNotFoundExceptionInfoNullHttpStatusTest() {
+        new EntityNotFoundExceptionInfo(null, kapuaEntityNotFoundException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void entityNotFoundExceptionInfoNullExceptionTest() {
+        new EntityNotFoundExceptionInfo(Response.Status.OK, null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfoTest.java
@@ -1,0 +1,101 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import org.eclipse.kapua.KapuaErrorCode;
+import org.eclipse.kapua.KapuaErrorCodes;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class ExceptionInfoTest extends Assert {
+
+    Response.Status[] statusList;
+    KapuaErrorCode[] kapuaErrorCodes;
+    int[] expectedStatusCodes;
+    String[] expectedErrorCodes;
+
+    @Before
+    public void initialize() {
+        statusList = new Response.Status[]{Response.Status.OK, Response.Status.CREATED, Response.Status.ACCEPTED, Response.Status.NO_CONTENT,
+                Response.Status.RESET_CONTENT, Response.Status.PARTIAL_CONTENT, Response.Status.MOVED_PERMANENTLY, Response.Status.FOUND,
+                Response.Status.SEE_OTHER, Response.Status.NOT_MODIFIED, Response.Status.USE_PROXY, Response.Status.TEMPORARY_REDIRECT,
+                Response.Status.BAD_REQUEST, Response.Status.UNAUTHORIZED, Response.Status.PAYMENT_REQUIRED, Response.Status.FORBIDDEN,
+                Response.Status.NOT_FOUND, Response.Status.METHOD_NOT_ALLOWED, Response.Status.NOT_ACCEPTABLE, Response.Status.PROXY_AUTHENTICATION_REQUIRED,
+                Response.Status.REQUEST_TIMEOUT, Response.Status.CONFLICT, Response.Status.GONE, Response.Status.LENGTH_REQUIRED,
+                Response.Status.PRECONDITION_FAILED, Response.Status.REQUEST_ENTITY_TOO_LARGE, Response.Status.REQUEST_URI_TOO_LONG, Response.Status.UNSUPPORTED_MEDIA_TYPE,
+                Response.Status.REQUESTED_RANGE_NOT_SATISFIABLE, Response.Status.EXPECTATION_FAILED, Response.Status.INTERNAL_SERVER_ERROR, Response.Status.NOT_IMPLEMENTED,
+                Response.Status.BAD_GATEWAY, Response.Status.SERVICE_UNAVAILABLE, Response.Status.GATEWAY_TIMEOUT, Response.Status.HTTP_VERSION_NOT_SUPPORTED};
+        kapuaErrorCodes = new KapuaErrorCodes[]{KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, KapuaErrorCodes.ENTITY_NOT_FOUND, KapuaErrorCodes.ENTITY_ALREADY_EXISTS, KapuaErrorCodes.DUPLICATE_NAME,
+                KapuaErrorCodes.DUPLICATE_EXTERNAL_ID, KapuaErrorCodes.ENTITY_UNIQUENESS, KapuaErrorCodes.ILLEGAL_ACCESS, KapuaErrorCodes.ILLEGAL_ARGUMENT,
+                KapuaErrorCodes.ILLEGAL_NULL_ARGUMENT, KapuaErrorCodes.ILLEGAL_STATE, KapuaErrorCodes.OPTIMISTIC_LOCKING, KapuaErrorCodes.UNAUTHENTICATED,
+                KapuaErrorCodes.OPERATION_NOT_SUPPORTED, KapuaErrorCodes.INTERNAL_ERROR, KapuaErrorCodes.SEVERE_INTERNAL_ERROR, KapuaErrorCodes.PARENT_LIMIT_EXCEEDED_IN_CONFIG,
+                KapuaErrorCodes.SUBJECT_UNAUTHORIZED, KapuaErrorCodes.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, KapuaErrorCodes.EXTERNAL_ID_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, KapuaErrorCodes.BUNDLE_START_ERROR,
+                KapuaErrorCodes.BUNDLE_STOP_ERROR, KapuaErrorCodes.PACKAGE_URI_SYNTAX_ERROR, KapuaErrorCodes.MAX_NUMBER_OF_ITEMS_REACHED, KapuaErrorCodes.DEVICE_NOT_FOUND, KapuaErrorCodes.DOWNLOAD_PACKAGE_EXCEPTION,
+                KapuaErrorCodes.PERMISSION_DELETE_NOT_ALLOWED, KapuaErrorCodes.SERVICE_DISABLED};
+        expectedStatusCodes = new int[]{200, 201, 202, 204, 205, 206, 301, 302, 303, 304, 305, 307, 400, 401, 402, 403, 404, 405, 406, 407, 408, 409, 410, 411, 412, 413, 414, 415, 416, 417, 500, 501, 502, 503, 504, 505};
+        expectedErrorCodes = new String[]{"ADMIN_ROLE_DELETED_ERROR", "ENTITY_NOT_FOUND", "ENTITY_ALREADY_EXISTS", "DUPLICATE_NAME", "DUPLICATE_EXTERNAL_ID", "ENTITY_UNIQUENESS", "ILLEGAL_ACCESS", "ILLEGAL_ARGUMENT",
+                "ILLEGAL_NULL_ARGUMENT", "ILLEGAL_STATE", "OPTIMISTIC_LOCKING", "UNAUTHENTICATED", "OPERATION_NOT_SUPPORTED", "INTERNAL_ERROR", "SEVERE_INTERNAL_ERROR", "PARENT_LIMIT_EXCEEDED_IN_CONFIG",
+                "SUBJECT_UNAUTHORIZED", "ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT", "EXTERNAL_ID_ALREADY_EXIST_IN_ANOTHER_ACCOUNT", "BUNDLE_START_ERROR", "BUNDLE_STOP_ERROR", "PACKAGE_URI_SYNTAX_ERROR", "MAX_NUMBER_OF_ITEMS_REACHED",
+                "DEVICE_NOT_FOUND", "DOWNLOAD_PACKAGE_EXCEPTION", "PERMISSION_DELETE_NOT_ALLOWED", "SERVICE_DISABLED"};
+    }
+
+    @Test
+    public void exceptionInfoWithoutParametersTest() {
+        ExceptionInfo exceptionInfo = new ExceptionInfo();
+
+        assertNull("Null expected.", exceptionInfo.getKapuaErrorCode());
+        assertEquals("Expected and actual values should be the same.", 0, exceptionInfo.getHttpErrorCode());
+    }
+
+    @Test
+    public void exceptionInfoWithParametersTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            for (int j = 0; j < kapuaErrorCodes.length; j++) {
+                KapuaException kapuaException = new KapuaException(kapuaErrorCodes[j]);
+                ExceptionInfo exceptionInfo = new ExceptionInfo(statusList[i], kapuaErrorCodes[j], kapuaException);
+                assertEquals("Expected and actual values should be the same.", expectedErrorCodes[j], exceptionInfo.getKapuaErrorCode());
+                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], exceptionInfo.getHttpErrorCode());
+            }
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void exceptionInfoNullHttpStatusTest() {
+        KapuaException kapuaException = new KapuaException(KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR);
+        new ExceptionInfo(null, KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaException);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void exceptionInfoNullErrorCodeTest() {
+        KapuaException kapuaException = new KapuaException(KapuaErrorCodes.BUNDLE_START_ERROR);
+        new ExceptionInfo(Response.Status.OK, null, kapuaException);
+    }
+
+    @Test
+    public void exceptionInfoNullExceptionTest() {
+        for (int i = 0; i < statusList.length; i++) {
+            for (int j = 0; j < kapuaErrorCodes.length; j++) {
+                ExceptionInfo exceptionInfo = new ExceptionInfo(statusList[i], kapuaErrorCodes[j], null);
+                assertEquals("Expected and actual values should be the same.", expectedErrorCodes[j], exceptionInfo.getKapuaErrorCode());
+                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], exceptionInfo.getHttpErrorCode());
+            }
+        }
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in exception package in rest-api/core module:
- InternalUserOnlyExceptionMapper class
- KapuaAuthenticationExceptionMapper class
- KapuaAuthorizationExceptionMapper class
- KapuaEntityNotFoundExceptionMapper class
- KapuaExceptionMapper class
- KapuaIllegalArgumentExceptionMapper class
- KapuaIllegalNullArgumentExceptionMapper class
- KapuaServiceDisabledExceptionMapper class
- ParamExceptionMapper class
- SelfManagedOnlyExceptionMapper class
- SubjectUnathorizedExceptionMapper class
- ThrowableMapper class

 - model package:
- EntityNotFoundExceptionInfo class
- ExceptionInfo class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
