### PR TITLE
Bumped version of Netty4 to 4.1.60.Final - CVE-2021-21290 - CWE-378

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
         <logback.version>1.2.3</logback.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.50.Final</netty.version>
+        <netty.version>4.1.60.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <opencsv.version>3.7</opencsv.version>
         <paho.version>1.2.1</paho.version>


### PR DESCRIPTION
Bump version of Netty-* from 4.1.50 to 4.1.60

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version.

There is already a CQ from Vertx project which is under approval.
[23135](https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23135)

**Screenshots**
_None_

**Any side note on the changes made**
_None_