### PR TITLE
Dynamic Trigger Date End on Trigger Tests

### DIFF
--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -733,7 +733,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Interval Job"
     And A regular trigger creator with the name "schedule0" is created
     And The trigger is set to start on 12-12-2020 at 10:00.
-    And The trigger is set to end on 12-05-2021 at 10:00.
+    And The trigger is set to end tomorrow at 10:00.
     Then I set retry interval to 2
     And I create a new trigger from the existing creator with previously defined date properties
     Then I delete trigger with name "schedule0"
@@ -755,7 +755,7 @@ Feature: Trigger service tests
     When I find scheduler properties with name "Cron Job"
     And A regular trigger creator with the name "schedule0" is created
     And The trigger is set to start on 12-12-2020 at 10:00.
-    And The trigger is set to end on 12-05-2021 at 10:00.
+    And The trigger is set to end tomorrow at 20:00.
     Then I set cron expression to "0 15 10 * * ?"
     And I create a new trigger from the existing creator with previously defined date properties
     Then I delete trigger with name "schedule0"


### PR DESCRIPTION
Use a dynamic end date for Trigger tests
**Related Issue**
Fixes #3311
