### PR TITLE
Don't check for specific CORS Origin if session is not yet created

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/CORSResponseFilter.java
@@ -106,8 +106,8 @@ public class CORSResponseFilter implements Filter {
         httpResponse.addHeader(ACCESS_CONTROL_ALLOW_METHODS, "GET, POST, DELETE, PUT");
         httpResponse.addHeader(ACCESS_CONTROL_ALLOW_HEADERS, "X-Requested-With, Content-Type, Authorization");
 
-        if (httpRequest.getMethod().equals("OPTIONS")) {
-            // Preflight request
+        if (httpRequest.getMethod().equals("OPTIONS") || KapuaSecurityUtils.getSession() == null) {
+            // Preflight request, or session not yet established (Authentication)
             if (checkOrigin(origin, null)) {
                 // Origin matches at least one defined Endpoint
                 httpResponse.addHeader(ACCESS_CONTROL_ALLOW_CREDENTIALS, "true");


### PR DESCRIPTION
After merging #3278, an error would be thrown at `/authentication` methods due to the `KapuaSession` not being populated yet

**Related Issue**
Introduced in #3278

**Description of the solution adopted**
Authentication calls are now treated the same as `OPTIONS` are, and will be checked against any of the allowed Origins in the whole system
