### PR TITLE
Exporting batch jobs does not create a file with no entries anymore

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/servlet/JobTargetExporterCsv.java
@@ -48,6 +48,7 @@ public class JobTargetExporterCsv extends JobTargetExporter {
     private String jobId;
     private DateFormat dateFormat;
     private CSVWriter writer;
+    private OutputStreamWriter outputWriter;
 
     public JobTargetExporterCsv(HttpServletResponse response) {
         super(response);
@@ -65,15 +66,11 @@ public class JobTargetExporterCsv extends JobTargetExporter {
         response.setHeader("Content-Disposition", "attachment; filename*=UTF-8''" + URLEncoder.encode(jobId, CharEncoding.UTF_8) + "_job_targets.csv");
         response.setHeader("Cache-Control", "no-transform, max-age=0");
 
-        OutputStreamWriter osw = new OutputStreamWriter(response.getOutputStream(), Charset.forName(CharEncoding.UTF_8));
-        try {
-            writer = new CSVWriter(osw);
+        outputWriter = new OutputStreamWriter(response.getOutputStream(), Charset.forName(CharEncoding.UTF_8));
+        writer = new CSVWriter(outputWriter);
 
-            List<String> cols = new ArrayList<String>(Arrays.asList(JOB_TARGET_PROPERTIES));
-            writer.writeNext(cols.toArray(new String[]{ }));
-        } finally {
-            osw.close();
-        }
+        List<String> cols = new ArrayList<String>(Arrays.asList(JOB_TARGET_PROPERTIES));
+        writer.writeNext(cols.toArray(new String[]{ }));
     }
 
     @Override
@@ -138,7 +135,7 @@ public class JobTargetExporterCsv extends JobTargetExporter {
     @Override
     public void close()
             throws ServletException, IOException {
-        writer.flush();
+        outputWriter.close();
         writer.close();
     }
 }


### PR DESCRIPTION
This PR fix the following issue: in the Web UI the "Export to CSV" feature present in the Batch Jobs section create a CSV file with empty entries.
In addition to this, it was optimised the `close` method of the `JobTargetExporterCsv` class.

**Description of the solution adopted**
- It's removed the `osw.close()` call present in the `init` method of the `JobTargetExporterCsv` class. That call closed the `OutputStreamWriter` before using it (causing the bug).
- The close of the `OutputStreamWriter` object is done when the `JobTargetExporterCsv` close is called.
- Since the `writer.close()` internally call `writer.flush()` the latter call is unnecessary, so it's removed from the `close` method of `JobTargetExporterCsv`.