### PR TITLE
Export OpenAPI Entities on Root OpenAPI file

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
@@ -30,6 +30,9 @@ paths:
                 password:
                   allOf:
                     - $ref: './authentication.yaml#/components/schemas/password'
+                trustKey:
+                  allOf:
+                    - $ref: './authentication.yaml#/components/schemas/trustKey'
               required:
                 - username
                 - password

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
@@ -38,6 +38,9 @@ components:
             refreshExpiresOn:
               type: string
               format: 'date-time'
+            trustKey:
+              allOf:
+                - $ref: '#/components/schemas/trustKey'
     loginInfo:
       type: object
       properties:

--- a/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/dataMessage/dataMessage.yaml
@@ -66,14 +66,7 @@ components:
             metrics:
               type: array
               items:
-                type: object
-                properties:
-                  valueType:
-                    type: string
-                  value:
-                    type: string
-                  name:
-                    type: string
+                $ref: '#/components/schemas/metric'
             body:
               type: string
               format: base64
@@ -217,3 +210,12 @@ components:
         status:
           type: integer
           format: int32
+    metric:
+      type: object
+      properties:
+        valueType:
+          type: string
+        value:
+          type: string
+        name:
+          type: string

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -35,10 +35,7 @@ components:
       schema:
         type: array
         items:
-          type: string
-          enum:
-            - connection
-            - lastEvent
+          $ref: '#/components/schemas/fetchAttribute'
     clientId:
       name: clientId
       in: query
@@ -329,3 +326,8 @@ components:
             action: CREATE
             responseCode: ACCEPTED
             eventMessage: 'acceptEncoding=gzip~~applicationFramework=Kura~~applicationFrameworkVersion=ESF_6.0.0~~applicationIdentifiers=heaterPROV-V2DEPLOY-V2VPNCLIENT-V2CONF-V1CERT-V1ASSET-V1CMD-V1~~availableProcessors=4~~bios=N/A~~biosVersion=N/A~~connectionInterface=lo (00:00:00:00:00:00)~~connectionIp=127.0.0.1~~containerFramework=Eclipse~~containerFrameworkVersion=1.8.0~~displayName=~~firmware=N/A~~firmwareVersion=N/A~~jvm=Java HotSpot(TM) 64-Bit Server VM~~jvmProfile=Java(TM) SE Runtime Environment 1.8.0_161-b12~~jvmVersion=25.161-b12 mixed mode~~modelId=ESF-Docker-RHEL~~modelName=ESF-Docker-RHEL~~os=Linux~~osArch=amd64~~osVersion=4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019~~partNumber=ESF-Docker-RHEL~~serialNumber=ESF-Docker-RHEL~~totalMemory=1023488~~uptime=187894320'
+    fetchAttribute:
+        type: string
+        enum:
+          - connection
+          - lastEvent

--- a/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceConfiguration/deviceConfiguration.yaml
@@ -29,12 +29,7 @@ components:
         Option:
           type: array
           items:
-            type: object
-            properties:
-              label:
-                type: string
-              value:
-                type: string
+            $ref: '#/components/schemas/option'
         default:
           type: string
         type:
@@ -100,12 +95,7 @@ components:
             Icon:
               type: array
               items:
-                type: object
-                properties:
-                  resource:
-                    type: string
-                  size:
-                    type: integer
+                $ref: '#/components/schemas/icon'
             name:
               type: string
             description:
@@ -226,3 +216,17 @@ components:
                   type: String
                   value:
                     - org.eclipse.kura.wire.graph.WireGraphService
+    icon:
+      type: object
+      properties:
+        resource:
+          type: string
+        size:
+          type: integer
+    option:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage.yaml
@@ -29,12 +29,7 @@ components:
             bundleInfo:
               type: array
               items:
-                type: object
-                properties:
-                  name:
-                    type: string
-                  version:
-                    type: string
+                $ref: '#/components/schemas/bundleInfo'
         installDate:
           type: string
           format: 'date-time'
@@ -117,3 +112,10 @@ components:
           blockTimeout: 5000
           notifyBlockSize: 256
           installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh
+    bundleInfo:
+      type: object
+      properties:
+        name:
+          type: string
+        version:
+          type: string

--- a/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobTriggerFired/job-scopeId-jobId-triggers-triggerId-fired.yaml
@@ -22,7 +22,16 @@ paths:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../job/job.yaml#/components/parameters/jobId'
         - $ref: './jobTriggerFired.yaml#/components/parameters/triggerId'
-        - $ref: './jobTriggerFired.yaml#/components/schemas/firedTriggerStatus'
+        - name: status
+          in: query
+          description: |
+            The optional status of the Fired Trigger
+
+            Allowed values:
+            - FIRED
+            - FAILED
+          schema:
+            $ref: './jobTriggerFired.yaml#/components/schemas/firedTriggerStatus'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -166,7 +166,7 @@ paths:
     $ref: './deviceConfiguration/deviceConfiguration-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1configurations'
   /{scopeId}/devices/{deviceId}/configurations/{componentId}:
     $ref: './deviceConfiguration/deviceConfiguration-scopeId-deviceId-componentId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1configurations~1{componentId}'
-  ### Device Bundle ###
+  ### Device Inventory ###
   /{scopeId}/devices/{deviceId}/inventory:
     $ref: './deviceInventory/deviceInventory-scopeId-deviceId.yaml#/paths/~1{scopeId}~1devices~1{deviceId}~1inventory'
   /{scopeId}/devices/{deviceId}/inventory/bundles:
@@ -631,6 +631,10 @@ components:
     clientInfoListResult:
       $ref: './dataClient/dataClient.yaml#/components/schemas/clientInfoListResult'
     ### Data Message Entities ###
+    metric:
+      $ref: './dataMessage/dataMessage.yaml#/components/schemas/metric'
+    position:
+      $ref: './dataMessage/dataMessage.yaml#/components/schemas/position'
     dataMessage:
       $ref: './dataMessage/dataMessage.yaml#/components/schemas/dataMessage'
     dataMessageInsertResponse:
@@ -643,6 +647,8 @@ components:
     metricInfoListResult:
       $ref: './dataMetric/dataMetric.yaml#/components/schemas/metricInfoListResult'
     ### Device Entities ###
+    fetchAttribute:
+      $ref: './device/device.yaml#/components/schemas/fetchAttribute'
     device:
       $ref: './device/device.yaml#/components/schemas/device'
     deviceCreator:
@@ -681,6 +687,14 @@ components:
       $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurations'
     componentConfigurationsInput:
       $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
+    icon:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/icon'
+    propertyDefinition:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/propertyDefinition'
+    option:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/option'
+    attributeDefinition:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/attributeDefinition'
     ### Device Connection Entities ###
     connection:
       $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connection'
@@ -692,13 +706,21 @@ components:
     deviceEventListResult:
       $ref: './deviceEvent/deviceEvent.yaml#/components/schemas/deviceEventListResult'
     ### Device Inventory Entities ###
+    inventoryItem:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/inventoryItem'
     deviceInventory:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventory'
+    deviceInventoryBundle:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryBundle'
     deviceInventoryBundles:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryBundles'
+    deviceInventoryPackage:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventorySystemPackage'
     deviceInventoryPackages:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventorySystemPackages'
-    deviceInventoryDeploymenyPackages:
+    deviceInventoryDeploymentPackage:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryDeploymentPackage'
+    deviceInventoryDeploymentPackages:
       $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryDeploymentPackages'
     ### Device Notification Entities ###
     deviceNotification:
@@ -706,11 +728,15 @@ components:
     deviceNotificationListResult:
       $ref: './deviceNotification/deviceNotification.yaml#/components/schemas/deviceNotificationListResult'
     ### Device Operation Entities ###
+    operationProperty:
+      $ref: './deviceOperation/deviceOperation.yaml#/components/schemas/operationProperty'
     deviceOperation:
       $ref: './deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
     deviceOperationListResult:
       $ref: './deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperationListResult'
     ### Device Package Entities ###
+    bundleInfo:
+      $ref: './devicePackage/devicePackage.yaml#/components/schemas/bundleInfo'
     devicePackage:
       $ref: './devicePackage/devicePackage.yaml#/components/schemas/devicePackage'
     devicePackages:
@@ -733,6 +759,8 @@ components:
     domainListResult:
       $ref: './domain/domain.yaml#/components/schemas/domainListResult'
     ### Endpoint Info Entities ###
+    usage:
+      $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/usage'
     endpointInfo:
       $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointInfo'
     endpointInfoCreator:
@@ -810,6 +838,10 @@ components:
     rolePermissionListResult:
       $ref: './role/role.yaml#/components/schemas/rolePermissionListResult'
     ### Service Configuration Entities ###
+    servicePropertyDefinition:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/propertyDefinition'
+    serviceIcon:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/icon'
     serviceComponentConfiguration:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfiguration'
     serviceComponentConfigurationInput:
@@ -818,6 +850,10 @@ components:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfigurations'
     serviceComponentConfigurationsInput:
       $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
+    serviceOption:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/option'
+    serviceAttributeDefinition:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/attributeDefinition'
     ### Tag Entities ###
     tag:
       $ref: './tag/tag.yaml#/components/schemas/tag'
@@ -826,6 +862,8 @@ components:
     tagListResult:
       $ref: './tag/tag.yaml#/components/schemas/tagListResult'
     ### Trigger Definition Entities ###
+    triggerDefinitionProperty:
+      $ref: './triggerDefinition/triggerDefinition.yaml#/components/schemas/triggerDefinitionProperty'
     triggerDefinition:
       $ref: './triggerDefinition/triggerDefinition.yaml#/components/schemas/triggerDefinition'
     triggerDefinitionListResult:

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -548,6 +548,7 @@ components:
               type: string
           required:
             - name
+    ### Other Base Entities ###
     kapuaError:
       description: The base object to represent an Error
       properties:
@@ -579,6 +580,267 @@ components:
         count:
           type: integer
           description: The total count of the Entities available in the Scope
+    ### AccessInfo Entities ###
+    accessInfo:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessInfo'
+    accessInfoCreator:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessInfoCreator'
+    accessInfoListResult:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessInfoListResult'
+    permission:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/permission'
+    accessPermission:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessPermission'
+    accessPermissionCreator:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessPermissionCreator'
+    accessPermissionListResult:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessPermissionListResult'
+    accessRole:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessRole'
+    accessRoleCreator:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessRoleCreator'
+    accessRoleListResult:
+      $ref: './accessInfo/accessInfo.yaml#/components/schemas/accessRoleListResult'
+    ### Account Entities ###
+    account:
+      $ref: './account/account.yaml#/components/schemas/account'
+    accountCreator:
+      $ref: './account/account.yaml#/components/schemas/accountCreator'
+    accountListResult:
+      $ref: './account/account.yaml#/components/schemas/accountListResult'
+    ### Authentication Entities ###
+    accessToken:
+      $ref: './authentication/authentication.yaml#/components/schemas/accessToken'
+    loginInfo:
+      $ref: './authentication/authentication.yaml#/components/schemas/loginInfo'
+    ### Credential Entities ###
+    credential:
+      $ref: './credential/credential.yaml#/components/schemas/credential'
+    credentialCreator:
+      $ref: './credential/credential.yaml#/components/schemas/credentialCreator'
+    credentialListResult:
+      $ref: './credential/credential.yaml#/components/schemas/credentialListResult'
+    ### Data Channel Entities ###
+    channelInfo:
+      $ref: './dataChannel/dataChannel.yaml#/components/schemas/channelInfo'
+    channelInfoListResult:
+      $ref: './dataChannel/dataChannel.yaml#/components/schemas/channelInfoListResult'
+    ### Data Client Entities ###
+    clientInfo:
+      $ref: './dataClient/dataClient.yaml#/components/schemas/clientInfo'
+    clientInfoListResult:
+      $ref: './dataClient/dataClient.yaml#/components/schemas/clientInfoListResult'
+    ### Data Message Entities ###
+    dataMessage:
+      $ref: './dataMessage/dataMessage.yaml#/components/schemas/dataMessage'
+    dataMessageInsertResponse:
+      $ref: './dataMessage/dataMessage.yaml#/components/schemas/dataMessageInsertResponse'
+    dataMessageListResult:
+      $ref: './dataMessage/dataMessage.yaml#/components/schemas/dataMessageListResult'
+    ### Data Metric Entities ###
+    metricInfo:
+      $ref: './dataMetric/dataMetric.yaml#/components/schemas/metricInfo'
+    metricInfoListResult:
+      $ref: './dataMetric/dataMetric.yaml#/components/schemas/metricInfoListResult'
+    ### Device Entities ###
+    device:
+      $ref: './device/device.yaml#/components/schemas/device'
+    deviceCreator:
+      $ref: './device/device.yaml#/components/schemas/deviceCreator'
+    deviceListResult:
+      $ref: './device/device.yaml#/components/schemas/deviceListResult'
+    ### Device Asset Entities ###
+    deviceAssetDefinition:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/deviceAssetDefinition'
+    deviceAssetDefinitions:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/deviceAssetDefinitions'
+    deviceAssetValue:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/deviceAssetValue'
+    deviceAssetValues:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/deviceAssetValues'
+    channelDefinition:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/channelDefinition'
+    channelValue:
+      $ref: './deviceAsset/deviceAsset.yaml#/components/schemas/channelValue'
+    ### Device Bundle Entities ###
+    deviceBundle:
+      $ref: './deviceBundle/deviceBundle.yaml#/components/schemas/deviceBundle'
+    deviceBundles:
+      $ref: './deviceBundle/deviceBundle.yaml#/components/schemas/deviceBundles'
+    ### Device Command Entities ###
+    commandInput:
+      $ref: './deviceCommand/deviceCommand.yaml#/components/schemas/commandInput'
+    commandOutput:
+      $ref: './deviceCommand/deviceCommand.yaml#/components/schemas/commandOutput'
+    ### Device Configuration Entities ###
+    componentConfiguration:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfiguration'
+    componentConfigurationInput:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurationInput'
+    componentConfigurations:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurations'
+    componentConfigurationsInput:
+      $ref: './deviceConfiguration/deviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
+    ### Device Connection Entities ###
+    connection:
+      $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connection'
+    connectionListResult:
+      $ref: './deviceConnection/deviceConnection.yaml#/components/schemas/connectionListResult'
+    ### Device Event Entities ###
+    deviceEvent:
+      $ref: './deviceEvent/deviceEvent.yaml#/components/schemas/deviceEvent'
+    deviceEventListResult:
+      $ref: './deviceEvent/deviceEvent.yaml#/components/schemas/deviceEventListResult'
+    ### Device Inventory Entities ###
+    deviceInventory:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventory'
+    deviceInventoryBundles:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryBundles'
+    deviceInventoryPackages:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventorySystemPackages'
+    deviceInventoryDeploymenyPackages:
+      $ref: './deviceInventory/deviceInventory.yaml#/components/schemas/deviceInventoryDeploymentPackages'
+    ### Device Notification Entities ###
+    deviceNotification:
+      $ref: './deviceNotification/deviceNotification.yaml#/components/schemas/deviceNotification'
+    deviceNotificationListResult:
+      $ref: './deviceNotification/deviceNotification.yaml#/components/schemas/deviceNotificationListResult'
+    ### Device Operation Entities ###
+    deviceOperation:
+      $ref: './deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
+    deviceOperationListResult:
+      $ref: './deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperationListResult'
+    ### Device Package Entities ###
+    devicePackage:
+      $ref: './devicePackage/devicePackage.yaml#/components/schemas/devicePackage'
+    devicePackages:
+      $ref: './devicePackage/devicePackage.yaml#/components/schemas/devicePackages'
+    devicePackageDownloadRequest:
+      $ref: './devicePackage/devicePackage.yaml#/components/schemas/devicePackageDownloadRequest'
+    ### Device Request Entities ###
+    requestInput:
+      $ref: './deviceRequest/deviceRequest.yaml#/components/schemas/requestInput'
+    requestOutput:
+      $ref: './deviceRequest/deviceRequest.yaml#/components/schemas/requestOutput'
+    ### Device Snapshot Entities ###
+    snapshot:
+      $ref: './deviceSnapshot/deviceSnapshot.yaml#/components/schemas/snapshot'
+    snapshots:
+      $ref: './deviceSnapshot/deviceSnapshot.yaml#/components/schemas/snapshots'
+    ### Domain Entities ###
+    domain:
+      $ref: './domain/domain.yaml#/components/schemas/domain'
+    domainListResult:
+      $ref: './domain/domain.yaml#/components/schemas/domainListResult'
+    ### Endpoint Info Entities ###
+    endpointInfo:
+      $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointInfo'
+    endpointInfoCreator:
+      $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointInfoCreator'
+    endpointInfoListResult:
+      $ref: './endpointInfo/endpointInfo.yaml#/components/schemas/endpointInfoListResult'
+    ### Group Entities ###
+    group:
+      $ref: './group/group.yaml#/components/schemas/group'
+    groupCreator:
+      $ref: './group/group.yaml#/components/schemas/groupCreator'
+    groupListResult:
+      $ref: './group/group.yaml#/components/schemas/groupListResult'
+    ### Job Entities ###
+    job:
+      $ref: './job/job.yaml#/components/schemas/job'
+    jobCreator:
+      $ref: './job/job.yaml#/components/schemas/jobCreator'
+    jobListResult:
+      $ref: './job/job.yaml#/components/schemas/jobListResult'
+    ### Job Engine Entities ###
+    isJobRunning:
+      $ref: './jobEngine/jobEngine.yaml#/components/schemas/isJobRunning'
+    jobStartOptions:
+      $ref: './jobEngine/jobEngine.yaml#/components/schemas/jobStartOptions'
+    ### Job Execution Entities ###
+    jobExecution:
+      $ref: './jobExecution/jobExecution.yaml#/components/schemas/jobExecution'
+    jobExecutionListResult:
+      $ref: './jobExecution/jobExecution.yaml#/components/schemas/jobExecutionListResult'
+    ### Job Step Entities ###
+    jobStep:
+      $ref: './jobStep/jobStep.yaml#/components/schemas/jobStep'
+    jobStepCreator:
+      $ref: './jobStep/jobStep.yaml#/components/schemas/jobStepCreator'
+    jobStepListResult:
+      $ref: './jobStep/jobStep.yaml#/components/schemas/jobStepListResult'
+    ### Job Step Definition Entities ###
+    jobStepDefinition:
+      $ref: './jobStepDefinition/jobStepDefinition.yaml#/components/schemas/jobStepDefinition'
+    jobStepDefinitionProperty:
+      $ref: './jobStepDefinition/jobStepDefinition.yaml#/components/schemas/jobStepDefinitionProperty'
+    jobStepDefinitionListResult:
+      $ref: './jobStepDefinition/jobStepDefinition.yaml#/components/schemas/jobStepDefinitionListResult'
+    ### Job Target Entities ###
+    jobTarget:
+      $ref: './jobTarget/jobTarget.yaml#/components/schemas/jobTarget'
+    jobTargetCreator:
+      $ref: './jobTarget/jobTarget.yaml#/components/schemas/jobTargetCreator'
+    jobTargetListResult:
+      $ref: './jobTarget/jobTarget.yaml#/components/schemas/jobTargetListResult'
+    ### Job Trigger Entities ###
+    jobTrigger:
+      $ref: './jobTrigger/jobTrigger.yaml#/components/schemas/jobTrigger'
+    jobTriggerCreator:
+      $ref: './jobTrigger/jobTrigger.yaml#/components/schemas/jobTriggerCreator'
+    jobTriggerListResult:
+      $ref: './jobTrigger/jobTrigger.yaml#/components/schemas/jobTriggerListResult'
+    ### Job Trigger Fired Entities ###
+    firedTrigger:
+      $ref: './jobTriggerFired/jobTriggerFired.yaml#/components/schemas/firedTrigger'
+    firedTriggerListResult:
+      $ref: './jobTriggerFired/jobTriggerFired.yaml#/components/schemas/firedTriggerListResult'
+    ### Role Entities ###
+    role:
+      $ref: './role/role.yaml#/components/schemas/role'
+    roleCreator:
+      $ref: './role/role.yaml#/components/schemas/roleCreator'
+    roleListResult:
+      $ref: './role/role.yaml#/components/schemas/roleListResult'
+    rolePermission:
+      $ref: './role/role.yaml#/components/schemas/rolePermission'
+    rolePermissionCreator:
+      $ref: './role/role.yaml#/components/schemas/rolePermissionCreator'
+    rolePermissionListResult:
+      $ref: './role/role.yaml#/components/schemas/rolePermissionListResult'
+    ### Service Configuration Entities ###
+    serviceComponentConfiguration:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfiguration'
+    serviceComponentConfigurationInput:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfigurationInput'
+    serviceComponentConfigurations:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfigurations'
+    serviceComponentConfigurationsInput:
+      $ref: './serviceConfiguration/serviceConfiguration.yaml#/components/schemas/componentConfigurationsInput'
+    ### Tag Entities ###
+    tag:
+      $ref: './tag/tag.yaml#/components/schemas/tag'
+    tagCreator:
+      $ref: './tag/tag.yaml#/components/schemas/tagCreator'
+    tagListResult:
+      $ref: './tag/tag.yaml#/components/schemas/tagListResult'
+    ### Trigger Definition Entities ###
+    triggerDefinition:
+      $ref: './triggerDefinition/triggerDefinition.yaml#/components/schemas/triggerDefinition'
+    triggerDefinitionListResult:
+      $ref: './triggerDefinition/triggerDefinition.yaml#/components/schemas/triggerDefinitionListResult'
+    ### User Entities ###
+    user:
+      $ref: './user/user.yaml#/components/schemas/user'
+    userCreator:
+      $ref: './user/user.yaml#/components/schemas/userCreator'
+    userListResult:
+      $ref: './user/user.yaml#/components/schemas/userListResult'
+    mfaOption:
+      $ref: './user/user.yaml#/components/schemas/mfaOption'
+    mfaOptionCreator:
+      $ref: './user/user.yaml#/components/schemas/mfaOptionCreator'
   requestBodies:
     kapuaQuery:
       description: An object to specify Query options

--- a/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
+++ b/rest-api/resources/src/main/resources/openapi/serviceConfiguration/serviceConfiguration.yaml
@@ -33,12 +33,7 @@ components:
         Option:
           type: array
           items:
-            type: object
-            properties:
-              label:
-                type: string
-              value:
-                type: string
+            $ref: '#/components/schemas/option'
         default:
           description: The default value for this field
           type: string
@@ -124,12 +119,7 @@ components:
             Icon:
               type: array
               items:
-                type: object
-                properties:
-                  resource:
-                    type: string
-                  size:
-                    type: integer
+                $ref: '#/components/schemas/icon'
             name:
               type: string
             description:
@@ -370,3 +360,18 @@ components:
                   type: Integer
                   value:
                     - '30'
+    option:
+      type: object
+      properties:
+        label:
+          type: string
+        value:
+          type: string
+    icon:
+      type: object
+      properties:
+        resource:
+          type: string
+        size:
+          type: integer
+

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
@@ -37,6 +37,8 @@ paths:
             - DISPLAY_NAME
             - EXTERNAL_ID
             - DESCRIPTION
+          schema:
+            type: string
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'


### PR DESCRIPTION
All OpenAPI entities have been linked from the main OpenAPI file in order to have them available in the SwaggerUI Main Page

**Related Issue**
No related issues
