### PR TITLE
Update Endpoint REST API to support CORS endpoints

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/EndpointInfos.java
@@ -67,6 +67,7 @@ public class EndpointInfos extends AbstractKapuaResource {
     public EndpointInfoListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("usage") String usage,
+            @QueryParam("endpointType") @DefaultValue(EndpointInfo.ENDPOINT_TYPE_RESOURCE) String endpointType,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         EndpointInfoQuery query = endpointInfoFactory.newQuery(scopeId);
@@ -80,7 +81,7 @@ public class EndpointInfos extends AbstractKapuaResource {
         query.setOffset(offset);
         query.setLimit(limit);
 
-        return query(scopeId, query);
+        return query(scopeId, endpointType, query);
     }
 
     /**
@@ -99,10 +100,11 @@ public class EndpointInfos extends AbstractKapuaResource {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public EndpointInfoListResult query(
             @PathParam("scopeId") ScopeId scopeId,
+            @QueryParam("endpointType") @DefaultValue(EndpointInfo.ENDPOINT_TYPE_RESOURCE) String endpointType,
             EndpointInfoQuery query) throws KapuaException {
         query.setScopeId(scopeId);
 
-        return endpointInfoService.query(query);
+        return endpointInfoService.query(query, endpointType);
     }
 
     /**
@@ -121,10 +123,11 @@ public class EndpointInfos extends AbstractKapuaResource {
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     public CountResult count(
             @PathParam("scopeId") ScopeId scopeId,
+            @QueryParam("endpointType") @DefaultValue(EndpointInfo.ENDPOINT_TYPE_RESOURCE) String endpointType,
             EndpointInfoQuery query) throws KapuaException {
         query.setScopeId(scopeId);
 
-        return new CountResult(endpointInfoService.count(query));
+        return new CountResult(endpointInfoService.count(query, endpointType));
     }
 
     /**

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_count.yaml
@@ -20,6 +20,7 @@ paths:
       operationId: endpointInfoCount
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-_query.yaml
@@ -20,6 +20,7 @@ paths:
       operationId: endpointInfoQuery
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
       requestBody:
         $ref: '../openapi.yaml#/components/requestBodies/kapuaQuery'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
@@ -25,6 +25,7 @@ paths:
           description: The endpointInfo usage to filter results
           schema:
             type: string
+        - $ref: './endpointInfo.yaml#/components/parameters/endpointType'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo.yaml
@@ -22,6 +22,15 @@ components:
       schema:
         $ref: '../openapi.yaml#/components/schemas/kapuaId'
       required: true
+    endpointType:
+      name: endpointType
+      in: query
+      description: The type of the Endpoints to query for
+      schema:
+        allOf:
+          - $ref: '#/components/schemas/endpointType'
+          - default: resource
+      required: false
   schemas:
     endpointInfo:
       allOf:
@@ -44,6 +53,7 @@ components:
             usages:
               - name: MESSAGE_BROKER
               - name: PROVISION
+            endpointType: resource
     endpointInfoCreator:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaUpdatableEntityCreator'
@@ -61,6 +71,8 @@ components:
               type: array
               items:
                 $ref: '#/components/schemas/usage'
+            endpointType:
+              $ref: '#/components/schemas/endpointType'
           example:
             schema: mqtt
             dns: 10.200.12.148
@@ -69,6 +81,7 @@ components:
             usages:
               - name: MESSAGE_BROKER
               - name: PROVISION
+            endpointType: resource
     endpointInfoListResult:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'
@@ -98,8 +111,14 @@ components:
                 usages:
                   - name: MESSAGE_BROKER
                   - name: PROVISION
+                endpointType: resource
     usage:
       type: object
       properties:
         name:
           type: string
+    endpointType:
+      type: string
+      enum:
+        - resource
+        - cors


### PR DESCRIPTION
Endpoints REST API Update to support CORS origins after the merge of #3278

**Related Issue**
No relate issues

**Description of the solution adopted**
A new `endpointType` query parameter has been added to the `GET v1/{scopeId}/endpoints`, `POST v1/{scopeId}/endpoints/_query` and `POST v1/{scopeId}/endpoints/_count` resources.
Other resources were already supporting `endpointType` in model objects.
