### PR TITLE
Bumped version of guava from 27.1-jre to 30.1-jre - CVE-2020-8908 - CWE-200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -54,7 +54,7 @@
         <findbugs.version>2.0.1</findbugs.version>
         <googleauth.version>1.5.0</googleauth.version>
         <gson.version>2.7</gson.version>
-        <guava.version>27.1-jre</guava.version>
+        <guava.version>30.1-jre</guava.version>
         <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
         <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>
         <guice.version>4.1.0</guice.version>
@@ -1220,10 +1220,6 @@
                     <exclusion>
                         <groupId>org.checkerframework</groupId>
                         <artifactId>checker-qual</artifactId>
-                    </exclusion>
-                    <exclusion>
-                        <groupId>org.codehaus.mojo</groupId>
-                        <artifactId>animal-sniffer-annotations</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
This PR bumps the version of Google Guava from 27.1-jre to 30.1-jre.

**Related Issue**
_None_

**Description of the solution adopted**
Just changed the version and removed `org.codehaus.mojo:animal-sniffer-annotations` from the exclusions since 30.1-jre no longer depends on that dependency: https://mvnrepository.com/artifact/com.google.guava/guava/30.1-jre

CQ on which we can piggyback: [23002](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23002)

**Screenshots**
_None_

**Any side note on the changes made**
_None_