### PR TITLE
Upgraded Jackson dependencies version from 2.10.1 to 2.12.2 - CVE-2020-25649 - CWE-611

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -61,7 +61,7 @@
         <h2.version>1.4.199</h2.version>
         <hk2-api.version>2.5.0-b05</hk2-api.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
-        <jackson.version>2.10.1</jackson.version>
+        <jackson.version>2.12.2</jackson.version>
         <javassist.version>3.19.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
         <javax-batch-api.version>1.0.1</javax-batch-api.version>

--- a/pom.xml
+++ b/pom.xml
@@ -18,8 +18,8 @@
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua</artifactId>
     <version>1.5.0-SNAPSHOT</version>
-    <name>kapua</name>
 
+    <name>kapua</name>
     <packaging>pom</packaging>
 
     <properties>
@@ -1753,6 +1753,8 @@
                 <artifactId>jersey-guava</artifactId>
                 <version>${jersey.version}</version>
             </dependency>
+
+            <!-- -->
             <!-- Jackson -->
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
@@ -1767,6 +1769,21 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-dataformat-cbor</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-dataformat-smile</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.core</groupId>
+                <artifactId>jackson-dataformat-yaml</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR bumps the versions of Jackson dependencies to 2.12.2

Dependencies:


- Jackson Annotations
- Jackson Core
- Jackson Databind
- Jackson Jaxrs Base
- Jackson Jaxrs Json Provider
- Jackson Module Jaxb Annotations

After looking at the `mvn dependency:tree` I discovered that we have other jackson dependencies imported by Elasticsearch which are on version `2.8.11`.

- Jackson Dataformat Cbor
- Jackson Dataformat Smile
- Jackson Dataformat Yaml

to avoid conflict or issues with running with different version, i've aligned them all to 2.12.2.

**Related Issue**
_None_

**Description of the solution adopted**
Bumped to the last version available. 
On each version we can piggy back on existing CQs for version 2.12.1

- Jackson Annotations: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22965
- Jackson Core: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22966
- Jackson Databind: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22967
- Jackson Jaxrs Base: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23003
- Jackson Jaxrs Json Provider: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23005
- Jackson Module Jaxb Annotations: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23006
- Jackson Dataformat Cbor: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22968

Following dependencies CQ have been filed.
- Jackson Dataformat Smile: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23166
- Jackson Dataformat Yaml: https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23167


**Screenshots**
_None_

**Any side note on the changes made**
_None_