### PR TITLE
Bumped version of commons-codec from 1.9 to 1.15 - CWE-200

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,7 +36,7 @@
         <camel.version>2.16.3</camel.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
-        <commons-codec.version>1.9</commons-codec.version>
+        <commons-codec.version>1.15</commons-codec.version>
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-fileupload.versison>1.4</commons-fileupload.versison>


### PR DESCRIPTION
This PR bumps the version of `commons-codec` tfrom 1.9 to 1.15

**Related Issue**
_None_

**Description of the solution adopted**

CQ on which we can piggy-back: [22641](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=22641)

**Screenshots**
_None_

**Any side note on the changes made**
_None_