### PR TITLE
Fixed test ElasticSearchClientProvider value

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/user/RunUserServiceI9nTest.java
@@ -39,7 +39,7 @@ import org.junit.runner.RunWith;
         strict = true,
         monochrome = true)
 @CucumberProperty(key = "kapua.config.url", value = "")
-@CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClient")
+@CucumberProperty(key = "datastore.elasticsearch.provider", value = "org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClientProvider")
 @CucumberProperty(key = "org.eclipse.kapua.qa.datastore.extraStartupDelay", value = "5")
 @CucumberProperty(key = "org.eclipse.kapua.qa.broker.extraStartupDelay", value = "5")
 public class RunUserServiceI9nTest {


### PR DESCRIPTION
This PR fixes  and issue with the test that came out after merge of #3315.
The PR build had test passing but after merge the issue arised even if the #3315 branch was up to date with `develop`

After a bit of investigation on error:

> Error:  Scenario: Stop datastore after all scenarios  Time elapsed: 1.523 s  <<< ERROR!
> org.eclipse.kapua.service.datastore.exception.DatastoreInternalError: Cannot instantiate Elasticsearch Client
> Caused by: java.lang.ClassCastException: org.eclipse.kapua.service.elasticsearch.client.rest.RestElasticsearchClient cannot be cast to org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClientProvider

I've found a test class that had the wrong value for the `datastore.elasticsearch.provider` property which was pointing to the Client class instead of the ClientProvider. 

**Related Issue**
_None_

**Description of the solution adopted**
Just fixed the wrong parameter

**Screenshots**
_None_

**Any side note on the changes made**
_None_