### PR TITLE
Added KapuaQuery.defaultSortCriteria

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQuery.java
@@ -15,10 +15,10 @@ package org.eclipse.kapua.commons.configuration;
 import org.eclipse.kapua.model.query.KapuaQuery;
 
 /**
- * Service configuration query.
+ * {@link ServiceConfig} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 public interface ServiceConfigQuery extends KapuaQuery {
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQueryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigQueryImpl.java
@@ -16,23 +16,26 @@ import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 
 /**
- * Service configuration query reference implementation.
+ * {@link ServiceConfigQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class ServiceConfigQueryImpl extends AbstractKapuaQuery implements ServiceConfigQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private ServiceConfigQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public ServiceConfigQueryImpl(KapuaId scopeId) {
         this();

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaNamedQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaNamedQuery.java
@@ -1,0 +1,64 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.model.query;
+
+import org.eclipse.kapua.model.KapuaNamedEntity;
+import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+
+/**
+ * {@link KapuaQuery} {@code abstract} implementation for {@link KapuaNamedEntity}.
+ * <p>
+ * It default the {@link #getSortCriteria()} on the {@link KapuaNamedEntityAttributes#NAME}
+ *
+ * @since 1.5.0
+ */
+public abstract class AbstractKapuaNamedQuery extends AbstractKapuaQuery implements KapuaQuery {
+
+    /**
+     * Constructor.
+     *
+     * @since 1.5.0
+     */
+    public AbstractKapuaNamedQuery() {
+        super();
+    }
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.5.0
+     */
+    public AbstractKapuaNamedQuery(KapuaId scopeId) {
+        super(scopeId);
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param query The {@link KapuaQuery} to clone.
+     * @since 1.5.0
+     */
+    public AbstractKapuaNamedQuery(KapuaQuery query) {
+        super(query);
+    }
+
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(KapuaNamedEntityAttributes.NAME, SortOrder.ASCENDING);
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
@@ -135,7 +135,7 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
 
     @Override
     public KapuaSortCriteria getDefaultSortCriteria() {
-        return fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING);
+        return fieldSortCriteria(KapuaEntityAttributes.ENTITY_ID, SortOrder.ASCENDING);
     }
 
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/AbstractKapuaQuery.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.model.query.predicate.AndPredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.model.query.predicate.OrPredicateImpl;
-import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.FieldSortCriteria;
@@ -51,13 +50,10 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
 
     /**
      * Constructor.
-     * <p>
-     * It defaults the {@link #sortCriteria} to order by the {@link KapuaEntity#getCreatedOn()} {@link SortOrder#ASCENDING}.
      *
      * @since 1.0.0
      */
     public AbstractKapuaQuery() {
-        setSortCriteria(fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
     }
 
     /**
@@ -80,11 +76,12 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
      * @param query the query to clone.
      */
     public AbstractKapuaQuery(@NotNull KapuaQuery query) {
-        this.setFetchAttributes(query.getFetchAttributes());
-        this.setPredicate(query.getPredicate());
-        this.setLimit(query.getLimit());
-        this.setOffset(query.getOffset());
-        this.setSortCriteria(query.getSortCriteria());
+        setFetchAttributes(query.getFetchAttributes());
+        setPredicate(query.getPredicate());
+        setLimit(query.getLimit());
+        setOffset(query.getOffset());
+        setSortCriteria(query.getSortCriteria());
+        setAskTotalCount(query.getAskTotalCount());
     }
 
     @Override
@@ -137,6 +134,11 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
     }
 
     @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING);
+    }
+
+    @Override
     public Integer getOffset() {
         return offset;
     }
@@ -154,6 +156,16 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
     @Override
     public void setLimit(Integer limit) {
         this.limit = limit;
+    }
+
+    @Override
+    public Boolean getAskTotalCount() {
+        return askTotalCount;
+    }
+
+    @Override
+    public void setAskTotalCount(Boolean askTotalCount) {
+        this.askTotalCount = askTotalCount;
     }
 
     //
@@ -192,14 +204,4 @@ public abstract class AbstractKapuaQuery implements KapuaQuery {
     public FieldSortCriteria fieldSortCriteria(String attributeName, SortOrder sortOrder) {
         return new FieldSortCriteriaImpl(attributeName, sortOrder);
     }
-
-    @Override
-    public Boolean getAskTotalCount() {
-        return askTotalCount;
-    }
-
-    public void setAskTotalCount(Boolean askTotalCount) {
-        this.askTotalCount = askTotalCount;
-    }
-
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/api/EventStoreRecordQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.event.store.api;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * KapuaEvent query definition.
+ * {@link EventStoreRecord} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImpl.java
@@ -16,23 +16,30 @@ import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 
+/**
+ * {@link EventStoreRecordQuery} implementation.
+ *
+ * @since 1.0.0
+ */
 public class EventStoreQueryImpl extends AbstractKapuaQuery implements EventStoreRecordQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public EventStoreQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public EventStoreQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
     }
-
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.service.internal;
 
+import com.google.common.base.MoreObjects;
 import org.apache.commons.lang.ArrayUtils;
 import org.eclipse.kapua.KapuaEntityExistsException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
@@ -433,15 +434,14 @@ public class ServiceDAO {
         // ORDER BY
         // Default to the KapuaEntity id if no ordering is specified.
         Order order;
-        if (kapuaQuery.getSortCriteria() != null) {
-            FieldSortCriteria sortCriteria = (FieldSortCriteria) kapuaQuery.getSortCriteria();
+        if (kapuaQuery.getSortCriteria() != null || kapuaQuery.getDefaultSortCriteria() != null) {
+            FieldSortCriteria sortCriteria = (FieldSortCriteria) MoreObjects.firstNonNull(kapuaQuery.getSortCriteria(), kapuaQuery.getDefaultSortCriteria());
 
             if (SortOrder.DESCENDING.equals(sortCriteria.getSortOrder())) {
                 order = cb.desc(extractAttribute(entityRoot, sortCriteria.getAttributeName()));
             } else {
                 order = cb.asc(extractAttribute(entityRoot, sortCriteria.getAttributeName()));
             }
-
         } else {
             order = cb.asc(entityRoot.get(entityType.getSingularAttribute(KapuaEntityAttributes.ENTITY_ID)));
         }

--- a/commons/src/test/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreQueryImplTest.java
@@ -27,7 +27,8 @@ public class EventStoreQueryImplTest extends Assert {
     @Test
     public void eventStoreQueryImplTest1() {
         EventStoreQueryImpl eventStoreQueryImpl = new EventStoreQueryImpl();
-        assertNotNull("Null not expected.", eventStoreQueryImpl.getSortCriteria());
+        assertNull("query.sortCriteria", eventStoreQueryImpl.getSortCriteria());
+        assertNotNull("query.defaultSortCriteria", eventStoreQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -35,11 +36,13 @@ public class EventStoreQueryImplTest extends Assert {
         KapuaId scopeId = new KapuaIdStatic(BigInteger.ONE);
 
         EventStoreQueryImpl eventStoreQueryImpl1 = new EventStoreQueryImpl(null);
-        assertNotNull("Null not expected.", eventStoreQueryImpl1.getSortCriteria());
+        assertNull("query.sortCriteria", eventStoreQueryImpl1.getSortCriteria());
+        assertNotNull("query.defaultSortCriteria", eventStoreQueryImpl1.getDefaultSortCriteria());
         assertNull("Null expected.", eventStoreQueryImpl1.getScopeId());
 
         EventStoreQueryImpl eventStoreQueryImpl2 = new EventStoreQueryImpl(scopeId);
-        assertNotNull("Null not expected.", eventStoreQueryImpl2.getSortCriteria());
+        assertNull("query.sortCriteria", eventStoreQueryImpl2.getSortCriteria());
+        assertNotNull("query.defaultSortCriteria", eventStoreQueryImpl2.getDefaultSortCriteria());
         assertEquals("Expected and actual values should be the same.", scopeId, eventStoreQueryImpl2.getScopeId());
     }
 }

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionQuery.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/queue/QueuedJobExecutionQuery.java
@@ -20,8 +20,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link QueuedJobExecutionQuery} definition.
+ * {@link QueuedJobExecution} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.1.0
  */
 @XmlRootElement(name = "query")

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionQueryImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionQueryImpl.java
@@ -17,16 +17,17 @@ import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 
 /**
- * {@link QueuedJobExecutionQuery} implementation
+ * {@link QueuedJobExecutionQuery} implementation.
  *
  * @since 1.1.0
  */
 public class QueuedJobExecutionQueryImpl extends AbstractKapuaQuery implements QueuedJobExecutionQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.1.0
      */
     public QueuedJobExecutionQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * Account query definition.
+ * {@link Account} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountQueryImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountQueryImpl.java
@@ -12,32 +12,34 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.account.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountQuery;
 
 /**
- * User roles factory service implementation.
+ * {@link AccountQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
-public class AccountQueryImpl extends AbstractKapuaQuery implements AccountQuery {
+public class AccountQueryImpl extends AbstractKapuaNamedQuery implements AccountQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private AccountQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public AccountQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
     }
-
 }

--- a/service/account/internal/src/main/resources/liquibase/1.5.0/account-name_indexes.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.5.0/account-name_indexes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-account-1.5.0.xml">
+
+    <changeSet id="changelog-account_1.5.0_name_indexes" author="eurotech">
+        <createIndex tableName="act_account" indexName="idx_act_account_scopeIdName">
+            <column name="scope_id"/>
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/1.5.0/changelog-account-1.5.0.xml
+++ b/service/account/internal/src/main/resources/liquibase/1.5.0/changelog-account-1.5.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-account-1.5.0.xml">
+
+    <include relativeToChangelogFile="true" file="./account-name_indexes.xml"/>
+
+</databaseChangeLog>

--- a/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
+++ b/service/account/internal/src/main/resources/liquibase/changelog-account-master.xml
@@ -21,5 +21,6 @@
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-account-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-account-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-account-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.5.0/changelog-account-1.5.0.xml"/>
 
 </databaseChangeLog>

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -114,6 +114,14 @@ public interface KapuaQuery {
     void setSortCriteria(@NotNull KapuaSortCriteria sortCriteria);
 
     /**
+     * Gets the default {@link KapuaSortCriteria} to use if {@link #getSortCriteria()} is not specified.
+     *
+     * @return The default {@link KapuaSortCriteria}
+     * @since 1.5.0
+     */
+    KapuaSortCriteria getDefaultSortCriteria();
+
+    /**
      * Gets the {@link KapuaQuery} offset.
      *
      * @return The {@link KapuaQuery} offset.

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaQuery.java
@@ -119,6 +119,7 @@ public interface KapuaQuery {
      * @return The default {@link KapuaSortCriteria}
      * @since 1.5.0
      */
+    @XmlTransient
     KapuaSortCriteria getDefaultSortCriteria();
 
     /**

--- a/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationQuery.java
+++ b/service/device/management/job/api/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementOperationQuery.java
@@ -20,8 +20,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link JobDeviceManagementOperationQuery} definition.
+ * {@link JobDeviceManagementOperation} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.1.0
  */
 @XmlRootElement(name = "query")

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationQueryImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationQueryImpl.java
@@ -26,7 +26,7 @@ public class JobDeviceManagementOperationQueryImpl extends AbstractKapuaQuery im
     /**
      * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
      * @since 1.1.0
      */
     public JobDeviceManagementOperationQueryImpl(KapuaId scopeId) {

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationQuery.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/DeviceManagementOperationQuery.java
@@ -20,13 +20,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link DeviceManagementOperationQuery} definition.
+ * {@link DeviceManagementOperation} {@link KapuaQuery} definition.
  *
- * @since 1.0
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceManagementOperationXmlRegistry.class, factoryMethod = "newQuery")
 public interface DeviceManagementOperationQuery extends KapuaQuery {
-
 }

--- a/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationQuery.java
+++ b/service/device/management/registry/api/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/ManagementOperationNotificationQuery.java
@@ -20,13 +20,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link ManagementOperationNotificationQuery} definition.
+ * {@link ManagementOperationNotification} {@link KapuaQuery} definition.
  *
- * @since 1.0
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = ManagementOperationNotificationXmlRegistry.class, factoryMethod = "newQuery")
 public interface ManagementOperationNotificationQuery extends KapuaQuery {
-
 }

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationQueryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationQueryImpl.java
@@ -14,23 +14,41 @@ package org.eclipse.kapua.service.device.management.registry.operation.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 
 /**
- * {@link DeviceManagementOperationQueryImpl} definition.
+ * {@link DeviceManagementOperationQuery} implementation.
  *
- * @since 1.0
+ * @since 1.1.0
  */
 public class DeviceManagementOperationQueryImpl extends AbstractKapuaQuery implements DeviceManagementOperationQuery {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.1.0
+     */
     private DeviceManagementOperationQueryImpl() {
         super();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.1.0
+     */
     public DeviceManagementOperationQueryImpl(KapuaId scopeId) {
         this();
 
         setScopeId(scopeId);
     }
 
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(DeviceManagementOperationAttributes.STARTED_ON, SortOrder.ASCENDING);
+    }
 }

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationQueryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationQueryImpl.java
@@ -14,23 +14,41 @@ package org.eclipse.kapua.service.device.management.registry.operation.notificat
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationAttributes;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationQuery;
 
 /**
- * {@link ManagementOperationNotificationQueryImpl} definition.
+ * {@link ManagementOperationNotificationQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class ManagementOperationNotificationQueryImpl extends AbstractKapuaQuery implements ManagementOperationNotificationQuery {
 
+    /**
+     * Constructor.
+     *
+     * @since 1.0.0
+     */
     private ManagementOperationNotificationQueryImpl() {
         super();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
     public ManagementOperationNotificationQueryImpl(KapuaId scopeId) {
         this();
 
         setScopeId(scopeId);
     }
 
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(ManagementOperationNotificationAttributes.SENT_ON, SortOrder.ASCENDING);
+    }
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/DeviceQuery.java
@@ -12,24 +12,31 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link Device} query definition.
+ * {@link Device} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceXmlRegistry.class, factoryMethod = "newQuery")
 public interface DeviceQuery extends KapuaQuery {
 
+    /**
+     * Instantiates a new {@link DeviceMatchPredicate}.
+     *
+     * @param matchTerm The term to use to match.
+     * @param <T>       The type of the term
+     * @return The newly instantiated {@link DeviceMatchPredicate}.
+     * @since 1.3.0
+     */
     <T> DeviceMatchPredicate<T> matchPredicate(T matchTerm);
-
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionQuery.java
@@ -12,21 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * Device connection query definition.
+ * {@link DeviceConnection} {@link KapuaQuery} definition.
  *
- * @since 1.0
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceConnectionXmlRegistry.class, factoryMethod = "newQuery")
 public interface DeviceConnectionQuery extends KapuaQuery {
-
 }

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/DeviceConnectionOptionQuery.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.connection.option;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * Device connection options query definition.
+ * {@link DeviceConnectionOption} {@link KapuaQuery} definition.
  *
- * @since 1.0
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/event/DeviceEventQuery.java
@@ -12,22 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * Device event query definition.
+ * {@link DeviceEvent} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = DeviceEventXmlRegistry.class, factoryMethod = "newQuery")
 public interface DeviceEventQuery extends KapuaQuery {
-
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionQueryImpl.java
@@ -14,29 +14,40 @@ package org.eclipse.kapua.service.device.registry.connection.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.device.registry.DeviceAttributes;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 
 /**
- * Device connection query.
+ * {@link DeviceConnectionQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class DeviceConnectionQueryImpl extends AbstractKapuaQuery implements DeviceConnectionQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private DeviceConnectionQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public DeviceConnectionQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
+    }
+
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(DeviceAttributes.CLIENT_ID, SortOrder.ASCENDING);
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionQueryImpl.java
@@ -17,23 +17,26 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionQuery;
 
 /**
- * Device connection options query.
+ * {@link DeviceConnectionOptionQuery} implementation.
  *
  * @since 1.0.0
  */
 public class DeviceConnectionOptionQueryImpl extends AbstractKapuaQuery implements DeviceConnectionOptionQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private DeviceConnectionOptionQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public DeviceConnectionOptionQueryImpl(KapuaId scopeId) {
         this();

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventQueryImpl.java
@@ -13,35 +13,41 @@
 package org.eclipse.kapua.service.device.registry.event.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
-import org.eclipse.kapua.commons.model.query.FieldSortCriteriaImpl;
-import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventAttributes;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
 
 /**
- * Device event query.
+ * {@link DeviceEventQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class DeviceEventQueryImpl extends AbstractKapuaQuery implements DeviceEventQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private DeviceEventQueryImpl() {
         super();
-
-        setSortCriteria(new FieldSortCriteriaImpl(DeviceEventAttributes.RECEIVED_ON, SortOrder.DESCENDING));
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public DeviceEventQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
+    }
+
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(DeviceEventAttributes.RECEIVED_ON, SortOrder.DESCENDING);
     }
 }

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceQueryImpl.java
@@ -13,9 +13,9 @@
 package org.eclipse.kapua.service.device.registry.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
-import org.eclipse.kapua.commons.model.query.FieldSortCriteriaImpl;
-import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.service.device.registry.DeviceAttributes;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
@@ -27,22 +27,28 @@ import org.eclipse.kapua.service.device.registry.DeviceQuery;
 public class DeviceQueryImpl extends AbstractKapuaQuery implements DeviceQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private DeviceQueryImpl() {
         super();
-
-        setSortCriteria(new FieldSortCriteriaImpl(DeviceAttributes.CLIENT_ID, SortOrder.ASCENDING));
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public DeviceQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
+    }
+
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(DeviceAttributes.CLIENT_ID, SortOrder.ASCENDING);
     }
 
     @Override

--- a/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
+++ b/service/endpoint/api/src/main/java/org/eclipse/kapua/service/endpoint/EndpointInfoQuery.java
@@ -20,8 +20,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link EndpointInfo} query definition.
+ * {@link EndpointInfo} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
  */
 @XmlRootElement(name = "query")

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoQueryImpl.java
@@ -23,6 +23,12 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
  */
 public class EndpointInfoQueryImpl extends AbstractKapuaQuery implements EndpointInfoQuery {
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
     public EndpointInfoQueryImpl(KapuaId scopeId) {
         super(scopeId);
     }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link JobQuery} definition.
+ * {@link Job} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/execution/JobExecutionQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.execution;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link JobExecutionQuery} definition.
+ * {@link JobExecution} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/JobStepQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link JobStepQuery} definition.
+ * {@link JobStep} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepDefinitionQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link JobStepDefinitionQuery} definition.
+ * {@link JobStepDefinition} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetQuery.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/targets/JobTargetQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.targets;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link JobTargetQuery} definition.
+ * {@link JobTarget} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
@@ -16,12 +16,18 @@ import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 
+/**
+ * {@link JobExecutionQuery} implementation.
+ *
+ * @since 1.0.0
+ */
 public class JobExecutionQueryImpl extends AbstractKapuaQuery implements JobExecutionQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public JobExecutionQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/internal/JobQueryImpl.java
@@ -12,16 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.JobQuery;
 
-public class JobQueryImpl extends AbstractKapuaQuery implements JobQuery {
+/**
+ * {@link JobQuery} implementation.
+ *
+ * @since 1.0.0
+ */
+public class JobQueryImpl extends AbstractKapuaNamedQuery implements JobQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public JobQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepDefinitionQueryImpl.java
@@ -12,21 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionQuery;
 
 /**
  * {@link JobStepDefinitionQuery} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
-public class JobStepDefinitionQueryImpl extends AbstractKapuaQuery implements JobStepDefinitionQuery {
+public class JobStepDefinitionQueryImpl extends AbstractKapuaNamedQuery implements JobStepDefinitionQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public JobStepDefinitionQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepQueryImpl.java
@@ -12,22 +12,22 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.step.JobStepQuery;
-import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionQuery;
 
 /**
- * {@link JobStepDefinitionQuery} definition.
+ * {@link JobStepQuery} definition.
  *
  * @since 1.0.0
  */
-public class JobStepQueryImpl extends AbstractKapuaQuery implements JobStepQuery {
+public class JobStepQueryImpl extends AbstractKapuaNamedQuery implements JobStepQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public JobStepQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetQueryImpl.java
@@ -16,12 +16,18 @@ import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.targets.JobTargetQuery;
 
+/**
+ * {@link JobTargetQuery} implementation.
+ *
+ * @since 1.0.0
+ */
 public class JobTargetQueryImpl extends AbstractKapuaQuery implements JobTargetQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public JobTargetQueryImpl(KapuaId scopeId) {
         super(scopeId);

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/changelog-job-1.5.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/changelog-job-1.5.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
+
+    <include relativeToChangelogFile="true" file="./job-name_indexes.xml"/>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/job-name_indexes.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/job-name_indexes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
+
+    <changeSet id="changelog-job_1.5.0_name_indexes" author="eurotech">
+        <createIndex tableName="job_job" indexName="idx_job_job_scopeIdName">
+            <column name="scope_id"/>
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -20,5 +20,6 @@
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-job-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.5.0/changelog-job-1.5.0.xml"/>
 
 </databaseChangeLog>

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionQuery.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/TriggerDefinitionQuery.java
@@ -22,7 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * {@link TriggerDefinition} {@link KapuaQuery} definition.
  *
- * @see org.eclipse.kapua.model.query.KapuaQuery
+ * @see KapuaQuery
  * @since 1.1.0
  */
 @XmlRootElement(name = "query")

--- a/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/FiredTriggerQuery.java
+++ b/service/scheduler/api/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/FiredTriggerQuery.java
@@ -22,6 +22,7 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * {@link FiredTrigger} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.5.0
  */
 @XmlRootElement(name = "query")

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionQueryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionQuery;
 
@@ -21,12 +21,12 @@ import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionQ
  *
  * @since 1.1.0
  */
-public class TriggerDefinitionQueryImpl extends AbstractKapuaQuery implements TriggerDefinitionQuery {
+public class TriggerDefinitionQueryImpl extends AbstractKapuaNamedQuery implements TriggerDefinitionQuery {
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId The scope {@link KapuaId} of the {@link TriggerDefinitionQuery}
+     * @param scopeId The {@link #getScopeId()}.
      * @since 1.1.0
      */
     public TriggerDefinitionQueryImpl(KapuaId scopeId) {

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerQueryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 
@@ -21,7 +21,7 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
  *
  * @since 1.0.0
  */
-public class TriggerQueryImpl extends AbstractKapuaQuery implements TriggerQuery {
+public class TriggerQueryImpl extends AbstractKapuaNamedQuery implements TriggerQuery {
 
     /**
      * Constructor.
@@ -33,14 +33,13 @@ public class TriggerQueryImpl extends AbstractKapuaQuery implements TriggerQuery
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId The scope {@link KapuaId}.
+     * @param scopeId The {@link #getScopeId()}.
      * @since 1.0.0
      */
     public TriggerQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
     }
-
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/CredentialQuery.java
@@ -12,22 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * Credential query definition.
+ * {@link Credential} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = CredentialXmlRegistry.class, factoryMethod = "newQuery")
 public interface CredentialQuery extends KapuaQuery {
-
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionQuery.java
@@ -20,11 +20,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link MfaOption} query definition.
+ * {@link MfaOption} {@link KapuaQuery} definition.
+ *
+ * @see KapuaQuery
+ * @since 1.3.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = MfaOptionXmlRegistry.class, factoryMethod = "newQuery")
 public interface MfaOptionQuery extends KapuaQuery {
-
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/ScratchCodeQuery.java
@@ -20,11 +20,13 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
- * {@link ScratchCode} query definition.
+ * {@link ScratchCode} {@link KapuaQuery} definition.
+ *
+ * @see KapuaQuery
+ * @since 1.3.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = ScratchCodeXmlRegistry.class, factoryMethod = "newQuery")
 public interface ScratchCodeQuery extends KapuaQuery {
-
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/token/AccessTokenQuery.java
@@ -15,11 +15,10 @@ package org.eclipse.kapua.service.authentication.token;
 import org.eclipse.kapua.model.query.KapuaQuery;
 
 /**
- * Access token query definition.
+ * {@link AccessToken} {@link KapuaQuery} definition.
  *
- * @since 1.0
- *
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 public interface AccessTokenQuery extends KapuaQuery {
-
 }

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessInfoQuery.java
@@ -12,16 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link AccessInfo} query definition.
+ * {@link AccessInfo} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
  */
 @XmlRootElement(name = "query")

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessPermissionQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link AccessPermission} query definition.
+ * {@link AccessPermission} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/access/AccessRoleQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link AccessRole} query definition.
+ * {@link AccessRole} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/domain/DomainQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link Domain} query definition.
+ * {@link Domain} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/group/GroupQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link Group} query definition.
+ * {@link Group} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RolePermissionQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link RolePermission} query definition.
+ * {@link RolePermission} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
+++ b/service/security/authorization/api/src/main/java/org/eclipse/kapua/service/authorization/role/RoleQuery.java
@@ -12,18 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link Role} query definition.
+ * {@link Role} {@link KapuaQuery} definition.
  *
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/CertificateQuery.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.service.certificate;
 
 import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.certificate.info.CertificateInfo;
 import org.eclipse.kapua.service.certificate.xml.CertificateXmlRegistry;
 
 import javax.xml.bind.annotation.XmlAccessType;
@@ -22,6 +23,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
+ * {@link Certificate} {@link KapuaQuery} definition.
+ *
+ * @see KapuaQuery
  * @since 1.0.0
  */
 @XmlRootElement(name = "query")
@@ -29,8 +33,20 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(factoryClass = CertificateXmlRegistry.class, factoryMethod = "newQuery")
 public interface CertificateQuery extends KapuaQuery {
 
+    /**
+     * Gets whether or not to get also inherited {@link CertificateInfo}s
+     *
+     * @return {@code true} if set to get inherited {@link CertificateInfo}s, {@code false} otherwise.
+     * @since 1.0.0
+     */
     @XmlElement(name = "includeInherited")
     Boolean getIncludeInherited();
 
+    /**
+     * Sets whether or not to get also inherited {@link CertificateInfo}s
+     *
+     * @param includeInherited {@code true} to get inherited {@link CertificateInfo}s, {@code false} otherwise.
+     * @since 1.0.0
+     */
     void setIncludeInherited(Boolean includeInherited);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoQuery.java
@@ -22,6 +22,9 @@ import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
 /**
+ * {@link CertificateInfo} {@link KapuaQuery} definition.
+ *
+ * @see KapuaQuery
  * @since 1.1.0
  */
 @XmlRootElement(name = "query")
@@ -29,8 +32,20 @@ import javax.xml.bind.annotation.XmlType;
 @XmlType(factoryClass = CertificateInfoXmlRegistry.class, factoryMethod = "newQuery")
 public interface CertificateInfoQuery extends KapuaQuery {
 
+    /**
+     * Gets whether or not to get also inherited {@link CertificateInfo}s
+     *
+     * @return {@code true} if set to get inherited {@link CertificateInfo}s, {@code false} otherwise.
+     * @since 1.1.0
+     */
     @XmlElement(name = "includeInherited")
     Boolean getIncludeInherited();
 
+    /**
+     * Sets whether or not to get also inherited {@link CertificateInfo}s
+     *
+     * @param includeInherited {@code true} to get inherited {@link CertificateInfo}s, {@code false} otherwise.
+     * @since 1.1.0
+     */
     void setIncludeInherited(Boolean includeInherited);
 }

--- a/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
+++ b/service/security/certificate/api/src/main/java/org/eclipse/kapua/service/certificate/info/CertificateInfoService.java
@@ -21,11 +21,21 @@ import org.eclipse.kapua.service.certificate.CertificateUsage;
 import java.util.List;
 
 /**
+ * {@link CertificateInfo} {@link KapuaEntityService} definition.
+ *
  * @since 1.1.0
  */
 public interface CertificateInfoService extends KapuaEntityService<CertificateInfo, CertificateInfoCreator> {
+
     @Override
     CertificateInfoListResult query(KapuaQuery query) throws KapuaException;
 
+    /**
+     * @param scopeId
+     * @param usage
+     * @return
+     * @throws KapuaException
+     * @since 1.1.0
+     */
     List<CertificateInfo> findAncestorsCertificates(KapuaId scopeId, CertificateUsage usage) throws KapuaException;
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoQueryImpl.java
@@ -12,30 +12,37 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.info.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 
-public class CertificateInfoQueryImpl extends AbstractKapuaQuery implements CertificateInfoQuery {
+/**
+ * {@link CertificateInfoQuery} implementation.
+ *
+ * @since 1.0.0
+ */
+public class CertificateInfoQueryImpl extends AbstractKapuaNamedQuery implements CertificateInfoQuery {
 
     private Boolean includeInherited = Boolean.FALSE;
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private CertificateInfoQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public CertificateInfoQueryImpl(KapuaId scopeId) {
         this();
         setScopeId(scopeId);
-
     }
 
     @Override

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateQueryImpl.java
@@ -12,17 +12,24 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.certificate.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.certificate.CertificateQuery;
 
-public class CertificateQueryImpl extends AbstractKapuaQuery implements CertificateQuery {
+/**
+ * {@link CertificateQuery} implementation.
+ *
+ * @since 1.0.0
+ */
+public class CertificateQueryImpl extends AbstractKapuaNamedQuery implements CertificateQuery {
 
     private Boolean includeInherited = Boolean.FALSE;
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private CertificateQueryImpl() {
         super();
@@ -31,7 +38,8 @@ public class CertificateQueryImpl extends AbstractKapuaQuery implements Certific
     /**
      * Constructor.
      *
-     * @param scopeId The scopeId of the {@link KapuaQuery}
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public CertificateQueryImpl(KapuaId scopeId) {
         this();
@@ -39,11 +47,10 @@ public class CertificateQueryImpl extends AbstractKapuaQuery implements Certific
     }
 
     /**
-     * Constructor
-     * <p>
-     * This deeply clones the given {@link CertificateQuery}
+     * Clone constructor.
      *
-     * @param query the query to clone
+     * @param query The {@link CertificateQuery} to clone.
+     * @since 1.0.0
      */
     public CertificateQueryImpl(KapuaQuery query) {
         super(query);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImpl.java
@@ -19,20 +19,25 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
 
 /**
  * {@link MfaOption} query implementation.
+ *
+ * @since 1.3.0
  */
 public class MfaOptionQueryImpl extends AbstractKapuaQuery implements MfaOptionQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.3.0
      */
     public MfaOptionQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.3.0
      */
     public MfaOptionQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImpl.java
@@ -17,21 +17,26 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
 
 /**
- * {@link ScratchCodeQuery} query implementation.
+ * {@link ScratchCodeQuery} implementation.
+ *
+ * @since 1.3.0
  */
 public class ScratchCodeQueryImpl extends AbstractKapuaQuery implements ScratchCodeQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.3.0
      */
     public ScratchCodeQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.3.0
      */
     public ScratchCodeQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImpl.java
@@ -17,23 +17,26 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 
 /**
- * Credential query implementation.
+ * {@link CredentialQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class CredentialQueryImpl extends AbstractKapuaQuery implements CredentialQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public CredentialQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public CredentialQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenQueryImpl.java
@@ -17,23 +17,26 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.token.AccessTokenQuery;
 
 /**
- * Access token query implementation.
+ * {@link AccessTokenQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class AccessTokenQueryImpl extends AbstractKapuaQuery implements AccessTokenQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private AccessTokenQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public AccessTokenQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoQueryImpl.java
@@ -17,23 +17,26 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessInfoQuery;
 
 /**
- * Access info query implementation.
+ * {@link AccessInfoQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class AccessInfoQueryImpl extends AbstractKapuaQuery implements AccessInfoQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public AccessInfoQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public AccessInfoQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImpl.java
@@ -14,27 +14,29 @@ package org.eclipse.kapua.service.authorization.access.shiro;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
 
 /**
- * {@link AccessPermission} query implementation.
+ * {@link AccessPermissionQuery}  implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class AccessPermissionQueryImpl extends AbstractKapuaQuery implements AccessPermissionQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public AccessPermissionQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public AccessPermissionQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImpl.java
@@ -14,27 +14,29 @@ package org.eclipse.kapua.service.authorization.access.shiro;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.access.AccessRole;
 import org.eclipse.kapua.service.authorization.access.AccessRoleQuery;
 
 /**
- * {@link AccessRole} query implementation.
+ * {@link AccessRoleQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public class AccessRoleQueryImpl extends AbstractKapuaQuery implements AccessRoleQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public AccessRoleQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public AccessRoleQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.domain.shiro;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 
@@ -21,15 +21,23 @@ import org.eclipse.kapua.service.authorization.domain.DomainQuery;
  *
  * @since 1.0.0
  */
-public class DomainQueryImpl extends AbstractKapuaQuery implements DomainQuery {
+public class DomainQueryImpl extends AbstractKapuaNamedQuery implements DomainQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public DomainQueryImpl() {
         super();
     }
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.5.0
+     */
     public DomainQueryImpl(KapuaId scopeId) {
         super(scopeId);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.group.shiro;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.group.GroupQuery;
 
@@ -21,8 +21,14 @@ import org.eclipse.kapua.service.authorization.group.GroupQuery;
  *
  * @since 1.0.0
  */
-public class GroupQueryImpl extends AbstractKapuaQuery implements GroupQuery {
+public class GroupQueryImpl extends AbstractKapuaNamedQuery implements GroupQuery {
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
     public GroupQueryImpl(KapuaId scopeId) {
         super(scopeId);
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImpl.java
@@ -14,27 +14,29 @@ package org.eclipse.kapua.service.authorization.role.shiro;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.authorization.role.RolePermission;
 import org.eclipse.kapua.service.authorization.role.RolePermissionQuery;
 
 /**
- * {@link RolePermission} query implementation.
+ * {@link RolePermissionQuery} implementation.
  *
  * @since 1.0.0
  */
 public class RolePermissionQueryImpl extends AbstractKapuaQuery implements RolePermissionQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public RolePermissionQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public RolePermissionQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImpl.java
@@ -12,28 +12,31 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role.shiro;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.role.RoleQuery;
 
 /**
- * Role query implementation.
+ * {@link RoleQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
-public class RoleQueryImpl extends AbstractKapuaQuery implements RoleQuery {
+public class RoleQueryImpl extends AbstractKapuaNamedQuery implements RoleQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     public RoleQueryImpl() {
         super();
     }
 
     /**
-     * Constructor
+     * Constructor.
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public RoleQueryImpl(KapuaId scopeId) {
         this();

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionQueryImplTest.java
@@ -24,8 +24,9 @@ public class MfaOptionQueryImplTest extends Assert {
     @Test
     public void mfaOptionQueryImplTest() {
         MfaOptionQueryImpl mfaOptionQueryImpl = new MfaOptionQueryImpl();
-        assertNotNull("NotNull expected.", mfaOptionQueryImpl.getSortCriteria());
         assertNull("Null expected.", mfaOptionQueryImpl.getScopeId());
+        assertNull("mfaOptionQueryImpl.sortCriteria", mfaOptionQueryImpl.getSortCriteria());
+        assertNotNull("mfaOptionQueryImpl.defaultSortCriteria", mfaOptionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -34,8 +35,9 @@ public class MfaOptionQueryImplTest extends Assert {
 
         for (KapuaId scopeId : scopeIds) {
             MfaOptionQueryImpl mfaOptionQueryImpl = new MfaOptionQueryImpl(scopeId);
-            assertNotNull("NotNull expected.", mfaOptionQueryImpl.getSortCriteria());
             assertEquals("Expected and actual values should be the same.", scopeId, mfaOptionQueryImpl.getScopeId());
+            assertNull("mfaOptionQueryImpl.sortCriteria", mfaOptionQueryImpl.getSortCriteria());
+            assertNotNull("mfaOptionQueryImpl.defaultSortCriteria", mfaOptionQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeQueryImplTest.java
@@ -25,7 +25,8 @@ public class ScratchCodeQueryImplTest extends Assert {
     public void scratchCodeQueryImplWithoutParameterTest() {
         ScratchCodeQueryImpl scratchCodeQueryImpl = new ScratchCodeQueryImpl();
         assertNull("Null expected.", scratchCodeQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", scratchCodeQueryImpl.getSortCriteria());
+        assertNull("scratchCodeQueryImpl.sortCriteria", scratchCodeQueryImpl.getSortCriteria());
+        assertNotNull("scratchCodeQueryImpl.defaultSortCriteria", scratchCodeQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -34,7 +35,8 @@ public class ScratchCodeQueryImplTest extends Assert {
         for (KapuaId scopeId : scopeIds) {
             ScratchCodeQueryImpl scratchCodeQueryImpl = new ScratchCodeQueryImpl(scopeId);
             assertEquals("Expected and actual values should be the same.", scopeId, scratchCodeQueryImpl.getScopeId());
-            assertNotNull("NotNull expected.", scratchCodeQueryImpl.getSortCriteria());
+            assertNull("scratchCodeQueryImpl.sortCriteria", scratchCodeQueryImpl.getSortCriteria());
+            assertNotNull("scratchCodeQueryImpl.defaultSortCriteria", scratchCodeQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialQueryImplTest.java
@@ -24,8 +24,9 @@ public class CredentialQueryImplTest extends Assert {
     @Test
     public void credentialQueryImplWithoutParameterTest() {
         CredentialQueryImpl credentialQueryImpl = new CredentialQueryImpl();
-        assertNotNull("NotNull expected.", credentialQueryImpl.getSortCriteria());
         assertNull("Null expected.", credentialQueryImpl.getScopeId());
+        assertNull("credentialQueryImpl.sortCriteria", credentialQueryImpl.getSortCriteria());
+        assertNotNull("credentialQueryImpl.defaultSortCriteria", credentialQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -33,8 +34,9 @@ public class CredentialQueryImplTest extends Assert {
         KapuaId[] scopeIds = {null, KapuaId.ONE};
         for (KapuaId scopeId : scopeIds) {
             CredentialQueryImpl credentialQueryImpl = new CredentialQueryImpl(scopeId);
-            assertNotNull("NotNull expected.", credentialQueryImpl.getSortCriteria());
             assertEquals("Expected and actual values should be the same.", scopeId, credentialQueryImpl.getScopeId());
+            assertNull("credentialQueryImpl.sortCriteria", credentialQueryImpl.getSortCriteria());
+            assertNotNull("credentialQueryImpl.defaultSortCriteria", credentialQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
@@ -25,20 +25,23 @@ public class AccessPermissionQueryImplTest extends Assert {
     public void accessPermissionQueryImplWithoutParametersTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl();
         assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessPermissionQueryImplScopeIdParameterTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(KapuaId.ONE);
         assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessPermissionQueryImplNullScopeIdParameterTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(null);
         assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", accessPermissionQueryImpl.getSortCriteria());
+        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
@@ -25,13 +25,15 @@ public class AccessRoleQueryImplTest extends Assert {
     public void accessRoleQueryImplWithoutParametersTest() {
         AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl();
         assertNull("Null expected.", accessRoleQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", accessRoleQueryImpl.getSortCriteria());
+        assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
+        assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessRoleQueryImplScopeIdParameterTest() {
         AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl(KapuaId.ONE);
         assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", accessRoleQueryImpl.getSortCriteria());
+        assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
+        assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
@@ -68,14 +68,16 @@ public class DomainFactoryImplTest extends Assert {
     public void newQueryTest() {
         DomainQuery domainQuery = domainFactoryImpl.newQuery(KapuaId.ONE);
         assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQuery.getScopeId());
-        assertNotNull("NotNull expected.", domainQuery.getSortCriteria());
+        assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
+        assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
     }
 
     @Test
     public void newQueryNullTest() {
         DomainQuery domainQuery = domainFactoryImpl.newQuery(null);
         assertNull("Null expected.", domainQuery.getScopeId());
-        assertNotNull("NotNull expected.", domainQuery.getSortCriteria());
+        assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
+        assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
     }
 
     @Test

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
@@ -25,13 +25,15 @@ public class GroupQueryImplTest extends Assert {
     public void groupQueryImplTest() {
         GroupQueryImpl groupQueryImpl = new GroupQueryImpl(KapuaId.ONE);
         assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", groupQueryImpl.getSortCriteria());
+        assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
+        assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void groupQueryImplNullTest() {
         GroupQueryImpl groupQueryImpl = new GroupQueryImpl(null);
         assertNull("Null expected.", groupQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", groupQueryImpl.getSortCriteria());
+        assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
+        assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
@@ -25,7 +25,8 @@ public class RolePermissionQueryImplTest extends Assert {
     public void rolePermissionQueryImplWithoutParametersTest() {
         RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl();
         assertNull("Null expected.", rolePermissionQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", rolePermissionQueryImpl.getSortCriteria());
+        assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
+        assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -35,7 +36,8 @@ public class RolePermissionQueryImplTest extends Assert {
         for (KapuaId scopeId : scopeIds) {
             RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl(scopeId);
             assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionQueryImpl.getScopeId());
-            assertNotNull("NotNull expected.", rolePermissionQueryImpl.getSortCriteria());
+            assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
+            assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
@@ -25,7 +25,8 @@ public class RoleQueryImplTest extends Assert {
     public void rolePermissionQueryImplWithoutParametersTest() {
         RoleQueryImpl roleQueryImpl = new RoleQueryImpl();
         assertNull("Null expected.", roleQueryImpl.getScopeId());
-        assertNotNull("NotNull expected.", roleQueryImpl.getSortCriteria());
+        assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
+        assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -35,7 +36,8 @@ public class RoleQueryImplTest extends Assert {
         for (KapuaId scopeId : scopeIds) {
             RoleQueryImpl roleQueryImpl = new RoleQueryImpl(scopeId);
             assertEquals("Expected and actual values should be the same.", scopeId, roleQueryImpl.getScopeId());
-            assertNotNull("NotNull expected.", roleQueryImpl.getSortCriteria());
+            assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
+            assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagQuery.java
+++ b/service/tag/api/src/main/java/org/eclipse/kapua/service/tag/TagQuery.java
@@ -12,18 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * {@link Tag} query definition.
+ * {@link Tag} {@link KapuaQuery} definition.
  *
+ * @see KapuaQuery
  * @since 1.0.0
- *
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagQueryImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagQueryImpl.java
@@ -12,7 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.tag.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.tag.TagQuery;
 
@@ -21,8 +21,14 @@ import org.eclipse.kapua.service.tag.TagQuery;
  *
  * @since 1.0.0
  */
-public class TagQueryImpl extends AbstractKapuaQuery implements TagQuery {
+public class TagQueryImpl extends AbstractKapuaNamedQuery implements TagQuery {
 
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
     public TagQueryImpl(KapuaId scopeId) {
         super(scopeId);
     }

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserQuery.java
@@ -12,23 +12,32 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user;
 
+import org.eclipse.kapua.model.query.KapuaQuery;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
-import org.eclipse.kapua.model.query.KapuaQuery;
-
 /**
- * User query definition.
+ * {@link User} {@link KapuaQuery} definition.
  *
- * @since 1.0
+ * @see KapuaQuery
+ * @since 1.0.0
  */
 @XmlRootElement(name = "query")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = UserXmlRegistry.class, factoryMethod = "newQuery")
 public interface UserQuery extends KapuaQuery {
 
+    /**
+     * Instantiates a new {@link UserMatchPredicate}.
+     *
+     * @param matchTerm The term to use to match.
+     * @param <T>       The type of the term
+     * @return The newly instantiated {@link UserMatchPredicate}.
+     * @since 1.3.0
+     */
     <T> UserMatchPredicate<T> matchPredicate(T matchTerm);
 
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserQueryImpl.java
@@ -12,19 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal;
 
-import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.user.UserQuery;
 
 /**
- * User query implementation.
+ * {@link UserQuery} implementation.
  *
- * @since 1.0
+ * @since 1.0.0
  */
-public class UserQueryImpl extends AbstractKapuaQuery implements UserQuery {
+public class UserQueryImpl extends AbstractKapuaNamedQuery implements UserQuery {
 
     /**
-     * Constructor
+     * Constructor.
+     *
+     * @since 1.0.0
      */
     private UserQueryImpl() {
         super();
@@ -33,7 +35,8 @@ public class UserQueryImpl extends AbstractKapuaQuery implements UserQuery {
     /**
      * Constructor
      *
-     * @param scopeId
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
      */
     public UserQueryImpl(KapuaId scopeId) {
         this();
@@ -44,5 +47,4 @@ public class UserQueryImpl extends AbstractKapuaQuery implements UserQuery {
     public <T> UserMatchPredicateImpl<T> matchPredicate(T matchTerm) {
         return new UserMatchPredicateImpl<>(matchTerm);
     }
-
 }

--- a/service/user/internal/src/main/resources/liquibase/1.5.0/changelog-user-1.5.0.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.5.0/changelog-user-1.5.0.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-user-1.5.0.xml">
+
+    <include relativeToChangelogFile="true" file="./user-name_indexes.xml"/>
+
+</databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/1.5.0/user-name_indexes.xml
+++ b/service/user/internal/src/main/resources/liquibase/1.5.0/user-name_indexes.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-user-1.5.0.xml">
+
+    <changeSet id="changelog-user_1.5.0_name_indexes" author="eurotech">
+        <createIndex tableName="usr_user" indexName="idx_usr_user_scopeIdName">
+            <column name="scope_id"/>
+            <column name="name"/>
+        </createIndex>
+    </changeSet>
+
+</databaseChangeLog>

--- a/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
+++ b/service/user/internal/src/main/resources/liquibase/changelog-user-master.xml
@@ -21,5 +21,6 @@
     <include relativeToChangelogFile="true" file="./1.0.0/changelog-user-1.0.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-user-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-user-1.2.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.5.0/changelog-user-1.5.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds an API method which enforces the implementation of the queries to define a default sorting which will be used if kapuaQuery.sortCriteria is not defined. 
Not this is achieved by the definition on the `AbstractKapuaQuery` constructor and can happen that if someone does not uses the default constructor with `super()` the sorting is not set. 

**Related Issue**
_None_

**Description of the solution adopted**
Added `getDefaultSortCriteria` to `KapuaQuery` API and a default implementation which defaults to sorting  `KapuaEntity.id`. 
Added also a new extendsion of `AbstractKapuaQuery` for `KapuaNamedEntity`es to default the sorting of the `KapuaNamedEntities` to `name` which is the most common sorting for those entities (i.e. User, Account, ...).
Added indexes on `scopeId, name` fields on Account, User and Job table to improve performances when searching and sorting by name from the console.

**Screenshots**
_None_

**Any side note on the changes made**
FIxed javadoc for classes