### PR TITLE
Add Endpoint service dependency after new CORS filter

### DIFF
--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -191,6 +191,14 @@
             <artifactId>kapua-user-internal</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-internal</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.apache.shiro</groupId>
             <artifactId>shiro-web</artifactId>
         </dependency>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -105,9 +105,10 @@
 
                         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-                        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
-                        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
         -->
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
+        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
+
         <api>org.eclipse.kapua.service.job.JobService</api>
         <api>org.eclipse.kapua.service.job.JobFactory</api>
 


### PR DESCRIPTION
After merging #3278, the Endpoint service dependency is needed also in JobEngine Application due to the new CORS Filter

**Related Issue**
No related issues
