### PR TITLE
Fixed logic that checks for job executions before editing JobStep

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -122,7 +122,9 @@ public class JobStepServiceImpl extends AbstractKapuaService
         //
         // Check Job Executions
         JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(jobStepCreator.getScopeId());
-        jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStepCreator.getJobId());
+        jobExecutionQuery.setPredicate(
+                jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStepCreator.getJobId())
+        );
 
         if (JOB_EXECUTION_SERVICE.count(jobExecutionQuery) > 0) {
             throw new CannotModifyJobStepsException(jobStepCreator.getJobId());
@@ -214,7 +216,9 @@ public class JobStepServiceImpl extends AbstractKapuaService
         //
         // Check Job Executions
         JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(jobStep.getScopeId());
-        jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStep.getJobId());
+        jobExecutionQuery.setPredicate(
+                jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStep.getJobId())
+        );
 
         if (JOB_EXECUTION_SERVICE.count(jobExecutionQuery) > 0) {
             throw new CannotModifyJobStepsException(jobStep.getJobId());
@@ -291,7 +295,9 @@ public class JobStepServiceImpl extends AbstractKapuaService
         //
         // Check Job Executions
         JobExecutionQuery jobExecutionQuery = JOB_EXECUTION_FACTORY.newQuery(scopeId);
-        jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStep.getJobId());
+        jobExecutionQuery.setPredicate(
+                jobExecutionQuery.attributePredicate(JobExecutionAttributes.JOB_ID, jobStep.getJobId())
+        );
 
         if (JOB_EXECUTION_SERVICE.count(jobExecutionQuery) > 0) {
             throw new CannotModifyJobStepsException(jobStep.getJobId());


### PR DESCRIPTION
This PR fixes an issue with the edit job step checks on JobExecutions run. 
Now is not possible to edit job if there is at least one execution in scope.

**Related Issue**
This PR fixes an issue introduced in https://github.com/eclipse/kapua/pull/3241

**Description of the solution adopted**
The `JOB_ID` predicate was created but not added.
Now is added to the query

**Screenshots**
_None_

**Any side note on the changes made**
_None_