### PR TITLE
REST API docker container debug

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -41,7 +41,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
                -Ddevice.management.response.stacktrace.show=\${DEVICE_MANAGEMENT_RESPONSE_STACKTRACE_SHOW:-false} \
                -Djavax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory \
-               -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR}"
+               -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
+               \${JETTY_DEBUG_OPTS}"
 
 USER 0
 

--- a/deployment/docker/compose/extras/docker-compose.broker-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-debug.yml
@@ -5,4 +5,4 @@ services:
     ports:
       - ${KAPUA_BROKER_DEBUG_PORT}:5005
     environment:
-      - ACTIVEMQ_DEBUG_OPTS="-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_BROKER_DEBUG_SUSPEND:-n},address=5005"
+      - ACTIVEMQ_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_BROKER_DEBUG_SUSPEND:-n},address=5005

--- a/deployment/docker/compose/extras/docker-compose.rest-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.rest-debug.yml
@@ -1,0 +1,8 @@
+version: '3.1'
+
+services:
+  kapua-api:
+    ports:
+      - ${KAPUA_REST_DEBUG_PORT}:5005
+    environment:
+      - JETTY_DEBUG_OPTS=-agentlib:jdwp=transport=dt_socket,server=y,suspend=${KAPUA_REST_DEBUG_SUSPEND:-n},address=5005

--- a/deployment/docker/unix/docker-deploy.sh
+++ b/deployment/docker/unix/docker-deploy.sh
@@ -34,6 +34,15 @@ docker_compose() {
         COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.broker-debug.yml")
     fi
 
+    if [[ -n "${KAPUA_REST_DEBUG_PORT}" ]]; then
+        if [[ "${KAPUA_REST_DEBUG_SUSPEND}" == "true" ]]; then
+            KAPUA_REST_DEBUG_SUSPEND="y"
+        else
+            KAPUA_REST_DEBUG_SUSPEND="n"
+        fi
+        COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.rest-debug.yml")
+    fi
+
     if [[ -n "${KAPUA_ELASTICSEARCH_DATA_DIR}" ]]; then
         COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/extras/docker-compose.es-storage-dir.yml")
     fi


### PR DESCRIPTION
Likewise to what was already possible for the broker, it is now possible to debug the REST API after creating the related docker image.

**Description of the solution adopted**

- The `docker-deploy` script now checks if the export of `KAPUA_REST_DEBUG_PORT` variable exists. If it exists, then it links the port specified in that variable with the debug of the REST API.

```
# Example of usage:

$ export KAPUA_REST_DEBUG_PORT="5051"
$ deployment/docker/unix/docker-deploy.sh # run the docker containers
# After that it's possibile to connect the debugger with the 5051 port in order to debug the REST API 
```


- Small edit in `docker-compose.broker-debug.yml` file in order to uniform the string `ACTIVEMQ_DEBUG_OPTS` with the new added string `JETTY_DEBUG_OPTS` in the `docker-compose.rest-debug.yml` file.