### PR TITLE
Bumped version of Snake Yaml from 1.15 to 1.28 - CVE-2017-18640 - CWE-189

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,7 +96,7 @@
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.5.3</shiro.version>
         <slf4j.version>1.7.30</slf4j.version>
-        <snakeyaml.version>1.15</snakeyaml.version>
+        <snakeyaml.version>1.28</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring-security.version>4.1.3.RELEASE</spring-security.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>


### PR DESCRIPTION
This PR bumps the version of Snake YAML from 1.15 to 1.28.

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version.

CQ filed: [23168](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23168)

**Screenshots**
_None_

**Any side note on the changes made**
_None_