### PR TITLE
Expose AccountService.findChildrenRecursive on REST API

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
@@ -53,20 +53,26 @@ public class Accounts extends AbstractKapuaResource {
     /**
      * Gets the {@link Account} list in the scope.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param name    The {@link Account} name in which to search results.
-     * @param offset  The result set offset.
-     * @param limit   The result set limit.
-     * @return The {@link AccountListResult} of all the accounts associated to the current selected scope.
-     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @param scopeId       The {@link ScopeId} in which to search results.
+     * @param name          The {@link Account} name in which to search results.
+     * @param recursive     The {@link Account} name in which to search results.
+     * @param offset        The result set offset.
+     * @param limit         The result set limit.
+     * @return              The {@link AccountListResult} of all the accounts associated to the current selected scope.
+     * @throws              KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
      */
     @GET
     @Produces({MediaType.APPLICATION_JSON, MediaType.APPLICATION_XML})
     public AccountListResult simpleQuery(@PathParam("scopeId") ScopeId scopeId, //
                                          @QueryParam("name") String name, //
+                                         @QueryParam("recursive") boolean recursive, //
                                          @QueryParam("offset") @DefaultValue("0") int offset, //
                                          @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
+
+        if (recursive) {
+            return accountService.findChildrenRecursively(scopeId);
+        }
 
         AccountQuery query = accountFactory.newQuery(scopeId);
 

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
@@ -25,6 +25,13 @@ paths:
           description: An optional string to filter Accounts according to their name
           schema:
             type: string
+        - name: recursive
+          in: query
+          description: |
+            An optional flag to include all accounts that are directly or indirectly children of the current one.
+            Setting this to `true` and also using the `name` parameter will result in this last one beign ignored.
+          schema:
+            type: boolean
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -340,7 +340,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check Access
-        checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
+        checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read, true);
         return entityManagerSession.doAction(EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> {
             AccountListResult result = null;
             TypedQuery<Account> q;
@@ -429,19 +429,23 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         return super.getConfigValues(entity.getId());
     }
 
+    private void checkAccountPermission(KapuaId scopeId, KapuaId accountId, Domain domain, Actions action) throws KapuaException {
+        checkAccountPermission(scopeId, accountId, domain, action, false);
+    }
+
     /**
      * Checks if the current session can retrieve the {@link Account}, by both having an explicit permission or because
      * it's looking for its own {@link Account}
      *
      * @param accountId The {@link KapuaId} of the {@link Account} to look for
      */
-    private void checkAccountPermission(KapuaId scopeId, KapuaId accountId, Domain domain, Actions action) throws KapuaException {
+    private void checkAccountPermission(KapuaId scopeId, KapuaId accountId, Domain domain, Actions action, boolean forwardable) throws KapuaException {
         if (KapuaSecurityUtils.getSession().getScopeId().equals(accountId)) {
             // I'm looking for myself, so let's check if I have the correct permission
-            authorizationService.checkPermission(permissionFactory.newPermission(domain, action, accountId));
+            authorizationService.checkPermission(permissionFactory.newPermission(domain, action, accountId, null, forwardable));
         } else {
             // I'm looking for another account, so I need to check the permission on the account scope
-            authorizationService.checkPermission(permissionFactory.newPermission(domain, action, scopeId));
+            authorizationService.checkPermission(permissionFactory.newPermission(domain, action, scopeId, null, forwardable));
         }
     }
 }


### PR DESCRIPTION
Use `/{scopeId}/accounts?recursive=true` to retrieve all the Accounts down the hierarchy starting from the current one

**Related Issue**
No related issues
