### PR TITLE
Don't return mfaSecretKey when activating MFA via REST API

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/MfaManagementPanel.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/client/tabs/credentials/MfaManagementPanel.java
@@ -143,7 +143,7 @@ public class MfaManagementPanel extends ContentPanel {
                     public void onSuccess(final GwtXSRFToken xsrfToken) {
                         getButtonBar().disable();
 
-                        keyEnabled = gwtMfaCredentialOptions != null && gwtMfaCredentialOptions.getAuthenticationKey() != null;
+                        keyEnabled = gwtMfaCredentialOptions != null;
                         if (!keyEnabled) {
                             doMask(MSGS.maskEnableMfa());
                             // MFA is disabled, so enable it
@@ -488,7 +488,7 @@ public class MfaManagementPanel extends ContentPanel {
     }
 
     private void updateUIComponents(GwtMfaCredentialOptions gwtMfaCredentialOptions) {
-        boolean multiFactorAuth = gwtMfaCredentialOptions != null && gwtMfaCredentialOptions.getAuthenticationKey() != null;
+        boolean multiFactorAuth = gwtMfaCredentialOptions != null;
         boolean hasCredentialWrite = currentSession.hasPermission(CredentialSessionPermission.write());
         boolean hasCredentialDelete = currentSession.hasPermission(CredentialSessionPermission.delete());
 

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtMfaCredentialOptionsServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtMfaCredentialOptionsServiceImpl.java
@@ -76,14 +76,17 @@ public class GwtMfaCredentialOptionsServiceImpl extends KapuaRemoteServiceServle
 
                     @Override
                     public MfaOption call() throws Exception {
-                        return MFA_OPTION_SERVICE.find(scopeId, mfaCredentialOptionsId);
+                        return setSecretKeyNullIfObjExists(MFA_OPTION_SERVICE.find(scopeId, mfaCredentialOptionsId));
                     }
 
                 });
             } else {
                 mfaCredentialOption = MFA_OPTION_SERVICE.find(scopeId, mfaCredentialOptionsId);
             }
-            return mfaCredentialOption != null ? KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(mfaCredentialOption) : null;
+
+            return mfaCredentialOption != null ?
+                    KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(setSecretKeyNullIfObjExists(mfaCredentialOption)) :
+                    null;
         } catch (Exception ex) {
             KapuaExceptionHandler.handle(ex);
             return null;
@@ -101,14 +104,18 @@ public class GwtMfaCredentialOptionsServiceImpl extends KapuaRemoteServiceServle
 
                     @Override
                     public MfaOption call() throws Exception {
-                        return MFA_OPTION_SERVICE.findByUserId(scopeId, userId);
+                        return setSecretKeyNullIfObjExists(MFA_OPTION_SERVICE.findByUserId(scopeId, userId));
                     }
 
                 });
             } else {
                 mfaCredentialOption = MFA_OPTION_SERVICE.findByUserId(scopeId, userId);
             }
-            return mfaCredentialOption != null ? KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(mfaCredentialOption) : null;
+
+            return mfaCredentialOption != null ?
+                    KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(setSecretKeyNullIfObjExists(mfaCredentialOption)) :
+                    null;
+
         } catch (Exception ex) {
             KapuaExceptionHandler.handle(ex);
             return null;
@@ -141,7 +148,9 @@ public class GwtMfaCredentialOptionsServiceImpl extends KapuaRemoteServiceServle
             } else {
                 mfaCredentialOptions = MFA_OPTION_SERVICE.create(mfaCredentialOptionCreator);
             }
-            gwtMfaCredentialOptions = KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(mfaCredentialOptions);
+
+            mfaCredentialOptions.setMfaSecretKey(null);
+            gwtMfaCredentialOptions = KapuaGwtAuthenticationModelConverter.convertMfaCredentialOptions(setSecretKeyNullIfObjExists(mfaCredentialOptions));
         } catch (Throwable t) {
             KapuaExceptionHandler.handle(t);
         }
@@ -174,6 +183,18 @@ public class GwtMfaCredentialOptionsServiceImpl extends KapuaRemoteServiceServle
         } catch (Exception ex) {
             KapuaExceptionHandler.handle(ex);
         }
+    }
+
+    /**
+     * Useful in order to improve security. When the secret key is not needed to be send,
+     * then it's better to apply this function. If not applied, a user who is sniffing the
+     * data send by/to the console can view the secret key.
+     */
+    private MfaOption setSecretKeyNullIfObjExists(MfaOption mfaCredentialOption) {
+        if (mfaCredentialOption != null) {
+            mfaCredentialOption.setMfaSecretKey(null);
+        }
+        return mfaCredentialOption;
     }
 
 }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
@@ -268,6 +268,9 @@ public class Users extends AbstractKapuaResource {
             throw new KapuaEntityNotFoundException(MfaOption.TYPE, "MfaOption");  // TODO: not sure "MfaOption" it's the best value to return here
         }
 
+        // Set the mfa secret key to null before returning the mfaOption, due to improve the security
+        mfaOption.setMfaSecretKey(null);
+
         return mfaOption;
     }
 

--- a/rest-api/resources/src/main/resources/openapi/user/user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user.yaml
@@ -111,8 +111,6 @@ components:
             userId:
               allOf:
                 - $ref: '../openapi.yaml#/components/schemas/kapuaId'
-            mfaSecretKey:
-              type: string
             trustKey:
               description: |
                 The key of the trusted machine.
@@ -159,7 +157,11 @@ components:
         type: mfaOption
         id: "Tu4UpgmN0A4"
         scopeId: "AQ"
+        createdOn: "2021-05-12T08:04:21.962Z"
+        createdBy: "AQ"
+        modifiedOn: "2021-05-12T08:04:21.962Z"
+        modifiedBy: "AQ"
+        optlock: 1,
         userId: "AQ"
-        mfaSecretKey: "exampleMfaSecretKey"
         trustKey: "exampleTrustKey"
         trustExpirationDate: '2020-31-12T00:00:00.000Z'


### PR DESCRIPTION
Fixes #3279, i.e. the `mfaSecretKey` was returned by the method `findMfa` of `Users` class even if it was not needed.
For security reasons is better to not return it.

**Description of the solution adopted**
In the `findMfa` use the method `setMfaSecretKey` of `mfaOption` object in order to set the `mfaSecretKey` to null before returning the result.