### PR TITLE
Added JUnit tests for device/management and message packages

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericRequestMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericRequestMessageTest.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.device.management;
+
+import org.eclipse.kapua.app.api.core.model.message.JsonKapuaPayload;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestChannel;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestMessage;
+import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
+import org.eclipse.kapua.service.storable.model.id.StorableId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class JsonGenericRequestMessageTest extends Assert {
+
+    GenericRequestMessage genericRequestMessage;
+    UUID id;
+    StorableId storableId;
+    Date timestamp, receivedOn, sentOn, capturedOn;
+    Date[] dates;
+    String clientId;
+    KapuaId scopeId, deviceId;
+    KapuaPosition kapuaPosition;
+    GenericRequestChannel genericRequestChannel;
+    GenericRequestPayload genericRequestPayload;
+    JsonGenericRequestMessage jsonGenericRequestMessage1, jsonGenericRequestMessage2;
+    KapuaPayload newKapuaPayload;
+
+    @Before
+    public void initialize() {
+        genericRequestMessage = Mockito.mock(GenericRequestMessage.class);
+        id = new UUID(10L, 100L);
+        storableId = Mockito.mock(StorableId.class);
+        timestamp = new Date();
+        scopeId = KapuaId.ONE;
+        clientId = "clientID";
+        deviceId = KapuaId.ONE;
+        receivedOn = new Date();
+        sentOn = new Date();
+        capturedOn = new Date();
+        dates = new Date[]{new Date(), new Date(99L), new Date(99999999999999L)};
+        kapuaPosition = Mockito.mock(KapuaPosition.class);
+        genericRequestChannel = Mockito.mock(GenericRequestChannel.class);
+        genericRequestPayload = Mockito.mock(GenericRequestPayload.class);
+        newKapuaPayload = Mockito.mock(KapuaPayload.class);
+
+        Mockito.when(genericRequestMessage.getId()).thenReturn(id);
+        Mockito.when(genericRequestMessage.getScopeId()).thenReturn(scopeId);
+        Mockito.when(genericRequestMessage.getDeviceId()).thenReturn(deviceId);
+        Mockito.when(genericRequestMessage.getClientId()).thenReturn(clientId);
+        Mockito.when(genericRequestMessage.getReceivedOn()).thenReturn(receivedOn);
+        Mockito.when(genericRequestMessage.getSentOn()).thenReturn(sentOn);
+        Mockito.when(genericRequestMessage.getCapturedOn()).thenReturn(capturedOn);
+        Mockito.when(genericRequestMessage.getPosition()).thenReturn(kapuaPosition);
+        Mockito.when(genericRequestMessage.getChannel()).thenReturn(genericRequestChannel);
+        Mockito.when(genericRequestMessage.getPayload()).thenReturn(genericRequestPayload);
+
+        jsonGenericRequestMessage1 = new JsonGenericRequestMessage();
+        jsonGenericRequestMessage2 = new JsonGenericRequestMessage(genericRequestMessage);
+    }
+
+    @Test
+    public void jsonGenericRequestMessageWithoutParameterTest() {
+        JsonGenericRequestMessage jsonGenericRequestMessage = new JsonGenericRequestMessage();
+
+        assertNull("Null expected.", jsonGenericRequestMessage.getId());
+        assertNull("Null expected.", jsonGenericRequestMessage.getScopeId());
+        assertNull("Null expected.", jsonGenericRequestMessage.getDeviceId());
+        assertNull("Null expected.", jsonGenericRequestMessage.getClientId());
+        assertNull("Null expected.", jsonGenericRequestMessage.getReceivedOn());
+        assertNull("Null expected.", jsonGenericRequestMessage.getSentOn());
+        assertNull("Null expected.", jsonGenericRequestMessage.getCapturedOn());
+        assertNull("Null expected.", jsonGenericRequestMessage.getPosition());
+        assertNull("Null expected.", jsonGenericRequestMessage.getChannel());
+        assertNull("Null expected.", jsonGenericRequestMessage.getPayload());
+    }
+
+    @Test
+    public void jsonGenericRequestMessageWithParameterTest() {
+        JsonGenericRequestMessage jsonGenericRequestMessage = new JsonGenericRequestMessage(genericRequestMessage);
+
+        assertEquals("Expected and actual values should be the same.", id, jsonGenericRequestMessage.getId());
+        assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericRequestMessage.getScopeId());
+        assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericRequestMessage.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", clientId, jsonGenericRequestMessage.getClientId());
+        assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericRequestMessage.getReceivedOn());
+        assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericRequestMessage.getSentOn());
+        assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericRequestMessage.getCapturedOn());
+        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericRequestMessage.getPosition());
+        assertEquals("Expected and actual values should be the same.", genericRequestChannel, jsonGenericRequestMessage.getChannel());
+        assertNotNull("NotNull expected.", jsonGenericRequestMessage.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonGenericRequestMessageWithNullParameterTest() {
+        new JsonGenericRequestMessage(null);
+    }
+
+    @Test
+    public void setAndGetIdTest() {
+        UUID newId = new UUID(1L, 99L);
+
+        jsonGenericRequestMessage1.setId(newId);
+        jsonGenericRequestMessage2.setId(newId);
+
+        assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage1.getId());
+        assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage2.getId());
+
+        jsonGenericRequestMessage1.setId(null);
+        jsonGenericRequestMessage2.setId(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getId());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getId());
+    }
+
+    @Test
+    public void setAndGetScopeIdTest() {
+        KapuaId newScopeId = KapuaId.ANY;
+
+        jsonGenericRequestMessage1.setScopeId(newScopeId);
+        jsonGenericRequestMessage2.setScopeId(newScopeId);
+
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage1.getScopeId());
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage2.getScopeId());
+
+        jsonGenericRequestMessage1.setScopeId(null);
+        jsonGenericRequestMessage2.setScopeId(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getScopeId());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getScopeId());
+    }
+
+    @Test
+    public void setAndGetDeviceIdTest() {
+        KapuaId newDeviceId = KapuaId.ANY;
+
+        jsonGenericRequestMessage1.setDeviceId(newDeviceId);
+        jsonGenericRequestMessage2.setDeviceId(newDeviceId);
+
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage1.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage2.getDeviceId());
+
+        jsonGenericRequestMessage1.setDeviceId(null);
+        jsonGenericRequestMessage2.setDeviceId(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getDeviceId());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getDeviceId());
+    }
+
+    @Test
+    public void setAndGetClientIdTest() {
+        String[] newClientIDs = {"ID", ",.  id *&64930 new ID ,,,", "  NEW12 ,./)(*&%^% IDnew", "newID  98*90__=88id ", ",,,.id new ID 847&^3#@!  "};
+
+        for (String newClientID : newClientIDs) {
+            jsonGenericRequestMessage1.setClientId(newClientID);
+            jsonGenericRequestMessage2.setClientId(newClientID);
+
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage1.getClientId());
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage2.getClientId());
+        }
+
+        jsonGenericRequestMessage1.setClientId(null);
+        jsonGenericRequestMessage2.setClientId(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getClientId());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getClientId());
+    }
+
+    @Test
+    public void setAndGetReceivedOnTest() {
+        for (Date newReceivedOn : dates) {
+            jsonGenericRequestMessage1.setReceivedOn(newReceivedOn);
+            jsonGenericRequestMessage2.setReceivedOn(newReceivedOn);
+
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage1.getReceivedOn());
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage2.getReceivedOn());
+        }
+
+        jsonGenericRequestMessage1.setReceivedOn(null);
+        jsonGenericRequestMessage2.setReceivedOn(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getReceivedOn());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getReceivedOn());
+    }
+
+    @Test
+    public void setAndGetSentOnTest() {
+        for (Date newSentOn : dates) {
+            jsonGenericRequestMessage1.setSentOn(newSentOn);
+            jsonGenericRequestMessage2.setSentOn(newSentOn);
+
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage1.getSentOn());
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage2.getSentOn());
+        }
+
+        jsonGenericRequestMessage1.setSentOn(null);
+        jsonGenericRequestMessage2.setSentOn(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getSentOn());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getSentOn());
+    }
+
+    @Test
+    public void setAndGetCapturedOnTest() {
+        for (Date newCapturedOn : dates) {
+            jsonGenericRequestMessage1.setCapturedOn(newCapturedOn);
+            jsonGenericRequestMessage2.setCapturedOn(newCapturedOn);
+
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage1.getCapturedOn());
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage2.getCapturedOn());
+        }
+
+        jsonGenericRequestMessage1.setCapturedOn(null);
+        jsonGenericRequestMessage2.setCapturedOn(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getCapturedOn());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getCapturedOn());
+    }
+
+    @Test
+    public void setAndGetPositionTest() {
+        KapuaPosition newPosition = Mockito.mock(KapuaPosition.class);
+
+        jsonGenericRequestMessage1.setPosition(newPosition);
+        jsonGenericRequestMessage2.setPosition(newPosition);
+
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage1.getPosition());
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage2.getPosition());
+
+        jsonGenericRequestMessage1.setPosition(null);
+        jsonGenericRequestMessage2.setPosition(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getPosition());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getPosition());
+    }
+
+    @Test
+    public void setAndGetChannelTest() {
+        GenericRequestChannel newGenericRequestChannel = Mockito.mock(GenericRequestChannel.class);
+
+        jsonGenericRequestMessage1.setChannel(newGenericRequestChannel);
+        jsonGenericRequestMessage2.setChannel(newGenericRequestChannel);
+
+        assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage1.getChannel());
+        assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage2.getChannel());
+
+        jsonGenericRequestMessage1.setChannel(null);
+        jsonGenericRequestMessage2.setChannel(null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getChannel());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getChannel());
+    }
+
+    @Test
+    public void setAndGetJsonKapuaPayloadTest() {
+        JsonKapuaPayload newJsonKapuaPayload = Mockito.mock(JsonKapuaPayload.class);
+
+        jsonGenericRequestMessage1.setPayload(newJsonKapuaPayload);
+        jsonGenericRequestMessage2.setPayload(newJsonKapuaPayload);
+
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage1.getPayload());
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage2.getPayload());
+
+        jsonGenericRequestMessage1.setPayload((JsonKapuaPayload) null);
+        jsonGenericRequestMessage2.setPayload((JsonKapuaPayload) null);
+
+        assertNull("Null expected.", jsonGenericRequestMessage1.getPayload());
+        assertNull("Null expected.", jsonGenericRequestMessage2.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setAndGetKapuaPayloadMessageWithoutParametersTest() {
+        jsonGenericRequestMessage1.setPayload(newKapuaPayload);
+
+        assertNotNull("NotNull expected.", jsonGenericRequestMessage1.getPayload());
+
+        jsonGenericRequestMessage1.setPayload((KapuaPayload) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setAndGetKapuaPayloadMessageWithParameterTest() {
+        jsonGenericRequestMessage2.setPayload(newKapuaPayload);
+
+        assertNotNull("NotNull expected.", jsonGenericRequestMessage2.getPayload());
+
+        jsonGenericRequestMessage2.setPayload((KapuaPayload) null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericResponseMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericResponseMessageTest.java
@@ -1,0 +1,308 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.device.management;
+
+import org.eclipse.kapua.app.api.core.model.message.JsonKapuaPayload;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseChannel;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
+import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
+import org.eclipse.kapua.service.storable.model.id.StorableId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class JsonGenericResponseMessageTest extends Assert {
+
+    GenericResponseMessage genericResponseMessage;
+    UUID id;
+    StorableId storableId;
+    Date timestamp, receivedOn, sentOn, capturedOn;
+    Date[] dates;
+    KapuaId scopeId, deviceId;
+    String clientId;
+    KapuaPosition kapuaPosition;
+    GenericResponseChannel genericResponseChannel;
+    GenericResponsePayload genericResponsePayload;
+    JsonGenericResponseMessage jsonGenericResponseMessage1, jsonGenericResponseMessage2;
+    KapuaPayload newKapuaPayload;
+
+    @Before
+    public void initialize() {
+        genericResponseMessage = Mockito.mock(GenericResponseMessage.class);
+        id = new UUID(10L, 100L);
+        storableId = Mockito.mock(StorableId.class);
+        timestamp = new Date();
+        scopeId = KapuaId.ONE;
+        deviceId = KapuaId.ONE;
+        clientId = "clientID";
+        receivedOn = new Date();
+        sentOn = new Date();
+        capturedOn = new Date();
+        dates = new Date[]{new Date(), new Date(99L), new Date(99999999999999L)};
+        kapuaPosition = Mockito.mock(KapuaPosition.class);
+        genericResponseChannel = Mockito.mock(GenericResponseChannel.class);
+        genericResponsePayload = Mockito.mock(GenericResponsePayload.class);
+        newKapuaPayload = Mockito.mock(KapuaPayload.class);
+
+        Mockito.when(genericResponseMessage.getId()).thenReturn(id);
+        Mockito.when(genericResponseMessage.getScopeId()).thenReturn(scopeId);
+        Mockito.when(genericResponseMessage.getDeviceId()).thenReturn(deviceId);
+        Mockito.when(genericResponseMessage.getClientId()).thenReturn(clientId);
+        Mockito.when(genericResponseMessage.getReceivedOn()).thenReturn(receivedOn);
+        Mockito.when(genericResponseMessage.getSentOn()).thenReturn(sentOn);
+        Mockito.when(genericResponseMessage.getCapturedOn()).thenReturn(capturedOn);
+        Mockito.when(genericResponseMessage.getPosition()).thenReturn(kapuaPosition);
+        Mockito.when(genericResponseMessage.getChannel()).thenReturn(genericResponseChannel);
+        Mockito.when(genericResponseMessage.getPayload()).thenReturn(genericResponsePayload);
+
+        jsonGenericResponseMessage1 = new JsonGenericResponseMessage();
+        jsonGenericResponseMessage2 = new JsonGenericResponseMessage(genericResponseMessage);
+    }
+
+    @Test
+    public void jsonGenericResponseMessageWithoutParameterTest() {
+        JsonGenericResponseMessage jsonGenericResponseMessage = new JsonGenericResponseMessage();
+
+        assertNull("Null expected.", jsonGenericResponseMessage.getId());
+        assertNull("Null expected.", jsonGenericResponseMessage.getScopeId());
+        assertNull("Null expected.", jsonGenericResponseMessage.getDeviceId());
+        assertNull("Null expected.", jsonGenericResponseMessage.getClientId());
+        assertNull("Null expected.", jsonGenericResponseMessage.getReceivedOn());
+        assertNull("Null expected.", jsonGenericResponseMessage.getSentOn());
+        assertNull("Null expected.", jsonGenericResponseMessage.getCapturedOn());
+        assertNull("Null expected.", jsonGenericResponseMessage.getPosition());
+        assertNull("Null expected.", jsonGenericResponseMessage.getChannel());
+        assertNull("Null expected.", jsonGenericResponseMessage.getPayload());
+    }
+
+    @Test
+    public void jsonGenericResponseMessageWithParameterTest() {
+        JsonGenericResponseMessage jsonGenericResponseMessage = new JsonGenericResponseMessage(genericResponseMessage);
+
+        assertEquals("Expected and actual values should be the same.", id, jsonGenericResponseMessage.getId());
+        assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericResponseMessage.getScopeId());
+        assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericResponseMessage.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", clientId, jsonGenericResponseMessage.getClientId());
+        assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericResponseMessage.getReceivedOn());
+        assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericResponseMessage.getSentOn());
+        assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericResponseMessage.getCapturedOn());
+        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericResponseMessage.getPosition());
+        assertEquals("Expected and actual values should be the same.", genericResponseChannel, jsonGenericResponseMessage.getChannel());
+        assertNotNull("NotNull expected.", jsonGenericResponseMessage.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonGenericResponseMessageWithNullParameterTest() {
+        new JsonGenericResponseMessage(null);
+    }
+
+    @Test
+    public void setAndGetIdTest() {
+        UUID newId = new UUID(1L, 99L);
+
+        jsonGenericResponseMessage1.setId(newId);
+        jsonGenericResponseMessage2.setId(newId);
+
+        assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage1.getId());
+        assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage2.getId());
+
+        jsonGenericResponseMessage1.setId(null);
+        jsonGenericResponseMessage2.setId(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getId());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getId());
+    }
+
+    @Test
+    public void setAndGetScopeIdTest() {
+        KapuaId newScopeId = KapuaId.ANY;
+
+        jsonGenericResponseMessage1.setScopeId(newScopeId);
+        jsonGenericResponseMessage2.setScopeId(newScopeId);
+
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage1.getScopeId());
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage2.getScopeId());
+
+        jsonGenericResponseMessage1.setScopeId(null);
+        jsonGenericResponseMessage2.setScopeId(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getScopeId());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getScopeId());
+    }
+
+    @Test
+    public void setAndGetDeviceIdTest() {
+        KapuaId newDeviceId = KapuaId.ANY;
+
+        jsonGenericResponseMessage1.setDeviceId(newDeviceId);
+        jsonGenericResponseMessage2.setDeviceId(newDeviceId);
+
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage1.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage2.getDeviceId());
+
+        jsonGenericResponseMessage1.setDeviceId(null);
+        jsonGenericResponseMessage2.setDeviceId(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getDeviceId());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getDeviceId());
+    }
+
+    @Test
+    public void setAndGetClientIdTest() {
+        String[] newClientIDs = {"ID", ",.  id *&64930 new ID ,,,", "  NEW12 ,./)(*&%^% IDnew", "newID  98*90__=88id ", ",,,.id new ID 847&^3#@!  "};
+
+        for (String newClientID : newClientIDs) {
+            jsonGenericResponseMessage1.setClientId(newClientID);
+            jsonGenericResponseMessage2.setClientId(newClientID);
+
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage1.getClientId());
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage2.getClientId());
+        }
+
+        jsonGenericResponseMessage1.setClientId(null);
+        jsonGenericResponseMessage2.setClientId(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getClientId());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getClientId());
+    }
+
+    @Test
+    public void setAndGetReceivedOnTest() {
+        for (Date newReceivedOn : dates) {
+            jsonGenericResponseMessage1.setReceivedOn(newReceivedOn);
+            jsonGenericResponseMessage2.setReceivedOn(newReceivedOn);
+
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage1.getReceivedOn());
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage2.getReceivedOn());
+        }
+
+        jsonGenericResponseMessage1.setReceivedOn(null);
+        jsonGenericResponseMessage2.setReceivedOn(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getReceivedOn());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getReceivedOn());
+    }
+
+    @Test
+    public void setAndGetSentOnTest() {
+        for (Date newSentOn : dates) {
+            jsonGenericResponseMessage1.setSentOn(newSentOn);
+            jsonGenericResponseMessage2.setSentOn(newSentOn);
+
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage1.getSentOn());
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage2.getSentOn());
+        }
+
+        jsonGenericResponseMessage1.setSentOn(null);
+        jsonGenericResponseMessage2.setSentOn(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getSentOn());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getSentOn());
+    }
+
+    @Test
+    public void setAndGetCapturedOnTest() {
+        for (Date newCapturedOn : dates) {
+            jsonGenericResponseMessage1.setCapturedOn(newCapturedOn);
+            jsonGenericResponseMessage2.setCapturedOn(newCapturedOn);
+
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage1.getCapturedOn());
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage2.getCapturedOn());
+        }
+
+        jsonGenericResponseMessage1.setCapturedOn(null);
+        jsonGenericResponseMessage2.setCapturedOn(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getCapturedOn());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getCapturedOn());
+    }
+
+    @Test
+    public void setAndGetPositionTest() {
+        KapuaPosition newPosition = Mockito.mock(KapuaPosition.class);
+
+        jsonGenericResponseMessage1.setPosition(newPosition);
+        jsonGenericResponseMessage2.setPosition(newPosition);
+
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage1.getPosition());
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage2.getPosition());
+
+        jsonGenericResponseMessage1.setPosition(null);
+        jsonGenericResponseMessage2.setPosition(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getPosition());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getPosition());
+    }
+
+    @Test
+    public void setAndGetChannelTest() {
+        GenericResponseChannel newGenericResponseChannel = Mockito.mock(GenericResponseChannel.class);
+
+        jsonGenericResponseMessage1.setChannel(newGenericResponseChannel);
+        jsonGenericResponseMessage2.setChannel(newGenericResponseChannel);
+
+        assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage1.getChannel());
+        assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage2.getChannel());
+
+        jsonGenericResponseMessage1.setChannel(null);
+        jsonGenericResponseMessage2.setChannel(null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getChannel());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getChannel());
+    }
+
+    @Test
+    public void setAndGetJsonKapuaPayloadTest() {
+        JsonKapuaPayload newJsonKapuaPayload = Mockito.mock(JsonKapuaPayload.class);
+
+        jsonGenericResponseMessage1.setPayload(newJsonKapuaPayload);
+        jsonGenericResponseMessage2.setPayload(newJsonKapuaPayload);
+
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage1.getPayload());
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage2.getPayload());
+
+        jsonGenericResponseMessage1.setPayload((JsonKapuaPayload) null);
+        jsonGenericResponseMessage2.setPayload((JsonKapuaPayload) null);
+
+        assertNull("Null expected.", jsonGenericResponseMessage1.getPayload());
+        assertNull("Null expected.", jsonGenericResponseMessage2.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setAndGetKapuaPayloadMessageWithoutParametersTest() {
+        jsonGenericResponseMessage1.setPayload(newKapuaPayload);
+
+        assertNotNull("NotNull expected.", jsonGenericResponseMessage1.getPayload());
+
+        jsonGenericResponseMessage1.setPayload((KapuaPayload) null);
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void setAndGetKapuaPayloadMessageWithParameterTest() {
+        jsonGenericResponseMessage2.setPayload(newKapuaPayload);
+
+        assertNotNull("NotNull expected.", jsonGenericResponseMessage2.getPayload());
+
+        jsonGenericResponseMessage2.setPayload((KapuaPayload) null);
+    }
+}

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/message/JsonKapuaPayloadTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/message/JsonKapuaPayloadTest.java
@@ -1,0 +1,114 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.message;
+
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.xml.XmlAdaptedMetric;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+
+@Category(JUnitTests.class)
+public class JsonKapuaPayloadTest extends Assert {
+
+    KapuaPayload kapuaPayload;
+    byte[] body;
+    Map<String, Object> map;
+
+    @Before
+    public void initialize() {
+        kapuaPayload = Mockito.mock(KapuaPayload.class);
+        body = new byte[]{1, 2, 3, 4, 5, 6, 7, 8, 9};
+        map = new HashMap<>();
+    }
+
+    @Test
+    public void jsonKapuaPayloadWithoutParameterTest() {
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload();
+
+        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        assertNull("Null expected.", jsonKapuaPayload.getBody());
+    }
+
+    @Test
+    public void jsonKapuaPayloadWithParameterEmptyMapTest() {
+        Mockito.when(kapuaPayload.getBody()).thenReturn(body);
+        Mockito.when(kapuaPayload.getMetrics()).thenReturn(map);
+
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
+
+        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+    }
+
+    @Test
+    public void jsonKapuaPayloadWithParameterNullMapValuesTest() {
+        map.put(null, null);
+
+        Mockito.when(kapuaPayload.getBody()).thenReturn(body);
+        Mockito.when(kapuaPayload.getMetrics()).thenReturn(map);
+
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
+        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+    }
+
+    @Test
+    public void jsonKapuaPayloadWithParameterTest() {
+        map.put("key1", "value2");
+        map.put("key2", "value2");
+
+        Mockito.when(kapuaPayload.getBody()).thenReturn(body);
+        Mockito.when(kapuaPayload.getMetrics()).thenReturn(map);
+
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
+        assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonKapuaPayloadWithNullParameterTest() {
+        new JsonKapuaPayload(null);
+    }
+
+    @Test
+    public void setAndGetMetricsTest() {
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
+        List<XmlAdaptedMetric> metrics = new LinkedList<>();
+        XmlAdaptedMetric jsonMetric = Mockito.mock(XmlAdaptedMetric.class);
+
+        metrics.add(jsonMetric);
+
+        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        jsonKapuaPayload.setMetrics(metrics);
+        assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
+    }
+
+    @Test
+    public void setAndGetBody() {
+        JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
+        byte[] newBody = {1, 2, 3, 4, 5};
+
+        assertNull("Null expected.", jsonKapuaPayload.getBody());
+        jsonKapuaPayload.setBody(newBody);
+        assertEquals("Expected and actual values should be the same.", newBody, jsonKapuaPayload.getBody());
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in rest-api/resources module:

 - device/management package:
   JsonGenericRequestMessage class
   JsonGenericResponseMessage class

 - message package:
   JsonKapuaPayload class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
