### PR TITLE
Fixed OpenID Connect tokens  for SSO

### DIFF
--- a/assembly/README.md
+++ b/assembly/README.md
@@ -48,10 +48,13 @@ For further information take a look at the `sso.md` manual located in the `docs/
 It is also possible to use a generic OpenID Connect provider, by providing to the console the following environment 
 variables:
 
-- `OPENID_JWT_ISSUER` : the base URL to the OpenID server provider.
-- `OPENID_AUTH_ENDPOINT` :  the endpoint URL to the authentication API.
-- `OPENID_TOKEN_ENDPOINT` : the endpoint URL to the token API.
-- `OPENID_LOGOUT_ENDPOINT` : the URL to the logout endpoint.
+- `OPENID_JWT_ISSUER` : the base URL to the OpenID Connect server provider.
+- `OPENID_CLIENT_ID` : the client id (the default value is `console`).
+- `CLIENT_SECRET` : the client secret (optional).
+- `JWT_AUDIENCE` : the JWT audience (the default value is `console`).
+- `OPENID_AUTH_ENDPOINT` : the endpoint URL to the authentication API (optional, already retrieved via well-known document).
+- `OPENID_TOKEN_ENDPOINT` : the endpoint URL to the token API (optional, already retrieved via well-known document).
+- `OPENID_LOGOUT_ENDPOINT` : the URL to the logout endpoint (optional, already retrieved via well-known document).
 - `KAPUA_CONSOLE_URL` : the `kapua-console` URL.
 
 ### Tomcat images

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/servlet/SsoCallbackServlet.java
@@ -17,7 +17,7 @@ import org.eclipse.kapua.app.console.core.server.util.SsoHelper;
 import org.eclipse.kapua.app.console.core.server.util.SsoLocator;
 import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
 import org.eclipse.kapua.plugin.sso.openid.OpenIDLocator;
-import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDAccessTokenException;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDTokenException;
 import org.eclipse.kapua.plugin.sso.openid.exception.uri.OpenIDIllegalUriException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,7 +84,7 @@ public class SsoCallbackServlet extends HttpServlet {
 
             if (authCode != null) {
                 final URI redirectUri = SsoHelper.getRedirectUri();
-                final JsonObject jsonObject = locator.getService().getAccessToken(authCode, redirectUri);
+                final JsonObject jsonObject = locator.getService().getTokens(authCode, redirectUri);
 
                 // Get and clean jwks_uri property
                 final String accessToken = jsonObject.getString(OPENID_ACCESS_TOKEN_PARAM);
@@ -98,7 +98,7 @@ public class SsoCallbackServlet extends HttpServlet {
                 logger.debug("Successfully sent the redirect response to {}", homeUri);
             } else {
 
-                // access_token is null, collect possible error
+                // 'code' parameter is null, collect possible error
                 final String error = req.getParameter(OPENID_ERROR_PARAM);
                 if (error != null) {
                     String errorDescription = req.getParameter(OPENID_ERROR_DESC_PARAM);
@@ -112,13 +112,13 @@ public class SsoCallbackServlet extends HttpServlet {
                 } else {
                     resp.sendError(400);
                     httpReqLogger.addParameter("Error", "400 Bad Request");
-                    logger.error("Invalid HttpServletRequest, both 'access_token' and 'error' parameters are 'null'");
+                    logger.error("Invalid HttpServletRequest, both 'code' and 'error' parameters are 'null'");
                 }
             }
         } catch (OpenIDIllegalUriException siue) {
             throw new ServletException("Failed to get Home URI (null or empty): " + siue.getMessage(), siue);
-        } catch (OpenIDAccessTokenException sate) {
-            throw new ServletException("Failed to get access token: " + sate.getMessage(), sate);
+        } catch (OpenIDTokenException sate) {
+            throw new ServletException("Failed to get tokens: " + sate.getMessage(), sate);
         } catch (URISyntaxException use) {
             throw new ServletException("Failed to parse redirect URL " + homeUri + " : " + use.getMessage(), use);
         } finally {

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -63,6 +63,17 @@ services:
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
+      - KAPUA_CONSOLE_URL
+      - OPENID_JWT_ISSUER
+      - OPENID_CLIENT_ID
+      - CLIENT_SECRET
+      - JWT_AUDIENCE
+      - OPENID_AUTH_ENDPOINT
+      - OPENID_TOKEN_ENDPOINT
+      - OPENID_LOGOUT_ENDPOINT
+      - KEYCLOAK_URL
+      - KEYCLOAK_CLIENT_ID
+      - KEYCLOAK_REALM
   kapua-api:
     image: kapua/kapua-api:${IMAGE_VERSION}
     ports:

--- a/deployment/docker/compose/sso/sso-docker-compose.yml
+++ b/deployment/docker/compose/sso/sso-docker-compose.yml
@@ -54,8 +54,6 @@ services:
       - es
       - events-broker
     environment:
-      - KEYCLOAK_URL
-      - KAPUA_CONSOLE_URL
       - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CA
@@ -65,6 +63,17 @@ services:
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
+      - KAPUA_CONSOLE_URL
+      - OPENID_JWT_ISSUER
+      - OPENID_CLIENT_ID
+      - CLIENT_SECRET
+      - JWT_AUDIENCE
+      - OPENID_AUTH_ENDPOINT
+      - OPENID_TOKEN_ENDPOINT
+      - OPENID_LOGOUT_ENDPOINT
+      - KEYCLOAK_URL
+      - KEYCLOAK_CLIENT_ID
+      - KEYCLOAK_REALM
   kapua-api:
     image: kapua/kapua-api:${IMAGE_VERSION}
     ports:
@@ -74,6 +83,24 @@ services:
       - broker
       - db
       - es
+      - events-broker
+    environment:
+      - KAPUA_DISABLE_SSL
+      - KAPUA_DISABLE_DATASTORE
+      - KAPUA_CA
+      - KAPUA_CRT
+      - KAPUA_KEY
+      - KAPUA_KEY_PASSWORD
+      - KAPUA_KEYSTORE
+      - KAPUA_KEYSTORE_PASSWORD
+      - LOGBACK_LOG_LEVEL
+  job-engine:
+    image: kapua/kapua-job-engine:${IMAGE_VERSION}
+    expose:
+      - 8080
+    depends_on:
+      - broker
+      - db
       - events-broker
     environment:
       - KAPUA_DISABLE_SSL

--- a/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/JwtProcessor.java
+++ b/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/JwtProcessor.java
@@ -35,4 +35,11 @@ public interface JwtProcessor extends AutoCloseable {
      * @throws OpenIDJwtException if JWT processing fails.
      */
     JwtContext process(final String jwt) throws OpenIDException;
+
+    /**
+     * Return the claim to be extracted form the JWT as user identifier.
+     *
+     * @return the claim in the form of a String
+     */
+    String getExternalIdClaimName();
 }

--- a/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/OpenIDService.java
+++ b/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/OpenIDService.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.plugin.sso.openid;
 
-import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDAccessTokenException;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDTokenException;
 import org.eclipse.kapua.plugin.sso.openid.exception.uri.OpenIDUriException;
 
 import javax.json.JsonObject;
@@ -45,10 +45,10 @@ public interface OpenIDService {
      *
      * @param authCode the authorization code from the HttpServletRequest.
      * @param redirectUri a URI object representing the redirect URI.
-     * @return the access token in the form of a {@link JsonObject}.
-     * @throws OpenIDAccessTokenException if it fails to retrieve the access token.
+     * @return the OpenID Connect tokens in the form of a {@link JsonObject}.
+     * @throws OpenIDTokenException if it fails to retrieve the tokens.
      */
-    JsonObject getAccessToken(String authCode, URI redirectUri) throws OpenIDAccessTokenException;
+    JsonObject getTokens(String authCode, URI redirectUri) throws OpenIDTokenException;
 
     /**
      * Get the Relying-Party-Initiated logout.

--- a/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/exception/OpenIDErrorCodes.java
+++ b/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/exception/OpenIDErrorCodes.java
@@ -32,11 +32,11 @@ public enum OpenIDErrorCodes implements KapuaErrorCode {
     LOGOUT_URI_ERROR,
 
     /**
-     * An error occurred while getting the access token.
+     * An error occurred while getting the tokens.
      *
      * @since 1.2.0
      */
-    ACCESS_TOKEN_ERROR,
+    TOKEN_ERROR,
 
     /**
      * An error occurred while extracting the Jwt.

--- a/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/exception/OpenIDTokenException.java
+++ b/plug-ins/sso/openid-connect/api/src/main/java/org/eclipse/kapua/plugin/sso/openid/exception/OpenIDTokenException.java
@@ -12,14 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.plugin.sso.openid.exception;
 
-public class OpenIDAccessTokenException extends OpenIDException {
+public class OpenIDTokenException extends OpenIDException {
 
     /**
      * Constructor.
      *
      * @param cause The original {@link Throwable}.
      */
-    public OpenIDAccessTokenException(Throwable cause) {
-        super(OpenIDErrorCodes.ACCESS_TOKEN_ERROR, cause, (Object[]) null);
+    public OpenIDTokenException(Throwable cause) {
+        super(OpenIDErrorCodes.TOKEN_ERROR, cause, (Object[]) null);
     }
 }

--- a/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/AbstractOpenIDService.java
+++ b/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/AbstractOpenIDService.java
@@ -21,7 +21,7 @@ import org.apache.http.client.utils.URLEncodedUtils;
 import org.apache.http.message.BasicNameValuePair;
 import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
 import org.eclipse.kapua.plugin.sso.openid.OpenIDService;
-import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDAccessTokenException;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDTokenException;
 import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDException;
 import org.eclipse.kapua.plugin.sso.openid.exception.uri.OpenIDLoginUriException;
 import org.eclipse.kapua.plugin.sso.openid.exception.uri.OpenIDLogoutUriException;
@@ -208,10 +208,10 @@ public abstract class AbstractOpenIDService implements OpenIDService {
     }
 
     /**
-     * @throws OpenIDAccessTokenException if an {@link IOException} is caught or the {@link #getTokenUri} method fails.
+     * @throws OpenIDTokenException if an {@link IOException} is caught or the {@link #getTokenUri} method fails.
      */
     @Override
-    public JsonObject getAccessToken(final String authCode, final URI redirectUri) throws OpenIDAccessTokenException {
+    public JsonObject getTokens(final String authCode, final URI redirectUri) throws OpenIDTokenException {
         // FIXME: switch to HttpClient implementation: better performance and connection caching
 
         ConfigurationPrinter reqLogger =
@@ -219,7 +219,7 @@ public abstract class AbstractOpenIDService implements OpenIDService {
                         .create()
                         .withLogger(logger)
                         .withLogLevel(ConfigurationPrinter.LogLevel.DEBUG)
-                        .withTitle("OpenID access token HTTP request");
+                        .withTitle("OpenID tokens HTTP request");
         try {
             URL url = new URL(getTokenUri());
             reqLogger.addParameter("URL", url);
@@ -273,24 +273,24 @@ public abstract class AbstractOpenIDService implements OpenIDService {
                         reqLogger.addParameter(entry.getKey(), entry.getValue());
                     }
                 }
-                logger.debug("Successfully obtained access token.");
+                logger.debug("Successfully obtained tokens.");
                 return result;
             }
         } catch (OpenIDException se) {
             logger.error("Error while retrieving the String of the token API endpoint {}", se.getLocalizedMessage(), se);
-            throw new OpenIDAccessTokenException(se);
+            throw new OpenIDTokenException(se);
         } catch (MalformedURLException mue) {
             logger.error("Malformed token API endpoint URL {}", mue.getLocalizedMessage(), mue);
-            throw new OpenIDAccessTokenException(mue);
+            throw new OpenIDTokenException(mue);
         } catch (ProtocolException pe) {
             logger.error("Wrong HTTP request method {}", pe.getLocalizedMessage(), pe);
-            throw new OpenIDAccessTokenException(pe);
+            throw new OpenIDTokenException(pe);
         } catch (UnsupportedEncodingException uee) {
             logger.error("Unsupported HTTP request default encoding {}", uee.getLocalizedMessage(), uee);
-            throw new OpenIDAccessTokenException(uee);
+            throw new OpenIDTokenException(uee);
         } catch (IOException ioe) {
-            logger.error("Error while getting the access token {}", ioe.getLocalizedMessage(), ioe);
-            throw new OpenIDAccessTokenException(ioe);
+            logger.error("Error while getting the tokens {}", ioe.getLocalizedMessage(), ioe);
+            throw new OpenIDTokenException(ioe);
         } finally {
             reqLogger.printLog();
         }

--- a/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/internal/DisabledLocator.java
+++ b/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/internal/DisabledLocator.java
@@ -41,7 +41,7 @@ public class DisabledLocator implements ProviderLocator {
         }
 
         @Override
-        public JsonObject getAccessToken(final String authCode, final URI redirectUri) {
+        public JsonObject getTokens(final String authCode, final URI redirectUri) {
             return null;
         }
 

--- a/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/internal/DisabledLocator.java
+++ b/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/internal/DisabledLocator.java
@@ -70,6 +70,11 @@ public class DisabledLocator implements ProviderLocator {
         public JwtContext process(String jwt) {
             return null;
         }
+
+        @Override
+        public String getExternalIdClaimName() {
+            return null;
+        }
     };
 
     private DisabledLocator() {

--- a/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/jwt/AbstractJwtProcessor.java
+++ b/plug-ins/sso/openid-connect/provider/src/main/java/org/eclipse/kapua/plugin/sso/openid/provider/jwt/AbstractJwtProcessor.java
@@ -23,6 +23,7 @@ import org.eclipse.kapua.plugin.sso.openid.exception.jwt.OpenIDJwtExtractionExce
 import org.eclipse.kapua.plugin.sso.openid.exception.jwt.OpenIDJwtProcessException;
 import org.jose4j.jwk.HttpsJwks;
 import org.jose4j.jwt.MalformedClaimException;
+import org.jose4j.jwt.ReservedClaimNames;
 import org.jose4j.jwt.consumer.InvalidJwtException;
 import org.jose4j.jwt.consumer.JwtConsumer;
 import org.jose4j.jwt.consumer.JwtConsumerBuilder;
@@ -114,6 +115,14 @@ public abstract class AbstractJwtProcessor implements JwtProcessor {
         return lookupProcessor(issuer)
                 .orElseThrow(() -> new IllegalStateException("Unable to auto-discover JWT endpoint"))
                 .process(jwt);
+    }
+
+    /**
+     * @return 'sub' (according to the official OpenID Connect 1.0 specification)
+     */
+    @Override
+    public String getExternalIdClaimName() {
+        return ReservedClaimNames.SUBJECT;
     }
 
     @Override

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/JwtCredentials.java
@@ -25,23 +25,23 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "jwtCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "jwt", "idToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
+@XmlType(propOrder = { "accessToken", "idToken" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newJwtCredentials")
 public interface JwtCredentials extends LoginCredentials {
 
     /**
-     * Gets the Json Web Token
+     * Gets the OpenID Connect accessToken
      *
      * @return
      */
-    @XmlElement(name = "jwt")
-    String getJwt();
+    @XmlElement(name = "accessToken")
+    String getAccessToken();
 
     /**
-     * Set the Json Web Token
+     * Set the OpenID Connect accessToken
      *
-     * @param jwt
+     * @param accessToken
      */
-    void setJwt(String jwt);
+    void setAccessToken(String accessToken);
 
     /**
      * Gets the OpenID Connect idToken

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -40,8 +40,8 @@ public class CredentialsFactoryImpl implements CredentialsFactory {
     }
 
     @Override
-    public JwtCredentials newJwtCredentials(String jwt, String idToken) {
-        return new JwtCredentialsImpl(jwt, idToken);
+    public JwtCredentials newJwtCredentials(String accessToken, String idToken) {
+        return new JwtCredentialsImpl(accessToken, idToken);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsImpl.java
@@ -29,18 +29,18 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
 
     private static final long serialVersionUID = -5920944517814926028L;
 
-    private String jwt;
+    private String accessToken;
     private String idToken;
 
     /**
      * Constructor.
      *
-     * @param jwt     The credential JWT.
-     * @param idToken The credential token.
+     * @param accessToken The credential access token
+     * @param idToken     The credential id token.
      * @since 1.4.0
      */
-    public JwtCredentialsImpl(String jwt, String idToken) {
-        setJwt(jwt);
+    public JwtCredentialsImpl(String accessToken, String idToken) {
+        setAccessToken(accessToken);
         setIdToken(idToken);
     }
 
@@ -51,18 +51,18 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
      * @since 1.5.0
      */
     public JwtCredentialsImpl(@NotNull JwtCredentials jwtCredentials) {
-        setJwt(jwtCredentials.getJwt());
+        setAccessToken(jwtCredentials.getAccessToken());
         setIdToken(jwtCredentials.getIdToken());
     }
 
     @Override
-    public String getJwt() {
-        return jwt;
+    public String getAccessToken() {
+        return accessToken;
     }
 
     @Override
-    public void setJwt(String jwt) {
-        this.jwt = jwt;
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 
     @Override
@@ -77,12 +77,12 @@ public class JwtCredentialsImpl implements JwtCredentials, AuthenticationToken {
 
     @Override
     public Object getPrincipal() {
-        return getJwt();
+        return getAccessToken();
     }
 
     @Override
     public Object getCredentials() {
-        return getJwt();
+        return getAccessToken();
     }
 
     /**

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -100,7 +100,7 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
         //
         // Extract credentials
         JwtCredentialsImpl token = (JwtCredentialsImpl) authenticationToken;
-        String jwt = token.getJwt();
+        String idToken = token.getIdToken();
 
         //
         // Get Services
@@ -115,7 +115,7 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
             throw new ShiroException("Error while getting services!", kre);
         }
 
-        final String id = extractExternalId(jwt);
+        final String id = extractExternalId(idToken);
         logger.debug("JWT contains external id: {}", id);
 
         // Get the associated user by external id
@@ -170,7 +170,7 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
 
         // Create credential
 
-        final Credential credential = new CredentialImpl(user.getScopeId(), user.getId(), CredentialType.JWT, jwt, CredentialStatus.ENABLED, null);
+        final Credential credential = new CredentialImpl(user.getScopeId(), user.getId(), CredentialType.JWT, idToken, CredentialStatus.ENABLED, null);
 
         // Build AuthenticationInfo
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtAuthenticatingRealm.java
@@ -192,7 +192,7 @@ public class JwtAuthenticatingRealm extends AuthenticatingRealm implements Destr
         final String id;
         try {
             final JwtContext ctx = jwtProcessor.process(jwt);
-            id = ctx.getJwtClaims().getSubject();
+            id = ctx.getJwtClaims().getClaimValueAsString(jwtProcessor.getExternalIdClaimName());
         } catch (final Exception e) {
             throw new ShiroException("Failed to parse JWT", e);
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcher.java
@@ -42,8 +42,8 @@ public class JwtCredentialsMatcher implements CredentialsMatcher {
     @Override
     public boolean doCredentialsMatch(AuthenticationToken authenticationToken, AuthenticationInfo authenticationInfo) {
 
-        final String jwt = ((JwtCredentialsImpl) authenticationToken).getJwt();
-        if (jwt == null) {
+        final String idToken = ((JwtCredentialsImpl) authenticationToken).getIdToken();
+        if (idToken == null) {
             // we don't have a JWT
             return false;
         }
@@ -61,13 +61,13 @@ public class JwtCredentialsMatcher implements CredentialsMatcher {
 
         // Match token with info
 
-        if (!jwt.equals(credentials.getCredentialKey())) {
+        if (!idToken.equals(credentials.getCredentialKey())) {
             return false;
         }
 
         try {
             // validate the JWT
-            return this.jwtProcessor.validate(jwt);
+            return this.jwtProcessor.validate(idToken);
         } catch (Exception e) {
             logger.error("Error while validating JWT credentials", e);
         }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
@@ -81,7 +81,7 @@ public class RegistrationServiceImpl implements RegistrationService, AutoCloseab
         }
 
         try {
-            final JwtContext context = jwtProcessor.process(credentials.getJwt());
+            final JwtContext context = jwtProcessor.process(credentials.getIdToken());
 
             for (final RegistrationProcessor processor : processors) {
                 final Optional<User> result = processor.createUser(context);

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImplTest.java
@@ -28,7 +28,7 @@ import org.junit.experimental.categories.Category;
 public class CredentialsFactoryImplTest extends Assert {
 
     CredentialsFactoryImpl credentialsFactoryImpl;
-    String[] usernames, passwords, apiKeys, idsToken, jwts, refreshTokens;
+    String[] usernames, passwords, apiKeys, idTokens, accessTokens, refreshTokens;
 
     @Before
     public void initialize() {
@@ -36,8 +36,8 @@ public class CredentialsFactoryImplTest extends Assert {
         usernames = new String[]{null, "", "user_name123!!", "user#999username", "USERNAME_9", "user,,,,name", "... us_er%%67na*(me"};
         passwords = new String[]{null, "", "pass-word0000@!!,,,#", "!@#00PaSSwOrD.", " password ---44<>", "pA_ss0###woE**9()", "    pass0wo-rd  12344*&^%"};
         apiKeys = new String[]{null, "", "api_key1122#$%", "   aPi)(..,,KEY", "apiKEYYY ./??)_)*", "<> 1111      ", "keyyy&^$$##Z||'", "%%%KEY api-key11"};
-        idsToken = new String[]{null, "", "   ID tokenID 747.,.,,,82(*&%<> ", "   token((11@-", "id)__.,TOKen65", "TOKENid543$#%&t   oken", "to-ken_id++=,", "id,,,,id3$^&"};
-        jwts = new String[]{null, "", "  j_w=t110.,<> jwt", "(!!)432j&^w$#3t", "##<>/.JWT    ", "__J!#W(-8T    ", "jw&* 990t  ", "jwt987)_=;'''     .", "jwt JWT-123"};
+        idTokens = new String[]{null, "", "   ID tokenID 747.,.,,,82(*&%<> ", "   token((11@-", "id)__.,TOKen65", "TOKENid543$#%&t   oken", "to-ken_id++=,", "id,,,,id3$^&"};
+        accessTokens = new String[]{null, "", "  j_w=t110.,<> jwt", "(!!)432j&^w$#3t", "##<>/.JWT    ", "__J!#W(-8T    ", "jw&* 990t  ", "jwt987)_=;'''     .", "jwt JWT-123"};
         refreshTokens = new String[]{null, "", "   refresh tokenREFRESH 747.,.,,,82(*&%<> ", "   token((11@-", "REFresh)__.,TOKen65", "TOKENrefresh543$#%&t   oken", "to-ken_++rE=fresh,", "refresh,,,,id3$^&"};
     }
 
@@ -62,10 +62,10 @@ public class CredentialsFactoryImplTest extends Assert {
 
     @Test
     public void newJwtCredentialsTest() {
-        for (String jwt : jwts) {
-            for (String idToken : idsToken) {
-                JwtCredentials jwtCredentials = credentialsFactoryImpl.newJwtCredentials(jwt, idToken);
-                assertEquals("Expected and actual values should be the same.", jwt, jwtCredentials.getJwt());
+        for (String accessToken : accessTokens) {
+            for (String idToken : idTokens) {
+                JwtCredentials jwtCredentials = credentialsFactoryImpl.newJwtCredentials(accessToken, idToken);
+                assertEquals("Expected and actual values should be the same.", accessToken, jwtCredentials.getAccessToken());
                 assertEquals("Expected and actual values should be the same.", idToken, jwtCredentials.getIdToken());
             }
         }
@@ -73,7 +73,7 @@ public class CredentialsFactoryImplTest extends Assert {
 
     @Test
     public void newAccessTokenCredentialsTest() {
-        for (String idToken : idsToken) {
+        for (String idToken : idTokens) {
             AccessTokenCredentials accessTokenCredentials = credentialsFactoryImpl.newAccessTokenCredentials(idToken);
             assertEquals("Expected and actual values should be the same.", idToken, accessTokenCredentials.getTokenId());
         }
@@ -81,7 +81,7 @@ public class CredentialsFactoryImplTest extends Assert {
 
     @Test
     public void newRefreshTokenCredentialsTest() {
-        for (String idToken : idsToken) {
+        for (String idToken : idTokens) {
             for (String refreshToken : refreshTokens) {
                 RefreshTokenCredentials refreshTokenCredentials = credentialsFactoryImpl.newRefreshTokenCredentials(idToken, refreshToken);
                 assertEquals("Expected and actual values should be the same.", idToken, refreshTokenCredentials.getTokenId());

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/JwtCredentialsTest.java
@@ -23,14 +23,14 @@ import org.junit.experimental.categories.Category;
 public class JwtCredentialsTest extends Assert {
 
     JwtCredentialsImpl jwtCredentialsImpl;
-    String[] jwts, idsToken, newJwts, newIdsToken;
+    String[] accessTokens, idsToken, newAccessTokens, newIdsToken;
 
     @Before
     public void initialize() {
-        jwtCredentialsImpl = new JwtCredentialsImpl("jwt", "idToken");
+        jwtCredentialsImpl = new JwtCredentialsImpl("accessToken", "idToken");
         idsToken = new String[]{null, "", "   ID tokenID 747.,.,,,82(*&%<> ", "   token((11@-", "id)__.,TOKen65", "TOKENid543$#%&t   oken", "to-ken_id++=,", "id,,,,id3$^&"};
-        jwts = new String[]{null, "", "  j_w=t110.,<> jwt", "(!!)432j&^w$#3t", "##<>/.JWT    ", "__J!#W(-8T    ", "jw&* 990t  ", "jwt987)_=;'''     .", "jwt JWT-123"};
-        newJwts = new String[]{null, "", "new_Jwt1122#$%", "   JWT)(..,,new", "NEW_jwt ./??)_)*", "<> 1111      ", "jwttt&^$$##Z||'", "%%%KEY NEW-JWT11"};
+        accessTokens = new String[]{null, "", "  j_w=t110.,<> jwt", "(!!)432j&^w$#3t", "##<>/.JWT    ", "__J!#W(-8T    ", "jw&* 990t  ", "jwt987)_=;'''     .", "jwt JWT-123"};
+        newAccessTokens = new String[]{null, "", "new_Jwt1122#$%", "   JWT)(..,,new", "NEW_jwt ./??)_)*", "<> 1111      ", "jwttt&^$$##Z||'", "%%%KEY NEW-JWT11"};
         newIdsToken = new String[]{null, "", "NEW tokenID0000@!!,,,#", "!@#00tokenID new.", " new id TOK --EN-44<>", "pA_ss0###woE**9()", "    tokenID new tokenID  12344*&^%"};
     }
 
@@ -46,7 +46,7 @@ public class JwtCredentialsTest extends Assert {
         JwtCredentialsImpl second = new JwtCredentialsImpl(first);
 
         assertNotEquals("JwtCredentialImpl", first, second);
-        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.accessToken", first.getAccessToken(), second.getAccessToken());
         assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
     }
 
@@ -57,7 +57,7 @@ public class JwtCredentialsTest extends Assert {
         JwtCredentialsImpl second = new JwtCredentialsImpl(first);
 
         assertNotEquals("JwtCredentialImpl", first, second);
-        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.accessToken", first.getAccessToken(), second.getAccessToken());
         assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
     }
 
@@ -78,7 +78,7 @@ public class JwtCredentialsTest extends Assert {
         JwtCredentialsImpl second = JwtCredentialsImpl.parse(first);
 
         assertEquals("JwtCredentialImpl", first, second);
-        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.accessToken", first.getAccessToken(), second.getAccessToken());
         assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
     }
 
@@ -89,31 +89,31 @@ public class JwtCredentialsTest extends Assert {
         JwtCredentialsImpl second = JwtCredentialsImpl.parse(first);
 
         assertNotEquals("JwtCredentialImpl", first, second);
-        assertEquals("JwtCredential.jwt", first.getJwt(), second.getJwt());
+        assertEquals("JwtCredential.accessToken", first.getAccessToken(), second.getAccessToken());
         assertEquals("JwtCredential.idToken", first.getIdToken(), second.getIdToken());
     }
 
 
     @Test
     public void jwtCredentialsImplTest() {
-        for (String jwt : jwts) {
+        for (String accessToken : accessTokens) {
             for (String idToken : idsToken) {
-                JwtCredentialsImpl jwtCredentialsImpl = new JwtCredentialsImpl(jwt, idToken);
-                assertEquals("Expected and actual values should be the same.", jwt, jwtCredentialsImpl.getJwt());
+                JwtCredentialsImpl jwtCredentialsImpl = new JwtCredentialsImpl(accessToken, idToken);
+                assertEquals("Expected and actual values should be the same.", accessToken, jwtCredentialsImpl.getAccessToken());
                 assertEquals("Expected and actual values should be the same.", idToken, jwtCredentialsImpl.getIdToken());
-                assertEquals("Expected and actual values should be the same.", jwt, jwtCredentialsImpl.getPrincipal());
-                assertEquals("Expected and actual values should be the same.", jwt, jwtCredentialsImpl.getCredentials());
+                assertEquals("Expected and actual values should be the same.", accessToken, jwtCredentialsImpl.getPrincipal());
+                assertEquals("Expected and actual values should be the same.", accessToken, jwtCredentialsImpl.getCredentials());
             }
         }
     }
 
     @Test
     public void setAndGetJwtPrincipalAndCredentialTest() {
-        for (String newJwt : newJwts) {
-            jwtCredentialsImpl.setJwt(newJwt);
-            assertEquals("Expected and actual values should be the same.", newJwt, jwtCredentialsImpl.getJwt());
-            assertEquals("Expected and actual values should be the same.", newJwt, jwtCredentialsImpl.getPrincipal());
-            assertEquals("Expected and actual values should be the same.", newJwt, jwtCredentialsImpl.getCredentials());
+        for (String newAccessToken : newAccessTokens) {
+            jwtCredentialsImpl.setAccessToken(newAccessToken);
+            assertEquals("Expected and actual values should be the same.", newAccessToken, jwtCredentialsImpl.getAccessToken());
+            assertEquals("Expected and actual values should be the same.", newAccessToken, jwtCredentialsImpl.getPrincipal());
+            assertEquals("Expected and actual values should be the same.", newAccessToken, jwtCredentialsImpl.getCredentials());
         }
     }
 
@@ -127,22 +127,22 @@ public class JwtCredentialsTest extends Assert {
 }
 
 class JwtCredentialsAnother implements JwtCredentials {
-    private String jwt;
+    private String accessToken;
     private String idToken;
 
-    public JwtCredentialsAnother(String jwt, String idToken) {
-        this.jwt = jwt;
+    public JwtCredentialsAnother(String accessToken, String idToken) {
+        this.accessToken = accessToken;
         this.idToken = idToken;
     }
 
     @Override
-    public String getJwt() {
-        return jwt;
+    public String getAccessToken() {
+        return accessToken;
     }
 
     @Override
-    public void setJwt(String jwt) {
-        this.jwt = jwt;
+    public void setAccessToken(String accessToken) {
+        this.accessToken = accessToken;
     }
 
     @Override

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcherTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/realm/JwtCredentialsMatcherTest.java
@@ -58,26 +58,26 @@ public class JwtCredentialsMatcherTest extends Assert {
 
     @Test
     public void doCredentialsMatchNullAuthenticationInfoNullJwtTest() {
-        Mockito.when(authenticationToken.getJwt()).thenReturn(null);
+        Mockito.when(authenticationToken.getIdToken()).thenReturn(null);
         assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, null));
     }
 
     @Test(expected = NullPointerException.class)
     public void doCredentialsMatchNullAuthenticationInfoTest() {
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, null);
     }
 
     @Test
     public void doCredentialsMatchNullJwtTest() {
-        Mockito.when(authenticationToken.getJwt()).thenReturn(null);
+        Mockito.when(authenticationToken.getIdToken()).thenReturn(null);
 
         assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
     }
 
     @Test
     public void doCredentialsMatchStringCredentialTest() {
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         Mockito.when(authenticationInfo.getCredentials()).thenReturn("credential");
 
         assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
@@ -85,7 +85,7 @@ public class JwtCredentialsMatcherTest extends Assert {
 
     @Test
     public void doCredentialsMatchDifferentKeysTest() {
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
         Mockito.when(credential.getCredentialKey()).thenReturn("credential key");
 
@@ -94,20 +94,20 @@ public class JwtCredentialsMatcherTest extends Assert {
 
     @Test
     public void doCredentialsMatchEqualKeysFalseTest() throws OpenIDException {
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
-        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
-        Mockito.when(jwtProcessor.validate("jwt")).thenReturn(false);
+        Mockito.when(credential.getCredentialKey()).thenReturn("idToken");
+        Mockito.when(jwtProcessor.validate("idToken")).thenReturn(false);
 
         assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
     }
 
     @Test
     public void doCredentialsMatchEqualKeysTrueTest() throws OpenIDException {
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
-        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
-        Mockito.when(jwtProcessor.validate("jwt")).thenReturn(true);
+        Mockito.when(credential.getCredentialKey()).thenReturn("idToken");
+        Mockito.when(jwtProcessor.validate("idToken")).thenReturn(true);
 
         assertTrue("True expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
     }
@@ -115,10 +115,10 @@ public class JwtCredentialsMatcherTest extends Assert {
     @Test
     public void doCredentialsMatchEqualKeysOpenIDExceptionTest() throws OpenIDException {
         JwtCredentialsMatcher jwtCredentialsMatcher = new JwtCredentialsMatcher(jwtProcessor);
-        Mockito.when(authenticationToken.getJwt()).thenReturn("jwt");
+        Mockito.when(authenticationToken.getIdToken()).thenReturn("idToken");
         Mockito.when(authenticationInfo.getCredentials()).thenReturn(credential);
-        Mockito.when(credential.getCredentialKey()).thenReturn("jwt");
-        Mockito.when(jwtProcessor.validate("jwt")).thenThrow(Mockito.mock(OpenIDException.class));
+        Mockito.when(credential.getCredentialKey()).thenReturn("idToken");
+        Mockito.when(jwtProcessor.validate("idToken")).thenThrow(Mockito.mock(OpenIDException.class));
 
         assertFalse("False expected.", jwtCredentialsMatcher.doCredentialsMatch(authenticationToken, authenticationInfo));
     }


### PR DESCRIPTION
This PR fixes the OIDC (OpenID Connect) authentication step by using the Id Token instead of the Access Token.

**Related Issue**
Fixes #3257

**Description of the solution adopted**
The OIDC Id Token is now used in place of the Access Token, because the claims that where extracted and/or checked in the Access Token are not always present in it (while they are present in the Id Token). The claims in the Access Token are not defined by the official OIDC specification, thus they change depending on the OIDC Provider. On the other hand, the Id Token claims are precisely defined in the spec.

Note that now the `idToken` is used in place of the `accessToken` in the JUnit tests when needed, and renames all the instances of `jwt` to `accessToken` (since `jwt` was ambiguous). Moreover, the JWT claim definition is moved to `JwtProcessor. This allows providing a custom claim name in a provider. 

This PR also adds OIDC env var to the `docker-compose.yml` file.

**Screenshots**
_n/a_

**Any side note on the changes made**
_n/a_