### PR TITLE
Fixed definition of `schdl_trigger_fired` with `ON DELETE CASCADE`

### DIFF
--- a/service/scheduler/quartz/src/main/resources/liquibase/1.5.0/fired_trigger.xml
+++ b/service/scheduler/quartz/src/main/resources/liquibase/1.5.0/fired_trigger.xml
@@ -59,7 +59,9 @@
                 baseColumnNames="trigger_id"
                 constraintName="fk-schdl_trigger_fired-triggerId"
                 referencedTableName="schdl_trigger"
-                referencedColumnNames="id"/>
+                referencedColumnNames="id"
+                onDelete="CASCADE"
+                onUpdate="RESTRICT"/>
 
         <rollback>
             <dropIndex tableName="schdl_trigger_fired" indexName="idx_schdl_trigger_fired_scopeId_triggerId_firedOn"/>


### PR DESCRIPTION
FIxed the definition of the table which was missing the `ON DELETE CASCADE` clause and is preventing the Trigger deletion if fired.

**Related Issue**
This PR fixes an issue introduced with https://github.com/eclipse/kapua/pull/3240

**Description of the solution adopted**
Just added the clause to the table definition

**Screenshots**
_None_

**Any side note on the changes made**
_None_