### PR TITLE
Improve Upsert Failed Error Message in Elasticsearch REST Client

### DIFF
--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -19,6 +19,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.http.ParseException;
 import org.apache.http.util.EntityUtils;
 import org.eclipse.kapua.commons.metric.MetricServiceFactory;
@@ -239,6 +240,10 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
                         String failureMessage = MSG_EMPTY_ERROR;
                         if (failureNode != null) {
                             failureMessage = failureNode.asText();
+                        }
+                        String reason = jsonNode.at("/error/reason").asText();
+                        if (StringUtils.isNotBlank(reason)) {
+                            failureMessage = reason;
                         }
                         bulkResponse.add(new UpdateResponse(metricId, new TypeDescriptor(indexName, typeName), failureMessage));
                         LOG.info("Upsert failed [{}, {}, {}]", indexName, typeName, failureMessage);


### PR DESCRIPTION
Improve error message of `Upsert failed` error messages in Elasticsearch REST Client

Before:

```
09:29:23.058 [Camel (camelContext) thread #14 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, Empty error message]
09:29:23.058 [Camel (camelContext) thread #14 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, Empty error message]
09:29:23.058 [Camel (camelContext) thread #14 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, Empty error message]
09:29:23.058 [Camel (camelContext) thread #14 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, Empty error message]
09:29:23.058 [Camel (camelContext) thread #14 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, Empty error message]
```

---

After:

```
10:56:56.557 [Camel (camelContext) thread #11 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, [_doc][GUO_n3FE7jiBZSt7VHxsQ08ilGK-159vwTD8m8zrTl0]: version conflict, document already exists (current version [1])]
10:56:57.851 [Camel (camelContext) thread #11 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, [_doc][m2E9Qg_ZsAb-IYzAFODHkhUZTuYAxvoQTcq7R0QVBIM]: version conflict, required seqNo [1], primary term [1]. current document has seqNo [4] and primary term [1]]
10:57:06.856 [Camel (camelContext) thread #4 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, [_doc][GUO_n3FE7jiBZSt7VHxsQ08ilGK-159vwTD8m8zrTl0]: version conflict, document already exists (current version [1])]
10:57:08.206 [Camel (camelContext) thread #4 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, [_doc][EnIYPCHV9mQxlXr698sbts6Um0IVzuHwsKFqrupVU2g]: version conflict, required seqNo [2], primary term [1]. current document has seqNo [5] and primary term [1]]
10:57:11.682 [Camel (camelContext) thread #4 - JmsConsumer[Consumer.eurotech:mainRoutelisteners:EXACTLY_ONCE.VirtualTopic.%3E]] INFO  o.e.k.s.e.c.r.RestElasticsearchClient - Upsert failed [.1-metric, _doc, [_doc][LVjuE4Gpng8yqdiwsbPiMhaWO1IxAHLCYwMHqCwBZDM]: version conflict, required seqNo [3], primary term [1]. current document has seqNo [6] and primary term [1]]
```

**Related Issue**
No related issues
