### PR TITLE
Added JUnit tests for rest-api/web module

### DIFF
--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -210,6 +210,11 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>percolator-client</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/JaxbContextResolverTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/JaxbContextResolverTest.java
@@ -1,0 +1,62 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.web;
+
+import org.eclipse.kapua.app.api.core.exception.model.EntityNotFoundExceptionInfo;
+import org.eclipse.kapua.model.config.metatype.KapuaTocd;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.account.Account;
+import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.authorization.group.Group;
+import org.eclipse.kapua.service.authorization.role.Role;
+import org.eclipse.kapua.service.datastore.model.ChannelInfo;
+import org.eclipse.kapua.service.device.call.kura.model.deploy.KuraDeploymentPackages;
+import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessage;
+import org.eclipse.kapua.service.device.management.message.response.KapuaResponseMessage;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.job.Job;
+import org.eclipse.kapua.service.user.User;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.xml.bind.JAXBContext;
+
+@Category(JUnitTests.class)
+public class JaxbContextResolverTest extends Assert {
+
+    JaxbContextResolver jaxbContextResolver;
+
+    @Before
+    public void initialize() {
+        jaxbContextResolver = new JaxbContextResolver();
+    }
+
+    @Test
+    public void getContextTest() {
+        Class[] classes = {String.class, Account.class, KapuaTocd.class, Exception.class, EntityNotFoundExceptionInfo.class, ChannelInfo.class, Device.class, Credential.class, Job.class,
+                KuraDeploymentPackages.class, KapuaRequestMessage.class, KapuaResponseMessage.class, DeviceManagementOperation.class, AccessToken.class, Role.class, Group.class, User.class};
+
+        for (Class clazz : classes) {
+            assertTrue("True expected.", jaxbContextResolver.getContext(clazz) instanceof JAXBContext);
+        }
+    }
+
+    @Test
+    public void getContextNullTest() {
+        assertTrue("True expected.", jaxbContextResolver.getContext(null) instanceof JAXBContext);
+    }
+}

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProviderTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProviderTest.java
@@ -1,0 +1,80 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.web;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.ContextResolver;
+import javax.ws.rs.ext.Providers;
+import javax.xml.bind.JAXBContext;
+
+@Category(JUnitTests.class)
+public class RestApiJAXBContextProviderTest extends Assert {
+
+    RestApiJAXBContextProvider restApiJAXBContextProvider;
+    Providers providers;
+    ContextResolver<JAXBContext> contextResolver;
+    JAXBContext jaxbContext;
+
+    @Before
+    public void initialize() {
+        restApiJAXBContextProvider = new RestApiJAXBContextProvider();
+        providers = Mockito.mock(Providers.class);
+        contextResolver = Mockito.mock(ContextResolver.class);
+        jaxbContext = Mockito.mock(JAXBContext.class);
+    }
+
+    @Test
+    public void getJAXBContextNullProvidersTest() {
+        restApiJAXBContextProvider.providers = null;
+
+        try {
+            restApiJAXBContextProvider.getJAXBContext();
+            fail("KapuaException expected.");
+        } catch (Exception e) {
+            assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to find any provider..", e.toString());
+        }
+    }
+
+    @Test
+    public void getJAXBNullContextTest() {
+        restApiJAXBContextProvider.providers = providers;
+
+        Mockito.when(providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(contextResolver);
+        Mockito.when(contextResolver.getContext(JAXBContext.class)).thenReturn(null);
+
+        try {
+            restApiJAXBContextProvider.getJAXBContext();
+            fail("KapuaException expected.");
+        } catch (Exception e) {
+            assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to get a JAXBContext..", e.toString());
+        }
+    }
+
+    @Test
+    public void getJAXBContextTest() throws KapuaException {
+        restApiJAXBContextProvider.providers = providers;
+
+        Mockito.when(providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(contextResolver);
+        Mockito.when(contextResolver.getContext(JAXBContext.class)).thenReturn(jaxbContext);
+
+        assertTrue("True expected.", restApiJAXBContextProvider.getJAXBContext() instanceof JAXBContext);
+    }
+}

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiListenerTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiListenerTest.java
@@ -1,0 +1,71 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.web;
+
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+import javax.servlet.ServletContextEvent;
+
+@Category(JUnitTests.class)
+public class RestApiListenerTest extends Assert {
+
+    RestApiListener restApiListener;
+    ServletContextEvent servletContextEvent;
+
+    @Before
+    public void initialize() {
+        restApiListener = new RestApiListener();
+        servletContextEvent = Mockito.mock(ServletContextEvent.class);
+    }
+
+    @Test
+    public void contextInitializedTest() {
+        try {
+            restApiListener.contextInitialized(servletContextEvent);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void contextInitializedNullTest() {
+        try {
+            restApiListener.contextInitialized(null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void contextDestroyedTest() {
+        try {
+            restApiListener.contextDestroyed(servletContextEvent);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+
+    @Test
+    public void contextDestroyedNullTest() {
+        try {
+            restApiListener.contextDestroyed(null);
+        } catch (Exception e) {
+            fail("Exception not expected.");
+        }
+    }
+}

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApisApplicationTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApisApplicationTest.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.web;
+
+import org.eclipse.kapua.app.api.core.KapuaSerializableBodyWriter;
+import org.eclipse.kapua.app.api.core.ListBodyWriter;
+import org.eclipse.kapua.app.api.core.MoxyJsonConfigContextResolver;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.glassfish.jersey.server.filter.UriConnegFilter;
+import org.glassfish.jersey.server.spi.ContainerLifecycleListener;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import javax.xml.bind.JAXBException;
+
+@Category(JUnitTests.class)
+public class RestApisApplicationTest extends Assert {
+
+    @Test
+    public void restApisApplicationTest() throws JAXBException {
+        RestApisApplication restApisApplication = new RestApisApplication();
+
+        assertEquals("{jersey.config.server.mediaTypeMappings={xml=application/xml, json=application/json}, jersey.config.server.wadl.disableWadl=true}", restApisApplication.getProperties().toString());
+        assertTrue("True expected.", restApisApplication.isRegistered(UriConnegFilter.class));
+        assertTrue("True expected.", restApisApplication.isRegistered(JaxbContextResolver.class));
+        assertTrue("True expected.", restApisApplication.isRegistered(RestApiJAXBContextProvider.class));
+        assertTrue("True expected.", restApisApplication.isRegistered(KapuaSerializableBodyWriter.class));
+        assertTrue("True expected.", restApisApplication.isRegistered(ListBodyWriter.class));
+        assertTrue("True expected.", restApisApplication.isRegistered(MoxyJsonConfigContextResolver.class));
+
+        assertFalse("False expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
+        assertFalse("False expected.", restApisApplication.isRegistered(String.class));
+
+        restApisApplication.register(ContainerLifecycleListener.class);
+        assertTrue("True expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
+    }
+}


### PR DESCRIPTION
This PR contains JUnit tests for classes in rest-api/web module:
 - JaxbContextResolver class
 - RestApiJAXBContextProvider class
 - RestApiListener class
 - RestApisApplication class

Signed-off-by: Sonja <sonja.matic@endava.com>

**Related Issue**
/

**Description of the solution adopted**
/

**Screenshots**
/

**Any side note on the changes made**
/
