### PR TITLE
Job Step Properties limits and basic validation

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/ArgumentValidator.java
@@ -212,19 +212,39 @@ public class ArgumentValidator {
      * Throws a {@link KapuaIllegalArgumentException} if the {@link String} given has {@link String#length()} less than the #minLength given or greater than the #maxLength given.
      *
      * @param value        The {@link String} to check
-     * @param minLength    The minimun valid value. If {@code null} it means unbounded.
-     * @param maxLength    The maximum valid value. If {@code null} it means unbounded.
+     * @param minLength    The minimum valid length. If {@code null} it means unbounded.
+     * @param maxLength    The maximum valid length. If {@code null} it means unbounded.
      * @param argumentName The argument name with will be used in the exception
      * @throws KapuaIllegalArgumentException If the given {@link String} excedees the given length limits.
      */
     public static void lengthRange(@NotNull String value, @Nullable Integer minLength, @Nullable Integer maxLength, @NotNull String argumentName) throws KapuaIllegalArgumentException {
 
         if (minLength != null && value.length() < minLength) {
-            throw new KapuaIllegalArgumentException(argumentName, "Value less than allowed min length. Min length is " + minLength);
+            throw new KapuaIllegalArgumentException(argumentName, "Value less than allowed min length. Min length is: " + minLength);
         }
 
         if (maxLength != null && value.length() > maxLength) {
-            throw new KapuaIllegalArgumentException(argumentName, "Value over than allowed max length. Max length is " + maxLength);
+            throw new KapuaIllegalArgumentException(argumentName, "Value over than allowed max length. Max length is: " + maxLength);
+        }
+    }
+
+    /**
+     * Throws a {@link KapuaIllegalArgumentException} if the {@link Comparable} given has a value less than the min value given or greater than the max value given.
+     *
+     * @param value        The {@link String} to check
+     * @param minValue     The minimum valid value. If {@code null} it means unbounded.
+     * @param maxValue     The maximum valid value. If {@code null} it means unbounded.
+     * @param argumentName The argument name with will be used in the exception
+     * @throws KapuaIllegalArgumentException If the given {@link String} excedees the given length limits.
+     */
+    public static <V extends Comparable<V>> void valueRange(@NotNull V value, @Nullable V minValue, @Nullable V maxValue, @NotNull String argumentName) throws KapuaIllegalArgumentException {
+
+        if (minValue != null && value.compareTo(minValue) < 0) {
+            throw new KapuaIllegalArgumentException(argumentName, "Value less than allowed min value. Min value is: " + minValue);
+        }
+
+        if (maxValue != null && value.compareTo(maxValue) > 0) {
+            throw new KapuaIllegalArgumentException(argumentName, "Value over than allowed max value. Max value is: " + maxValue);
         }
     }
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/ArgumentValidatorTest.java
@@ -668,22 +668,22 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void lengthRangeTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"londo","londonIsGoodIdea", "london", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"};
-        String [] valueForNegativeTest = new String[] {"", "lond", "is", "L", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
+        String[] valueForPositiveTest = new String[]{"londo", "londonIsGoodIdea", "london", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"};
+        String[] valueForNegativeTest = new String[]{"", "lond", "is", "L", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
 
         int minLength = 5;
         int maxLength = 255;
-        for (String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
-                fail("Value less than allowed min length. Min length is " + minLength);
+                fail("Value less than allowed min length. Min length is: " + minLength);
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
-                fail("Value less than allowed min length. Min length is " + minLength);
+                fail("Value less than allowed min length. Min length is: " + minLength);
             } catch (KapuaIllegalArgumentException ex) {
                 //expected
             }
@@ -692,35 +692,35 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void minLengthOverThanMaxRangeTest() throws KapuaIllegalArgumentException {
-        String [] valueForTest = new String[] {"londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
+        String[] valueForTest = new String[]{"londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
 
         int minLength = 10;
         int maxLength = 5;
-        for(String element : valueForTest){
+        for (String element : valueForTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
-                fail("Value over than allowed max length. Max length is " + maxLength);
+                fail("Value over than allowed max length. Max length is: " + maxLength);
             } catch (KapuaIllegalArgumentException ex) {
-              //expected
+                //expected
             }
         }
     }
 
     @Test
     public void equalsMinAndMaxRangeTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"londonlond", "goodIdealo"};
-        String [] valueForNegativeTest = new String[] {"", "lond", "is", "L", "londonIsGoodIdea", "london", "good"};
+        String[] valueForPositiveTest = new String[]{"londonlond", "goodIdealo"};
+        String[] valueForNegativeTest = new String[]{"", "lond", "is", "L", "londonIsGoodIdea", "london", "good"};
 
         int minLength = 10;
         int maxLength = 10;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
-                fail("Value over than allowed max length. Max length is " + maxLength);
+                fail("Value over than allowed max length. Max length is: " + maxLength);
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
                 fail("Exception expected.");
@@ -732,21 +732,21 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void nullMinLengthAndValidMaxLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"londonlondon", "lo", "", "null", "0", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
-        String [] valueForNegativeTest = new String[] {"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
+        String[] valueForPositiveTest = new String[]{"londonlondon", "lo", "", "null", "0", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
+        String[] valueForNegativeTest = new String[]{"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
 
         int maxLength = 255;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, null, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
-                fail("Value over than allowed max length. Max length is " + maxLength);
+                fail("Value over than allowed max length. Max length is: " + maxLength);
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, null, maxLength, "londonIsGoodIdea");
-                fail("Value over than allowed max length. Max length is " + maxLength);
+                fail("Value over than allowed max length. Max length is: " + maxLength);
             } catch (KapuaIllegalArgumentException ex) {
                 //expected
             }
@@ -755,19 +755,19 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void nullMaxLengthAndValidMinLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"
+        String[] valueForPositiveTest = new String[]{"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"
                 , "londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea", "lon"};
-        String [] valueForNegativeTest = new String[] {"", "lo", "is", "L"};
+        String[] valueForNegativeTest = new String[]{"", "lo", "is", "L"};
 
         int minLength = 3;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, null, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
                 fail("No exception expected");
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, null, "londonIsGoodIdea");
                 fail("Exception expected.");
@@ -779,12 +779,12 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void nullMinAndMaxLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForTest = new String[] {"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea",
+        String[] valueForTest = new String[]{"londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea",
                 "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea",
                 "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"
                 , "londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea", "lon"};
 
-        for(String element : valueForTest){
+        for (String element : valueForTest) {
             try {
                 ArgumentValidator.lengthRange(element, null, null, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
@@ -795,20 +795,20 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void zeroMinLengthAndValidMaxLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
+        String[] valueForPositiveTest = new String[]{"", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
                 , "londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea", "lon"};
-        String [] valueForNegativeTest = new String[] {};
+        String[] valueForNegativeTest = new String[]{};
 
         int maxLength = 255;
         int minLength = 0;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
                 fail("No exception expected");
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, 255, "londonIsGoodIdea");
                 fail("Exception expected.");
@@ -820,12 +820,12 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void zeroMaxLengthAndValidMinLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForTest = new String[] {"lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
+        String[] valueForTest = new String[]{"lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
                 , "londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea", ""};
 
         int maxLength = 0;
         int minLength = 3;
-        for(String element : valueForTest){
+        for (String element : valueForTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
                 fail("Exception expected");
@@ -837,20 +837,20 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void zeroMinAndMaxLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {""};
-        String [] valueForNegativeTest = new String[] {"lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
+        String[] valueForPositiveTest = new String[]{""};
+        String[] valueForNegativeTest = new String[]{"lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"
                 , "londonlondon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea",};
 
         int maxLength = 0;
         int minLength = 0;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
                 fail("Exception expected");
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
                 fail("Exception expected.");
@@ -862,19 +862,19 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void minAndMaxIntegerValuesLengthTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"", "l", "lo", "lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
-        String [] valueForNegativeTest = new String[] {};
+        String[] valueForPositiveTest = new String[]{"", "l", "lo", "lon", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdea"};
+        String[] valueForNegativeTest = new String[]{};
 
         int maxLength = 2147483647;
         int minLength = -2147483648;
-        for(String element : valueForPositiveTest){
+        for (String element : valueForPositiveTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
             } catch (KapuaIllegalArgumentException ex) {
                 fail("No exception expected");
             }
         }
-        for(String element : valueForNegativeTest){
+        for (String element : valueForNegativeTest) {
             try {
                 ArgumentValidator.lengthRange(element, minLength, maxLength, "londonIsGoodIdea");
                 fail("Exception expected.");
@@ -886,15 +886,15 @@ public class ArgumentValidatorTest extends Assert {
 
     @Test
     public void validateEntityNameTest() throws KapuaIllegalArgumentException {
-        String [] valueForPositiveTest = new String[] {"londonIsGoodIdea", "london", "123", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"};
-        String [] valueForNegativeTest = new String[] {"lo", "l", ""};
+        String[] valueForPositiveTest = new String[]{"londonIsGoodIdea", "london", "123", "londonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIdealondonIsGoodIde"};
+        String[] valueForNegativeTest = new String[]{"lo", "l", ""};
 
         String argName = "validateEntityNameTest";
         for (String value : valueForPositiveTest) {
             try {
                 ArgumentValidator.validateEntityName(value, argName);
             } catch (KapuaIllegalArgumentException ex) {
-                fail("Value less than allowed min length. Min length is 3");
+                fail("Value less than allowed min length. Min length is: 3");
             }
         }
         for (String value : valueForNegativeTest) {
@@ -987,7 +987,7 @@ public class ArgumentValidatorTest extends Assert {
     @Test
     public void extendedValidateEntityNameMinLengthIntTest() throws Exception {
         try {
-            ArgumentValidator.validateEntityName("validName", -2147483648 , 255, "validateEntityName2Test");
+            ArgumentValidator.validateEntityName("validName", -2147483648, 255, "validateEntityName2Test");
         } catch (KapuaIllegalArgumentException ex) {
             fail("No exception expected");
         }
@@ -996,7 +996,7 @@ public class ArgumentValidatorTest extends Assert {
     @Test
     public void extendedValidateEntityNameMaxLengthIntTest() throws Exception {
         try {
-            ArgumentValidator.validateEntityName("validName", 3 , 2147483647, "validateEntityName2Test");
+            ArgumentValidator.validateEntityName("validName", 3, 2147483647, "validateEntityName2Test");
         } catch (KapuaIllegalArgumentException ex) {
             fail("No exception expected");
         }
@@ -1005,7 +1005,7 @@ public class ArgumentValidatorTest extends Assert {
     @Test
     public void extendedValidateEntityNameMaxAndMinIntLengthTest() throws Exception {
         try {
-            ArgumentValidator.validateEntityName("validName", -2147483648 , 2147483647, "validateEntityName2Test");
+            ArgumentValidator.validateEntityName("validName", -2147483648, 2147483647, "validateEntityName2Test");
         } catch (KapuaIllegalArgumentException ex) {
             fail("No exception expected");
         }
@@ -1014,7 +1014,7 @@ public class ArgumentValidatorTest extends Assert {
     @Test
     public void extendedValidateEntityNameMinLengthNullTest() throws Exception {
         try {
-            ArgumentValidator.validateEntityName("validName", null , 255, "validateEntityName2Test");
+            ArgumentValidator.validateEntityName("validName", null, 255, "validateEntityName2Test");
         } catch (KapuaIllegalArgumentException ex) {
             fail("No exception expected");
         }
@@ -1023,7 +1023,7 @@ public class ArgumentValidatorTest extends Assert {
     @Test
     public void extendedValidateEntityNameMaxLengthNullTest() throws Exception {
         try {
-            ArgumentValidator.validateEntityName("validName", 3 , null, "validateEntityName2Test");
+            ArgumentValidator.validateEntityName("validName", 3, null, "validateEntityName2Test");
         } catch (KapuaIllegalArgumentException ex) {
             fail("No exception expected");
         }

--- a/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/RegexFieldValidator.java
+++ b/console/module/api/src/main/java/org/eclipse/kapua/app/console/module/api/client/ui/validator/RegexFieldValidator.java
@@ -17,28 +17,35 @@ import com.extjs.gxt.ui.client.widget.form.Validator;
 import com.google.gwt.core.client.GWT;
 import org.eclipse.kapua.app.console.module.api.client.messages.ConsoleMessages;
 
+import javax.validation.constraints.NotNull;
+
 public class RegexFieldValidator implements Validator {
 
     private static final ConsoleMessages MSGS = GWT.create(ConsoleMessages.class);
 
-    private GwtValidationRegex regex;
+    private String regex;
     private String validationMessage;
 
     public RegexFieldValidator(GwtValidationRegex regex) {
         this(regex, null);
     }
 
-    public RegexFieldValidator(GwtValidationRegex regex, String validationMessage) {
+    public RegexFieldValidator(String regex, String validationMessage) {
         this.regex = regex;
+        this.validationMessage = validationMessage;
+    }
+
+    public RegexFieldValidator(@NotNull GwtValidationRegex regex, @NotNull String validationMessage) {
+        this.regex = regex.getRegex();
         this.validationMessage = validationMessage;
     }
 
     @Override
     public String validate(Field<?> field, String value) {
-        if (!value.matches(regex.getRegex())) {
+        if (!value.matches(regex)) {
 
             String illegalChars = value;
-            illegalChars.replaceAll(regex.getRegex(), "");
+            illegalChars.replaceAll(regex, "");
 
             return (validationMessage != null && !validationMessage.isEmpty()) ? validationMessage : MSGS.regexValidatorErrorMessage(illegalChars);
         }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -28,8 +28,6 @@ import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
 import com.extjs.gxt.ui.client.widget.form.Field;
 import com.extjs.gxt.ui.client.widget.form.FieldSet;
-import com.extjs.gxt.ui.client.widget.form.NumberField;
-import com.extjs.gxt.ui.client.widget.form.TextArea;
 import com.extjs.gxt.ui.client.widget.form.TextField;
 import com.google.gwt.core.client.GWT;
 import com.google.gwt.user.client.rpc.AsyncCallback;
@@ -41,6 +39,9 @@ import org.eclipse.kapua.app.console.module.api.client.resources.icons.KapuaIcon
 import org.eclipse.kapua.app.console.module.api.client.ui.button.KapuaButton;
 import org.eclipse.kapua.app.console.module.api.client.ui.dialog.entity.EntityAddEditDialog;
 import org.eclipse.kapua.app.console.module.api.client.ui.panel.FormPanel;
+import org.eclipse.kapua.app.console.module.api.client.ui.validator.RegexFieldValidator;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaNumberField;
+import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextArea;
 import org.eclipse.kapua.app.console.module.api.client.ui.widget.KapuaTextField;
 import org.eclipse.kapua.app.console.module.api.client.util.ConsoleInfo;
 import org.eclipse.kapua.app.console.module.api.client.util.DialogUtils;
@@ -254,13 +255,31 @@ public class JobStepAddDialog extends EntityAddEditDialog {
             if (property.getPropertyValue() == null) {
                 fieldLabel = "* " + fieldLabel;
             }
-            if (propertyType.equals(String.class.getName()) || property.isEnum() || KAPUA_ID_CLASS_NAME.equals(propertyType)) {
+            if (
+                    (propertyType.equals(String.class.getName()) &&
+                            (
+                                    property.getMaxLength() == null ||
+                                            (property.getMaxLength() != null && property.getMaxLength() < 255)
+                            )
+                    ) ||
+                            property.isEnum() ||
+                            KAPUA_ID_CLASS_NAME.equals(propertyType)
+            ) {
                 KapuaTextField<String> textField = new KapuaTextField<String>();
                 if (property.getPropertyValue() == null) {
                     textField.setAllowBlank(false);
                 }
                 textField.setFieldLabel(fieldLabel);
-                textField.setMaxLength(255);
+                if (property.getMinLength() != null) {
+                    textField.setMinLength(property.getMinLength());
+                }
+                if (property.getMaxLength() != null) {
+                    textField.setMaxLength(property.getMaxLength());
+                }
+                if (property.getValidationRegex() != null) {
+                    textField.setValidator(new RegexFieldValidator(property.getValidationRegex(), "The value provided does not match regex: " + property.getValidationRegex()));
+                }
+
                 textField.setEmptyText(KapuaSafeHtmlUtils.htmlUnescape(property.getPropertyValue()));
                 textField.setData(PROPERTY_TYPE, property.getPropertyType());
                 textField.setData(PROPERTY_NAME, property.getPropertyName());
@@ -270,23 +289,34 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                             propertyType.equals(Integer.class.getName()) ||
                             propertyType.equals(Float.class.getName()) ||
                             propertyType.equals(Double.class.getName())) {
-                NumberField numberField = new NumberField();
+                KapuaNumberField numberField = new KapuaNumberField();
                 if (property.getPropertyValue() == null) {
                     numberField.setAllowBlank(false);
                 }
                 numberField.setFieldLabel(fieldLabel);
+                if (property.getMinLength() != null) {
+                    numberField.setMinLength(property.getMinLength());
+                }
+                if (property.getMaxLength() != null) {
+                    numberField.setMaxLength(property.getMaxLength());
+                }
                 numberField.setEmptyText(KapuaSafeHtmlUtils.htmlUnescape(property.getPropertyValue()));
                 numberField.setData(PROPERTY_TYPE, property.getPropertyType());
                 numberField.setData(PROPERTY_NAME, property.getPropertyName());
                 numberField.setToolTip(JOB_MSGS.dialogAddStepTimeoutTooltip());
+
                 if (propertyType.equals(Long.class.getName())) {
-                    numberField.setMaxValue(MAX_SAFE_INTEGER);
+                    numberField.setMinValue(property.getMinValue() != null ? Long.parseLong(property.getMinValue()) : -MAX_SAFE_INTEGER);
+                    numberField.setMaxValue(property.getMaxValue() != null ? Long.parseLong(property.getMaxValue()) : MAX_SAFE_INTEGER);
                 } else if (propertyType.equals(Integer.class.getName())) {
-                    numberField.setMaxValue(Integer.MAX_VALUE);
+                    numberField.setMinValue(property.getMinValue() != null ? Integer.parseInt(property.getMinValue()) : Integer.MIN_VALUE);
+                    numberField.setMaxValue(property.getMaxValue() != null ? Integer.parseInt(property.getMaxValue()) : Integer.MAX_VALUE);
                 } else if (propertyType.equals(Float.class.getName())) {
-                    numberField.setMaxValue(Float.MAX_VALUE);
+                    numberField.setMinValue(property.getMinValue() != null ? Float.parseFloat(property.getMinValue()) : Float.MIN_VALUE);
+                    numberField.setMaxValue(property.getMaxValue() != null ? Float.parseFloat(property.getMaxValue()) : Float.MAX_VALUE);
                 } else if (propertyType.equals(Double.class.getName())) {
-                    numberField.setMaxValue(Double.MAX_VALUE);
+                    numberField.setMinValue(property.getMinValue() != null ? Double.parseDouble(property.getMinValue()) : Double.MIN_VALUE);
+                    numberField.setMaxValue(property.getMaxValue() != null ? Double.parseDouble(property.getMaxValue()) : Double.MAX_VALUE);
                 }
                 jobStepPropertiesPanel.add(numberField);
             } else if (propertyType.equals(Boolean.class.getName())) {
@@ -297,14 +327,25 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                 checkBox.setData(PROPERTY_NAME, property.getPropertyName());
                 jobStepPropertiesPanel.add(checkBox);
             } else {
-                final TextArea textArea = new TextArea();
+                final KapuaTextArea textArea = new KapuaTextArea();
                 if (property.getPropertyValue() == null) {
                     textArea.setAllowBlank(false);
                 }
                 textArea.setFieldLabel(fieldLabel);
+                if (property.getMinLength() != null) {
+                    textArea.setMinLength(property.getMinLength());
+                }
+                if (property.getMaxLength() != null) {
+                    textArea.setMaxLength(property.getMaxLength());
+                }
+                if (property.getValidationRegex() != null) {
+                    textArea.setValidator(new RegexFieldValidator(property.getValidationRegex(), "The value provided does not match regex: " + property.getValidationRegex()));
+                }
+
                 textArea.setData(PROPERTY_TYPE, property.getPropertyType());
                 textArea.setData(PROPERTY_NAME, property.getPropertyName());
                 jobStepPropertiesPanel.add(textArea);
+
                 if (property.getExampleValue() != null) {
                     final String exampleValue = KapuaSafeHtmlUtils.htmlUnescape(property.getExampleValue());
                     exampleButton = new KapuaButton(getExampleButtonText(), new KapuaIcon(IconSet.EDIT), new SelectionListener<ButtonEvent>() {
@@ -321,6 +362,8 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                 }
                 jobStepPropertiesPanel.add(propertiesButtonPanel);
             }
+
+            jobStepPropertiesPanel.layout(true);
         }
         jobStepPropertiesPanel.layout(true);
     }
@@ -329,7 +372,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
         List<GwtJobStepProperty> jobStepProperties = new ArrayList<GwtJobStepProperty>();
         for (Component component : jobStepPropertiesPanel.getItems()) {
             if (component instanceof Field) {
-                Field field = (Field) component;
+                Field<?> field = (Field<?>) component;
                 GwtJobStepProperty property = new GwtJobStepProperty();
                 property.setPropertyValue(!field.getRawValue().isEmpty() ? field.getRawValue() : null);
                 property.setPropertyType(field.getData(PROPERTY_TYPE).toString());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
@@ -48,6 +48,46 @@ public class GwtJobStepProperty extends KapuaBaseModel {
         set("exampleValue", exampleValue);
     }
 
+    public Integer getMinLength() {
+        return get("minLength");
+    }
+
+    public void setMinLength(Integer minLength) {
+        set("minLength", minLength);
+    }
+
+    public Integer getMaxLength() {
+        return get("maxLength");
+    }
+
+    public void setMaxLength(Integer maxLength) {
+        set("maxLength", maxLength);
+    }
+
+    public String getMinValue() {
+        return get("minValue");
+    }
+
+    public void setMinValue(String minValue) {
+        set("minValue", minValue);
+    }
+
+    public String getMaxValue() {
+        return get("maxValue");
+    }
+
+    public void setMaxValue(String maxValue) {
+        set("maxValue", maxValue);
+    }
+
+    public String getValidationRegex() {
+        return get("validationRegex");
+    }
+
+    public void setValidationRegex(String validationRegex) {
+        set("validationRegex", validationRegex);
+    }
+
     public boolean isEnum() {
         return get("isEnum");
     }
@@ -55,5 +95,6 @@ public class GwtJobStepProperty extends KapuaBaseModel {
     public void setEnum(boolean isEnum) {
         set("isEnum", isEnum);
     }
+
 
 }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/GwtKapuaJobModelConverter.java
@@ -29,12 +29,12 @@ import org.eclipse.kapua.app.console.module.job.shared.model.GwtJobTargetQuery;
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTriggerProperty;
 import org.eclipse.kapua.app.console.module.job.shared.model.scheduler.GwtTriggerQuery;
 import org.eclipse.kapua.commons.model.query.FieldSortCriteriaImpl;
-import org.eclipse.kapua.model.query.FieldSortCriteria;
-import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.job.engine.JobEngineFactory;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.FieldSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
@@ -303,9 +303,9 @@ public class GwtKapuaJobModelConverter {
         query.setPredicate(query.attributePredicate(JobExecutionAttributes.JOB_ID, GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobExecutionQuery.getJobId())));
         String sortField = StringUtils.isEmpty(pagingLoadConfig.getSortField()) ? JobAttributes.NAME : pagingLoadConfig.getSortField();
         if (sortField.equals("startedOnFormatted")) {
-            sortField = JobAttributes.STARTED_ON;
+            sortField = JobExecutionAttributes.STARTED_ON;
         } else if (sortField.equals("endedOnFormatted")) {
-            sortField = JobAttributes.ENDED_ON;
+            sortField = JobExecutionAttributes.ENDED_ON;
         }
         SortOrder sortOrder = pagingLoadConfig.getSortDir().equals(SortDir.DESC) ? SortOrder.DESCENDING : SortOrder.ASCENDING;
         query.setSortCriteria(query.fieldSortCriteria(sortField, sortOrder));

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -86,6 +86,11 @@ public class KapuaGwtJobModelConverter {
             gwtJobStepProperty.setPropertyType(jobStepProperty.getPropertyType());
             gwtJobStepProperty.setPropertyValue(jobStepProperty.getPropertyValue());
             gwtJobStepProperty.setExampleValue(jobStepProperty.getExampleValue());
+            gwtJobStepProperty.setMinLength(jobStepProperty.getMinLength());
+            gwtJobStepProperty.setMaxLength(jobStepProperty.getMaxLength());
+            gwtJobStepProperty.setMinValue(jobStepProperty.getMinValue());
+            gwtJobStepProperty.setMaxValue(jobStepProperty.getMaxValue());
+            gwtJobStepProperty.setValidationRegex(jobStepProperty.getValidationRegex());
             gwtJobStepPropertyList.add(gwtJobStepProperty);
         }
 

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/operation/DefaultTargetWriter.java
@@ -69,6 +69,11 @@ public class DefaultTargetWriter extends AbstractItemWriter implements TargetWri
 
             JobTarget jobTarget = KapuaSecurityUtils.doPrivileged(() -> JOB_TARGET_SERVICE.find(processedJobTarget.getScopeId(), processedJobTarget.getId()));
 
+            if (jobTarget == null) {
+                jobLogger.warn("Target {} has not been found. Likely the target or job has been deleted when it was running... Status was: {}", processedJobTarget.getId(), processedJobTarget.getStatus());
+                continue;
+            }
+
             jobTarget.setStepIndex(stepContextWrapper.getStepIndex());
             jobTarget.setStatus(processedJobTarget.getStatus());
             jobTarget.setStatusMessage(processedWrappedJobTarget.getProcessingException() != null ? processedWrappedJobTarget.getProcessingException().getMessage() : null);

--- a/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextWrapper.java
+++ b/job-engine/commons/src/main/java/org/eclipse/kapua/job/engine/commons/wrappers/StepContextWrapper.java
@@ -58,7 +58,7 @@ public class StepContextWrapper {
         return stepNextIndexString != null ? Integer.parseInt(stepNextIndexString) : null;
     }
 
-    public <T> T getStepProperty(String stepPropertyName, Class<T> type) throws KapuaIllegalArgumentException {
+    public <T, E extends Enum<E>> T getStepProperty(String stepPropertyName, Class<T> type) throws KapuaIllegalArgumentException {
         Properties jobContextProperties = stepContext.getProperties();
         String stepPropertyString = jobContextProperties.getProperty(stepPropertyName);
 
@@ -81,7 +81,7 @@ public class StepContextWrapper {
             } else if (type == KapuaId.class) {
                 stepProperty = (T) KapuaEid.parseCompactId(stepPropertyString);
             } else if (type.isEnum()) {
-                Class<? extends Enum> enumType = (Class<? extends Enum>) type;
+                Class<E> enumType = (Class<E>) type;
 
                 try {
                     stepProperty = (T) Enum.valueOf(enumType, stepPropertyString);

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -69,7 +69,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be raised
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 64."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 64."
     And I create endpoint with schema "aYUrdWClCWvg98SN11A1TuFEgjobJLtPxOwaNkdHAj1z7vs0GncKhNuSsJr9aAopl", domain "abc.com" and port 2221
     Then An exception was thrown
     And I logout

--- a/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
@@ -15,149 +15,149 @@
 @integration
 
 Feature: Job step service CRUD tests
-    The Job Step service is responsible for maintaining job steps.
+  The Job Step service is responsible for maintaining job steps.
 
-Scenario: Init Security Context for all scenarios
+  Scenario: Init Security Context for all scenarios
 
-  Given Init Security Context
+    Given Init Security Context
 
-Scenario: Regular step creation
+  Scenario: Regular step creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     And A regular step creator with the name "TestStep" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
-        | prop2 | t2   | v2    |
-        | prop3 | t3   | v3    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
+      | prop2 | java.lang.String | v2    |
+      | prop3 | java.lang.String | v3    |
     When I create a new step entity from the existing creator
     Then No exception was thrown
     When I search for the last step in the database
     And The step item matches the creator
     Then I logout
 
-Scenario: Step with a null scope ID
+  Scenario: Step with a null scope ID
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     Given A null scope
     And A regular step creator with the name "TestStep" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
-        | prop2 | t2   | v2    |
-        | prop3 | t3   | v3    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
+      | prop2 | java.lang.String | v2    |
+      | prop3 | java.lang.String | v3    |
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "scopeId"
     When I create a new step entity from the existing creator
     Then An exception was thrown
     Then I logout
 
-Scenario: Change an existing step name
+  Scenario: Change an existing step name
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     And A regular step creator with the name "TestStep" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
     Then I create a new step entity from the existing creator
     When I change the step name to "TestStep2"
     And I query for a step with the name "TestStep2"
     Then I count 1
     Then I logout
 
-Scenario: Count steps in the database
+  Scenario: Count steps in the database
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     Given A regular step creator with the name "TestStep1" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
     Then I create a new step entity from the existing creator
     Given A regular step creator with the name "TestStep2" and the following properties
-        | name  | type | value |
-        | prop2 | t2   | v2    |
+      | name  | type             | value |
+      | prop2 | java.lang.String | v2    |
     Then I create a new step entity from the existing creator
     Given A regular step creator with the name "TestStep3" and the following properties
-        | name  | type | value |
-        | prop3 | t3   | v3    |
+      | name  | type             | value |
+      | prop3 | java.lang.String | v3    |
     Then I create a new step entity from the existing creator
     When I count the steps in the scope
     Then I count 3
     Then I logout
 
-Scenario: Delete an existing step
+  Scenario: Delete an existing step
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     And A regular step creator with the name "TestStep" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
     Then I create a new step entity from the existing creator
     When I delete the last step
     And I search for the last step in the database
     Then There is no such step item in the database
     Then I logout
 
-Scenario: Delete a non-existing step
+  Scenario: Delete a non-existing step
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular step definition with the name "TestDefinition" and the following properties
-        | name  | type |
-        | prop1 | t1   |
-        | prop2 | t2   |
-        | prop3 | t3   |
+      | name  | type             |
+      | prop1 | java.lang.String |
+      | prop2 | java.lang.String |
+      | prop3 | java.lang.String |
     And A regular step creator with the name "TestStep" and the following properties
-        | name  | type | value |
-        | prop1 | t1   | v1    |
+      | name  | type             | value |
+      | prop1 | java.lang.String | v1    |
     Then I create a new step entity from the existing creator
     When I delete the last step
     Given I expect the exception "KapuaEntityNotFoundException" with the text "jobStep"
@@ -165,10 +165,10 @@ Scenario: Delete a non-existing step
     Then An exception was thrown
     Then I logout
 
-Scenario: Step factory sanity checks
+  Scenario: Step factory sanity checks
 
     Given I test the sanity of the step factory
 
-Scenario: Reset Security Context for all scenarios
+  Scenario: Reset Security Context for all scenarios
 
     Given Reset Security Context

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -70,47 +70,6 @@ Feature: JobEngineService restart job tests with online device
     Then KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Command Execution step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Command Execution step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
-    And The type of the last event is "BIRTH"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name         | type                                                                   | value                                                                                                                                                             |
-      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandInvalidTag>pwd</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
-      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                             |
-    And I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
-    Then KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job with valid Bundle Start step two times
   Create a new job and set a connected KuraMock device as the job target.
   Add a new Bundle Start step to the created job. Restart the job two times.
@@ -429,54 +388,6 @@ Feature: JobEngineService restart job tests with online device
     Then KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Command Execution and Package Install step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add new invalid Command Execution and invalid Package Install steps to the created job.
-  Restart the job two times. After the executed job is finished, the executed target's step
-  index should be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Command pwd is executed
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                 |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                               |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    Then KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job with valid Bundle Start And Bundle Stop steps two times
   Create a new job and set a connected KuraMock device as the job target.
   Add new Bundle Start and Bundle Stop steps to the created job. Restart the job two times.
@@ -628,46 +539,6 @@ Feature: JobEngineService restart job tests with online device
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     When I search events from devices in account "kapua-sys" and 3 or more events are found
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Command Execution step and multiple devices two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Command Execution step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 2 second
-    Then Devices status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Command pwd is executed
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "COMMAND"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name         | type                                                                   | value                                                                                                                                                             |
-      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandInvalidTag>pwd</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
-      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                             |
-    And I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
     Then KuraMock is disconnected
     And I logout
 
@@ -886,47 +757,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting a job with invalid Package Uninstall step and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Package Uninstall step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And I wait 2 second
-    And Devices are connected
-    Then Devices status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Packages are requested and 1 package is received
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
     # *************************************************************
     # * Restarting a job with multiple Targets and multiple Steps *
     # *************************************************************
@@ -973,55 +803,6 @@ Feature: JobEngineService restart job tests with online device
     And I confirm the executed job is finished
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Command Execution and Package Install steps and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Command Execution and invalid Package Install steps to the created job.
-  Restart the job two times. After the executed job is finished, the executed target's step
-  index should be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 2 second
-    Then Devices status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Command pwd is executed
-    And Packages are requested and 1 package is received
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                 |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                               |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search for the last job target in the database
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    When I search events from devices in account "kapua-sys" and 3 events is found
-    And Packages are requested and 1 package is received
     Then KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -116,52 +116,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Bundle Start step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Bundle Start step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job with valid Bundle Stop step two times
   Create a new job and set a connected KuraMock device as the job target.
   Add a new valid Bundle Stop step to the created job. Restart the job two times.
@@ -205,52 +159,6 @@ Feature: JobEngineService restart job tests with online device
     Then I find 3 or more device events
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Bundle Stop step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Bundle Stop step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    Then Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
     And I logout
 
@@ -400,61 +308,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Bundle Start and Bundle Stop steps two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add new valid Bundle Start and Bundle Stop steps to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I search the database for created job steps and I find 2
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And KuraMock is disconnected
-    And I logout
-
      #*******************************************************
      #* Restarting a job with multiple Targets and one Step *
      #*******************************************************
@@ -543,50 +396,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Bundle Start step and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Bundle Start step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job with valid Bundle Stop step and multiple devices two times
   Create a new job and set a connected KuraMock devices as the job targets.
   Add a new valid Bundle Stop step to the created job. Restart the job two times.
@@ -628,50 +437,6 @@ Feature: JobEngineService restart job tests with online device
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Bundle Stop step and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Bundle Stop step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    Then Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
     And I logout
 
@@ -813,59 +578,6 @@ Feature: JobEngineService restart job tests with online device
     And Bundles are requested
     Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and ACTIVE
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Bundle Start and Bundle Stop steps and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a two new invalid Bundle Start steps to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    When I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Devices status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "BUNDLE"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I search the database for created job steps and I find 2
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -295,49 +295,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting a job with invalid Package Uninstall step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Package Uninstall step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And I wait 2 second
-    And Devices is connected
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Packages are requested and 1 package is received
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
      #*******************************************************
      #* Restarting a job with one Target and multiple Steps *
      #*******************************************************

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -58,13 +58,13 @@ Feature: JobEngineService restart job tests with online device - second part
     And I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     And I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     When I search for events from device "rpione3" in account "kapua-sys"
@@ -102,13 +102,13 @@ Feature: JobEngineService restart job tests with online device - second part
     And I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     When I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
     When I search for events from device "rpione3" in account "kapua-sys"
@@ -146,13 +146,13 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     When I search for events from device "rpione3" in account "kapua-sys"
@@ -200,13 +200,13 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I restart a job
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     When I search for events from device "rpione3" in account "kapua-sys"
@@ -297,13 +297,13 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     And I search events from devices in account "kapua-sys" and 3 or more events are found
@@ -377,13 +377,13 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     And I search events from devices in account "kapua-sys" and 3 or more events is found
@@ -430,13 +430,13 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I restart a job
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
+    And I wait 2 second
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
     When I search events from devices in account "kapua-sys" and 3 or more events is found

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -162,51 +162,6 @@ Feature: JobEngineService restart job tests with online device - second part
     Then KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job with invalid Asset Write step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Asset Write step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "ASSET"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name    | type                                                           | value                                                                                                                                                                                                                                       |
-      | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    Then KuraMock is disconnected
-    And I logout
-
     # *******************************************************
     # * Restarting a job with one Target and multiple Steps *
     # *******************************************************
@@ -308,58 +263,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Package Uninstall and Asset Write steps two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add new invalid Package Uninstall and invalid Asset Write steps to the created job.
-  Restart the job two times. After the executed job is finished, the executed target's step
-  index should be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definitions with the name
-      | Package Uninstall |
-      | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                       |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                        |
-      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
     Then KuraMock is disconnected
     And I logout
 
@@ -489,49 +392,6 @@ Feature: JobEngineService restart job tests with online device - second part
     Then KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting job With invalid Asset Write and multiple two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Asset Write step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 1 second
-    Then Devices status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    And The type of the last event is "ASSET"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name    | type                                                           | value                                                                                                                                                                                                                                       |
-      | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    Then KuraMock is disconnected
-    And I logout
-
     # *************************************************************
     # * Restarting a job with multiple Targets and multiple Steps *
     # *************************************************************
@@ -630,56 +490,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
-    Then KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Package Uninstall and Asset Write steps and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Package Uninstall and invalid Asset Write steps to the created job.
-  Restart the job two times. After the executed job is finished, the executed target's step
-  index should be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 1 second
-    Then Devices status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Packages are requested and 1 package is received
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search events from devices in account "kapua-sys" and 3 events is found
-    And The type of the last event is "ASSET"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for step definitions with the name
-      | Package Uninstall |
-      | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                       |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                        |
-      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 3 events is found
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
     Then KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -74,51 +74,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting a job with invalid Configuration Put step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "CONFIGURATION"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag> |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-    Then I create a new step entity from the existing creator
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    When I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    When I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    And I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting a job with valid Package Install step two times
   Create a new job and set a connected KuraMock device as the job target.
   Add a new valid Package Install step to the created job. Restart the job two times.
@@ -544,48 +499,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting a job with invalid Configuration Put and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job target.
-  Add a new invalid Configuration Put step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag> |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     And KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -117,49 +117,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting a job with invalid Package Install step two times
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Package Install step to the created job. Restart the job two times.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
-    When I create a new step entity from the existing creator
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    When Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job With valid Asset Write step two times
   Create a new job and set a connected KuraMock device as the job target.
   Add a new valid Asset Write step to the created job. Restart the job two times.
@@ -301,56 +258,6 @@ Feature: JobEngineService restart job tests with online device - second part
     Then I find 3 or more device events
     Then Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Configuration Put And Command Execution steps two times
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Configuration Put and Command Execution steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And Command pwd is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And The type of the last event is "COMMAND"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definitions with the name
-      | Configuration Put |
-      | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsIvanlidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurationsInvalidTag> |
-      | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     When KuraMock is disconnected
     And I logout
 
@@ -539,45 +446,6 @@ Feature: JobEngineService restart job tests with online device - second part
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Restarting a job with invalid Package Install step and multiple devices two times
-  Create a new job and set a connected KuraMock devices as the job targets. Add a new invalid Package Install
-  step to the created job. Restart the job two times. After the executed job is finished, the executed target's
-  step index should be 0 and the status PROCESS_FAILED.
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Packages are requested and 1 package is received
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    Given I create a job with the name "TestJob"
-    And A new job target item
-    And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
-    When I create a new step entity from the existing creator
-    And I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Then I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events is found
-    When Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Restarting job with valid Asset Write step and multiple devices two times
   Create a new job and set a connected KuraMock devices as the job targets.
   Add a new valid Asset Write step to the created job. Restart the job two times.
@@ -714,55 +582,6 @@ Feature: JobEngineService restart job tests with online device - second part
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     Then Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Restarting job with invalid Configuration Put and Command Execution steps and multiple devices two times
-  Create a new job. Set connected Kura Mock devices as a job target.
-  Add a new invalid Configuration Put and Command Execution steps to the created job. Restart the job two times.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    Then I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 1 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And Command pwd is executed
-    When I search events from devices in account "kapua-sys" and 3 events is found
-    And The type of the last event is "COMMAND"
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for step definitions with the name
-      | Configuration Put |
-      | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsIvanlidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurationsInvalidTag> |
-      | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    Then I restart a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 1 second
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 3 events is found
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     When KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -65,42 +65,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Command Execution step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new Command Execution step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED.
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
-    And The type of the last event is "BIRTH"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name         | type                                                                   | value                                                                                                                                                                                 |
-      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><commandInvalidTag>pwd</commandInvalidTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag> |
-      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                                                                 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Bundle Start step
   Create a new job and set a connected KuraMock device as the job target.
   Add a new Bundle Start step to the created job. Start the job.
@@ -298,45 +262,6 @@ Feature: JobEngineService start job tests with online device
     And The type of the last event is "CONFIGURATION"
     And Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Configuration Put step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Configuration Put step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    When Configuration is requested
-    Then A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "CONFIGURATION"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag> |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-    Then I create a new step entity from the existing creator
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     And KuraMock is disconnected
     And I logout
 
@@ -617,49 +542,6 @@ Feature: JobEngineService start job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     And I find 3 or more device events
     And Packages are requested and 2 packages are received
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting job with invalid Command Execution and Package Install steps
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Command Execution and Package Install steps to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Command "pwd" is executed
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 device events
-    Then The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                 |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                               |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    When I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 device events
-    And Packages are requested and 1 package is received
     When KuraMock is disconnected
     And I logout
 
@@ -977,43 +859,6 @@ Feature: JobEngineService start job tests with online device
     When KuraMock is disconnected
     And I logout
 
-  Scenario: Starting job with invalid Command Execution step and multiple devices
-  Create a new job. Set connected Kura Mock devices as a job targets.
-  Add a new invalid Command Execution step to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Command "pwd" is executed
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "COMMAND"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name         | type                                                                   | value                                                                                                                                               |
-      | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
-      | timeout      | java.lang.Long                                                         | 10000                                                                                                                                               |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 2 device events
-    When KuraMock is disconnected
-    And I logout
-
   Scenario: Starting job with valid Bundle Start step and multiple devices
   Create a new job. Set connected Kura Mock devices as a job targets.
   Add a new Bundle Start step to the created job. Start the job.
@@ -1198,43 +1043,6 @@ Feature: JobEngineService start job tests with online device
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Configuration Put step and multiple devices
-  Create a new job and set connected KuraMock devices as the job targets.
-  Add a new invalid Configuration Put step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And I wait 2 second
-    And Devices are connected
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    Given I create a job with the name "TestJob"
-    And I add targets to job
-    When I count the targets in the current scope and I count 2
-    And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsInvalidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configurationInvalidTag><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configurationInvalidTag></configurationsInvalidTag> |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
-    Then I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     And KuraMock is disconnected
     And I logout
 
@@ -1496,47 +1304,6 @@ Feature: JobEngineService start job tests with online device
     And I confirm the executed job is finished
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting job with invalid Command Execution, invalid Package Install steps and multiple devices
-  Create a new job. Set connected Kura Mock devices as a job targets.
-  Add a new invalid Command Execution and Package Install steps to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Command "pwd" is executed
-    And Packages are requested and 1 package is received
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for step definition with the name
-      | Command Execution          |
-      | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><commandTag>pwd</commandTag><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                 |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                               |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And Packages are requested and 1 package is received
     When KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -105,46 +105,6 @@ Feature: JobEngineService start job tests with online device
     When KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Bundle Start step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new Bundle Start step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "BUNDLE"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    When I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Bundles are requested
-    And A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Bundle Stop step
   Create a new job and set a connected KuraMock device as the job target.
   Add a new Bundle Stop step to the created job. Start the job.
@@ -182,46 +142,6 @@ Feature: JobEngineService start job tests with online device
     Then I find 3 device events
     And Bundles are requested
     And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and RESOLVED
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Bundle Stop step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new Bundle Stop step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    And Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "BUNDLE"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
     And KuraMock is disconnected
     And I logout
 
@@ -303,44 +223,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Package Install step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Package Install step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED.
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "DEPLOY"
-    Given I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    When Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Asset Write step
   Create a new job and set a connected KuraMock device as the job target.
   Add a new valid Asset Write step to the created job. Start the job.
@@ -381,46 +263,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Asset Write step
-  Create a new job and set a connected KuraMock device as the job target.
-  Add a new invalid Asset Write step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
-    And The type of the last event is "ASSET"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name    | type                                                           | value                                                                                                                                                                                                                                       |
-      | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Package Uninstall step
   Create a new job. Set a connected Kura Mock device as a job target.
   Add a new valid Package Uninstall step to the created job. Start the job.
@@ -457,44 +299,6 @@ Feature: JobEngineService start job tests with online device
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 3 or more device events
     And Packages are requested and 0 packages are received
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Package Uninstall step
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Package Uninstall step to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_OK
-
-    Given I start the Kura Mock
-    When Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
-    And The type of the last event is "DEPLOY"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    Then I find 2 device events
-    And The type of the last event is "DEPLOY"
-    And Packages are requested and 1 package is received
     And KuraMock is disconnected
     And I logout
 
@@ -593,54 +397,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Bundle Start and Bundle Stop steps
-  Create a new job and set a connected KuraMock device as the job target.
-  Add two new Bundle Start and Bundle Stop steps to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 1 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And The type of the last event is "BUNDLE"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting job with valid Configuration Put and Command Execution steps
   Create a new job. Set a connected Kura Mock device as a job target.
   Add a new valid Configuration Put and Command Execution steps to the created job. Start the job.
@@ -682,50 +438,6 @@ Feature: JobEngineService start job tests with online device
     Then I find 5 device events
     And Configuration is requested
     Then A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting job with invalid Configuration Put and Command Execution steps
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Configuration Put and Command Execution steps to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And Command pwd is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And The type of the last event is "COMMAND"
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definitions with the name
-      | Configuration Put |
-      | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsIvanlidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurationsInvalidTag> |
-      | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     When KuraMock is disconnected
     And I logout
 
@@ -771,52 +483,6 @@ Feature: JobEngineService start job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Package Uninstall and Asset Write steps
-  Create a new job and set a connected KuraMock device as the job target.
-  Add new invalid Package Uninstall and Asset Write steps to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 1 and the status PROCESS_FAILED
-
-    Given I start the Kura Mock
-    And Device is connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock device
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    And The type of the last event is "DEPLOY"
-    Then Number of received packages is 1
-    And I create a job with the name "TestJob"
-    And I create a new job target item
-    And I search for step definitions with the name
-      | Package Uninstall |
-      | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                       |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                        |
-      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
-    When Device assets are requested
-    Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
     And KuraMock is disconnected
     And I logout
 
@@ -973,44 +639,6 @@ Feature: JobEngineService start job tests with online device
     Then KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Bundle Stop step and multiple devices
-  Create a new job and set connected KuraMock devices as the job targets.
-  Add a new invalid Bundle Stop step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "BUNDLE"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | *77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    Then Bundles are requested
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Configuration Put step and multiple devices
   Create a new job and set connected KuraMock devices as the job targets.
   Add a new valid Configuration Put step to the created job. Start the job.
@@ -1084,44 +712,6 @@ Feature: JobEngineService start job tests with online device
     When KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Asset Write step and multiple targets
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Asset Write step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "ASSET"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name    | type                                                           | value                                                                                                                                                                                                                                       |
-      | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Package Uninstall step and multiple targets
   Create a new job. Set a connected Kura Mock device as a job target.
   Add a new valid Package Uninstall step to the created job. Start the job.
@@ -1157,41 +747,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Package Uninstall step and multiple targets
-  Create a new job. Set a connected Kura Mock device as a job target.
-  Add a new invalid Package Uninstall step to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_OK
-
-    Given I add 2 devices to Kura Mock
-    When Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Packages are requested and 1 package is received
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    Given I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    When Packages are requested and 1 package is received
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting a job with valid Package Install step and multiple devices
   Create a new job and set a connected KuraMock devices as the job targets.
   Add a new valid Package Install step to the created job. Start the job.
@@ -1224,41 +779,6 @@ Feature: JobEngineService start job tests with online device
     And I confirm the executed job is finished
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     When Packages are requested and 2 packages are received
-    And KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Package Install step and multiple devices
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Package Install step to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED.
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Packages are requested and 1 package is received
-    And I search events from devices in account "kapua-sys" and 2 events are found
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
-      | name                   | type                                                                                             | value                                                                                                                                                                                                                                                               |
-      | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>###http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-      | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                               |
-    When I create a new step entity from the existing creator
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    When Packages are requested and 1 package is received
     And KuraMock is disconnected
     And I logout
 
@@ -1353,53 +873,6 @@ Feature: JobEngineService start job tests with online device
     And KuraMock is disconnected
     And I logout
 
-  Scenario: Starting a job with invalid Bundle Start and Bundle Stop steps and multiple devices
-  Create a new job and set connected KuraMock devices as the job targets.
-  Add two new invalid Bundle Start and Bundle Stop steps to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 1 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And The type of the last event is "BUNDLE"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #34   |
-      | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    Then Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
-      | name     | type             | value |
-      | bundleId | java.lang.String | #77   |
-      | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 2 events are found
-    And Bundles are requested
-    Then A bundle named slf4j.api with id 34 and version 1.7.21 is present and RESOLVED
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And A bundle named org.eclipse.kura.linux.bluetooth with id 77 and version 1.0.300 is present and ACTIVE
-    And KuraMock is disconnected
-    And I logout
-
   Scenario: Starting job with valid Configuration Put and Command Execution steps and multiple devices
   Create a new job. Set connected Kura Mock devices as a job targets.
   Add a new valid Configuration Put and Command Execution steps to the created job. Start the job.
@@ -1439,49 +912,6 @@ Feature: JobEngineService start job tests with online device
     When I search events from devices in account "kapua-sys" and 5 events are found
     Then Configuration is requested
     And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 10
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting job with invalid Configuration Put and Command Execution steps and multiple devices
-  Create a new job. Set connected Kura Mock devices as a job targets.
-  Add a new invalid Configuration Put and Command Execution steps to the created job. Start the job.
-  After the executed job is finished, the step index of executed targets should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    And Devices are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    And I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
-    And Command pwd is executed
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And The type of the last event is "COMMAND"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And Search for step definition with the name "Configuration Put"
-    And I search for step definitions with the name
-      | Configuration Put |
-      | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-      | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurationsIvanlidTag xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurationsInvalidTag> |
-      | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInputInvalidTag><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInputInvalidTag>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
-      | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    Then Configuration is requested
-    And A Configuration named org.eclipse.kura.clock.ClockService has property clock.ntp.retry.interval with value 5
     When KuraMock is disconnected
     And I logout
 
@@ -1526,50 +956,6 @@ Feature: JobEngineService start job tests with online device
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
-    When KuraMock is disconnected
-    And I logout
-
-  Scenario: Starting a job with invalid Package Uninstall and Asset Write steps and multiple devices
-  Create a new job and set a connected KuraMock devices as the job targets.
-  Add a new invalid Package Uninstall and Asset Write steps to the created job. Start the job.
-  After the executed job is finished, the executed target's step index should
-  be 0 and the status PROCESS_FAILED
-
-    Given I add 2 devices to Kura Mock
-    When Device are connected
-    And I wait 2 second
-    Then Device status is "CONNECTED"
-    When I login as user with name "kapua-sys" and password "kapua-password"
-    And I select account "kapua-sys"
-    And I get the KuraMock devices
-    And Packages are requested and 1 package is received
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And The type of the last event is "ASSET"
-    And I create a job with the name "TestJob"
-    And I add targets to job
-    And I search for step definitions with the name
-      | Package Uninstall |
-      | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
-      | name                    | type                                                                                               | value                                                                                                                                                                                                                                       |
-      | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><packageName>org.eclipse.kura.example.beacon</packageName><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                        |
-      | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><assetValue>java.lang.Integer</assetValue><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
-      | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                       |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
-    And I start a job
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I wait 2 second
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search events from devices in account "kapua-sys" and 3 events are found
-    And Device assets are requested
-    And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    And Packages are requested and 1 package is received
     When KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -342,7 +342,7 @@ Feature: Trigger service tests
     And A regular trigger creator with the name "wwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwwww" is created
     And The trigger is set to start today at 10:00.
     And I set retry interval to 1
-    Then I expect the exception "KapuaIllegalArgumentException" with the text " Value over than allowed max length. Max length is 255."
+    Then I expect the exception "KapuaIllegalArgumentException" with the text " Value over than allowed max length. Max length is: 255."
     And I create a new trigger from the existing creator with previously defined date properties
     And An exception was thrown
     And I logout

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: {}
+paths: { }
 
 components:
   parameters:
@@ -33,6 +33,21 @@ components:
         propertyValue:
           type: string
         exampleValue:
+          type: string
+          readOnly: true
+        minLength:
+          type: integer
+          readOnly: true
+        maxLength:
+          type: integer
+          readOnly: true
+        minValue:
+          type: string
+          readOnly: true
+        maxValue:
+          type: string
+          readOnly: true
+        validationRegex:
           type: string
           readOnly: true
     jobStepDefinition:

--- a/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/domain/Domain.java
@@ -12,12 +12,17 @@
  *******************************************************************************/
 package org.eclipse.kapua.model.domain;
 
+import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaService;
+
 import java.util.Set;
 
 /**
- * The {@link org.eclipse.kapua.service.KapuaEntityService} {@link Domain}.
+ * The {@link KapuaEntityService} {@link Domain}.
  * <p>
- * A {@link org.eclipse.kapua.service.KapuaService} can be associated with a domain which it uses to validate access
+ * A {@link KapuaService} can be associated with a domain which it uses to validate access
+ *
+ * @since 1.0.0
  */
 public interface Domain {
 

--- a/service/device/registry/test/src/test/resources/features/DeviceRegistry.feature
+++ b/service/device/registry/test/src/test/resources/features/DeviceRegistry.feature
@@ -73,7 +73,7 @@ Feature: Device Registry CRUD tests
         Create a single device with clientID that contains 256 characters.
         Kapua should return an error.
 
-        Given I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 255."
+        Given I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
         When I create a device with name "validDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDevicevalidDeviceval"
         Then An exception was thrown
 

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/Job.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
+import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.KapuaNamedEntity;
 import org.eclipse.kapua.service.job.step.JobStep;
 
@@ -23,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link Job} {@link org.eclipse.kapua.model.KapuaEntity} definition.
+ * {@link Job} {@link KapuaEntity} definition.
  *
  * @since 1.0.0
  */
@@ -39,13 +40,45 @@ public interface Job extends KapuaNamedEntity {
         return TYPE;
     }
 
+    /**
+     * Gets the {@link List} of {@link JobStep}.
+     *
+     * @return The {@link List} of {@link JobStep}.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The {@link JobStep} are no longer bound to the {@link Job}.
+     */
+    @Deprecated
     @XmlTransient
     List<JobStep> getJobSteps();
 
+    /**
+     * Sets the {@link List} of {@link JobStep}.
+     *
+     * @param jobSteps The {@link List} of {@link JobStep}.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The {@link JobStep} are no longer bound to the {@link Job}.
+     */
+    @Deprecated
     void setJobSteps(List<JobStep> jobSteps);
 
+    /**
+     * Gets the jBatch Job xml definition.
+     *
+     * @return The jBatch Job xml definition.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The definition is no longer generated.
+     */
+    @Deprecated
     String getJobXmlDefinition();
 
+    /**
+     * Sets the jBatch Job xml definition.
+     *
+     * @param jobXmlDefinition The jBatch Job xml definition.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The definition is no longer generated.
+     */
+    @Deprecated
     void setJobXmlDefinition(String jobXmlDefinition);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobAttributes.java
@@ -12,16 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
+import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 
 /**
- * {@link JobAttributes} attributes.
+ * {@link Job} {@link KapuaEntityAttributes}.
  *
- * @see org.eclipse.kapua.model.KapuaEntityAttributes
+ * @see KapuaEntityAttributes
  * @since 1.0.0
  */
 public class JobAttributes extends KapuaNamedEntityAttributes {
-
-    public static final String ENDED_ON = "endedOn";
-    public static final String STARTED_ON = "startedOn";
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobCreator.java
@@ -12,17 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
+import org.eclipse.kapua.model.KapuaEntityCreator;
 import org.eclipse.kapua.model.KapuaNamedEntityCreator;
 import org.eclipse.kapua.service.job.step.JobStep;
 
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
+import javax.xml.bind.annotation.XmlTransient;
 import javax.xml.bind.annotation.XmlType;
 import java.util.List;
 
 /**
- * {@link JobCreator} {@link org.eclipse.kapua.model.KapuaEntityCreator} definition.
+ * {@link Job} {@link KapuaEntityCreator} definition.
  *
  * @since 1.0.0
  */
@@ -31,12 +33,45 @@ import java.util.List;
 @XmlType(factoryClass = JobXmlRegistry.class, factoryMethod = "newJobCreator")
 public interface JobCreator extends KapuaNamedEntityCreator<Job> {
 
+    /**
+     * Gets the {@link List} of {@link JobStep}.
+     *
+     * @return The {@link List} of {@link JobStep}.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The {@link JobStep} are no longer bound to the {@link Job}.
+     */
+    @Deprecated
+    @XmlTransient
     List<JobStep> getJobSteps();
 
+    /**
+     * Sets the {@link List} of {@link JobStep}.
+     *
+     * @param jobSteps The {@link List} of {@link JobStep}.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The {@link JobStep} are no longer bound to the {@link Job}.
+     */
+    @Deprecated
     void setJobSteps(List<JobStep> jobSteps);
 
+    /**
+     * Gets the jBatch Job xml definition.
+     *
+     * @return The jBatch Job xml definition.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The definition is no longer generated.
+     */
+    @Deprecated
     String getJobXmlDefinition();
 
+    /**
+     * Sets the jBatch Job xml definition.
+     *
+     * @param jobXmlDefinition The jBatch Job xml definition.
+     * @since 1.0.0
+     * @deprecated Since 1.1.0. The definition is no longer generated.
+     */
+    @Deprecated
     void setJobXmlDefinition(String jobXmlDefinition);
 
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomain.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomain.java
@@ -21,15 +21,15 @@ import java.util.HashSet;
 import java.util.Set;
 
 /**
- * {@link Job} domain.<br>
+ * {@link Job} {@link Domain}.<br>
  * Used to describe the {@link Job} {@link Domain} in the {@link JobService}.
  *
  * @since 1.0.0
  */
-public class JobDomain extends AbstractDomain {
+public class JobDomain extends AbstractDomain implements Domain {
 
-    private String name = "job";
-    private Set<Actions> actions = new HashSet<>(Arrays.asList(Actions.read, Actions.delete, Actions.write, Actions.execute));
+    private final String name = "job";
+    private final Set<Actions> actions = new HashSet<>(Arrays.asList(Actions.read, Actions.delete, Actions.write, Actions.execute));
 
     @Override
     public String getName() {

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomains.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/JobDomains.java
@@ -12,9 +12,21 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job;
 
+import org.eclipse.kapua.model.domain.Domain;
+
+/**
+ * Available {@link Domain}s for {@code kapua-job-api} module.
+ *
+ * @since 1.0.0
+ */
 public class JobDomains {
 
-    private JobDomains() { }
+    private JobDomains() {
+    }
 
+    /**
+     * @see JobDomain
+     * @since 1.0.0
+     */
     public static final JobDomain JOB_DOMAIN = new JobDomain();
 }

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.job.step.definition;
 
+import org.eclipse.kapua.service.job.step.JobStepXmlRegistry;
+
 import javax.xml.bind.annotation.XmlAccessType;
 import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
-
-import org.eclipse.kapua.service.job.step.JobStepXmlRegistry;
 
 @XmlRootElement(name = "jobStepProperty")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -40,4 +40,23 @@ public interface JobStepProperty {
 
     void setExampleValue(String exampleValue);
 
+    Integer getMinLength();
+
+    void setMinLength(Integer minLength);
+
+    Integer getMaxLength();
+
+    void setMaxLength(Integer maxLength);
+
+    String getMinValue();
+
+    void setMinValue(String minValue);
+
+    String getMaxValue();
+
+    void setMaxValue(String maxValue);
+
+    String getValidationRegex();
+
+    void setValidationRegex(String validationRegex);
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
@@ -34,8 +34,28 @@ public class JobStepPropertyImpl implements JobStepProperty {
     private String propertyValue;
 
     @Basic
-    @Column(name = "example_value", nullable = false, updatable = false)
+    @Column(name = "example_value", nullable = true, updatable = true)
     private String propertyExampleValue;
+
+    @Basic
+    @Column(name = "min_length", nullable = true, updatable = true)
+    private Integer minLength;
+
+    @Basic
+    @Column(name = "max_length", nullable = true, updatable = true)
+    private Integer maxLength;
+
+    @Basic
+    @Column(name = "min_value", nullable = true, updatable = true)
+    private String minValue;
+
+    @Basic
+    @Column(name = "max_value", nullable = true, updatable = true)
+    private String maxValue;
+
+    @Basic
+    @Column(name = "validation_regex", nullable = true, updatable = true)
+    private String validationRegex;
 
     public JobStepPropertyImpl() {
     }
@@ -45,6 +65,10 @@ public class JobStepPropertyImpl implements JobStepProperty {
         setPropertyType(jobStepProperty.getPropertyType());
         setPropertyValue(jobStepProperty.getPropertyValue());
         setExampleValue(jobStepProperty.getExampleValue());
+        setMinLength(jobStepProperty.getMinLength());
+        setMaxLength(jobStepProperty.getMaxLength());
+        setMinValue(jobStepProperty.getMinValue());
+        setMaxValue(jobStepProperty.getMaxValue());
     }
 
     public JobStepPropertyImpl(String name, String propertyType, String propertyValue, String propertyExampleValue) {
@@ -92,6 +116,56 @@ public class JobStepPropertyImpl implements JobStepProperty {
     @Override
     public void setExampleValue(String exampleValue) {
         this.propertyExampleValue = exampleValue;
+    }
+
+    @Override
+    public Integer getMinLength() {
+        return minLength;
+    }
+
+    @Override
+    public void setMinLength(Integer minLength) {
+        this.minLength = minLength;
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        return maxLength;
+    }
+
+    @Override
+    public void setMaxLength(Integer maxLength) {
+        this.maxLength = maxLength;
+    }
+
+    @Override
+    public String getMinValue() {
+        return minValue;
+    }
+
+    @Override
+    public void setMinValue(String minValue) {
+        this.minValue = minValue;
+    }
+
+    @Override
+    public String getMaxValue() {
+        return maxValue;
+    }
+
+    @Override
+    public void setMaxValue(String maxValue) {
+        this.maxValue = maxValue;
+    }
+
+    @Override
+    public String getValidationRegex() {
+        return validationRegex;
+    }
+
+    @Override
+    public void setValidationRegex(String validationRegex) {
+        this.validationRegex = validationRegex;
     }
 
     public static JobStepPropertyImpl parse(JobStepProperty jobStepProperty) {

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_definition_properties-limits.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_definition_properties-limits.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2019, 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_step_definition_properties-1.5.0_addLimits" author="eurotech">
+        <addColumn tableName="job_job_step_definition_properties">
+            <column name="min_length" type="varchar(64)"/>
+            <column name="max_length" type="varchar(64)"/>
+            <column name="min_value" type="varchar(64)"/>
+            <column name="max_value" type="varchar(64)"/>
+            <column name="validation_regex" type="varchar(1024)"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_properties-limits.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_properties-limits.xml
@@ -10,16 +10,24 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
         logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
 
-    <include relativeToChangelogFile="true" file="./job-name_indexes.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_properties-limits.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_definition_properties-limits.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
+    <changeSet id="changelog-job_step_properties-1.5.0_addLimits" author="eurotech">
+        <addColumn tableName="job_job_step_properties">
+            <column name="min_length" type="varchar(64)"/>
+            <column name="max_length" type="varchar(64)"/>
+            <column name="min_value" type="varchar(64)"/>
+            <column name="max_value" type="varchar(64)"/>
+            <column name="validation_regex" type="varchar(1024)"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/service/job/test/src/test/resources/features/JobService.feature
+++ b/service/job/test/src/test/resources/features/JobService.feature
@@ -16,208 +16,208 @@
 Feature: Job service CRUD tests
   The Job service is responsible for maintaining jobs.
 
-Scenario: Create a valid job entry
+  Scenario: Create a valid job entry
   Creating a role entry with specified name only. Once created, search for it - it should have been created.
   Kapua should not return any error.
 
-  Given I prepare a job with name "jobN" and description "jobDescription"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobN"
-  And No exception was thrown
+    Given I prepare a job with name "jobN" and description "jobDescription"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobN"
+    And No exception was thrown
 
-Scenario: Creating a job with null name
+  Scenario: Creating a job with null name
   Create a job entry, with null name and description e.g "jobDescription".
   Kapua should return an error.
 
-  Given I prepare a job with name "" and description "jobDescription"
-  And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
-  When I create a new job entity from the existing creator
-  Then An exception was thrown
+    Given I prepare a job with name "" and description "jobDescription"
+    And I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
+    When I create a new job entity from the existing creator
+    Then An exception was thrown
 
-Scenario: Creating a job with name only
+  Scenario: Creating a job with name only
   Create a job with name "jobName" only.
   Kapua should not return any errors since description field is not mandatory.
 
-  Given I prepare a job with name "jobN" and description ""
-  And I create a new job entity from the existing creator
-  When I search for the job in the database
-  Then I find a job with name "jobN"
-  And No exception was thrown
+    Given I prepare a job with name "jobN" and description ""
+    And I create a new job entity from the existing creator
+    When I search for the job in the database
+    Then I find a job with name "jobN"
+    And No exception was thrown
 
-Scenario: Creating job with too short name without description
+  Scenario: Creating job with too short name without description
   Create a job with too short name (e.g "jo").
   Kapua should return an error.
 
-  Given I prepare a job with name "jo" and description ""
-  And I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is 3."
-  When I create a new job entity from the existing creator
-  Then An exception was thrown
+    Given I prepare a job with name "jo" and description ""
+    And I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is: 3."
+    When I create a new job entity from the existing creator
+    Then An exception was thrown
 
-Scenario: Creating job with short name without description
+  Scenario: Creating job with short name without description
   Create a job with short name (e.g "job").
   Kapua should not return an error.
 
-  Given I prepare a job with name "job" and description ""
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "job"
-  And No exception was thrown
+    Given I prepare a job with name "job" and description ""
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "job"
+    And No exception was thrown
 
-Scenario: Creating job with long name without description
+  Scenario: Creating job with long name without description
   Create a job with 255 characters long name and without description.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description ""
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob"
-  And No exception was thrown
+    Given I prepare a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description ""
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob"
+    And No exception was thrown
 
-Scenario: Creating job with too long name without description
+  Scenario: Creating job with too long name without description
   Create a job with 256 characters long name and without description.
   Kapua should return an error.
 
-  Given I prepare a job with name "JjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description ""
-  And I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 255."
-  When I create a new job entity from the existing creator
-  And An exception was thrown
+    Given I prepare a job with name "JjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description ""
+    And I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
+    When I create a new job entity from the existing creator
+    And An exception was thrown
 
-Scenario: Creating job with permitted symbols in name without description
+  Scenario: Creating job with permitted symbols in name without description
   Create a job with permitted symbols in name (e.g "jobName_ or "jobName-").
   Kapua should not return any error.
 
-  When I try to create job with permitted symbols "-_" in name
-  And No exception was thrown
+    When I try to create job with permitted symbols "-_" in name
+    And No exception was thrown
 
-Scenario: Creating job with invalid symbols in name without description
+  Scenario: Creating job with invalid symbols in name without description
   Create a job with invalid symbols in name (e.g "jobName*" or "jobName/").
   Kapua should return an error.
 
-  Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument jobCreator.name"
-  When I try to create job with invalid symbols "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
-  And An exception was thrown
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument jobCreator.name"
+    When I try to create job with invalid symbols "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
+    And An exception was thrown
 
-Scenario: Creating job without name and without description
+  Scenario: Creating job without name and without description
   Create a job without name and without description.
   Kapua should return an error.
 
-  Given I prepare a job with name "" and description ""
-  Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
-  When I create a new job entity from the existing creator
-  And An exception was thrown
+    Given I prepare a job with name "" and description ""
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
+    When I create a new job entity from the existing creator
+    And An exception was thrown
 
-Scenario: Creating job with numbers in name without description
+  Scenario: Creating job with numbers in name without description
   Create a job that contains numbers in the name (e.g "jobName123").
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName123" and description ""
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobName123"
-  And No exception was thrown
+    Given I prepare a job with name "jobName123" and description ""
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobName123"
+    And No exception was thrown
 
-Scenario: Creating unique job with non-unique description
+  Scenario: Creating unique job with non-unique description
   Create a job with unique name and with non-unique description (e.g "description").
   Kapua should not return any errors, description can be non-unique.
 
-  Given I prepare a job with name "jobN" and description "description"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  When I find a job with name "jobN"
-  Given I prepare a job with name "jobN1" and description "description"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobN1"
-  And No exception was thrown
+    Given I prepare a job with name "jobN" and description "description"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    When I find a job with name "jobN"
+    Given I prepare a job with name "jobN1" and description "description"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobN1"
+    And No exception was thrown
 
-Scenario: Creating non-unique job name with valid job description
+  Scenario: Creating non-unique job name with valid job description
   Create a non-unique job name (e.g "jobN") with valid description.
   Kapua should return an error. Job name must be unique.
 
-  Given I prepare a job with name "jobN" and description "description"
-  When I create a new job entity from the existing creator
-  Then I prepare a job with name "jobN" and description "description123"
-  And I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobN already exists."
-  When I create a new job entity from the existing creator
-  Then An exception was thrown
+    Given I prepare a job with name "jobN" and description "description"
+    When I create a new job entity from the existing creator
+    Then I prepare a job with name "jobN" and description "description123"
+    And I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobN already exists."
+    When I create a new job entity from the existing creator
+    Then An exception was thrown
 
-Scenario: Creating job with short name and valid job description
+  Scenario: Creating job with short name and valid job description
   Create a job with short name (e.g "job") and valid description (e.g "description").
   Kapua should not return any error.
 
-  Given I prepare a job with name "job" and description "description"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "job"
-  And No exception was thrown
+    Given I prepare a job with name "job" and description "description"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "job"
+    And No exception was thrown
 
-Scenario: Creating job with too short name and valid description
+  Scenario: Creating job with too short name and valid description
   Create a job with too short name (e.g "j") and valid description (e.g "description").
   Kapua should return an error.
 
-  Given I prepare a job with name "j" and description "description"
-  And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument jobCreator.name: Value less than allowed min length. Min length is 3."
-  When I create a new job entity from the existing creator
-  Then An exception was thrown
+    Given I prepare a job with name "j" and description "description"
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument jobCreator.name: Value less than allowed min length. Min length is: 3."
+    When I create a new job entity from the existing creator
+    Then An exception was thrown
 
-Scenario: Creating job with long name and valid description
+  Scenario: Creating job with long name and valid description
   Create a job with 255 characters long name and description.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description "description"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob"
-  And No exception was thrown
+    Given I prepare a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description "description"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob"
+    And No exception was thrown
 
-Scenario: Creating job with too long name and valid description
+  Scenario: Creating job with too long name and valid description
   Create a job with 256 characters long name and description.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "JjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description "description"
-  Then I expect the exception "KapuaIllegalArgumentException" with the text " An illegal value was provided for the argument jobCreator.name: Value over than allowed max length. Max length is 255."
-  When I create a new job entity from the existing creator
-  And An exception was thrown
+    Given I prepare a job with name "JjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjobNjob" and description "description"
+    Then I expect the exception "KapuaIllegalArgumentException" with the text " An illegal value was provided for the argument jobCreator.name: Value over than allowed max length. Max length is: 255."
+    When I create a new job entity from the existing creator
+    And An exception was thrown
 
-Scenario: Creating a job without name with valid description
+  Scenario: Creating a job without name with valid description
   Create a job without name but with description.
   Kapua should return an error. Name is mandatory.
 
-  Given I prepare a job with name "" and description "description"
-  Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
-  When I create a new job entity from the existing creator
-  And An exception was thrown
+    Given I prepare a job with name "" and description "description"
+    Then I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument jobCreator.name"
+    When I create a new job entity from the existing creator
+    And An exception was thrown
 
-Scenario: Creating job with numbers in name and valid description
+  Scenario: Creating job with numbers in name and valid description
   Create a job with name that contains numbers (e.g "jobName123") and with description (e.g "description").
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName123" and description "description"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with name "jobName123"
-  And No exception was thrown
+    Given I prepare a job with name "jobName123" and description "description"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with name "jobName123"
+    And No exception was thrown
 
-Scenario: Creating unique job with short description
+  Scenario: Creating unique job with short description
   Create a job with very short description (e.g "d").
   Kapua should not return any errors. Description field is not limited in any way.
 
-  Given I prepare a job with name "jobN" and description "d"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with description "d"
-  And No exception was thrown
+    Given I prepare a job with name "jobN" and description "d"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with description "d"
+    And No exception was thrown
 
-Scenario: Creating unique job with long description
+  Scenario: Creating unique job with long description
   Create a unique job with description that has 255 characters.
   Kapua should not return any errors as Desription field can have max 255 characters.
 
-  Given I prepare a job with name "jobN" and description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
-  When I create a new job entity from the existing creator
-  And I search for the job in the database
-  Then I find a job with description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
-  And No exception was thrown
+    Given I prepare a job with name "jobN" and description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
+    When I create a new job entity from the existing creator
+    And I search for the job in the database
+    Then I find a job with description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
+    And No exception was thrown
 
 # Related to issue 2856
 #Scenario: Creating unique job with too long description
@@ -230,130 +230,130 @@ Scenario: Creating unique job with long description
 #  Then I find a job with description "ddescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
 #  And No exception was thrown
 
-Scenario: Changing job name to unique one
+  Scenario: Changing job name to unique one
   Try to edit job name to a unique one, leave description as it is.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName" and description "jobDescription"
-  When I create a new job entity from the existing creator
-  Then I change name of job from "jobName" to "jobName1"
-  And I search for the job in the database
-  Then I find a job with name "jobName1"
-  And No exception was thrown
-  Then I search for the job in the database
-  And There is no job with name "jobName" in database
+    Given I prepare a job with name "jobName" and description "jobDescription"
+    When I create a new job entity from the existing creator
+    Then I change name of job from "jobName" to "jobName1"
+    And I search for the job in the database
+    Then I find a job with name "jobName1"
+    And No exception was thrown
+    Then I search for the job in the database
+    And There is no job with name "jobName" in database
 
-Scenario: Changing job name to non-unique one
+  Scenario: Changing job name to non-unique one
   Try to edit job name to a non-unique one, leave description as it is.
   Kapua should return an error.
 
-  Given I prepare a job with name "jobName" and description "jobDescription"
-  When I create a new job entity from the existing creator
-  Then I prepare a job with name "jobName1" and description "jobDescription"
-  And I create a new job entity from the existing creator
-  Then I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobName already exists."
-  When I change name of job from "jobName1" to "jobName"
-  And An exception was thrown
+    Given I prepare a job with name "jobName" and description "jobDescription"
+    When I create a new job entity from the existing creator
+    Then I prepare a job with name "jobName1" and description "jobDescription"
+    And I create a new job entity from the existing creator
+    Then I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name jobName already exists."
+    When I change name of job from "jobName1" to "jobName"
+    And An exception was thrown
 
-Scenario: Changing job name to short one without description
+  Scenario: Changing job name to short one without description
   Try to edit job name so it is very short (e.g "job") but still is valid.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName" and description ""
-  When I create a new job entity from the existing creator
-  Then I change name of job from "jobName" to "job"
-  And I search for the job in the database
-  Then I find a job with name "job"
-  And No exception was thrown
+    Given I prepare a job with name "jobName" and description ""
+    When I create a new job entity from the existing creator
+    Then I change name of job from "jobName" to "job"
+    And I search for the job in the database
+    Then I find a job with name "job"
+    And No exception was thrown
 
-Scenario: Changing job name to a too short one without description
+  Scenario: Changing job name to a too short one without description
   Try to edit job name so it is too short (e.g "j").
   Kapua should return an error.
 
-  Given I prepare a job with name "jobName" and description ""
-  When I create a new job entity from the existing creator
-  And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument job.name: Value less than allowed min length. Min length is 3."
-  Then I change name of job from "jobName" to "j"
-  And An exception was thrown
+    Given I prepare a job with name "jobName" and description ""
+    When I create a new job entity from the existing creator
+    And I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument job.name: Value less than allowed min length. Min length is: 3."
+    Then I change name of job from "jobName" to "j"
+    And An exception was thrown
 
-Scenario: Changing job name to a long one without description
+  Scenario: Changing job name to a long one without description
   Try to edit job name so it is 255 characters long without special symbols or numbers.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName" and description ""
-  When I create a new job entity from the existing creator
-  Then I change the job name to "jobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob"
-  And I search for the job in the database
-  Then I find a job with name "jobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob"
-  And No exception was thrown
+    Given I prepare a job with name "jobName" and description ""
+    When I create a new job entity from the existing creator
+    Then I change the job name to "jobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob"
+    And I search for the job in the database
+    Then I find a job with name "jobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob"
+    And No exception was thrown
 
-Scenario: Changing job name to a too long one without description
+  Scenario: Changing job name to a too long one without description
   Try to edit the job name so it is 256 characters long without special symbols or numbers.
   Kapua should return an error.
 
-  Given I prepare a job with name "JjobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob" and description ""
-  Then I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 255."
-  When I create a new job entity from the existing creator
-  And An exception was thrown
+    Given I prepare a job with name "JjobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejobNamejob" and description ""
+    Then I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
+    When I create a new job entity from the existing creator
+    And An exception was thrown
 
-Scenario: Changing job name to contain permitted symbols in name without description
+  Scenario: Changing job name to contain permitted symbols in name without description
   Try to change job name so it contains permitted symbols (-,_).
   Kapua should not return any errors.
 
-  When I try to update job name with permitted symbols "-_" in name
-  And I search for the job in the database
-  Then I find a job with name "jobName_"
-  And No exception was thrown
+    When I try to update job name with permitted symbols "-_" in name
+    And I search for the job in the database
+    Then I find a job with name "jobName_"
+    And No exception was thrown
 
-Scenario: Changing job name to contain invalid symbols in name without description
+  Scenario: Changing job name to contain invalid symbols in name without description
   Try to change job name so it contains invalid symbols.
   Kapua should return an error.
 
-  Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument job.name"
-  When I try to update job name with invalid symbols "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
-  Then An exception was thrown
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument job.name"
+    When I try to update job name with invalid symbols "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
+    Then An exception was thrown
 
-Scenario: Changing job description to unique one
+  Scenario: Changing job description to unique one
   Try to change a job description to unique one (e.g. "description 123").
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName" and description "jobDescription"
-  Then I create a new job entity from the existing creator
-  When I change the job description from "jobDescription" to "description123"
-  Then I find a job with description "description123"
-  And No exception was thrown
+    Given I prepare a job with name "jobName" and description "jobDescription"
+    Then I create a new job entity from the existing creator
+    When I change the job description from "jobDescription" to "description123"
+    Then I find a job with description "description123"
+    And No exception was thrown
 
-Scenario: Changing job description to non-unique one
+  Scenario: Changing job description to non-unique one
   Try to change a job description to non-unique one (e.g "jobDescription123").
   Kapua should not return any errors. Description can be non-unique.
 
-  Given I prepare a job with name "jobName" and description "jobDescription"
-  When I create a new job entity from the existing creator
-  Then I prepare a job with name "jobName1" and description "jobDescription1"
-  And I create a new job entity from the existing creator
-  When I change the job description from "jobDescription" to "jobDescription"
-  And No exception was thrown
+    Given I prepare a job with name "jobName" and description "jobDescription"
+    When I create a new job entity from the existing creator
+    Then I prepare a job with name "jobName1" and description "jobDescription1"
+    And I create a new job entity from the existing creator
+    When I change the job description from "jobDescription" to "jobDescription"
+    And No exception was thrown
 
-Scenario: Changing job description to very short one
+  Scenario: Changing job description to very short one
   Try to change job description to very short one (e.g "d").
   Kapua should not return any errors. Description field is not limited downwards
 
-  Given I prepare a job with name "jobName" and description "jobDescription"
-  Then I create a new job entity from the existing creator
-  And I change the job description to "j"
-  Then I search for the job in the database
-  When I find a job with description "j"
-  Then No exception was thrown
+    Given I prepare a job with name "jobName" and description "jobDescription"
+    Then I create a new job entity from the existing creator
+    And I change the job description to "j"
+    Then I search for the job in the database
+    When I find a job with description "j"
+    Then No exception was thrown
 
-Scenario: Changing job description to the long one
+  Scenario: Changing job description to the long one
   Try to edit description on a job with description that has 255 characters.
   Kapua should not return any errors.
 
-  Given I prepare a job with name "jobName" and description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
-  And I create a new job entity from the existing creator
-  When I search for the job in the database
-  Then I find a job with description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
-  And No exception was thrown
+    Given I prepare a job with name "jobName" and description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
+    And I create a new job entity from the existing creator
+    When I search for the job in the database
+    Then I find a job with description "descriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondescriptiondedescription"
+    And No exception was thrown
 
 # Related to issue 2856
 #Scenario: Changing the job description to the too-long one

--- a/service/security/test/src/test/resources/features/RoleServiceUnitTests.feature
+++ b/service/security/test/src/test/resources/features/RoleServiceUnitTests.feature
@@ -16,265 +16,265 @@ Feature: Role Service
   Role Service is responsible for CRUD operations on Roles. This service is currently
   used to attach roles to Users.
 
-   Scenario: Creating a valid role
-     Create a role entry with specified name and description. Once created, search for it - it should have been created.
-     Kapua should not return any errors.
+  Scenario: Creating a valid role
+  Create a role entry with specified name and description. Once created, search for it - it should have been created.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleName"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleName"
+    And No exception was thrown
 
-   Scenario: Creating a role with null name
-     Create a role entry, with null name and description e.g "roleDescription".
-     Kapua should return an error.
+  Scenario: Creating a role with null name
+  Create a role entry, with null name and description e.g "roleDescription".
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "" and description "roleDescription"
-     But I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument roleCreator.name."
-     When I create a new role entity from the existing creator
-     And An exception was thrown
+    Given I prepare a role creator with name "" and description "roleDescription"
+    But I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument roleCreator.name."
+    When I create a new role entity from the existing creator
+    And An exception was thrown
 
-   Scenario: Creating a role with name only
-     Create a role with name "roleName" only.
-     Kapua should not return any errors.
+  Scenario: Creating a role with name only
+  Create a role with name "roleName" only.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description ""
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleName"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName" and description ""
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleName"
+    And No exception was thrown
 
-   Scenario:  Creating a role with too short name
-     Create a role with too short name e.g "ro" and description "roleDescription"
-     Kapua should return an error.
+  Scenario:  Creating a role with too short name
+  Create a role with too short name e.g "ro" and description "roleDescription"
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "ro" and description "roleDescription"
-     But I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is 3."
-     When I create a new role entity from the existing creator
-     And An exception was thrown
+    Given I prepare a role creator with name "ro" and description "roleDescription"
+    But I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is: 3."
+    When I create a new role entity from the existing creator
+    And An exception was thrown
 
-   Scenario: Creating a role with regular name and very short description" as description cannot be too short, as even one character is enough
-     Creating a role with regular name and very short description.
-     Kapua should not return any errors, "description" cannot be too short.
+  Scenario: Creating a role with regular name and very short description" as description cannot be too short, as even one character is enough
+  Creating a role with regular name and very short description.
+  Kapua should not return any errors, "description" cannot be too short.
 
-     Given I prepare a role creator with name "roleName" and description "d"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleName"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName" and description "d"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleName"
+    And No exception was thrown
 
-   Scenario: Creating a role wtih 255 characters long name
-     Create a role with 255 characters long name and with a regular description e.g "roleDescription".
-     Kapua should not return any errors.
+  Scenario: Creating a role wtih 255 characters long name
+  Create a role with 255 characters long name and with a regular description e.g "roleDescription".
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNam" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNam"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNam" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNam"
+    And No exception was thrown
 
-   Scenario: Creating a role with too long name
-     Create a role with too long name and a regular description.
-     Kapua should return an error.
+  Scenario: Creating a role with too long name
+  Create a role with too long name and a regular description.
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleName" and description "roleDescription"
-     But I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 255."
-     Then I create a new role entity from the existing creator
-     And An exception was thrown
+    Given I prepare a role creator with name "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleName" and description "roleDescription"
+    But I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
+    Then I create a new role entity from the existing creator
+    And An exception was thrown
 
-   Scenario: Creating a role with 255 characters long description
-     Creating a role with a valid name and with 255 character long description.
-     Kapua should not return any errors.
+  Scenario: Creating a role with 255 characters long description
+  Creating a role with a valid name and with 255 character long description.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescription"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleName"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescription"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleName"
+    And No exception was thrown
 
-   Scenario: Creating a role with valid name and with too long description
-     Create a role with valid name e.g "roleName" and with too long description.
-     Kapua should return an error.
+  Scenario: Creating a role with valid name and with too long description
+  Create a role with valid name e.g "roleName" and with too long description.
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescrsdsdsdsdsdsiptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescription"
-     When I create a new role entity from the existing creator
+    Given I prepare a role creator with name "roleName" and description "roleDescrsdsdsdsdsdsiptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescriptionroleDescription"
+    When I create a new role entity from the existing creator
 
-   Scenario: Creating a role with the name that contains digits
-     Create a role with name that contains digits (e.g "role123") and with description (e.g "roleDescription").
-     Kapua should not return any error.
+  Scenario: Creating a role with the name that contains digits
+  Create a role with name that contains digits (e.g "role123") and with description (e.g "roleDescription").
+  Kapua should not return any error.
 
-     Given I prepare a role creator with name "role123" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "role123"
-     And No exception was thrown
+    Given I prepare a role creator with name "role123" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "role123"
+    And No exception was thrown
 
-   Scenario: Creating a role with forbidden symbols in its name
-     Create a role with name containing special symbols (e.g. "roleName%") and with a valid description (e.g "roleDescription").
-     Kapua should return an error.
+  Scenario: Creating a role with forbidden symbols in its name
+  Create a role with name containing special symbols (e.g. "roleName%") and with a valid description (e.g "roleDescription").
+  Kapua should return an error.
 
-     Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
-     Then I try to create roles with invalid characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
-     And An exception was thrown
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
+    Then I try to create roles with invalid characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in name
+    And An exception was thrown
 
-   Scenario: Creating a role with special characters in the description
-     Create a role with a valid name (e.g "roleName") and with description containing special symbols (e.g "descripti@n!@#").
-     Kapua should not return any errors.
+  Scenario: Creating a role with special characters in the description
+  Create a role with a valid name (e.g "roleName") and with description containing special symbols (e.g "descripti@n!@#").
+  Kapua should not return any errors.
 
-     Given I try to create roles with invalid characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in description
-     Then I find a role with name "roleName0"
-     And No exception was thrown
+    Given I try to create roles with invalid characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«" in description
+    Then I find a role with name "roleName0"
+    And No exception was thrown
 
-   Scenario: Creating a role with a name and description that contain digits only
-     Create a role with name e.g "123" and with description e.g "123".
-     Kapua should not return any errors.
+  Scenario: Creating a role with a name and description that contain digits only
+  Create a role with name e.g "123" and with description e.g "123".
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "123" and description "123"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "123"
-     And No exception was thrown
+    Given I prepare a role creator with name "123" and description "123"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "123"
+    And No exception was thrown
 
-   Scenario: Creating two roles with the same name
-     Create first role with name e.g "roleName" and with description "roleDescription".
-     After that create another role with same name but different description."
-     Kapua should return an error.
+  Scenario: Creating two roles with the same name
+  Create first role with name e.g "roleName" and with description "roleDescription".
+  After that create another role with same name but different description."
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription123"
-     When I create a new role entity from the existing creator
-     Then I prepare a role creator with name "roleName" and description "roleDescription"
-     But I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name roleName already exists."
-     Then I create a new role entity from the existing creator
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription123"
+    When I create a new role entity from the existing creator
+    Then I prepare a role creator with name "roleName" and description "roleDescription"
+    But I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name roleName already exists."
+    Then I create a new role entity from the existing creator
+    And An exception was thrown
 
-   Scenario: Creating two roles with the same description
-     Create first role with name e.g "roleName" and with description "roleDescription".
-     After that create another role with same description but different name."
-     Kapua should not return an error.
+  Scenario: Creating two roles with the same description
+  Create first role with name e.g "roleName" and with description "roleDescription".
+  After that create another role with same description but different name."
+  Kapua should not return an error.
 
-     Given I prepare a role creator with name "roleName1" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I prepare a role creator with name "roleName2" and description "roleDescription"
-     Then I create a new role entity from the existing creator
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName1" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I prepare a role creator with name "roleName2" and description "roleDescription"
+    Then I create a new role entity from the existing creator
+    And No exception was thrown
 
-   Scenario: Creating a role name with allowed symbols in its name
-     Create a role with a name that contains allowed symbol (e.g "roleName-123").
-     Kapua should not return any errors.
+  Scenario: Creating a role name with allowed symbols in its name
+  Create a role with a name that contains allowed symbol (e.g "roleName-123").
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName-123_" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I find a role with name "roleName-123_"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName-123_" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I find a role with name "roleName-123_"
+    And No exception was thrown
 
-   Scenario: Counting created roles items in the DB
-     Create 15 roles and find all of them in the DB.
-     Kapua should not return any errors.
+  Scenario: Counting created roles items in the DB
+  Create 15 roles and find all of them in the DB.
+  Kapua should not return any errors.
 
-     Given I create 15 roles
-     When I count the roles in the database
-     Then I count 15
-     And No exception was thrown
+    Given I create 15 roles
+    When I count the roles in the database
+    Then I count 15
+    And No exception was thrown
 
-   Scenario: Changing role's name to a valid one
-     Create a role with name e.g "roleName". After that try to edit it to e.g "roleName2.
-     Kapua should not return any errors.
+  Scenario: Changing role's name to a valid one
+  Create a role with name e.g "roleName". After that try to edit it to e.g "roleName2.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     And I update the role name to "roleName2"
-     Then I find a role with name "roleName2"
-     And No exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    And I update the role name to "roleName2"
+    Then I find a role with name "roleName2"
+    And No exception was thrown
 
-   Scenario: Changing role description to a valid one
-     Create a role with a valid name and valid description (e.g "roleDescription").
-     After that try to edit role description to e.g "roleDescription123.
-     Kapua should not return any errors.
+  Scenario: Changing role description to a valid one
+  Create a role with a valid name and valid description (e.g "roleDescription").
+  After that try to edit role description to e.g "roleDescription123.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     And I update the role description to "roleDescription123"
-     Then I search for a role with description "roleDescription"
-     And I find no roles
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    And I update the role description to "roleDescription123"
+    Then I search for a role with description "roleDescription"
+    And I find no roles
 
-   Scenario: Changing name of a nonexisting role
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
-     After that delete it and try to update it.
-     Kapua should return an error.
+  Scenario: Changing name of a nonexisting role
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
+  After that delete it and try to update it.
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I delete the role with name "roleName"
-     But I expect the exception "KapuaEntityNotFoundException" with the text "*"
-     And I update the last created role name to "roleName2"
-     Then An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I delete the role with name "roleName"
+    But I expect the exception "KapuaEntityNotFoundException" with the text "*"
+    And I update the last created role name to "roleName2"
+    Then An exception was thrown
 
-   Scenario: Changing description of a nonexisting role
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
-     After that delete it and try to update role description.
-     Kapua should return an error.
+  Scenario: Changing description of a nonexisting role
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
+  After that delete it and try to update role description.
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I delete the role with name "roleName"
-     But I expect the exception "KapuaEntityNotFoundException" with the text "*"
-     And I update the role description to "roleDescription123"
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I delete the role with name "roleName"
+    But I expect the exception "KapuaEntityNotFoundException" with the text "*"
+    And I update the role description to "roleDescription123"
+    And An exception was thrown
 
-   Scenario: Changing role name to null
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
-     After that try to update role name to "null".
-     Kapua should return an error.
+  Scenario: Changing role name to null
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
+  After that try to update role name to "null".
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     But I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument role.name."
-     Then I update the role name to ""
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    But I expect the exception "KapuaIllegalNullArgumentException" with the text "An illegal null value was provided for the argument role.name."
+    Then I update the role name to ""
+    And An exception was thrown
 
-   Scenario: Changing role name to contain special character
-     Create a role with name e.g "roleName" and with description e.g "roleDescription",
-     then try to update role name with special characters ( e.g "roleName%").
-     Kapua should return an errors.
+  Scenario: Changing role name to contain special character
+  Create a role with name e.g "roleName" and with description e.g "roleDescription",
+  then try to update role name with special characters ( e.g "roleName%").
+  Kapua should return an errors.
 
-     But I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument role.name"
-     Then I update the role name with special characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«"
-     And An exception was thrown
+    But I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument role.name"
+    Then I update the role name with special characters "!#$%&'()=»Ç>:;<.,⁄@‹›€*ı–°·‚±Œ„‰?“‘”’ÉØ∏{}|ÆæÒÔÓÌÏÎÍÅ«"
+    And An exception was thrown
 
-   Scenario:  Change role name so it is too short
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
-     After that try to change role name to "ro".
-     Kapua should return an error.
+  Scenario:  Change role name so it is too short
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
+  After that try to change role name to "ro".
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     But I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is 3."
-     Then I update the role name to "ro"
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    But I expect the exception "KapuaIllegalArgumentException" with the text "Value less than allowed min length. Min length is: 3."
+    Then I update the role name to "ro"
+    And An exception was thrown
 
-   Scenario: Changing role name so it is too long
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription"),
-     then try to update role name so it contains more than 255 characters.
-     Kapua should return an error.
+  Scenario: Changing role name so it is too long
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription"),
+  then try to update role name so it contains more than 255 characters.
+  Kapua should return an error.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     But I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is 255."
-     Then I update the role name to "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleName"
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    But I expect the exception "KapuaIllegalArgumentException" with the text "Value over than allowed max length. Max length is: 255."
+    Then I update the role name to "roleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleNameroleName"
+    And An exception was thrown
 
-   Scenario: Deleting an existing role
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
-     After that try to delete it.
-     Kapua should not return any errors.
+  Scenario: Deleting an existing role
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription").
+  After that try to delete it.
+  Kapua should not return any errors.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I delete the role with name "roleName" and description "roleDescription"
-     And I search for the role with name "roleName"
-     But I find no roles
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I delete the role with name "roleName" and description "roleDescription"
+    And I search for the role with name "roleName"
+    But I find no roles
 
-   Scenario: Deleting a role twice
-     Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription"),
-     then try to delete role with name "roleName" twice - Kapua should return an error on the second try.
+  Scenario: Deleting a role twice
+  Create a role with a valid name (e.g "roleName") and with a valid description (e.g "roleDescription"),
+  then try to delete role with name "roleName" twice - Kapua should return an error on the second try.
 
-     Given I prepare a role creator with name "roleName" and description "roleDescription"
-     When I create a new role entity from the existing creator
-     Then I delete the role with name "roleName" and description "roleDescription"
-     But I expect the exception "KapuaEntityNotFoundException" with the text "*"
-     Then I delete the role with name "roleName" and description "roleDescription"
-     And An exception was thrown
+    Given I prepare a role creator with name "roleName" and description "roleDescription"
+    When I create a new role entity from the existing creator
+    Then I delete the role with name "roleName" and description "roleDescription"
+    But I expect the exception "KapuaEntityNotFoundException" with the text "*"
+    Then I delete the role with name "roleName" and description "roleDescription"
+    And An exception was thrown

--- a/service/tag/test/src/test/resources/features/TagService.feature
+++ b/service/tag/test/src/test/resources/features/TagService.feature
@@ -17,86 +17,86 @@ Feature: Tag Service
   Tag Service is responsible for CRUD operations on Tags. This service is currently
   used to attach tags to Devices, but could be used to tag any kapua entity, like
   User for example.
-  
+
   Scenario: Creating Unique Tag Without Description
-    Create a tag with unique name without description. Kapua should not return any error.
+  Create a tag with unique name without description. Kapua should not return any error.
 
     Given A tag with name "Tag123" is created
     When Tag with name "Tag123" is searched
     Then I find a tag with name "Tag123"
 
   Scenario: Creating Non-unique Tag Without Description
-    Create a tag with non-unique name without description. Kapua should return Exception.
+  Create a tag with non-unique name without description. Kapua should return Exception.
 
     Given A tag with name "Tag123" is created
     When Tag with name "Tag123" is searched
     Then I expect the exception "KapuaDuplicateNameException" with the text "An entity with the same name Tag123 already exists."
 
   Scenario: Creating Tag With Short Name Without Description
-    Create a tag with short name without description. Kapua should not return any errors.
+  Create a tag with short name without description. Kapua should not return any errors.
 
     Given A tag with name "abc" is created
     When Tag with name "abc" is searched
     Then I find a tag with name "abc"
 
   Scenario: Creating Tag With Too Short Name Without Description
-    Create a tag with too short name without description. Kapua should return Exception.
+  Create a tag with too short name without description. Kapua should return Exception.
 
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value less than allowed min length. Min length is 3."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value less than allowed min length. Min length is: 3."
     When I create tag with name "a"
     Then An exception was thrown
 
   Scenario: Creating Tag With Long Name Without Description
-    Create a tag with long (255 characters) name without description. Kapua should not return any errors.
+  Create a tag with long (255 characters) name without description. Kapua should not return any errors.
 
     Given A tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh" is created
     When Tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh" is searched
     Then I find a tag with name "Y5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh"
 
   Scenario: Creating Tag With Too Long Name Without Description
-    Create a tag with too long (256 characters) name without description. Kapua should return Exception.
+  Create a tag with too long (256 characters) name without description. Kapua should return Exception.
 
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is: 255."
     When I create tag with name "aY5gJ7o5XPkLBBFttelFa6tKTfF2G905xbQL7MTpoKcW8hDnXUORC0Rv0z6MJm1vKZPt6Wm6EB7RiJrP0D0hi28R2272J5inIlA7KiDxSKljwX4N7zW8RK7fwhUkwemA5qyF2DQ2DncXTUxsyAlXhh9qIJ43cPC7lSWyTNUFnMshYlLtB2ArnXPgLDQLooJlfdn6qbwTnNUOxML0OYrVoV1spfsZQEYsmFk9r53mfLajIfxDeHtoEShDxnHL4fgh"
     Then An exception was thrown
 
   Scenario: Creating Tag With Permitted Symbols In Name Without Description
-    Create a tag name with permitted ('-' and '_') symbols without description. Kapua should not return any errors.
+  Create a tag name with permitted ('-' and '_') symbols without description. Kapua should not return any errors.
 
     Given A tag with name "Tag-12_3" is created
     When Tag with name "Tag-12_3" is searched
     Then I find a tag with name "Tag-12_3"
 
   Scenario: Creating Tag With Invalid Symbols In Name Without Description
-    Try to create a tag name with invalid symbols without description. Kapua should return Exception.
+  Try to create a tag name with invalid symbols without description. Kapua should return Exception.
 
     Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
     When I try to create tags with that include invalid symbols in name
     Then An exception was thrown
 
   Scenario: Creating Tag Without a Name And Without Description
-    Create a tag witout a name and without a description. Kapua should return an error.
+  Create a tag witout a name and without a description. Kapua should return an error.
 
     Given I expect the exception "Exception"
     When I create tag with name ""
     Then An exception was thrown
 
   Scenario: Creating Tag With Numbers In Name Without Description
-    Create a tag with numbers in name without description. Kapua should not return any errors.
+  Create a tag with numbers in name without description. Kapua should not return any errors.
 
     Given A tag with name "0123456789" is created
     When Tag with name "0123456789" is searched
     Then I find a tag with name "0123456789"
 
   Scenario: Creating Unique Tag With Unique Description
-    Create a tag with unique name and unique description. Kapua should not return any errors.
+  Create a tag with unique name and unique description. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" and description "Description-@12#$456"
     When Tag with name "Tag1" is searched
     Then I find a tag with name "Tag1"
 
   Scenario: Creating Unique Tag With Non-unique Description
-    Create two unique tags with same description. Kapua should not return any errors.
+  Create two unique tags with same description. Kapua should not return any errors.
 
     Given I create tag with name "Tag123" and description "Description1"
     And I create tag with name "Tag456" and description "Description1"
@@ -104,7 +104,7 @@ Feature: Tag Service
     Then I find a tag with name "Tag123"
 
   Scenario: Creating Non-Unique Tag With Valid Description
-    Create non-unique tag with valid description. Kapua should throw Exception.
+  Create non-unique tag with valid description. Kapua should throw Exception.
 
     Given I expect the exception "KapuaDuplicateNameException"
     When I create tag with name "Tag123" and description "Description1"
@@ -112,77 +112,77 @@ Feature: Tag Service
     Then An exception was thrown
 
   Scenario: Creating Tag With Short Name With Valid Description
-    Try to create tag with short name with valid Description. Kapua should not return any errors.
+  Try to create tag with short name with valid Description. Kapua should not return any errors.
 
     Given I create tag with name "Tag" and description "Valid description 123"
     When Tag with name "Tag" is searched
     Then I find a tag with name "Tag"
 
   Scenario: Creating Tag With Too Short Name With Valid Description
-    Try to create tag with too short name with valid description.Kapua should throw Exception.
+  Try to create tag with too short name with valid description.Kapua should throw Exception.
 
     Given I expect the exception "Exception"
     When I create tag with name "t" and description "Valid description 123"
     Then An exception was thrown
 
   Scenario: Creating Tag With Long Name With Valid Description
-    Try to create tag with long name with valid description. Kapua should not return any errors.
+  Try to create tag with long name with valid description. Kapua should not return any errors.
 
     Given I create tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" and description "Valid description 123"
     When Tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" is searched
     Then I find a tag with name "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj"
 
   Scenario: Creating Tag With Too Long Name With Valid Description
-    Try to create tag with too long name with valid description. Kapua should throw Exception.
+  Try to create tag with too long name with valid description. Kapua should throw Exception.
 
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tagCreator.name: Value over than allowed max length. Max length is: 255."
     When I create tag with name "aoAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj" and description "Valid description 123"
     Then An exception was thrown
 
   Scenario: Creating Tag With Permitted Symbols In Name With Valid Description
-    Try to create tag with permitted symbols in name with valid description. Kapua should not return any errors.
+  Try to create tag with permitted symbols in name with valid description. Kapua should not return any errors.
 
     Given I create tag with name "Tag_12-3" and description "Valid description 123"
     When Tag with name "Tag_12-3" is searched
     Then I find a tag with name "Tag_12-3"
 
   Scenario: Creating Tag With Invalid Symbols In Name With Valid Description
-    Try to create a tag with invalid symbols with valid description. Kapua should throw Exception.
+  Try to create a tag with invalid symbols with valid description. Kapua should throw Exception.
 
     Given I expect the exception "Exception"
     When I create tag with name "Tag@123" and description "Valid description 123"
     Then An exception was thrown
 
   Scenario: Creating Tag Without a Name And With Valid Description
-    Try to create a tag without a name with valid description. Kapua should throw Exception.
+  Try to create a tag without a name with valid description. Kapua should throw Exception.
 
     Given I expect the exception "KapuaIllegalNullArgumentException"
     When I create tag with name "" and description "Valid description 123"
     Then An exception was thrown
 
   Scenario: Creating Tag With Numbers In Name With Valid Description
-    Try to create a tag with numbers in name with valid description. Kapua should not return any errors.
+  Try to create a tag with numbers in name with valid description. Kapua should not return any errors.
 
     Given I create tag with name "0123456789" and description "Valid-description@33-2"
     And Tag with name "0123456789" is searched
     Then I find a tag with name "0123456789"
 
   Scenario: Creating Unique Tag With Short Description
-    Try to create a tag with short description. Kapua should not return any errors.
+  Try to create a tag with short description. Kapua should not return any errors.
 
     Given I create tag with name "Tag123" and description "a"
     When Tag with name "Tag123" is searched
     Then I find a tag with name "Tag123"
 
   Scenario: Creating Unique Tag With Long Description
-    Try to create a tag with long description. Kapua should not return any errors.
+  Try to create a tag with long description. Kapua should not return any errors.
 
     Given I create tag with name "Tag123" and description "oAB7rpR552NlNY0TV8G4h7pikTASljfgRzc50ZSXBX5finW69LHoExMG3gyYpOeboQ01plWuF74qrYT2fvgtjmpLVn7UkbAVWvok7kDodu3rJGqaHIIBIxdAm1FhoWM0sc9ROSeEyv0RV1WVH2Fey4eVFf5aqG3T6hSwUNpJFblaZvfLoh3f9aBPNibEsVFSmqvJwdH3Vi1q8NHfv3hlTUxZidLCphUSTGaB8Yecp7mJJXVM1OwXCpiOcyGc5Uj"
     When Tag with name "Tag123" is searched
     Then I find a tag with name "Tag123"
 
   Scenario: Changing Tag's Name To Unique One
-    Try to edit tag's name into a unique one. Kapua should not return any errors.
+  Try to edit tag's name into a unique one. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Name of tag "Tag1" is changed into "Tag2"
@@ -192,7 +192,7 @@ Feature: Tag Service
     Then Tag with name "Tag1" is not found
 
   Scenario: Changing Tag's Name To Non-Unique One
-    Try to edit tag's name to non-unique one. Kapua should throw Exception.
+  Try to edit tag's name to non-unique one. Kapua should throw Exception.
 
     When I create tag with name "Tag1" without description
     And I create tag with name "Tag2" without description
@@ -201,7 +201,7 @@ Feature: Tag Service
     Then An exception was thrown
 
   Scenario: Changing Tag's Name To Short One Without Description
-    Try to edit tag's name to short one. Kapua should not return any errors.
+  Try to edit tag's name to short one. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Name of tag "Tag1" is changed into "abc"
@@ -211,15 +211,15 @@ Feature: Tag Service
     Then Tag with name "Tag1" is not found
 
   Scenario: Changing Tag's Name To a Too Short One Without Description
-    Try to edit tag's name to a too short one. Kapua should throw Exception.
+  Try to edit tag's name to a too short one. Kapua should throw Exception.
 
     When I create tag with name "Tag1" without description
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value less than allowed min length. Min length is 3."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value less than allowed min length. Min length is: 3."
     When Tag name is changed into name "a"
     Then An exception was thrown
 
   Scenario: Changing Tag's Name To a Long One Without Description
-    Try to edit tag's name to a long (255 characters) one. Kapua should not return any errors.
+  Try to edit tag's name to a long (255 characters) one. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Name of tag "Tag1" is changed into "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
@@ -229,15 +229,15 @@ Feature: Tag Service
     Then Tag with name "Tag1" is not found
 
   Scenario: Changing Tag's Name To a Too Long One Without Description
-    Try to edit tag's name to a too long (256 characters) one. Kapua should throw Exception.
+  Try to edit tag's name to a too long (256 characters) one. Kapua should throw Exception.
 
     When I create tag with name "Tag1" without description
-    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value over than allowed max length. Max length is 255."
+    Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Value over than allowed max length. Max length is: 255."
     When Name of tag "Tag1" is changed into "aYXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
     Then An exception was thrown
 
   Scenario: Changing Tag's Name To Contain Permitted Symbols In Name Without Description
-    Try to edit tag's name to a name with permitted symbols. Kapua should not return any errors.
+  Try to edit tag's name to a name with permitted symbols. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Tag name is changed into name "T-a-g_1"
@@ -245,7 +245,7 @@ Feature: Tag Service
     Then I find a tag with name "T-a-g_1"
 
   Scenario: Changing Tag's Name To Contain Invalid Symbols In Name Without Description
-    Try to edit tag's name to a name with invalid symbols. Kapua should throw Exception.
+  Try to edit tag's name to a name with invalid symbols. Kapua should throw Exception.
 
     When I create tag with name "Tag1" without description
     Given I expect the exception "KapuaIllegalArgumentException" with the text "An illegal value was provided for the argument tag.name: Tag@1#2?*=)3."
@@ -253,7 +253,7 @@ Feature: Tag Service
     Then An exception was thrown
 
   Scenario: Deleting Tag's Name And Leaving It Empty Without Description
-    Try to edit tag's name to an empty name. Kapua should throw Exception, name is mandatory.
+  Try to edit tag's name to an empty name. Kapua should throw Exception, name is mandatory.
 
     When I create tag with name "Tag1" without description
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
@@ -261,7 +261,7 @@ Feature: Tag Service
     Then An exception was thrown
 
   Scenario: Editing Tag's Name To Contain Numbers Without Description
-    Try to edit tag's name to a name that contains numbers. Kapua should not return any errors.
+  Try to edit tag's name to a name that contains numbers. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Name of tag "Tag1" is changed into "Tag0123456789"
@@ -271,7 +271,7 @@ Feature: Tag Service
     Then Tag with name "Tag1" is not found
 
   Scenario: Changing Tag's Description To Unique One
-    Try to edit tag's description so it stays unique. Kapua should not return any errors.
+  Try to edit tag's description so it stays unique. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When Description of tag "Tag1" is changed into "Valid description 123"
@@ -281,7 +281,7 @@ Feature: Tag Service
     Then No exception was thrown
 
   Scenario: Changing Tag's Description To Non-Unique One
-    Try to edit tag's description to a non-unique one. Kapua should not return any errors.
+  Try to edit tag's description to a non-unique one. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" and description "Description 123"
     When I create tag with name "Tag2" and description "Description 567"
@@ -289,14 +289,14 @@ Feature: Tag Service
     Then No exception was thrown
 
   Scenario: Changing Description On Tag With Short Name
-    Try to edit description on a tag with too short name. Kapua should not throw any errors.
+  Try to edit description on a tag with too short name. Kapua should not throw any errors.
 
     Given I create tag with name "abc" without description
     When Description of tag "abc" is changed into "Description 123"
     Then No exception was thrown
 
   Scenario: Changing Description On Tag With Long Name
-    Try to edit description on a tag with long name. Kapua should not return any errors.
+  Try to edit description on a tag with long name. Kapua should not return any errors.
 
     Given I create tag with name "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX" and description "Description"
     When Description of tag "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX" is changed into "Description 123"
@@ -304,14 +304,14 @@ Feature: Tag Service
     Then I find a tag with name "YXZb6s4L1f6Xk9J23S5RcNcH4Befzk4fg1fDi0PkIbCGtaIN50lWeklthY7Ngo06ss6lmUcqaHiChWjXYdqlcn1UMyqCHcuP4eG0qc9h7a9FLlnXgiFvcAQfvki8iwTPVEdEpBzOWZoWEssb9v966k0tSeQye4yxFC2FyR2SlNZTW06D0krB6zjKa8k5t1BJ2HbJwj5cp8Gsabjyk8lEtlMBeDLqCJv3ik3MZhySD1UvXMkWpOPZoixik8tCBHX"
 
   Scenario: Changing Description On Tag With Permitted Symbols In Name
-    Try to edit description on a tag with permitted symbols. Kapua should not return any errors.
+  Try to edit description on a tag with permitted symbols. Kapua should not return any errors.
 
     Given I create tag with name "T_a_g-1" without description
     When Description of tag "T_a_g-1" is changed into "Description 123"
     Then No exception was thrown
 
   Scenario: Changing Description On Tag With Numbers In Name
-    Try to edit description on a tag with numbers in its name. Kapua should not return any errors.
+  Try to edit description on a tag with numbers in its name. Kapua should not return any errors.
 
     Given I create tag with name "Tag123" and description "Description"
     When Description of tag "Tag123" is changed into "Description 123"
@@ -320,21 +320,21 @@ Feature: Tag Service
     Then I find a tag with name "Tag123"
 
   Scenario: Changing Description On Tag With Short Description
-    Try to edit description on a tag with short description. Kapua should not return any errors.
+  Try to edit description on a tag with short description. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" and description "a"
     When Description of tag "Tag1" is changed into "b"
     Then No exception was thrown
 
   Scenario: Changing Description On Tag With Long Description
-    Try to edit description on a tag with long (255 characters) description. Kapua should not return any errors.
+  Try to edit description on a tag with long (255 characters) description. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" and description "mrZ4vBeOJbGkSlfzSHMY3Dj7gLO3E5SZFrtv7X4RF5LX1OWhRhBaRPubBJSglhS9ueguyStqJOcDs49mMVyuM2E08aPxcAMasSi6KWXmRcQaXl99oyFTScQT4ILK7I7EKuWFArivwLZkEPeK52OKnZjLxer8WGQ88CDqrooUUYt0lIOytrAGftGBO69DcIEjFrs73Mgyec0MvKkVeYYQ3dzDez2tGHPRTx19TVxHGtem52JOT6H7g0I3eGX5Ju0"
     When Tag description is changed into "Description 123"
     Then No exception was thrown
 
   Scenario: Deleting existing tag
-    Create a tag and after that try to delete it. Kapua should not return any errors.
+  Create a tag and after that try to delete it. Kapua should not return any errors.
 
     Given I create tag with name "Tag1" without description
     When I create tag with name "Tag2" and description "Tag with description"
@@ -346,7 +346,7 @@ Feature: Tag Service
     Then No tag was found
 
   Scenario: Deleting Non-Existent Tag
-    Try to delete an non-existent tag. Kapua should throw Exception.
+  Try to delete an non-existent tag. Kapua should throw Exception.
 
     Given I create tag with name "Tag1" without description
     When I delete tag with name "Tag1"
@@ -356,7 +356,7 @@ Feature: Tag Service
     Then An exception was thrown
 
   Scenario: Deleting Existing Tag And Creating It Again With Same Name
-    Delete an existing tag and creating it again with the same name. Kapua should not throw any errors.
+  Delete an existing tag and creating it again with the same name. Kapua should not throw any errors.
 
     Given I create tag with name "Tag1" without description
     When I delete tag with name "Tag1"
@@ -366,7 +366,7 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Adding Regular Tag Without Description To Device
-    Create a tag. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
+  Create a tag. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
 
     Given I create tag with name "Tag123" without description
     And I create a device with name "Device1"
@@ -375,7 +375,7 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Adding Tag With Long Name Without Description To Device
-    Create a tag with long (255 characters) name. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
+  Create a tag with long (255 characters) name. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
 
     Given A device named "Device1"
     And I create tag with name "FxJpmQN9CU3ruFCAGtPDmKymN88CK7rn5L1AAYH184hCaxEpJsOQWKc3ACV2Gw44yWFz0o74rnsCabGHmX7azzplDPAe4mVYmHGLnMmlliQUpljJYB5i1Wq4flevCI8lIjZQ7UT7ll6I2C4eqvhXmt4GOD50bhiLzMDDZJeXXC8IjCidnz60QmbzUxpRC1YP8MQqosesjER2xm4jPrk3eH0egSwxvnPCeAWTXtSHeejOFVKLL78IW1xlhXkbOCh" without description
@@ -384,7 +384,7 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Adding Tag With Short Name Without Description To Device
-    Create a tag with short (3) name. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
+  Create a tag with short (3) name. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
 
     Given A device named "Device1"
     And I create tag with name "abc" without description
@@ -393,7 +393,7 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Adding Tag With Special Symbols Without Description To Device
-    Create a tag with name that contains permitted special symbols. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
+  Create a tag with name that contains permitted special symbols. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
 
     Given A device named "Device1"
     And I create tag with name "T-a-g_1_" without description
@@ -402,7 +402,7 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Adding Tag With Numbers Without Description To Device
-    Create a tag with name that contains numbers. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
+  Create a tag with name that contains numbers. Go to devices, select a device and add created tag to it. Kapua should not return any errors.
 
     Given A device named "Device1"
     And I create tag with name "Tag1234567890" without description
@@ -411,9 +411,9 @@ Feature: Tag Service
     And No exception was thrown
 
   Scenario: Deleting Tag From Device
-    Create a tag. Go to devices, select a device and add created tag to it.
-    Kapua should not return any errors. Go to devices, select tag and remove it from selected device.
-    Check if tag is removed.
+  Create a tag. Go to devices, select a device and add created tag to it.
+  Kapua should not return any errors. Go to devices, select tag and remove it from selected device.
+  Check if tag is removed.
 
     Given A device named "Device1"
     And I create tag with name "Tag1" without description
@@ -424,10 +424,10 @@ Feature: Tag Service
     Then Tag "Tag1" is not assigned to device "Device1"
 
   Scenario: Adding Previously Deleted Tag From Device Again
-    Create a tag. Go to devices, select a device and add created tag to it.
-    Kapua should not return any errors. Go to devices, select tag and remove it from selected device.
-    Check if tag is removed. Assign the removed tag to device again.
-    Kapua should not return any errors.
+  Create a tag. Go to devices, select a device and add created tag to it.
+  Kapua should not return any errors. Go to devices, select tag and remove it from selected device.
+  Check if tag is removed. Assign the removed tag to device again.
+  Kapua should not return any errors.
 
     Given A device named "Device1"
     And I create tag with name "Tag1" without description
@@ -441,7 +441,7 @@ Feature: Tag Service
     Then No exception was thrown
 
   Scenario: Adding "Empty" Tag To Device
-    Try to add non existent tag without description to a device. Kapua should throw Exception.
+  Try to add non existent tag without description to a device. Kapua should throw Exception.
 
     Given A device named "Device1"
     And I expect the exception "NullPointerException" with the text "*"


### PR DESCRIPTION
This PR add some fields to perform validation on `JobStepProperty`es when creating a Step.
As per default no validation is added for existing `JobStepDefinitions` to not break any existing JobStep Definition.

**Related Issue**
_None_

**Description of the solution adopted**
Added following fields to `JobStepProperty`:

- minLength
- maxLength
- minValue
- maxValue
- validationRegex

These fields will be enforced only if specified. 

**Screenshots**
_None_

**Any side note on the changes made**
_None_
