### PR TITLE
Fixed Liquibase properties which where not compatible with MySQL

### DIFF
--- a/commons/src/main/resources/liquibase/common-properties.xml
+++ b/commons/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/0.2.0/account-configuration.xml
+++ b/service/account/internal/src/main/resources/liquibase/0.2.0/account-configuration.xml
@@ -12,13 +12,13 @@
         Eurotech - initial API and implementation
  -->
 <databaseChangeLog
-  xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
-  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-  xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
-  logicalFilePath="KapuaDB/changelog-account-0.2.0.xml">
+        logicalFilePath="KapuaDB/changelog-account-0.2.0.xml">
 
-    <include relativeToChangelogFile="true" file="../common-properties.xml" />
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
     <changeSet id="changelog-account-configuration-0.2.0_seed" author="eurotech">
         <insert tableName="sys_configuration">

--- a/service/account/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/account/internal/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,7 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
+
 </databaseChangeLog>

--- a/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/device/registry/internal/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>

--- a/service/security/shiro/src/main/resources/liquibase/common-properties.xml
+++ b/service/security/shiro/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>

--- a/service/tag/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/tag/internal/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/common-properties.xml
+++ b/service/user/internal/src/main/resources/liquibase/common-properties.xml
@@ -19,5 +19,6 @@
 
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="now()" dbms="postgresql"/>
-    <property name="now" value="current_timestamp(3)" dbms="mysql,mariadb,h2"/>
+    <property name="now" value="now(3)" dbms="mysql"/>
+    <property name="now" value="current_timestamp(3)" dbms="mariadb,h2"/>
 </databaseChangeLog>


### PR DESCRIPTION
This PR fixes Liquibase properties for MySQL which are currently not compatible 

**Related Issue**
_None_

**Description of the solution adopted**
For some reasons MySQL database was replacing the `CURRENT_TIMESTAMP(3)` invocation with `NOW()` which makes defintions like:

`created_on TIMESTAMP(3) DEFAULT NOW()`

result the following error:

> Caused by: liquibase.exception.DatabaseException: (conn=9) Invalid default value for 'created_on' [Failed SQL: (1067) CREATE TABLE kapuadb.athz_domain (scope_id BIGINT unsigned NULL, id BIGINT unsigned AUTO_INCREMENT NOT NULL, created_on timestamp(3) DEFAULT NOW() NOT NULL, created_by BIGINT unsigned NOT NULL, name VARCHAR(255) NOT NULL, serviceName VARCHAR(1023) NOT NULL, CONSTRAINT PK_ATHZ_DOMAIN PRIMARY KEY (id), UNIQUE (name))]

Replacing `CURRENT_TIMESTAMP(3)` with `NOW(3)` makes everything work as expected in MySQL.

**Screenshots**
_None_

**Any side note on the changes made**
Since H2 works fine with `NOW()`, `CURRENT_TIMESTAMP()` and `CURRENT_TIMESTAMP(3)` it has been left using `CURRENT_TIMESTAMP(3)`