### PR TITLE
Added JUnit tests for model/data package

### DIFF
--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -92,5 +92,15 @@
             <groupId>org.glassfish.jersey.core</groupId>
             <artifactId>jersey-server</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-qa-markers</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonDatastoreMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonDatastoreMessageTest.java
@@ -1,0 +1,154 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.data;
+
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
+import org.eclipse.kapua.service.storable.model.id.StorableId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class JsonDatastoreMessageTest extends Assert {
+
+    DatastoreMessage datastoreMessage;
+    UUID id;
+    StorableId storableId;
+    Date timestamp, receivedOn, sentOn, capturedOn;
+    KapuaId scopeId, deviceId;
+    String clientId;
+    KapuaPosition kapuaPosition;
+    KapuaDataChannel kapuaDataChannel;
+    KapuaPayload kapuaPayload;
+
+    @Before
+    public void initialize() {
+        datastoreMessage = Mockito.mock(DatastoreMessage.class);
+        id = new UUID(10L, 100L);
+        storableId = Mockito.mock(StorableId.class);
+        timestamp = new Date();
+        scopeId = KapuaId.ONE;
+        deviceId = KapuaId.ONE;
+        clientId = "clientID";
+        receivedOn = new Date();
+        sentOn = new Date();
+        capturedOn = new Date();
+        kapuaPosition = Mockito.mock(KapuaPosition.class);
+        kapuaDataChannel = Mockito.mock(KapuaDataChannel.class);
+        kapuaPayload = Mockito.mock(KapuaPayload.class);
+
+        Mockito.when(datastoreMessage.getId()).thenReturn(id);
+        Mockito.when(datastoreMessage.getDatastoreId()).thenReturn(storableId);
+        Mockito.when(datastoreMessage.getTimestamp()).thenReturn(timestamp);
+        Mockito.when(datastoreMessage.getScopeId()).thenReturn(scopeId);
+        Mockito.when(datastoreMessage.getDeviceId()).thenReturn(deviceId);
+        Mockito.when(datastoreMessage.getClientId()).thenReturn(clientId);
+        Mockito.when(datastoreMessage.getReceivedOn()).thenReturn(receivedOn);
+        Mockito.when(datastoreMessage.getSentOn()).thenReturn(sentOn);
+        Mockito.when(datastoreMessage.getCapturedOn()).thenReturn(capturedOn);
+        Mockito.when(datastoreMessage.getPosition()).thenReturn(kapuaPosition);
+        Mockito.when(datastoreMessage.getChannel()).thenReturn(kapuaDataChannel);
+        Mockito.when(datastoreMessage.getPayload()).thenReturn(kapuaPayload);
+    }
+
+    @Test
+    public void jsonDatastoreMessageWithoutParameterTest() {
+        JsonDatastoreMessage jsonDatastoreMessage = new JsonDatastoreMessage();
+
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getDatastoreId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getTimestamp());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getScopeId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getDeviceId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getClientId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getSentOn());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getPosition());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getChannel());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage.getPayload());
+    }
+
+    @Test
+    public void jsonDatastoreMessageWithParameterTest() {
+        JsonDatastoreMessage jsonDatastoreMessage = new JsonDatastoreMessage(datastoreMessage);
+
+        assertEquals("Expected and actual values should be the same.", id, jsonDatastoreMessage.getId());
+        assertEquals("Expected and actual values should be the same.", storableId, jsonDatastoreMessage.getDatastoreId());
+        assertEquals("Expected and actual values should be the same.", timestamp, jsonDatastoreMessage.getTimestamp());
+        assertEquals("Expected and actual values should be the same.", scopeId, jsonDatastoreMessage.getScopeId());
+        assertEquals("Expected and actual values should be the same.", deviceId, jsonDatastoreMessage.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", clientId, jsonDatastoreMessage.getClientId());
+        assertEquals("Expected and actual values should be the same.", receivedOn, jsonDatastoreMessage.getReceivedOn());
+        assertEquals("Expected and actual values should be the same.", sentOn, jsonDatastoreMessage.getSentOn());
+        assertEquals("Expected and actual values should be the same.", capturedOn, jsonDatastoreMessage.getCapturedOn());
+        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonDatastoreMessage.getPosition());
+        assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonDatastoreMessage.getChannel());
+        Assert.assertNotNull("NotNull expected.", jsonDatastoreMessage.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonDatastoreMessageWithNullParameterTest() {
+        new JsonDatastoreMessage(null);
+    }
+
+    @Test
+    public void setAndGetDatastoreIdTest() {
+        StorableId datastoreId = Mockito.mock(StorableId.class);
+        JsonDatastoreMessage jsonDatastoreMessage1 = new JsonDatastoreMessage();
+        JsonDatastoreMessage jsonDatastoreMessage2 = new JsonDatastoreMessage(datastoreMessage);
+
+        jsonDatastoreMessage1.setDatastoreId(datastoreId);
+        jsonDatastoreMessage2.setDatastoreId(datastoreId);
+
+        assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage1.getDatastoreId());
+        assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage2.getDatastoreId());
+
+        jsonDatastoreMessage1.setDatastoreId(null);
+        jsonDatastoreMessage2.setDatastoreId(null);
+
+        Assert.assertNull("Null expected.", jsonDatastoreMessage1.getDatastoreId());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage2.getDatastoreId());
+    }
+
+    @Test
+    public void setAndGetTimestampTest() {
+        Date[] dates = {new Date(), new Date(99L), new Date(99999999999999L)};
+        JsonDatastoreMessage jsonDatastoreMessage1 = new JsonDatastoreMessage();
+        JsonDatastoreMessage jsonDatastoreMessage2 = new JsonDatastoreMessage(datastoreMessage);
+
+        for (Date newTimestamp : dates) {
+            jsonDatastoreMessage1.setTimestamp(newTimestamp);
+            jsonDatastoreMessage2.setTimestamp(newTimestamp);
+
+            assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage1.getTimestamp());
+            assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage2.getTimestamp());
+        }
+
+        jsonDatastoreMessage1.setTimestamp(null);
+        jsonDatastoreMessage2.setTimestamp(null);
+
+        Assert.assertNull("Null expected.", jsonDatastoreMessage1.getTimestamp());
+        Assert.assertNull("Null expected.", jsonDatastoreMessage2.getTimestamp());
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonKapuaDataMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonKapuaDataMessageTest.java
@@ -1,0 +1,313 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.data;
+
+import org.eclipse.kapua.app.api.core.model.message.JsonKapuaPayload;
+import org.eclipse.kapua.message.KapuaPayload;
+import org.eclipse.kapua.message.KapuaPosition;
+import org.eclipse.kapua.message.device.data.KapuaDataChannel;
+import org.eclipse.kapua.message.device.data.KapuaDataMessage;
+import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.storable.model.id.StorableId;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.Date;
+import java.util.UUID;
+
+@Category(JUnitTests.class)
+public class JsonKapuaDataMessageTest extends Assert {
+
+    KapuaDataMessage kapuaDataMessage;
+    UUID id;
+    StorableId storableId;
+    Date timestamp, receivedOn, sentOn, capturedOn;
+    Date[] dates;
+    KapuaId scopeId, deviceId;
+    String clientId;
+    KapuaPosition kapuaPosition;
+    KapuaDataChannel kapuaDataChannel;
+    KapuaDataPayload kapuaPayload;
+    JsonKapuaDataMessage jsonKapuaDataMessage1, jsonKapuaDataMessage2;
+
+    @Before
+    public void initialize() {
+        kapuaDataMessage = Mockito.mock(KapuaDataMessage.class);
+        id = new UUID(10L, 100L);
+        storableId = Mockito.mock(StorableId.class);
+        timestamp = new Date();
+        scopeId = KapuaId.ONE;
+        deviceId = KapuaId.ONE;
+        clientId = "clientID";
+        receivedOn = new Date();
+        sentOn = new Date();
+        capturedOn = new Date();
+        dates = new Date[]{new Date(), new Date(99L), new Date(99999999999999L)};
+        kapuaPosition = Mockito.mock(KapuaPosition.class);
+        kapuaDataChannel = Mockito.mock(KapuaDataChannel.class);
+        kapuaPayload = Mockito.mock(KapuaDataPayload.class);
+
+        Mockito.when(kapuaDataMessage.getId()).thenReturn(id);
+        Mockito.when(kapuaDataMessage.getScopeId()).thenReturn(scopeId);
+        Mockito.when(kapuaDataMessage.getDeviceId()).thenReturn(deviceId);
+        Mockito.when(kapuaDataMessage.getClientId()).thenReturn(clientId);
+        Mockito.when(kapuaDataMessage.getReceivedOn()).thenReturn(receivedOn);
+        Mockito.when(kapuaDataMessage.getSentOn()).thenReturn(sentOn);
+        Mockito.when(kapuaDataMessage.getCapturedOn()).thenReturn(capturedOn);
+        Mockito.when(kapuaDataMessage.getPosition()).thenReturn(kapuaPosition);
+        Mockito.when(kapuaDataMessage.getChannel()).thenReturn(kapuaDataChannel);
+        Mockito.when(kapuaDataMessage.getPayload()).thenReturn(kapuaPayload);
+
+        jsonKapuaDataMessage1 = new JsonKapuaDataMessage(kapuaDataMessage);
+        jsonKapuaDataMessage2 = new JsonKapuaDataMessage();
+    }
+
+    @Test
+    public void jsonKapuaDataMessageWithoutParameterTest() {
+        JsonKapuaDataMessage jsonKapuaDataMessage = new JsonKapuaDataMessage();
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getScopeId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getDeviceId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getClientId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getSentOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getPosition());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getChannel());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage.getPayload());
+    }
+
+    @Test
+    public void jsonKapuaDataMessageWithParameterTest() {
+        JsonKapuaDataMessage jsonKapuaDataMessage = new JsonKapuaDataMessage(kapuaDataMessage);
+
+        assertEquals("Expected and actual values should be the same.", id, jsonKapuaDataMessage.getId());
+        assertEquals("Expected and actual values should be the same.", scopeId, jsonKapuaDataMessage.getScopeId());
+        assertEquals("Expected and actual values should be the same.", deviceId, jsonKapuaDataMessage.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", clientId, jsonKapuaDataMessage.getClientId());
+        assertEquals("Expected and actual values should be the same.", receivedOn, jsonKapuaDataMessage.getReceivedOn());
+        assertEquals("Expected and actual values should be the same.", sentOn, jsonKapuaDataMessage.getSentOn());
+        assertEquals("Expected and actual values should be the same.", capturedOn, jsonKapuaDataMessage.getCapturedOn());
+        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonKapuaDataMessage.getPosition());
+        assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonKapuaDataMessage.getChannel());
+        Assert.assertNotNull("NotNull expected.", jsonKapuaDataMessage.getPayload());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonKapuaDataMessageWithNullParameterTest() {
+        new JsonKapuaDataMessage(null);
+    }
+
+    @Test
+    public void setAndGetIdTest() {
+        UUID newId = new UUID(1L, 99L);
+
+        jsonKapuaDataMessage1.setId(newId);
+        jsonKapuaDataMessage2.setId(newId);
+
+        assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage1.getId());
+        assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage2.getId());
+
+        jsonKapuaDataMessage1.setId(null);
+        jsonKapuaDataMessage2.setId(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getId());
+    }
+
+    @Test
+    public void setAndGetScopeIdTest() {
+        KapuaId newScopeId = KapuaId.ANY;
+
+        jsonKapuaDataMessage1.setScopeId(newScopeId);
+        jsonKapuaDataMessage2.setScopeId(newScopeId);
+
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage1.getScopeId());
+        assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage2.getScopeId());
+
+        jsonKapuaDataMessage1.setScopeId(null);
+        jsonKapuaDataMessage2.setScopeId(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getScopeId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getScopeId());
+    }
+
+    @Test
+    public void setAndGetDeviceIdTest() {
+        KapuaId newDeviceId = KapuaId.ANY;
+
+        jsonKapuaDataMessage1.setDeviceId(newDeviceId);
+        jsonKapuaDataMessage2.setDeviceId(newDeviceId);
+
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage1.getDeviceId());
+        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage2.getDeviceId());
+
+        jsonKapuaDataMessage1.setDeviceId(null);
+        jsonKapuaDataMessage2.setDeviceId(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getDeviceId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getDeviceId());
+    }
+
+    @Test
+    public void setAndGetClientIdTest() {
+        String[] newIds = {"idNEW12<>$*%7464", "", "id123-NEW 1  ^54IDnew 32^$%$", "idNEW    !@#$%^  123&*<>|  ", "  id 12NEW;':...,, id ()   ", "!@#id '>? id ID ,,12NEW1$#  ", "idNew*(-0123 idID 0123!@@,.,,"};
+
+        for (String newClientID : newIds) {
+            jsonKapuaDataMessage1.setClientId(newClientID);
+            jsonKapuaDataMessage2.setClientId(newClientID);
+
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage1.getClientId());
+            assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage2.getClientId());
+        }
+
+        jsonKapuaDataMessage1.setClientId(null);
+        jsonKapuaDataMessage2.setClientId(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getClientId());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getClientId());
+    }
+
+    @Test
+    public void setAndGetReceivedOnTest() {
+        for (Date newReceivedOn : dates) {
+            jsonKapuaDataMessage1.setReceivedOn(newReceivedOn);
+            jsonKapuaDataMessage2.setReceivedOn(newReceivedOn);
+
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage1.getReceivedOn());
+            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage2.getReceivedOn());
+        }
+
+        jsonKapuaDataMessage1.setReceivedOn(null);
+        jsonKapuaDataMessage2.setReceivedOn(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getReceivedOn());
+    }
+
+    @Test
+    public void setAndGetSentOnTest() {
+        for (Date newSentOn : dates) {
+            jsonKapuaDataMessage1.setSentOn(newSentOn);
+            jsonKapuaDataMessage2.setSentOn(newSentOn);
+
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage1.getSentOn());
+            assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage2.getSentOn());
+        }
+
+        jsonKapuaDataMessage1.setSentOn(null);
+        jsonKapuaDataMessage2.setSentOn(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getSentOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getSentOn());
+    }
+
+    @Test
+    public void setAndGetCapturedOnTest() {
+        for (Date newCapturedOn : dates) {
+            jsonKapuaDataMessage1.setCapturedOn(newCapturedOn);
+            jsonKapuaDataMessage2.setCapturedOn(newCapturedOn);
+
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage1.getCapturedOn());
+            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage2.getCapturedOn());
+        }
+
+        jsonKapuaDataMessage1.setCapturedOn(null);
+        jsonKapuaDataMessage2.setCapturedOn(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getCapturedOn());
+    }
+
+    @Test
+    public void setAndGetPositionTest() {
+        KapuaPosition newPosition = Mockito.mock(KapuaPosition.class);
+
+        jsonKapuaDataMessage1.setPosition(newPosition);
+        jsonKapuaDataMessage2.setPosition(newPosition);
+
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage1.getPosition());
+        assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage2.getPosition());
+
+        jsonKapuaDataMessage1.setPosition(null);
+        jsonKapuaDataMessage2.setPosition(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getPosition());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getPosition());
+    }
+
+    @Test
+    public void setAndGetChannelTest() {
+        KapuaDataChannel newChannel = Mockito.mock(KapuaDataChannel.class);
+
+        jsonKapuaDataMessage1.setChannel(newChannel);
+        jsonKapuaDataMessage2.setChannel(newChannel);
+
+        assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage1.getChannel());
+        assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage2.getChannel());
+
+        jsonKapuaDataMessage1.setChannel(null);
+        jsonKapuaDataMessage2.setChannel(null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getChannel());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getChannel());
+    }
+
+    @Test
+    public void setAndGetJsonKapuaPayloadTest() {
+        JsonKapuaPayload newJsonKapuaPayload = Mockito.mock(JsonKapuaPayload.class);
+
+        jsonKapuaDataMessage1.setPayload(newJsonKapuaPayload);
+        jsonKapuaDataMessage2.setPayload(newJsonKapuaPayload);
+
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage1.getPayload());
+        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage2.getPayload());
+
+        jsonKapuaDataMessage1.setPayload((JsonKapuaPayload) null);
+        jsonKapuaDataMessage2.setPayload((JsonKapuaPayload) null);
+
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage1.getPayload());
+        Assert.assertNull("Null expected.", jsonKapuaDataMessage2.getPayload());
+    }
+
+    @Test
+    public void setAndGetKapuaPayloadTest() {
+        KapuaPayload newKapuaPayload = Mockito.mock(KapuaPayload.class);
+
+        jsonKapuaDataMessage1.setPayload(newKapuaPayload);
+        jsonKapuaDataMessage2.setPayload(newKapuaPayload);
+
+        Assert.assertNotNull("NotNull expected.", jsonKapuaDataMessage1.getPayload());
+        Assert.assertNotNull("NotNull expected.", jsonKapuaDataMessage2.getPayload());
+
+        try {
+            jsonKapuaDataMessage1.setPayload((KapuaPayload) null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            jsonKapuaDataMessage2.setPayload((KapuaPayload) null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageListResultTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageListResultTest.java
@@ -1,0 +1,69 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.data;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.elasticsearch.client.model.ResultList;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class JsonMessageListResultTest extends Assert {
+
+    ResultList<JsonDatastoreMessage> resultList;
+    List expectedList;
+    JsonDatastoreMessage item1, item2;
+
+    @Before
+    public void initialize() {
+        resultList = new ResultList<>(3);
+        item1 = Mockito.mock(JsonDatastoreMessage.class);
+        item2 = Mockito.mock(JsonDatastoreMessage.class);
+
+        resultList.add(item1);
+        resultList.add(null);
+        resultList.add(item2);
+        expectedList = new LinkedList<>();
+
+        expectedList.add(item1);
+        expectedList.add(null);
+        expectedList.add(item2);
+    }
+
+    @Test
+    public void jsonMessageListResultWithoutParameterTest() {
+        JsonMessageListResult jsonMessageListResult = new JsonMessageListResult();
+
+        Assert.assertTrue("True expected.", jsonMessageListResult.getItems().isEmpty());
+        Assert.assertNull("Null expected.", jsonMessageListResult.getTotalCount());
+    }
+
+    @Test
+    public void jsonMessageListResultWithParameterTest() {
+        JsonMessageListResult jsonMessageListResult = new JsonMessageListResult(resultList);
+
+        assertEquals("Expected and actual values should be the same.", expectedList, jsonMessageListResult.getItems());
+        assertEquals("Expected and actual values should be the same.", (Long) 3L, jsonMessageListResult.getTotalCount());
+    }
+
+    @Test(expected = NullPointerException.class)
+    public void jsonMessageListResultWithNullParameterTest() {
+        new JsonMessageListResult(null);
+    }
+} 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageQueryTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageQueryTest.java
@@ -1,0 +1,285 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.model.data;
+
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
+import org.eclipse.kapua.service.storable.model.query.XmlAdaptedSortField;
+import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicate;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import java.util.LinkedList;
+import java.util.List;
+
+@Category(JUnitTests.class)
+public class JsonMessageQueryTest extends Assert {
+
+    KapuaId kapuaId;
+    JsonMessageQuery jsonMessageQuery1, jsonMessageQuery2;
+    StorableFetchStyle[] fetchStyles;
+
+    @Before
+    public void initialize() {
+        kapuaId = KapuaId.ONE;
+        jsonMessageQuery1 = new JsonMessageQuery();
+        jsonMessageQuery2 = new JsonMessageQuery(kapuaId);
+        fetchStyles = new StorableFetchStyle[]{StorableFetchStyle.FIELDS, StorableFetchStyle.SOURCE_FULL, StorableFetchStyle.SOURCE_SELECT};
+    }
+
+    @Test
+    public void jsonMessageQueryWithoutParameterTest() {
+        JsonMessageQuery jsonMessageQuery = new JsonMessageQuery();
+
+        Assert.assertNull("Null expected.", jsonMessageQuery.getScopeId());
+        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
+        Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
+    }
+
+    @Test
+    public void jsonMessageQueryWithParameterTest() {
+        JsonMessageQuery jsonMessageQuery = new JsonMessageQuery(kapuaId);
+
+        assertEquals("Expected and actual values should be the same.", kapuaId, jsonMessageQuery.getScopeId());
+        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
+        Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
+    }
+
+    @Test
+    public void jsonMessageQueryWithNullParameterTest() {
+        JsonMessageQuery jsonMessageQuery = new JsonMessageQuery(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery.getScopeId());
+        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
+        Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
+    }
+
+    @Test
+    public void setAndGetScopeIdTest() {
+        jsonMessageQuery1.setScopeId(KapuaId.ANY);
+        jsonMessageQuery2.setScopeId(KapuaId.ANY);
+
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery1.getScopeId());
+        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery2.getScopeId());
+
+        jsonMessageQuery1.setScopeId(null);
+        jsonMessageQuery2.setScopeId(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getScopeId());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getScopeId());
+    }
+
+    @Test
+    public void setAndGetPredicateTest() {
+        StorablePredicate storablePredicate = Mockito.mock(StorablePredicate.class);
+
+        jsonMessageQuery1.setPredicate(storablePredicate);
+        jsonMessageQuery2.setPredicate(storablePredicate);
+
+        assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery1.getPredicate());
+        assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery2.getPredicate());
+
+        jsonMessageQuery1.setPredicate(null);
+        jsonMessageQuery2.setPredicate(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getPredicate());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getPredicate());
+    }
+
+    @Test
+    public void setAndGetOffsetTest() {
+        Integer[] offsets = {-2147483648, -1000000, -10, 0, 10, 1000000, 2147483647};
+
+        for (Integer offset : offsets) {
+            jsonMessageQuery1.setOffset(offset);
+            jsonMessageQuery2.setOffset(offset);
+
+            assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery1.getOffset());
+            assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery2.getOffset());
+        }
+
+        jsonMessageQuery1.setOffset(null);
+        jsonMessageQuery2.setOffset(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getOffset());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getOffset());
+    }
+
+    @Test
+    public void setAndGetLimitTest() {
+        Integer[] limits = {-2147483648, -1000000, -10, 0, 10, 1000000, 2147483647};
+
+        for (Integer limit : limits) {
+            jsonMessageQuery1.setLimit(limit);
+            jsonMessageQuery2.setLimit(limit);
+
+            assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery1.getLimit());
+            assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery2.getLimit());
+        }
+
+        jsonMessageQuery1.setLimit(null);
+        jsonMessageQuery2.setLimit(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getLimit());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getLimit());
+    }
+
+    @Test
+    public void setAndIsAskTotalCountTest() {
+        boolean[] askTotalCounts = {true, false};
+
+        for (boolean askTotalCount : askTotalCounts) {
+            jsonMessageQuery1.setAskTotalCount(askTotalCount);
+            jsonMessageQuery2.setAskTotalCount(askTotalCount);
+
+            assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery1.isAskTotalCount());
+            assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery2.isAskTotalCount());
+        }
+    }
+
+    @Test
+    public void setAndGetFetchStyleTest() {
+        for (StorableFetchStyle fetchStyle : fetchStyles) {
+            jsonMessageQuery1.setFetchStyle(fetchStyle);
+            jsonMessageQuery2.setFetchStyle(fetchStyle);
+
+            assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery1.getFetchStyle());
+            assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery2.getFetchStyle());
+        }
+        jsonMessageQuery1.setFetchStyle(null);
+        jsonMessageQuery2.setFetchStyle(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getFetchStyle());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getFetchStyle());
+    }
+
+    @Test
+    public void setGetAndAddFetchAttributesTest() {
+        List<String> fetchAttributeNames = new LinkedList<>();
+        List<String> expectedValue = new LinkedList<>();
+        String attributeName1 = "AttributeName1";
+        String attributeName2 = "AttributeName2";
+        String attributeName3 = "AttributeName3";
+
+        fetchAttributeNames.add(attributeName1);
+        fetchAttributeNames.add(attributeName2);
+
+        expectedValue.add(attributeName1);
+        expectedValue.add(attributeName2);
+
+        jsonMessageQuery1.setFetchAttributes(fetchAttributeNames);
+        jsonMessageQuery2.setFetchAttributes(fetchAttributeNames);
+
+        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
+        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
+
+        jsonMessageQuery1.addFetchAttributes(attributeName3);
+        jsonMessageQuery2.addFetchAttributes(attributeName3);
+
+        expectedValue.add(attributeName3);
+        expectedValue.add(attributeName3);
+
+        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
+        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
+
+        jsonMessageQuery1.setFetchAttributes(null);
+        jsonMessageQuery2.setFetchAttributes(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getFetchAttributes());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getFetchAttributes());
+    }
+
+    @Test
+    public void setAndGetSortFieldsTest() {
+        List<XmlAdaptedSortField> sortFields = new LinkedList<>();
+        XmlAdaptedSortField xmlAdaptedSortField1 = Mockito.mock(XmlAdaptedSortField.class);
+        XmlAdaptedSortField xmlAdaptedSortField2 = Mockito.mock(XmlAdaptedSortField.class);
+        sortFields.add(xmlAdaptedSortField1);
+        sortFields.add(xmlAdaptedSortField2);
+
+        jsonMessageQuery1.setSortFields(sortFields);
+        jsonMessageQuery2.setSortFields(sortFields);
+
+        assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery1.getSortFields());
+        assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery2.getSortFields());
+
+        jsonMessageQuery1.setSortFields(null);
+        jsonMessageQuery2.setSortFields(null);
+
+        Assert.assertNull("Null expected.", jsonMessageQuery1.getSortFields());
+        Assert.assertNull("Null expected.", jsonMessageQuery2.getSortFields());
+    }
+
+    @Test
+    public void getIncludesTest() {
+        for (StorableFetchStyle fetchStyle : fetchStyles) {
+            Assert.assertNotNull("NotNull expected.", jsonMessageQuery1.getIncludes(fetchStyle));
+            Assert.assertNotNull("NotNull expected.", jsonMessageQuery2.getIncludes(fetchStyle));
+        }
+    }
+
+    @Test
+    public void getIncludesNullTest() {
+        try {
+            jsonMessageQuery1.getIncludes(null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            jsonMessageQuery2.getIncludes(null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void getExcludesTest() {
+        for (StorableFetchStyle fetchStyle : fetchStyles) {
+            Assert.assertNotNull("NotNull expected.", jsonMessageQuery1.getExcludes(fetchStyle));
+            Assert.assertNotNull("NotNull expected.", jsonMessageQuery2.getExcludes(fetchStyle));
+        }
+    }
+
+    @Test
+    public void getExcludesNullTest() {
+        try {
+            jsonMessageQuery1.getExcludes(null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+
+        try {
+            jsonMessageQuery2.getExcludes(null);
+            Assert.fail("NullPointerException expected.");
+        } catch (Exception e) {
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+        }
+    }
+
+    @Test
+    public void getFieldsTest() {
+        assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery1.getFields().length);
+        assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery2.getFields().length);
+    }
+} 


### PR DESCRIPTION
This PR contains JUnit tests for classes in model/data package in
rest-api/resources module:
 - JsonDatastoreMessage class
 - JsonKapuaDataMessage class
 - JsonMessageListResult class
 - JsonMessageQuery class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
