### PR TITLE
Dynamic CORS Filter

### DIFF
--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -49,6 +49,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-console-module-device</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-console-module-endpoint</artifactId>
+        </dependency>
 
         <!-- Internal dependencies -->
         <dependency>

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabCors.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsTabCors.java
@@ -1,0 +1,45 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client;
+
+import org.eclipse.kapua.app.console.module.account.client.cors.CorsView;
+import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.IconSet;
+import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon;
+import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+
+import com.google.gwt.user.client.Element;
+
+public class AccountDetailsTabCors extends KapuaTabItem<GwtAccount> {
+
+    private final AccountDetailsView accountDetailsView;
+
+    public AccountDetailsTabCors(GwtSession currentSession, AccountDetailsView accountDetailsView) {
+        super(currentSession, "CORS", new KapuaIcon(IconSet.EXTERNAL_LINK));
+        this.accountDetailsView = accountDetailsView;
+    }
+
+    @Override
+    protected void doRefresh() {
+
+    }
+
+    @Override
+    protected void onRender(Element parent, int index) {
+        super.onRender(parent, index);
+        CorsView corsView = new CorsView(currentSession);
+        add(corsView);
+    }
+
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/AccountDetailsView.java
@@ -23,11 +23,13 @@ import com.extjs.gxt.ui.client.widget.layout.BorderLayoutData;
 import com.extjs.gxt.ui.client.widget.layout.FitLayout;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.Element;
+
 import org.eclipse.kapua.app.console.module.account.client.messages.ConsoleAccountMessages;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.api.client.ui.tab.KapuaTabItem;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractView;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.permission.EndpointSessionPermission;
 
 public class AccountDetailsView extends AbstractView {
 
@@ -79,8 +81,14 @@ public class AccountDetailsView extends AbstractView {
         AccountDetailsTabDescription accountDescriptionTab = new AccountDetailsTabDescription(currentSession);
         settingsTabItem.setDescriptionTab(accountDescriptionTab);
         accountDescriptionTab.setEntity(selectedAccount);
+
         tabPanel.add(accountDescriptionTab);
         tabPanel.add(settingsTabItem);
+        if (currentSession.hasPermission(EndpointSessionPermission.read())) {
+            AccountDetailsTabCors accountDetailsTabCors = new AccountDetailsTabCors(currentSession, this);
+            accountDetailsTabCors.setEntity(selectedAccount);
+            tabPanel.add(accountDetailsTabCors);
+        }
         bodyLayoutContainer.add(tabPanel, northData);
 
         add(bodyLayoutContainer);

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsAddDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsAddDialog.java
@@ -1,0 +1,122 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client.cors;
+
+import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
+import org.eclipse.kapua.app.console.module.api.client.messages.ValidationMessages;
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointModel;
+import org.eclipse.kapua.app.console.module.endpoint.client.messages.ConsoleEndpointMessages;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpointCreator;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointService;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointServiceAsync;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public class CorsAddDialog extends EntityAddEditDialog {
+
+    private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+    protected static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
+    protected static final ConsoleMessages CMSGS = GWT.create(ConsoleMessages.class);
+    protected static final ValidationMessages VAL_MSGS = GWT.create(ValidationMessages.class);
+
+    protected KapuaTextField<String> corsOriginField;
+
+    public CorsAddDialog(GwtSession currentSession) {
+        super(currentSession);
+        DialogUtils.resizeDialog(this, 400, 150);
+    }
+
+    @Override
+    public void createBody() {
+        submitButton.disable();
+        FormPanel endpointFormPanel = new FormPanel(FORM_LABEL_WIDTH);
+
+        corsOriginField = new KapuaTextField<String>();
+        corsOriginField.setAllowBlank(false);
+        corsOriginField.setFieldLabel("* " + MSGS.corsDialogAddFieldOrigin());
+        corsOriginField.setToolTip(MSGS.corsDialogAddFieldOriginTooltip());
+        corsOriginField.setMaxLength(64);
+        endpointFormPanel.add(corsOriginField);
+
+        bodyPanel.add(endpointFormPanel);
+    }
+
+    @Override
+    public void submit() {
+        GwtEndpointCreator gwtEndpointCreator = new GwtEndpointCreator();
+        gwtEndpointCreator.setScopeId(currentSession.getSelectedAccountId());
+
+        GWT_ENDPOINT_SERVICE.parseEndpointModel(gwtEndpointCreator, corsOriginField.getValue(), new AsyncCallback<EndpointModel>() {
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                exitStatus = false;
+                status.hide();
+                formPanel.getButtonBar().enable();
+                unmask();
+                submitButton.enable();
+                cancelButton.enable();
+                ConsoleInfo.display(CMSGS.error(), MSGS.corsDialogUnableToParse());
+                corsOriginField.markInvalid(MSGS.corsDialogUnableToParse());
+            }
+
+            @Override
+            public void onSuccess(EndpointModel gwtEndpointCreator) {
+                GWT_ENDPOINT_SERVICE.create((GwtEndpointCreator) gwtEndpointCreator, new AsyncCallback<GwtEndpoint>() {
+
+                    @Override
+                    public void onSuccess(GwtEndpoint gwtEndpoint) {
+                        exitStatus = true;
+                        exitMessage = MSGS.corsDialogAddConfirmation();
+                        hide();
+                    }
+
+                    @Override
+                    public void onFailure(Throwable cause) {
+                        exitStatus = false;
+                        status.hide();
+                        formPanel.getButtonBar().enable();
+                        unmask();
+                        submitButton.enable();
+                        cancelButton.enable();
+                        if (!isPermissionErrorMessage(cause)) {
+                            FailureHandler.handleFormException(formPanel, cause);
+                            corsOriginField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                        }
+                    }
+                });
+
+            }
+        });
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return MSGS.corsDialogAddHeader();
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return MSGS.corsDialogAddInfo();
+    }
+
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsDeleteDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsDeleteDialog.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client.cors;
+
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityDeleteDialog;
+import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.endpoint.client.messages.ConsoleEndpointMessages;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointService;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointServiceAsync;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public class CorsDeleteDialog extends EntityDeleteDialog {
+
+    private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
+
+    private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+
+    private GwtEndpoint gwtEndpoint;
+
+    public CorsDeleteDialog(GwtEndpoint gwtEndpoint) {
+        this.gwtEndpoint = gwtEndpoint;
+        DialogUtils.resizeDialog(this, 300, 135);
+        setDisabledFormPanelEvents(true);
+    }
+
+    @Override
+    public void submit() {
+        GWT_ENDPOINT_SERVICE.delete(gwtEndpoint.getScopeId(), gwtEndpoint.getId(), new AsyncCallback<Void>() {
+
+            @Override
+            public void onFailure(Throwable cause) {
+                exitStatus = false;
+                if (!isPermissionErrorMessage(cause)) {
+                    FailureHandler.handle(cause);
+                    exitMessage = MSGS.dialogDeleteError(cause.getLocalizedMessage());
+                }
+                hide();
+
+            }
+
+            @Override
+            public void onSuccess(Void arg0) {
+                exitStatus = true;
+                exitMessage = MSGS.dialogDeleteConfirmation();
+                hide();
+            }
+        });
+
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return MSGS.dialogDeleteHeader(gwtEndpoint.toString());
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return MSGS.dialogDeleteInfo();
+    }
+
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsEditDialog.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsEditDialog.java
@@ -1,0 +1,104 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client.cors;
+
+import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
+import org.eclipse.kapua.app.console.module.api.client.util.FailureHandler;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointModel;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointService;
+import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointServiceAsync;
+
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
+
+public class CorsEditDialog extends CorsAddDialog {
+
+    private static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
+    private final GwtEndpoint selectedEndpoint;
+
+    public CorsEditDialog(GwtSession currentSession, GwtEndpoint selectedEndpoint) {
+        super(currentSession);
+        this.selectedEndpoint = selectedEndpoint;
+    }
+
+    @Override
+    public void createBody() {
+
+        super.createBody();
+        populateEditDialog(selectedEndpoint);
+    }
+
+    @Override
+    public void submit() {
+        GWT_ENDPOINT_SERVICE.parseEndpointModel(selectedEndpoint, corsOriginField.getValue(), new AsyncCallback<EndpointModel>() {
+
+            @Override
+            public void onFailure(Throwable throwable) {
+                exitStatus = false;
+                status.hide();
+                formPanel.getButtonBar().enable();
+                unmask();
+                submitButton.enable();
+                cancelButton.enable();
+                ConsoleInfo.display(CMSGS.error(), MSGS.corsDialogUnableToParse());
+                corsOriginField.markInvalid(MSGS.corsDialogUnableToParse());
+            }
+
+            @Override
+            public void onSuccess(EndpointModel gwtEndpoint) {
+
+                GWT_ENDPOINT_SERVICE.update((GwtEndpoint) gwtEndpoint, new AsyncCallback<GwtEndpoint>() {
+
+                    @Override
+                    public void onFailure(Throwable cause) {
+                        exitStatus = false;
+                        status.hide();
+                        formPanel.getButtonBar().enable();
+                        unmask();
+                        submitButton.enable();
+                        cancelButton.enable();
+                        if (!isPermissionErrorMessage(cause)) {
+                            FailureHandler.handleFormException(formPanel, cause);
+                            corsOriginField.markInvalid(VAL_MSGS.DUPLICATE_NAME());
+                        }
+
+                    }
+
+                    @Override
+                    public void onSuccess(GwtEndpoint arg0) {
+                        exitStatus = true;
+                        exitMessage = MSGS.corsDialogEditConfirmation();
+                        hide();
+                    }
+                });
+            }
+        });
+    }
+
+    @Override
+    public String getHeaderMessage() {
+        return MSGS.corsDialogEditHeader(selectedEndpoint.toString());
+    }
+
+    @Override
+    public String getInfoMessage() {
+        return MSGS.corsDialogEditInfo();
+    }
+
+    private void populateEditDialog(GwtEndpoint gwtEndpoint) {
+        corsOriginField.setValue(gwtEndpoint.toString());
+    }
+
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsGrid.java
@@ -10,19 +10,14 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.console.module.endpoint.client;
+package org.eclipse.kapua.app.console.module.account.client.cors;
 
-import com.extjs.gxt.ui.client.data.PagingLoadConfig;
-import com.extjs.gxt.ui.client.data.PagingLoadResult;
-import com.extjs.gxt.ui.client.data.RpcProxy;
-import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
-import com.google.gwt.core.client.GWT;
-import com.google.gwt.user.client.rpc.AsyncCallback;
+import java.util.ArrayList;
+import java.util.List;
 
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.CreatedByNameCellRenderer;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
-import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaPagingToolbarMessages;
 import org.eclipse.kapua.app.console.module.api.shared.model.query.GwtQuery;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
@@ -33,10 +28,14 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointS
 import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointServiceAsync;
 import org.eclipse.kapua.service.endpoint.EndpointInfo;
 
-import java.util.ArrayList;
-import java.util.List;
+import com.extjs.gxt.ui.client.data.PagingLoadConfig;
+import com.extjs.gxt.ui.client.data.PagingLoadResult;
+import com.extjs.gxt.ui.client.data.RpcProxy;
+import com.extjs.gxt.ui.client.widget.grid.ColumnConfig;
+import com.google.gwt.core.client.GWT;
+import com.google.gwt.user.client.rpc.AsyncCallback;
 
-public class EndpointGrid extends EntityGrid<GwtEndpoint> {
+public class CorsGrid extends EntityGrid<GwtEndpoint> {
 
     private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
     private static final ConsoleMessages C_MSGS = GWT.create(ConsoleMessages.class);
@@ -44,9 +43,12 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
 
     protected static final GwtEndpointServiceAsync GWT_ENDPOINT_SERVICE = GWT.create(GwtEndpointService.class);
     protected GwtEndpointQuery query;
+    private CorsToolbarGrid toolbar;
 
-    protected EndpointGrid(AbstractEntityView<GwtEndpoint> entityView, GwtSession currentSession) {
-        super(entityView, currentSession);
+    protected CorsGrid(GwtSession currentSession, CorsView corsView) {
+        super(corsView, currentSession);
+        java.util.logging.Logger logger = java.util.logging.Logger.getLogger("CorsGrid");
+        logger.log(java.util.logging.Level.INFO, corsView.getClass().getName());
         query = new GwtEndpointQuery();
         query.setScopeId(currentSession.getSelectedAccountId());
     }
@@ -79,7 +81,7 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
             @Override
             protected void load(Object loadConfig,
                     AsyncCallback<PagingLoadResult<GwtEndpoint>> callback) {
-                GWT_ENDPOINT_SERVICE.query((PagingLoadConfig) loadConfig, query, EndpointInfo.ENDPOINT_TYPE_RESOURCE, callback);
+                GWT_ENDPOINT_SERVICE.query((PagingLoadConfig) loadConfig, query, EndpointInfo.ENDPOINT_TYPE_CORS, callback);
 
             }
         };
@@ -128,8 +130,11 @@ public class EndpointGrid extends EntityGrid<GwtEndpoint> {
     }
 
     @Override
-    protected EndpointToolbarGrid getToolbar() {
-        return new EndpointToolbarGrid(currentSession);
+    protected CorsToolbarGrid getToolbar() {
+        if (toolbar == null) {
+            toolbar = new CorsToolbarGrid(currentSession);
+        }
+        return toolbar;
     }
 
 }

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsTabDescriptionDescriptor.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsTabDescriptionDescriptor.java
@@ -1,0 +1,42 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client.cors;
+
+import org.eclipse.kapua.app.console.module.api.client.ui.view.descriptor.AbstractEntityTabDescriptor;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointTabDescription;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.permission.EndpointSessionPermission;
+
+public class CorsTabDescriptionDescriptor extends AbstractEntityTabDescriptor<GwtEndpoint, EndpointTabDescription, CorsView> {
+
+    @Override
+    public EndpointTabDescription getTabViewInstance(CorsView view, GwtSession currentSession) {
+        return new EndpointTabDescription(currentSession);
+    }
+
+    @Override
+    public String getViewId() {
+        return "cors.description";
+    }
+
+    @Override
+    public Integer getOrder() {
+        return 100;
+    }
+
+    @Override
+    public Boolean isEnabled(GwtSession currentSession) {
+        return currentSession.hasPermission(EndpointSessionPermission.read());
+    }
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsToolbarGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsToolbarGrid.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.account.client.cors;
+
+import org.eclipse.kapua.app.console.module.api.client.ui.dialog.KapuaDialog;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.EntityCRUDToolbar;
+import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
+import org.eclipse.kapua.app.console.module.endpoint.shared.model.permission.EndpointSessionPermission;
+
+public class CorsToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
+
+    public CorsToolbarGrid(GwtSession currentSession) {
+        super(currentSession);
+    }
+
+    public CorsToolbarGrid(GwtSession currentSession, boolean slaveEntity) {
+        super(currentSession, slaveEntity);
+    }
+
+    @Override
+    protected KapuaDialog getAddDialog() {
+        return new CorsAddDialog(currentSession);
+    }
+
+    @Override
+    protected KapuaDialog getEditDialog() {
+        GwtEndpoint selectedEndpoint = gridSelectionModel.getSelectedItem();
+        CorsEditDialog dialog = null;
+        if (selectedEndpoint != null) {
+            dialog = new CorsEditDialog(currentSession, selectedEndpoint);
+        }
+        return dialog;
+    }
+
+    @Override
+    protected KapuaDialog getDeleteDialog() {
+        GwtEndpoint selectedEndpoint = gridSelectionModel.getSelectedItem();
+        CorsDeleteDialog dialog = null;
+        if (selectedEndpoint != null) {
+            dialog = new CorsDeleteDialog(selectedEndpoint);
+        }
+        return dialog;
+    }
+
+    @Override
+    protected void updateButtonEnablement() {
+        super.updateButtonEnablement();
+
+        //
+        // Force disabled if entity is inherited from parent scopes
+        addEntityButton.setEnabled(currentSession.hasPermission(EndpointSessionPermission.writeAll()));
+
+        editEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.writeAll()));
+        deleteEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.deleteAll()));
+    }
+}

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsView.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsView.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2018, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,43 +10,35 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.console.module.endpoint.client;
+package org.eclipse.kapua.app.console.module.account.client.cors;
 
-import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.api.client.ui.grid.EntityGrid;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.EntityFilterPanel;
 import org.eclipse.kapua.app.console.module.api.client.ui.view.AbstractEntityView;
+import org.eclipse.kapua.app.console.module.api.client.ui.view.EntityView;
 import org.eclipse.kapua.app.console.module.api.shared.model.session.GwtSession;
 import org.eclipse.kapua.app.console.module.endpoint.client.messages.ConsoleEndpointMessages;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
 
-public class EndpointView extends AbstractEntityView<GwtEndpoint> {
+import com.google.gwt.core.client.GWT;
 
-    private EndpointGrid endpointGrid;
+public class CorsView extends AbstractEntityView<GwtEndpoint> implements EntityView<GwtEndpoint> {
 
     private static final ConsoleEndpointMessages MSGS = GWT.create(ConsoleEndpointMessages.class);
 
-    public EndpointView(GwtSession gwtSession) {
-        super(gwtSession);
-    }
-
-    public static String getName() {
-        return MSGS.endpoints();
+    public CorsView(GwtSession currentSession) {
+        super();
+        this.currentSession = currentSession;
     }
 
     @Override
-    public EntityGrid<GwtEndpoint> getEntityGrid(AbstractEntityView<GwtEndpoint> entityView,
-            GwtSession currentSession) {
-        if (endpointGrid == null) {
-            endpointGrid = new EndpointGrid(entityView, currentSession);
-        }
-        return endpointGrid;
+    public EntityGrid<GwtEndpoint> getEntityGrid(AbstractEntityView<GwtEndpoint> entityView, GwtSession currentSession) {
+        return new CorsGrid(currentSession, this);
     }
 
     @Override
-    public EntityFilterPanel<GwtEndpoint> getEntityFilterPanel(AbstractEntityView<GwtEndpoint> entityView,
-            GwtSession currentSession) {
-        return new EndpointFilterPanel(this, currentSession);
+    public EntityFilterPanel<GwtEndpoint> getEntityFilterPanel(AbstractEntityView<GwtEndpoint> entityView, GwtSession currentSession2) {
+        return null;
     }
 
 }

--- a/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
+++ b/console/module/account/src/main/resources/org/eclipse/kapua/app/console/module/account/adminModuleAccount.gwt.xml
@@ -20,6 +20,7 @@
     <inherits name="org.eclipse.kapua.app.console.module.user.adminModuleUser"/>
     <inherits name="org.eclipse.kapua.app.console.module.data.adminModuleData"/>
     <inherits name="org.eclipse.kapua.app.console.module.device.adminModuleDevice"/>
+    <inherits name="org.eclipse.kapua.app.console.module.endpoint.adminModuleEndpoint"/>
 
     <!-- Specify the paths for translatable code                        -->
     <source path='shared'/>

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/grid/EntityGrid.java
@@ -67,7 +67,6 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
     protected SelectionMode selectionMode = SelectionMode.SINGLE;
     protected boolean keepSelectedItemsAfterLoad = true;
     protected boolean entityGridConfigured;
-    private EntityGridLoadListener<M> entityGridLoadListener;
     protected boolean selectedAgain;
     protected M selectedItem;
     private boolean deselectable;
@@ -206,7 +205,7 @@ public abstract class EntityGrid<M extends GwtEntityModel> extends ContentPanel 
 
         //
         // Grid Data Load Listener
-        entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore, EntityFilterPanel.getSearchButton(), EntityFilterPanel.getResetButton());
+        EntityGridLoadListener<M> entityGridLoadListener = new EntityGridLoadListener<M>(this, entityStore, EntityFilterPanel.getSearchButton(), EntityFilterPanel.getResetButton());
         entityGridLoadListener.setKeepSelectedOnLoad(keepSelectedItemsAfterLoad);
 
         entityLoader.addLoadListener(entityGridLoadListener);

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractEntityView.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/view/AbstractEntityView.java
@@ -37,15 +37,6 @@ import java.util.List;
 
 public abstract class AbstractEntityView<M extends GwtEntityModel> extends AbstractView implements EntityView<M> {
 
-    @Override
-    public void onUserChange() {
-        if (entityGrid != null) {
-            entityGrid.getFilterQuery().setScopeId(currentSession.getSelectedAccountId());
-            entityGrid.refresh();
-        }
-    }
-
-
     private EntityGrid<M> entityGrid;
     private KapuaTabPanel<M> tabsPanel;
 
@@ -62,6 +53,14 @@ public abstract class AbstractEntityView<M extends GwtEntityModel> extends Abstr
 
     public void setSelectedEntity(M entity) {
         tabsPanel.setEntity(entity);
+    }
+
+    @Override
+    public void onUserChange() {
+        if (entityGrid != null) {
+            entityGrid.getFilterQuery().setScopeId(currentSession.getSelectedAccountId());
+            entityGrid.refresh();
+        }
     }
 
     @Override
@@ -104,7 +103,6 @@ public abstract class AbstractEntityView<M extends GwtEntityModel> extends Abstr
             @Override
             public void onSuccess(List<TabDescriptor> result) {
                 tabsPanel = new KapuaTabPanel<M>();
-
                 for (TabDescriptor tabDescriptor : result) {
                     if (tabDescriptor.isEnabled(currentSession)) {
                         tabsPanel.add(tabDescriptor.getTabViewInstance(AbstractEntityView.this, currentSession));

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtConsoleServiceImpl.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/server/GwtConsoleServiceImpl.java
@@ -63,7 +63,7 @@ public class GwtConsoleServiceImpl extends KapuaRemoteServiceServlet implements 
         for (MainViewDescriptor descriptorClass : MAIN_VIEW_DESCRIPTOR_CLASSES) {
             for (int i = 0; i < MAIN_VIEW_DESCRIPTORS.size(); i++) {
                 JsonObject descriptor = MAIN_VIEW_DESCRIPTORS.getJsonObject(i);
-                if (descriptor.getString("descriptor").equals(descriptorClass.getClass().getName())) {
+                if (descriptor.containsKey("descriptor") && descriptorClass.getClass().getName().equals(descriptor.getString("descriptor"))) {
                     views.add(descriptorClass);
                     break;
                 }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointAddDialog.java
@@ -29,6 +29,7 @@ import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpointCre
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.validation.GwtEndpointValidationRegex;
 import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointService;
 import org.eclipse.kapua.app.console.module.endpoint.shared.service.GwtEndpointServiceAsync;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
 
 import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
@@ -128,6 +129,7 @@ public class EndpointAddDialog extends EntityAddEditDialog {
         gwtEndpointCreator.setDns(endpointDnsField.getValue());
         gwtEndpointCreator.setPort(endpointPortField.getValue());
         gwtEndpointCreator.setSecure(endpointSecureCheckboxGroup.getValue() != null);
+        gwtEndpointCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
 
         GWT_ENDPOINT_SERVICE.create(gwtEndpointCreator, new AsyncCallback<GwtEndpoint>() {
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointModel.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/client/EndpointModel.java
@@ -1,0 +1,39 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.endpoint.client;
+
+import java.io.Serializable;
+
+public interface EndpointModel extends Serializable {
+
+    String getSchema();
+
+    void setSchema(String schema);
+
+    String getDns();
+
+    void setDns(String dns);
+
+    Number getPort();
+
+    void setPort(Number port);
+
+    boolean getSecure();
+
+    void setSecure(boolean secure);
+
+    String getEndpointType();
+
+    void setEndpointType(String endpointType);
+
+}

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpoint.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpoint.java
@@ -13,10 +13,11 @@
 package org.eclipse.kapua.app.console.module.endpoint.shared.model;
 
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtUpdatableEntityModel;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointModel;
 
 import com.google.gwt.user.client.rpc.IsSerializable;
 
-public class GwtEndpoint extends GwtUpdatableEntityModel {
+public class GwtEndpoint extends GwtUpdatableEntityModel implements EndpointModel {
 
     public enum GwtEndpointSecure implements IsSerializable {
         ANY, TRUE, FALSE;
@@ -35,40 +36,58 @@ public class GwtEndpoint extends GwtUpdatableEntityModel {
         }
     }
 
+    @Override
     public String getSchema() {
         return get("schema");
     }
 
+    @Override
     public void setSchema(String schema) {
         set("schema", schema);
     }
 
+    @Override
     public String getDns() {
         return get("dns");
     }
 
+    @Override
     public void setDns(String dns) {
         set("dns", dns);
     }
 
+    @Override
     public Number getPort() {
         return get("port");
     }
 
+    @Override
     public void setPort(Number port) {
         set("port", port);
     }
 
+    @Override
     public boolean getSecure() {
         return get("secure");
     }
 
+    @Override
     public void setSecure(boolean secure) {
         set("secure", secure);
     }
 
     public GwtEndpointSecure gwtEndpointSecureEnum() {
         return (GwtEndpointSecure) get("secureEnum");
+    }
+
+    @Override
+    public String getEndpointType() {
+        return get("endpointType");
+    }
+
+    @Override
+    public void setEndpointType(String endpointType) {
+        set("endpointType", endpointType);
     }
 
     @Override

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointCreator.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/GwtEndpointCreator.java
@@ -13,47 +13,68 @@
 package org.eclipse.kapua.app.console.module.endpoint.shared.model;
 
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtEntityCreator;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointModel;
 
-public class GwtEndpointCreator extends GwtEntityCreator {
+public class GwtEndpointCreator extends GwtEntityCreator implements EndpointModel {
 
     private String schema;
     private String dns;
     private Number port;
     private boolean secure;
+    private String endpointType;
 
     public GwtEndpointCreator() {
         super();
     }
 
+    @Override
     public String getSchema() {
         return schema;
     }
 
+    @Override
     public void setSchema(String schema) {
         this.schema = schema;
     }
 
+    @Override
     public String getDns() {
         return dns;
     }
 
+    @Override
     public void setDns(String dns) {
         this.dns = dns;
     }
 
+    @Override
     public Number getPort() {
         return port;
     }
 
+    @Override
     public void setPort(Number port) {
         this.port = port;
     }
 
+    @Override
     public boolean getSecure() {
         return secure;
     }
 
+    @Override
     public void setSecure(boolean secure) {
         this.secure = secure;
     }
+
+    @Override
+    public String getEndpointType() {
+        return endpointType;
+    }
+
+    @Override
+    public void setEndpointType(String endpointType) {
+        this.endpointType = endpointType;
+    }
+
 }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/validation/GwtEndpointValidationRegex.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/model/validation/GwtEndpointValidationRegex.java
@@ -30,7 +30,9 @@ public enum GwtEndpointValidationRegex implements GwtValidationRegex, IsSerializ
     /**
      * ^[a-zA-Z][a-zA-Z0-9\-\.\+]{0,}$
      */
-    URI_PORT("^[0-9]{1,5}$");
+    URI_PORT("^[0-9]{1,5}$"),
+
+    URI_ORIGIN("^(https?)://([A-Za-z0-9\\-\\.]+)(:(\\d{1-5}))?$");
 
     private String regex;
 

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/service/GwtEndpointService.java
@@ -19,6 +19,7 @@ import com.google.gwt.user.client.rpc.RemoteService;
 import com.google.gwt.user.client.rpc.RemoteServiceRelativePath;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.shared.model.GwtGroupedNVPair;
+import org.eclipse.kapua.app.console.module.endpoint.client.EndpointModel;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpoint;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpointCreator;
 import org.eclipse.kapua.app.console.module.endpoint.shared.model.GwtEndpointQuery;
@@ -28,18 +29,20 @@ import java.util.List;
 @RemoteServiceRelativePath("endpoint")
 public interface GwtEndpointService extends RemoteService {
 
-    public GwtEndpoint create(GwtEndpointCreator gwtEndpointCreator) throws GwtKapuaException;
+    GwtEndpoint create(GwtEndpointCreator gwtEndpointCreator) throws GwtKapuaException;
 
-    public GwtEndpoint update(GwtEndpoint gwtEndpoint) throws GwtKapuaException;
+    GwtEndpoint update(GwtEndpoint gwtEndpoint) throws GwtKapuaException;
 
-    public GwtEndpoint find(String scopeShortId, String roleShortId) throws GwtKapuaException;
+    GwtEndpoint find(String scopeShortId, String roleShortId) throws GwtKapuaException;
 
-    public PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, GwtEndpointQuery gwtEndpointQuery) throws GwtKapuaException;
+    PagingLoadResult<GwtEndpoint> query(PagingLoadConfig loadConfig, GwtEndpointQuery gwtEndpointQuery, String section) throws GwtKapuaException;
 
-    public void delete(String scopeId, String endpointId) throws GwtKapuaException;
+    void delete(String scopeId, String endpointId) throws GwtKapuaException;
 
-    public ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String endpointShortId) throws GwtKapuaException;
+    ListLoadResult<GwtGroupedNVPair> getEndpointDescription(String scopeShortId, String endpointShortId) throws GwtKapuaException;
 
-    public List<GwtEndpoint> findAll(String scopeId) throws GwtKapuaException;
+    List<GwtEndpoint> findAll(String scopeId) throws GwtKapuaException;
+
+    public EndpointModel parseEndpointModel(EndpointModel endpointModel, String origin) throws GwtKapuaException;
 
 }

--- a/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/KapuaGwtEndpointModelConverter.java
+++ b/console/module/endpoint/src/main/java/org/eclipse/kapua/app/console/module/endpoint/shared/util/KapuaGwtEndpointModelConverter.java
@@ -41,6 +41,7 @@ public class KapuaGwtEndpointModelConverter {
         gwtEndpoint.setDns(endpoint.getDns());
         gwtEndpoint.setPort(endpoint.getPort());
         gwtEndpoint.setSecure(endpoint.getSecure());
+        gwtEndpoint.setEndpointType(endpoint.getEndpointType());
 
         return gwtEndpoint;
     }

--- a/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/client/messages/ConsoleEndpointMessages.properties
+++ b/console/module/endpoint/src/main/resources/org/eclipse/kapua/app/console/module/endpoint/client/messages/ConsoleEndpointMessages.properties
@@ -26,7 +26,7 @@ gridEndpointColumnHeaderCreatedOn=Created On
 #
 # Add dialog
 dialogAddHeader=New Endpoint
-dialogAddInfo=Create a new endpoint. 
+dialogAddInfo=Create a new endpoint.
 dialogAddConfirmation=Endpoint successfully created.
 dialogAddError=Endpoint creation failed: {0}
 dialogAddFieldSchema=Schema
@@ -61,3 +61,18 @@ filterFieldEndpointSchemaLabel=Schema
 filterFieldEndpointDnsLabel=Domain name
 filterFieldEndpointPortLabel=Port
 filterFieldEndpointSecureLabel=Secure
+
+#
+# CORS
+corsDialogAddHeader=New CORS Origin
+corsDialogAddInfo=Create a new CORS Origin.
+corsDialogAddConfirmation=CORS Origin successfully created.
+corsDialogAddError=CORS Origin creation failed: {0}
+corsDialogUnableToParse=Unable to parse CORS Origin
+corsDialogAddFieldOrigin=CORS Origin
+corsDialogAddFieldOriginTooltip=The CORS Origin complete with protocol and port
+corsDialogEditHeader=Edit CORS Origin: {0}
+corsDialogEditInfo=Edit CORS Origin''s data.
+corsDialogEditLoadFailed=Cannot load CORS Origin: {0}
+corsDialogEditConfirmation=CORS Origin successfully updated.
+corsDialogEditError=CORS Origin edit failed: {0}

--- a/console/web/src/main/resources/org/eclipse/kapua/app/console/view-descriptors.json
+++ b/console/web/src/main/resources/org/eclipse/kapua/app/console/view-descriptors.json
@@ -16,6 +16,12 @@
     "view": "org.eclipse.kapua.app.console.module.account.client.AccountDetailsView"
   },
   {
+    "view": "org.eclipse.kapua.app.console.module.account.client.cors.CorsView",
+    "tabs": [
+      "org.eclipse.kapua.app.console.module.account.client.cors.CorsTabDescriptionDescriptor"
+    ]
+  },
+  {
     "descriptor": "org.eclipse.kapua.app.console.module.account.client.AccountViewDescriptor",
     "view": "org.eclipse.kapua.app.console.module.account.client.AccountView",
     "tabs": [

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -102,5 +102,9 @@
             <artifactId>mockito-core</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
+        </dependency>
     </dependencies>
 </project>

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -13,6 +13,14 @@
 package org.eclipse.kapua.app.api.core;
 
 import java.io.IOException;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
 
 import javax.servlet.Filter;
 import javax.servlet.FilterChain;
@@ -20,29 +28,175 @@ import javax.servlet.FilterConfig;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSetting;
+import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSettingKeys;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountListResult;
+import org.eclipse.kapua.service.account.AccountQuery;
+import org.eclipse.kapua.service.account.AccountService;
+import org.eclipse.kapua.service.endpoint.EndpointInfo;
+import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
+import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
+import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+
+import com.google.common.collect.HashMultimap;
+import com.google.common.collect.Multimap;
+import liquibase.util.StringUtils;
 import org.apache.shiro.web.util.WebUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 public class CORSResponseFilter implements Filter {
 
+    private final KapuaLocator locator = KapuaLocator.getInstance();
+    private final AccountService accountService = locator.getService(AccountService.class);
+    private final AccountFactory accountFactory = locator.getFactory(AccountFactory.class);
+    private final EndpointInfoService endpointInfoService = locator.getService(EndpointInfoService.class);
+    private final EndpointInfoFactory endpointInfoFactory = locator.getFactory(EndpointInfoFactory.class);
+
+    private static final String ACCESS_CONTROL_ALLOW_CREDENTIALS = "Access-Control-Allow-Credentials";
+    private static final String ACCESS_CONTROL_ALLOW_HEADERS = "Access-Control-Allow-Headers";
+    private static final String ACCESS_CONTROL_ALLOW_METHODS = "Access-Control-Allow-Methods";
+    private static final String ACCESS_CONTROL_ALLOW_ORIGIN = "Access-Control-Allow-Origin";
+    private static final String ORIGIN = "Origin";
+
+    private final Logger logger = LoggerFactory.getLogger(CORSResponseFilter.class);
+
+    private final ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
+    private ScheduledFuture<?> refreshTask;
+
+    private Multimap<String, KapuaId> allowedOrigins = HashMultimap.create();
+    private final List<String> allowedSystemOrigins = KapuaApiCoreSetting.getInstance().getList(String.class, KapuaApiCoreSettingKeys.API_CORS_ORIGINS_ALLOWED);
+
     @Override
     public void init(FilterConfig filterConfig) {
-        // No init required
+        logger.info("Initializing with FilterConfig: {}", filterConfig);
+        int intervalSecs = KapuaApiCoreSetting.getInstance().getInt(KapuaApiCoreSettingKeys.API_CORS_REFRESH_INTERVAL, 60);
+        initRefreshThread(intervalSecs);
     }
 
     @Override
     public void destroy() {
-        // No destroy required
+        logger.info("Shutting down...");
+        if (refreshTask != null) {
+            refreshTask.cancel(true);
+        }
+        logger.info("Shutting down... DONE!");
     }
 
     @Override
     public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
         HttpServletResponse httpResponse = WebUtils.toHttp(response);
-        httpResponse.addHeader("Access-Control-Allow-Origin", "*");
-        httpResponse.addHeader("Access-Control-Allow-Methods", "GET, POST, DELETE, PUT");
-        httpResponse.addHeader("Access-Control-Allow-Headers", "X-Requested-With, Content-Type, Authorization");
+        HttpServletRequest httpRequest = WebUtils.toHttp(request);
+        String origin = httpRequest.getHeader(ORIGIN);
+        if (StringUtils.isEmpty(origin)) {
+            // Not a CORS request. Move along.
+            chain.doFilter(request, response);
+            return;
+        }
+
+        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, DELETE, PUT");
+        httpResponse.addHeader(ACCESS_CONTROL_ALLOW_HEADERS, "X-Requested-With, Content-Type, Authorization");
+
+        if (httpRequest.getMethod().equals("OPTIONS")) {
+            // Preflight request
+            if (checkOrigin(origin, null)) {
+                // Origin matches at least one defined Endpoint
+                httpResponse.addHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+                httpResponse.addHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                httpResponse.addHeader("Vary", ORIGIN);
+            } else {
+                throw new ServletException(String.format("HTTP Origin not allowed: %s", origin));
+            }
+        } else {
+            // Actual request
+            if (checkOrigin(origin, KapuaSecurityUtils.getSession().getScopeId())) {
+                // Origin matches at least one defined Endpoint
+                httpResponse.addHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");
+                httpResponse.addHeader(ACCESS_CONTROL_ALLOW_ORIGIN, origin);
+                httpResponse.addHeader("Vary", ORIGIN);
+            } else {
+                throw new ServletException(String.format("HTTP Origin not allowed: %s", origin));
+            }
+        }
         chain.doFilter(request, response);
+    }
+
+    private String getExplicitOrigin(String origin) throws MalformedURLException {
+        URL originUrl = new URL(origin);
+        if (originUrl.getPort() != -1) {
+            return origin;
+        }
+        switch (originUrl.getProtocol()) {
+            case "http":
+                return origin + ":80";
+            case "https":
+                return origin + ":443";
+            default:
+                return origin;
+        }
+    }
+
+    private boolean checkOrigin(String origin, KapuaId scopeId) {
+        String explicitOrigin;
+        try {
+            explicitOrigin = getExplicitOrigin(origin);
+        } catch (MalformedURLException malformedURLException) {
+            return false;
+        }
+        if (scopeId == null) {
+            // No scopeId, so the call is no authenticated. Return true only if origin
+            // is enabled in any account or system settings
+            return allowedOrigins.containsKey(explicitOrigin);
+        } else {
+            // scopeId has a value, so validate the account as well
+            Collection<KapuaId> allowedAccountIds = allowedOrigins.get(explicitOrigin);
+            return allowedAccountIds.contains(scopeId) || allowedAccountIds.contains(KapuaId.ANY);
+        }
+    }
+
+    private synchronized void initRefreshThread(int intervalSecs) {
+        if (refreshTask == null) {
+            refreshTask = executorService.scheduleAtFixedRate(this::refreshOrigins, 0, intervalSecs, TimeUnit.SECONDS);
+        }
+    }
+
+    private synchronized void refreshOrigins() {
+        try {
+            logger.info("Refreshing list of origins...");
+            Multimap<String, KapuaId> newAllowedOrigins = HashMultimap.create();
+            AccountQuery accounts = accountFactory.newQuery(null);
+            AccountListResult accountListResult = KapuaSecurityUtils.doPrivileged(() -> accountService.query(accounts));
+            accountListResult.getItems().forEach(account -> {
+                EndpointInfoQuery endpointInfoQuery = endpointInfoFactory.newQuery(account.getId());
+                try {
+                    EndpointInfoListResult endpointInfoListResult = KapuaSecurityUtils.doPrivileged(() -> endpointInfoService.query(endpointInfoQuery, EndpointInfo.ENDPOINT_TYPE_CORS));
+                    endpointInfoListResult.getItems().forEach(endpointInfo -> newAllowedOrigins.put(endpointInfo.toStringURI(), account.getId()));
+                } catch (KapuaException kapuaException) {
+                    logger.warn("Unable to add endpoints for account {} to CORS filter", account.getId().toCompactId(), kapuaException);
+                }
+            });
+            for (String allowedSystemOrigin : allowedSystemOrigins) {
+                try {
+                    String explicitAllowedSystemOrigin = getExplicitOrigin(allowedSystemOrigin);
+                    newAllowedOrigins.put(explicitAllowedSystemOrigin, KapuaId.ANY);
+                } catch (MalformedURLException malformedURLException) {
+                    logger.warn(String.format("Unable to parse origin %s", allowedSystemOrigin), malformedURLException);
+                }
+            }
+            allowedOrigins = newAllowedOrigins;
+            logger.info("Refreshing list of origins... DONE!");
+        } catch (Exception exception) {
+            logger.warn("Unable to refresh list of origins", exception);
+        }
     }
 
 }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
@@ -21,7 +21,9 @@ import org.eclipse.kapua.commons.setting.SettingKey;
  */
 public enum KapuaApiCoreSettingKeys implements SettingKey {
     API_PATH_PARAM_SCOPEID_WILDCARD("api.path.param.scopeId.wildcard"),
-    API_EXCEPTION_STACKTRACE_SHOW("api.exception.stacktrace.show");
+    API_EXCEPTION_STACKTRACE_SHOW("api.exception.stacktrace.show"),
+    API_CORS_REFRESH_INTERVAL("api.cors.refresh.interval"),
+    API_CORS_ORIGINS_ALLOWED("api.cors.origins.allowed");
 
     private final String key;
 

--- a/rest-api/core/src/main/resources/kapua-api-core-settings.properties
+++ b/rest-api/core/src/main/resources/kapua-api-core-settings.properties
@@ -13,3 +13,5 @@
 ###############################################################################
 api.path.param.scopeId.wildcard=_
 api.exception.stacktrace.show=false
+api.cors.refresh.interval=60
+api.cors.origins.allowed=

--- a/rest-api/web/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/web/src/main/webapp/WEB-INF/web.xml
@@ -35,21 +35,21 @@
     <!-- Filters -->
 
     <filter>
-        <filter-name>CORSResponseFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.CORSResponseFilter</filter-class>
-    </filter>
-    <filter-mapping>
-        <filter-name>CORSResponseFilter</filter-name>
-        <url-pattern>/v1/*</url-pattern>
-    </filter-mapping>
-
-    <filter>
         <filter-name>ShiroFilter</filter-name>
         <filter-class>org.apache.shiro.web.servlet.ShiroFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>ShiroFilter</filter-name>
         <url-pattern>/*</url-pattern>
+    </filter-mapping>
+
+    <filter>
+        <filter-name>CORSResponseFilter</filter-name>
+        <filter-class>org.eclipse.kapua.app.api.core.CORSResponseFilter</filter-class>
+    </filter>
+    <filter-mapping>
+        <filter-name>CORSResponseFilter</filter-name>
+        <url-pattern>/v1/*</url-pattern>
     </filter-mapping>
 
     <filter>

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfo.java
@@ -36,6 +36,9 @@ public interface EndpointInfo extends KapuaUpdatableEntity {
 
     String TYPE = "endpointInfo";
 
+    String ENDPOINT_TYPE_RESOURCE = "resource";
+    String ENDPOINT_TYPE_CORS = "cors";
+
     @Override
     default String getType() {
         return TYPE;
@@ -81,4 +84,8 @@ public interface EndpointInfo extends KapuaUpdatableEntity {
             throw KapuaRuntimeException.internalError(e, "Unable to build URI for EndpointInfo: " + getId().toCompactId());
         }
     }
+
+    String getEndpointType();
+
+    void setEndpointType(String endpointType);
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoAttributes.java
@@ -21,5 +21,6 @@ public class EndpointInfoAttributes extends KapuaUpdatableEntityAttributes {
     public static final String PORT = "port";
     public static final String SECURE = "secure";
     public static final String USAGES = "usages";
+    public static final String ENDPOINT_TYPE = "endpointType";
 
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoCreator.java
@@ -50,4 +50,9 @@ public interface EndpointInfoCreator extends KapuaEntityCreator<EndpointInfo> {
     Set<EndpointUsage> getUsages();
 
     void setUsages(Set<EndpointUsage> usages);
+
+    String getEndpointType();
+
+    void setEndpointType(String endpointType);
+
 }

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoService.java
@@ -36,4 +36,11 @@ public interface EndpointInfoService extends KapuaEntityService<EndpointInfo, En
     @Override
     EndpointInfoListResult query(KapuaQuery query)
             throws KapuaException;
+
+    EndpointInfoListResult query(KapuaQuery query, String section)
+            throws KapuaException;
+
+    long count(KapuaQuery query, String section)
+            throws KapuaException;
+
 }

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoCreatorImpl.java
@@ -33,6 +33,7 @@ public class EndpointInfoCreatorImpl extends AbstractKapuaEntityCreator<Endpoint
     private int port;
     private boolean secure;
     private Set<EndpointUsage> usages;
+    private String endpointType;
 
     protected EndpointInfoCreatorImpl(KapuaId scopeId) {
         super(scopeId);
@@ -91,4 +92,15 @@ public class EndpointInfoCreatorImpl extends AbstractKapuaEntityCreator<Endpoint
     public void setUsages(Set<EndpointUsage> usages) {
         this.usages = usages;
     }
+
+    @Override
+    public String getEndpointType() {
+        return endpointType;
+    }
+
+    @Override
+    public void setEndpointType(String endpointType) {
+        this.endpointType = endpointType;
+    }
+
 }

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoDAO.java
@@ -47,6 +47,7 @@ public class EndpointInfoDAO extends ServiceDAO {
         endpointInfo.setPort(creator.getPort());
         endpointInfo.setSecure(creator.getSecure());
         endpointInfo.setUsages(creator.getUsages());
+        endpointInfo.setEndpointType(creator.getEndpointType());
 
         return ServiceDAO.create(em, endpointInfo);
     }

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoImpl.java
@@ -57,6 +57,9 @@ public class EndpointInfoImpl extends AbstractKapuaUpdatableEntity implements En
     @CollectionTable(name = "endp_endpoint_info_usage", joinColumns = @JoinColumn(name = "endpoint_info_id", referencedColumnName = "id"))
     private Set<EndpointUsageImpl> usages;
 
+    @Column(name = "endpoint_type", updatable = false, nullable = false)
+    private String endpointType;
+
     /**
      * Constructor.
      *
@@ -148,4 +151,13 @@ public class EndpointInfoImpl extends AbstractKapuaUpdatableEntity implements En
 
         usages.forEach(u -> this.usages.add(EndpointUsageImpl.parse(u)));
     }
+
+    public String getEndpointType() {
+        return endpointType;
+    }
+
+    public void setEndpointType(String endpointType) {
+        this.endpointType = endpointType;
+    }
+
 }

--- a/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
+++ b/service/endpoint/internal/src/main/resources/META-INF/persistence.xml
@@ -22,6 +22,7 @@
 
         <class>org.eclipse.kapua.service.endpoint.internal.EndpointInfoImpl</class>
         <class>org.eclipse.kapua.service.endpoint.internal.EndpointUsageImpl</class>
+        <class>org.eclipse.kapua.service.endpoint.internal.cors.CorsEndpointInfoImpl</class>
 
         <!-- Base classes and External classes -->
         <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.5.0/changelog-endpoint-1.5.0.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.5.0/changelog-endpoint-1.5.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint-1.5.0.xml">
+
+    <include relativeToChangelogFile="true" file="./endpoint_info-add_type.xml"/>
+
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/1.5.0/endpoint_info-add_type.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/1.5.0/endpoint_info-add_type.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-endpoint-1.5.0.xml">
+
+    <changeSet id="changelog-endpoint-1.5.0_add-type" author="eurotech">
+        <addColumn tableName="endp_endpoint_info">
+            <column name="endpoint_type" type="varchar(255)" />
+        </addColumn>
+    </changeSet>
+    <changeSet id="changelog-endpoint-1.5.0_popoulate-type" author="eurotech">
+        <update tableName="endp_endpoint_info">
+            <column name="endpoint_type" value="resource" />
+        </update>
+    </changeSet>
+</databaseChangeLog>

--- a/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
+++ b/service/endpoint/internal/src/main/resources/liquibase/changelog-endpoint-master.xml
@@ -18,5 +18,6 @@
 
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-endpoint-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-endpoint-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.5.0/changelog-endpoint-1.5.0.xml"/>
 
 </databaseChangeLog>

--- a/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
+++ b/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
@@ -134,6 +134,7 @@ public class EndpointServiceSteps extends TestBase {
         endpointInfoCreator.setSchema(schema);
         endpointInfoCreator.setDns(dns);
         endpointInfoCreator.setPort(port);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             stepData.remove(ENDPOINT_INFO);
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
@@ -157,6 +158,7 @@ public class EndpointServiceSteps extends TestBase {
             endpointInfoCreator.setSchema(schema);
             endpointInfoCreator.setDns("dns.com");
             endpointInfoCreator.setPort(2222);
+            endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
             try {
                 stepData.remove("EndpointInfo");
                 EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
@@ -172,6 +174,7 @@ public class EndpointServiceSteps extends TestBase {
         EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
         endpointInfoCreator.setDns(dns);
         endpointInfoCreator.setPort(port);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -184,6 +187,7 @@ public class EndpointServiceSteps extends TestBase {
     public void iCreateEndpointWithSchemaOnly(String schema) throws Exception {
         EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
         endpointInfoCreator.setSchema(schema);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -198,6 +202,7 @@ public class EndpointServiceSteps extends TestBase {
         endpointInfoCreator.setSchema(null);
         endpointInfoCreator.setDns(null);
         endpointInfoCreator.setPort(0);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -443,6 +448,7 @@ public class EndpointServiceSteps extends TestBase {
         endpointInfoCreator.setSchema(schema);
         endpointInfoCreator.setPort(port);
         endpointInfoCreator.setDns(null);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -455,6 +461,7 @@ public class EndpointServiceSteps extends TestBase {
     public void iCreateEndpointWithDomainWithoutSchemaAndPort(String domainName) throws Throwable{
         EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
         endpointInfoCreator.setDns(domainName);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -468,6 +475,7 @@ public class EndpointServiceSteps extends TestBase {
         EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
         endpointInfoCreator.setDns(domainName);
         endpointInfoCreator.setSchema(schema);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -480,6 +488,7 @@ public class EndpointServiceSteps extends TestBase {
     public void iCreateEndpointWithPortWithoutSchemaAndDomain(int port) throws Throwable{
         EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
         endpointInfoCreator.setPort(port);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         try {
             EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
             stepData.put("EndpointInfo", endpointInfo);
@@ -494,6 +503,7 @@ public class EndpointServiceSteps extends TestBase {
         endpointInfoCreator.setSchema(schema);
         endpointInfoCreator.setDns(domainName);
         endpointInfoCreator.setPort(port);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_RESOURCE);
         if (secureField.equals("ENABLED")) {
             endpointInfoCreator.setSecure(true);
         } else {


### PR DESCRIPTION
Introducing Dynamic CORS Filter

This is a refactoring of the existing CORS filter, that is currently allowing all Cross Origins requests responding with `Access-Control-Allow-Origin: *` to any REST request. From now on, the CORS Filter will only allow calls from specific Origins that can be configured per-account or for the whole system.

**Related Issue**
No related issues

**Description of the solution adopted**
The filter leverages the Endpoints feature to register allowed Origins for any given account. 

A new tab will appear under the Settings menu item, named CORS. Here you can add HTTP Origins that will be allowed for a given account. Since those items are actually leveraging the Endpoints feature, the same inheritance rules will apply (i.e. if not CORS Origins are found in a given account, the account hierarchy will be traversed up until the root account until a CORS Origin definition will be found).

System-wide CORS Origins can also be configured via the `api.cors.origins.allow` system property.

**Screenshots**
New Add Endpoint Dialog:

![CORS Window](https://user-images.githubusercontent.com/8140139/112362311-9672e680-8cd4-11eb-9266-33e22081b6b6.png)

**Any side note on the changes made**
The Endpoints registered as valid CORS Origins will have the `cors` Endpoint Type. Regular Endpoints will have the `resource` Endpoint Type.
