### PR TITLE
Added JUnit tests for exception and model packages

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
@@ -1,0 +1,118 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class RestApiRuntimeExceptionTest extends Assert {
+
+    RestApiErrorCodes errorCode;
+    Object stringObject, intObject, charObject;
+    Throwable cause;
+
+    @Before
+    public void initialize() {
+        errorCode = RestApiErrorCodes.SESSION_NOT_POPULATED;
+        stringObject = "String Object";
+        intObject = 10;
+        charObject = 'c';
+        cause = new Throwable();
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void restApiRuntimeExceptionNullCodeTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null);
+
+        assertNull("Null expected.", restApiRuntimeException.getCode());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+        restApiRuntimeException.getMessage();
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, stringObject, intObject, charObject);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void restApiRuntimeExceptionNullCodeArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, stringObject, intObject, charObject);
+
+        assertNull("Null expected.", restApiRuntimeException.getCode());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+        restApiRuntimeException.getMessage();
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeNullArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, null);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeCauseArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, cause, stringObject, intObject, charObject);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void restApiRuntimeExceptionNullCodeCauseArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, cause, stringObject, intObject, charObject);
+
+        assertNull("Null expected.", restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+
+        restApiRuntimeException.getMessage();
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeNullCauseArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, null, stringObject, intObject, charObject);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        assertNull("Null expected.", restApiRuntimeException.getCause());
+    }
+
+    @Test
+    public void restApiRuntimeExceptionCodeCauseNullArgumentsTest() {
+        RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, cause, null);
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+    }
+}  

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SessionNotPopulatedExceptionTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SessionNotPopulatedExceptionTest.java
@@ -1,0 +1,31 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception;
+
+        import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+        import org.junit.Assert;
+        import org.junit.Test;
+        import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class SessionNotPopulatedExceptionTest extends Assert {
+
+    @Test
+    public void sessionNotPopulatedExceptionTest() {
+        SessionNotPopulatedException sessionNotPopulatedException = new SessionNotPopulatedException();
+
+        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, sessionNotPopulatedException.getCode());
+        assertNull("Null expected.", sessionNotPopulatedException.getCause());
+        assertEquals("Expected and actual values should be the same.", "Error: ", sessionNotPopulatedException.getMessage());
+    }
+}  

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ByteArrayParamTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ByteArrayParamTest.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class ByteArrayParamTest extends Assert {
+
+    @Test
+    public void byteArrayParamTest() {
+        String[] base64encoded = {"", "Some0-)9 t  ext    12", "1text5--=<>67890", "!@#$stri%^ng&12*()", "   _ +' string;.text,|<>", "  te5432<> string 98   <>..,,, d", " ,,:!2text 09 00238*&^  ,,"};
+        for (String encoded : base64encoded) {
+            ByteArrayParam byteArrayParam = new ByteArrayParam(encoded);
+            Assert.assertNotNull("NotNull expected.", byteArrayParam.getValue());
+        }
+    }
+
+    @Test
+    public void byteArrayParamNullTest() {
+        ByteArrayParam byteArrayParam = new ByteArrayParam(null);
+        Assert.assertNull("Null expected.", byteArrayParam.getValue());
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/CountResultTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/CountResultTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class CountResultTest extends Assert {
+
+    @Test
+    public void countResultWithoutParameterTest() {
+        CountResult countResult = new CountResult();
+        assertEquals("Expected and actual values should be the same.", 0, countResult.getCount());
+    }
+
+    @Test
+    public void countResultWithParameterTest() {
+        long[] countValues = {-9223372036854775808L, -10000000L, -10, -1L, 0L, 1L, 10, 9223372036854775807L};
+
+        for (long countValue : countValues) {
+            CountResult countResult = new CountResult(countValue);
+            assertEquals("Expected and actual values should be the same.", countValue, countResult.getCount());
+        }
+    }
+
+    @Test
+    public void setAndGetCount() {
+        long[] countValues = {-9223372036854775808L, -10000000L, -10L, -1L, 0L, 1L, 10L, 9223372036854775807L};
+        CountResult countResult1 = new CountResult();
+        CountResult countResult2 = new CountResult(100L);
+
+        for (long countValue : countValues) {
+            countResult1.setCount(countValue);
+            countResult2.setCount(countValue);
+
+            assertEquals("Expected and actual values should be the same.", countValue, countResult1.getCount());
+            assertEquals("Expected and actual values should be the same.", countValue, countResult2.getCount());
+        }
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/DateParamTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/DateParamTest.java
@@ -1,0 +1,49 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class DateParamTest extends Assert {
+
+    @Test
+    public void dateParamTest() throws KapuaIllegalArgumentException {
+        String[] dates = {"2020-10-27T21:32:52", " 2020-10-27T21:32:52+02:00", " 2020-10-27T19:32:52Z", " 2020-10-27T19:32:52+00:00"};
+
+        for (int i = 0; i < dates.length; i++) {
+            DateParam dateParam = new DateParam(dates[i]);
+            assertNotNull("Null not expected.", dateParam.getDate());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void dateParamNullTest() throws KapuaIllegalArgumentException {
+        DateParam dateParam = new DateParam(null);
+
+        dateParam.getDate();
+    }
+
+    @Test(expected = KapuaIllegalArgumentException.class)
+    public void dateParamInvalidDateTest() throws KapuaIllegalArgumentException {
+        String[] invalidDates = {"", "2020-10-27", " 2020-10-27T21:32 ", " 2020-10-27T25:32:52+02:00", " 2020-10-27T21:32"};
+
+        for (String invalidDate : invalidDates) {
+            new DateParam(invalidDate);
+        }
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/EntityIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/EntityIdTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.math.BigInteger;
+
+@Category(JUnitTests.class)
+public class EntityIdTest extends Assert {
+
+    @Test
+    public void entityIdTest() {
+        String[] compactEntityId = {"111", "entityId", "1000000", "-111", "12"};
+        String[] expectedValues = {"-10403", "134670355735069", "-174798351539", "-303755", "-41"};
+
+        for (int i = 0; i < compactEntityId.length; i++) {
+            EntityId entityId = new EntityId(compactEntityId[i]);
+
+            assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.getId().toString());
+            assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.toString());
+        }
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void entityIdNullTest() {
+        new EntityId(null);
+    }
+
+    @Test(expected = NumberFormatException.class)
+    public void entityIdEmptyTest() {
+        new EntityId("");
+    }
+
+    @Test
+    public void setAndGetIdToStringTest() {
+        EntityId entityId = new EntityId("111");
+
+        assertEquals("Expected and actual values should be the same.", "-10403", entityId.getId().toString());
+        assertEquals("Expected and actual values should be the same.", "-10403", entityId.toString());
+
+        entityId.setId(BigInteger.ONE);
+        assertEquals("Expected and actual values should be the same.", "1", entityId.getId().toString());
+        assertEquals("Expected and actual values should be the same.", "1", entityId.toString());
+
+        entityId.setId(null);
+        assertNull("Null expected.", entityId.getId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toStringNullIdTest() {
+        EntityId entityId = new EntityId("111");
+        entityId.setId(null);
+        entityId.toString();
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/MetricTypeTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/MetricTypeTest.java
@@ -1,0 +1,53 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.KapuaIllegalArgumentException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.util.Date;
+
+@Category(JUnitTests.class)
+public class MetricTypeTest extends Assert {
+
+    @Test
+    public void metricTypeTest() throws KapuaIllegalArgumentException {
+        String[] types = {"string", "integer", "int", "long", "float", "double", "boolean", "date", "binary"};
+        Class[] expectedClasses = {String.class, Integer.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class};
+
+        for (int i = 0; i < types.length; i++) {
+            MetricType metricType = new MetricType(types[i]);
+            assertEquals("Expected and actual values should be the same.", expectedClasses[i], metricType.getType());
+        }
+    }
+
+    @Test
+    public void metricEmptyTypeTest() throws KapuaIllegalArgumentException {
+        MetricType metricType = new MetricType("");
+        Assert.assertNull("Null expected.", metricType.getType());
+    }
+
+    @Test
+    public void metricNullTypeTest() throws KapuaIllegalArgumentException {
+        MetricType metricType = new MetricType(null);
+        Assert.assertNull("Null expected.", metricType.getType());
+    }
+
+    @Test(expected = KapuaIllegalArgumentException.class)
+    public void metricInvalidTypeTest() throws KapuaIllegalArgumentException {
+        new MetricType("invalid type");
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ScopeIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ScopeIdTest.java
@@ -1,0 +1,78 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.app.api.core.exception.SessionNotPopulatedException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.math.BigInteger;
+import java.util.Base64;
+
+@Category(JUnitTests.class)
+public class ScopeIdTest extends Assert {
+
+    @Test(expected = NullPointerException.class)
+    public void scopeIdNullTest() {
+        new ScopeId(null);
+    }
+
+    @Test
+    public void scopeIdEqualIdsTest() {
+        KapuaSession kapuaSession = Mockito.mock(KapuaSession.class);
+        KapuaSecurityUtils.setSession(kapuaSession);
+
+        Mockito.when(kapuaSession.getScopeId()).thenReturn(KapuaId.ONE);
+        ScopeId scopeId = new ScopeId("_");
+
+        assertEquals("Expected and actual values should be the same.", BigInteger.ONE, scopeId.getId());
+    }
+
+    @Test
+    public void scopeIdDifferentIdsTest() {
+        ScopeId scopeId = new ScopeId("scopeID");
+
+        assertEquals("Expected and actual values should be the same.", new BigInteger(Base64.getUrlDecoder().decode("scopeID")), scopeId.getId());
+    }
+
+    @Test(expected = SessionNotPopulatedException.class)
+    public void scopeIdNullSessionTest() {
+        KapuaSecurityUtils.clearSession();
+        new ScopeId("_");
+    }
+
+    @Test
+    public void setAndGetIdToStringTest() {
+        ScopeId scopeId = new ScopeId("scopeID");
+
+        scopeId.setId(BigInteger.TEN);
+        assertEquals("Expected and actual values should be the same.", BigInteger.TEN, scopeId.getId());
+        assertEquals("Expected and actual values should be the same.", "10", scopeId.toString());
+
+        scopeId.setId(null);
+        assertNull("Null expected.", scopeId.getId());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void toStringNullIdTest() {
+        ScopeId scopeId = new ScopeId("scopeID");
+        scopeId.setId(null);
+        scopeId.toString();
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/StorableEntityIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/StorableEntityIdTest.java
@@ -1,0 +1,68 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(JUnitTests.class)
+public class StorableEntityIdTest extends Assert {
+
+    @Test
+    public void storableEntityIdWithParameterTest() {
+        String[] ids = {"id", "", "id123", "id!@#$%^123&*<>|", "  id 1  2;':...,, id ()   ", "        !@#id '>? id ID ,,12$#  ", "id*(-01.23 idID 0123!@@,.,,   "};
+
+        for (String id : ids) {
+            StorableEntityId storableEntityId = new StorableEntityId(id);
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId.getId());
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId.toString());
+        }
+    }
+
+    @Test
+    public void storableEntityIdWithNullParameterTest() {
+        StorableEntityId storableEntityId = new StorableEntityId(null);
+
+        Assert.assertNull("Null expected.", storableEntityId.getId());
+        Assert.assertNull("Null expected.", storableEntityId.toString());
+    }
+
+    @Test
+    public void storableEntityIdWithoutParameterTest() {
+
+        StorableEntityId storableEntityId = new StorableEntityId();
+        Assert.assertNull("Null expected.", storableEntityId.getId());
+        Assert.assertNull("Null expected.", storableEntityId.toString());
+    }
+
+    @Test
+    public void setAndGetIdTest() {
+        StorableEntityId storableEntityId1 = new StorableEntityId();
+        StorableEntityId storableEntityId2 = new StorableEntityId("id");
+
+        String[] newIds = {null, "", "idNEW12<>$*%7464", "", "id123-NEW 1  ^54IDnew 32^$%$", "idNEW    !@#$%^  123&*<>|  ", "  id 12NEW;':...,, id ()   ", "!@#id '>? id ID ,,12NEW1$#  ", "idNew*(-0123 idID 0123!@@,.,,"};
+
+        for (String id : newIds) {
+            storableEntityId1.setId(id);
+            storableEntityId2.setId(id);
+
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId1.getId());
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId1.toString());
+
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId2.getId());
+            assertEquals("Expected and actual values should be the same.", id, storableEntityId2.toString());
+        }
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
@@ -1,0 +1,76 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.resources;
+
+import org.eclipse.kapua.app.api.core.model.ScopeId;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
+
+@Category(JUnitTests.class)
+public class AbstractKapuaResourceTest extends Assert {
+
+    private class AbstractKapuaResourceImpl extends AbstractKapuaResource {
+
+    }
+
+    AbstractKapuaResource abstractKapuaResource;
+    Object[] objects;
+
+    @Before
+    public void initialize() {
+        abstractKapuaResource = new AbstractKapuaResourceImpl();
+        objects = new Object[]{new Object(), "", "string", 10, 'c', KapuaId.ONE, new Throwable(), new ScopeId("111")};
+    }
+
+    @Test
+    public void returnNotNullEntityTest() {
+        for (Object object : objects) {
+            assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnNotNullEntity(object));
+        }
+    }
+
+    @Test
+    public void returnNotNullEntityNullTest() {
+        try {
+            abstractKapuaResource.returnNotNullEntity(null);
+            fail("WebApplicationException expected.");
+        } catch (Exception e) {
+            assertEquals("WebApplicationException expected.", new WebApplicationException(Response.Status.NOT_FOUND).toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void returnOkTest() {
+        assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=200, reason=OK, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnOk().toString());
+    }
+
+    @Test
+    public void returnNoContentTest() {
+        assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=204, reason=No Content, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnNoContent().toString());
+    }
+
+    @Test
+    public void returnCreatedTest() {
+        for (Object object : objects) {
+            assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=201, reason=Created, hasEntity=true, closed=false, buffered=false}", abstractKapuaResource.returnCreated(object).toString());
+            assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnCreated(object).getEntity());
+        }
+    }
+}


### PR DESCRIPTION
This PR JUnit tests for classes in exception and model packages in rest-api/resources module:

 - exception package:
RestApiRuntimeException class
SessionNotPopulatedException class

- model package
ByteArrayParam class
CountResult class
DateParam class
EntityId class
MetricType class
ScopeId class
StorableEntityId class

Also it contains JUnit tests for class AbstractKapuaResource.

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
