### PR TITLE
Fixed typos "adress" and "loged"

### DIFF
--- a/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountCredentialService.feature
@@ -28,7 +28,7 @@ Scenario: Init Security Context for all scenarios
   User should be locked
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -64,7 +64,7 @@ Scenario: Init Security Context for all scenarios
   There should be no problems as  lockoutPolicy is disabled
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | false  |
@@ -100,7 +100,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -134,7 +134,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -166,7 +166,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     Given I expect the exception "KapuaConfigurationException" with the text "*"
     And I configure credential service
       | type    | name                       | value  |
@@ -185,7 +185,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -221,7 +221,7 @@ Scenario: Init Security Context for all scenarios
   User should not be locked and no exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -258,7 +258,7 @@ Scenario: Init Security Context for all scenarios
   User should not be locked
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value  |
       | boolean | lockoutPolicy.enabled      | true   |
@@ -294,7 +294,7 @@ Scenario: Init Security Context for all scenarios
   User should not be locked
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     Given I expect the exception "KapuaConfigurationException" with the text "*"
     And I configure credential service
       | type    | name                       | value  |
@@ -314,7 +314,7 @@ Scenario: Init Security Context for all scenarios
   Login again with correct password, no exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value |
       | boolean | lockoutPolicy.enabled      | true  |
@@ -351,7 +351,7 @@ Scenario: Init Security Context for all scenarios
   Login again with correct password, no exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure credential service
       | type    | name                       | value |
       | boolean | lockoutPolicy.enabled      | true  |
@@ -383,7 +383,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     Given I expect the exception "KapuaConfigurationException" with the text "*"
     When I configure credential service
       | type    | name                       | value |

--- a/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountDeviceRegistryService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the device registry service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -46,7 +46,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Devices should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the device registry service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -68,7 +68,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the device registry service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -87,7 +87,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the device registry service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -112,7 +112,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the device registry service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountGroupService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountGroupService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the group service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -45,7 +45,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Groups should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the group service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -66,7 +66,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the group service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -85,7 +85,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the group service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -109,7 +109,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the group service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountJobService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountJobService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the job service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -46,7 +46,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Jobs should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the job service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -68,7 +68,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the job service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -87,7 +87,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the job service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -112,7 +112,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the job service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountRoleService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountRoleService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the role service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -46,7 +46,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Roles should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the role service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -67,7 +67,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the role service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -86,7 +86,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the role service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -110,7 +110,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the role service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountService.feature
@@ -24,7 +24,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "account-1", organization name "organization" and email adress "org@abc.com"
+    When I create an account with name "account-1", organization name "organization" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -33,9 +33,9 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "account-1", organization name "organization1" and email adress "org1@abc.com"
+    When I create an account with name "account-1", organization name "organization1" and email address "org1@abc.com"
     And I select account "kapua-sys"
-    When I create an account with name "account-2", organization name "organization2" and email adress "org2@abc.com"
+    When I create an account with name "account-2", organization name "organization2" and email address "org2@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -45,10 +45,10 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "account-1", organization name "organization" and email adress "org@abc.com"
+    When I create an account with name "account-1", organization name "organization" and email address "org@abc.com"
     And I select account "kapua-sys"
     Given I expect the exception "KapuaDuplicateNameException" with the text "*"
-    When I create an account with name "account-1", organization name "organization2" and email adress "org2@abc.com"
+    When I create an account with name "account-1", organization name "organization2" and email address "org2@abc.com"
     Then An exception was thrown
     And I logout
 
@@ -57,7 +57,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown, dash and numbers are allowed
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "1231-2323", organization name "organization" and email adress "org@abc.com"
+    When I create an account with name "1231-2323", organization name "organization" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -67,7 +67,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
-    When I create an account with name "", organization name "org" and email adress "org@org.com"
+    When I create an account with name "", organization name "org" and email address "org@org.com"
     Then An exception was thrown
     And I logout
 
@@ -76,7 +76,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "abc", organization name "organization" and email adress "org@abc.com"
+    When I create an account with name "abc", organization name "organization" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -85,17 +85,17 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "7j5w5HFyvkWta6W3pr6c35ihjHUxNVkcEovzXyySjKqWhsXbe3", organization name "organization" and email adress "org@abc.com"
+    When I create an account with name "7j5w5HFyvkWta6W3pr6c35ihjHUxNVkcEovzXyySjKqWhsXbe3", organization name "organization" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
-  Scenario: Creating An Account Without Ogranization Name
+  Scenario: Creating An Account Without Organization Name
   Login as kapua-sys, try to create an account without organization name
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
-    When I create an account with name "acc1", organization name "" and email adress "org@abc.com"
+    When I create an account with name "acc1", organization name "" and email address "org@abc.com"
     Then An exception was thrown
     And I logout
 
@@ -104,7 +104,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "acc1", organization name "o" and email adress "org@abc.com"
+    When I create an account with name "acc1", organization name "o" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -113,7 +113,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "acc1", organization name "70PhDFZYDvBRNWU3J0rLqXa7ynQs0ZcjI9BXILV8ufsdvr3JtR07nxjvbaqPAlQVEOGjpopecZaBVTmrzw45ARl64Alw2QNjVxbRp56lJTxCGePcys0PLj4ZbQSmi8xdUVOQsNn5WDd6xx1lt3OXsugq77tG9dbaheeQTWvaMpri9gDL61uS5O8me4YXQ6AMkNQZxwuibsk3ohsGBSN9Z5ahmBeCCgTZulFXjdiHABaDIEiTM8qH05hhWmTs9jp" and email adress "org@abc.com"
+    When I create an account with name "acc1", organization name "70PhDFZYDvBRNWU3J0rLqXa7ynQs0ZcjI9BXILV8ufsdvr3JtR07nxjvbaqPAlQVEOGjpopecZaBVTmrzw45ARl64Alw2QNjVxbRp56lJTxCGePcys0PLj4ZbQSmi8xdUVOQsNn5WDd6xx1lt3OXsugq77tG9dbaheeQTWvaMpri9gDL61uS5O8me4YXQ6AMkNQZxwuibsk3ohsGBSN9Z5ahmBeCCgTZulFXjdiHABaDIEiTM8qH05hhWmTs9jp" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -123,16 +123,16 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I expect the exception "KapuaException" with the text "*"
-    When I create an account with name "acc1", organization name "a70PhDFZYDvBRNWU3J0rLqXa7ynQs0ZcjI9BXILV8ufsdvr3JtR07nxjvbaqPAlQVEOGjpopecZaBVTmrzw45ARl64Alw2QNjVxbRp56lJTxCGePcys0PLj4ZbQSmi8xdUVOQsNn5WDd6xx1lt3OXsugq77tG9dbaheeQTWvaMpri9gDL61uS5O8me4YXQ6AMkNQZxwuibsk3ohsGBSN9Z5ahmBeCCgTZulFXjdiHABaDIEiTM8qH05hhWmTs9jp" and email adress "org@abc.com"
+    When I create an account with name "acc1", organization name "a70PhDFZYDvBRNWU3J0rLqXa7ynQs0ZcjI9BXILV8ufsdvr3JtR07nxjvbaqPAlQVEOGjpopecZaBVTmrzw45ARl64Alw2QNjVxbRp56lJTxCGePcys0PLj4ZbQSmi8xdUVOQsNn5WDd6xx1lt3OXsugq77tG9dbaheeQTWvaMpri9gDL61uS5O8me4YXQ6AMkNQZxwuibsk3ohsGBSN9Z5ahmBeCCgTZulFXjdiHABaDIEiTM8qH05hhWmTs9jp" and email address "org@abc.com"
     Then An exception was thrown
     And I logout
 
   Scenario: Creating An Account With Special Symbols In Organization Name
   Login as kapua-sys, try to create an account with organization name that contains special symbols
-  No exception should be thrown as all charcters are allowed for contact name
+  No exception should be thrown as all characters are allowed for contact name
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    When I create an account with name "acc1", organization name "org@#$%&/!)=?(" and email adress "org@abc.com"
+    When I create an account with name "acc1", organization name "org@#$%&/!)=?(" and email address "org@abc.com"
     Then No exception was thrown
     And I logout
 
@@ -142,11 +142,11 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
-    When I create an account with name "acc1", organization name "org1" and email adress "org@abc.commmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommm"
+    When I create an account with name "acc1", organization name "org1" and email address "org@abc.commmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommmcommm"
     Then An exception was thrown
     And I select account "kapua-sys"
     Given I expect the exception "KapuaIllegalArgumentException" with the text "*"
-    When I create an account with name "acc2", organization name "org2" and email adress "org@abc.c"
+    When I create an account with name "acc2", organization name "org2" and email address "org@abc.c"
     Then An exception was thrown
     And I logout
 
@@ -156,7 +156,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I expect the exception "KapuaIllegalArgumentException" with the text "*"
-    When I create an account with name "acc1", organization name "org1" and email adress "orgabc.com"
+    When I create an account with name "acc1", organization name "org1" and email address "orgabc.com"
     Then An exception was thrown
     And I logout
 
@@ -166,7 +166,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I expect the exception "KapuaIllegalArgumentException" with the text "*"
-    When I create an account with name "acc1", organization name "org1" and email adress "org@abccom"
+    When I create an account with name "acc1", organization name "org1" and email address "org@abccom"
     Then An exception was thrown
     And I logout
 
@@ -176,7 +176,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I expect the exception "KapuaIllegalNullArgumentException" with the text "*"
-    When I create an account with name "acc1", organization name "org1" and email adress ""
+    When I create an account with name "acc1", organization name "org1" and email address ""
     Then An exception was thrown
     And I logout
 
@@ -187,17 +187,17 @@ Scenario: Init Security Context for all scenarios
   All accounts should be created
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 0     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc13", organization name "acc13" and email adress "acc13@org.com"
+    And I create an account with name "acc13", organization name "acc13" and email address "acc13@org.com"
     Then No exception was thrown
     And I logout
 
@@ -208,57 +208,57 @@ Scenario: Init Security Context for all scenarios
   No accounts should be created
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
       | integer | maxNumberChildEntities | 0     |
     Then I select account "acc1"
     Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then An exception was thrown
     Then I logout
 
-  Scenario: Creating Sub-accounts When InfiniteChildAccoounts Is Set To True And maxNumberChildAccounts Is Set
+  Scenario: Creating Sub-accounts When InfiniteChildAccounts Is Set To True And maxNumberChildAccounts Is Set
   Login as kapua-sys, create an account
   Configure AccountService of that account, set infiniteChildAccounts to true and maxNumberChildAccounts To 1
   Try to create a few (more than one) sub-accounts under created account
   All accounts should be created because we allow infinite child accounts so maxNumberChildAccounts value does not matter
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 1     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc13", organization name "acc13" and email adress "acc13@org.com"
+    And I create an account with name "acc13", organization name "acc13" and email address "acc13@org.com"
     Then No exception was thrown
     When I query for all sub-accounts in "acc1"
     Then I find 3 accounts
     And I logout
 
-  Scenario: Creating Sub-accounts When InfiniteChildAccoounts Is Set To False And maxNumberChildAccounts Is Set
+  Scenario: Creating Sub-accounts When InfiniteChildAccounts Is Set To False And maxNumberChildAccounts Is Set
   Login as kapua-sys, create an account
   Configure AccountService of that account, set infiniteChildAccounts to true and maxNumberChildAccounts To 1
   Try to create a few sub-accounts under created account
   Only 1 account is created  because infiniteChildAccounts is set to false so maximum number of child account is 1
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
       | integer | maxNumberChildEntities | 1     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
     Given I expect the exception "KapuaMaxNumberOfItemsReachedException" with the text "*"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     Then An exception was thrown
     When I query for all sub-accounts in "acc1"
     Then I find 1 account
@@ -272,15 +272,15 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 0     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     When I query for all sub-accounts in "acc1"
     Then I find 2 accounts
     Then I select account "acc1"
@@ -300,15 +300,15 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
       | integer | maxNumberChildEntities | 2     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     When I query for all sub-accounts in "acc1"
     Then I find 2 accounts
     Then I select account "acc1"
@@ -328,15 +328,15 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 0     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     When I query for all sub-accounts in "acc1"
     Then I find 2 accounts
     Then I select account "acc1"
@@ -355,15 +355,15 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
       | integer | maxNumberChildEntities | 2     |
     Then I select account "acc1"
-    And I create an account with name "acc11", organization name "acc11" and email adress "acc11@org.com"
+    And I create an account with name "acc11", organization name "acc11" and email address "acc11@org.com"
     Then I select account "acc1"
-    And I create an account with name "acc12", organization name "acc12" and email adress "acc12@org.com"
+    And I create an account with name "acc12", organization name "acc12" and email address "acc12@org.com"
     When I query for all sub-accounts in "acc1"
     Then I find 2 accounts
     Then I select account "acc1"
@@ -381,7 +381,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure account service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountTagService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountTagService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the tag service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -46,7 +46,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Tags should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the tag service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -67,7 +67,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the tag service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -86,7 +86,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the tag service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -110,7 +110,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure the tag service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/account/AccountUserService.feature
+++ b/qa/integration/src/test/resources/features/account/AccountUserService.feature
@@ -27,7 +27,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -46,7 +46,7 @@ Scenario: Init Security Context for all scenarios
   Only 3 Users should be created, creating more will throw an Exception
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -67,7 +67,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | false |
@@ -86,7 +86,7 @@ Scenario: Init Security Context for all scenarios
   Exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -110,7 +110,7 @@ Scenario: Init Security Context for all scenarios
   No exception should be thrown
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
-    Then I create an account with name "acc1", organization name "acc1" and email adress "acc1@org.com"
+    Then I create an account with name "acc1", organization name "acc1" and email address "acc1@org.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -340,7 +340,7 @@ Scenario: Init Security Context for all scenarios
     User service is configured for user to have 3 failed attempts before it is locked
     out. Lockout policy on user service has to be enabled.
     User tries to login two times with wrong password and is not yet locked out. Then
-    it logins with correct password and is loged in.
+    it logins with correct password and is logged in.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
       | type    | name                       | value |
@@ -377,7 +377,7 @@ Scenario: Init Security Context for all scenarios
     User service is configured for user to have 1 failed attempt before it is locked
     out. Lockout policy on user service has to be enabled.
     User tries to login with wrong password and is locked out. Then it waits for lockout
-    time of 1 second to pass and then it logins with correct password and is loged in.
+    time of 1 second to pass and then it logins with correct password and is logged in.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
       | type    | name                       | value |
@@ -420,7 +420,7 @@ Scenario: Init Security Context for all scenarios
   out. Lockout policy on user service has to be enabled.
   User tries to login with wrong password and is locked out. Then it waits for lockout
   time of 1 second to pass. This wait is not enough, it should wait 5 seconds.
-  After wait it logins with correct password and but it is not loged in.
+  After wait it logins with correct password and but it is not logged in.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
       | type    | name                       | value |
@@ -463,7 +463,7 @@ Scenario: Init Security Context for all scenarios
   out. Lockout policy on user service has to be enabled.
   User tries to login with wrong password but it waits one second between logins. Failed
   logins are reset every second, so user does not get locked out.
-  After two failed attempts it logins with correct password and is loged in.
+  After two failed attempts it logins with correct password and is logged in.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
       | type    | name                       | value |

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -349,7 +349,7 @@ Scenario: Init Security Context for all scenarios
     And I add access role "test_role" to user "user1"
     And I logout
     Then I login as user with name "user1" and password "User@10031995"
-    And I create an account with name "account1", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "account1", organization name "organization" and email address "organization@gmail.com"
     And I find account with name "account1"
     And I try to edit description to "account in child account"
     And I delete account "account1"
@@ -1056,7 +1056,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -1080,7 +1080,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1121,7 +1121,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1162,7 +1162,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1204,7 +1204,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1230,7 +1230,7 @@ Scenario: Init Security Context for all scenarios
     And I add access role "Role1" to user "SubUser" in account "SubAccount"
     And I logout
     And I login as user with name "SubUser" and password "User@10031995"
-    And I create an account with name "TestAccount", organization name "Organization" and email adress "organization@org.com"
+    And I create an account with name "TestAccount", organization name "Organization" and email address "organization@org.com"
     And I find account with name "TestAccount"
     And I expect the exception "KapuaAccountException" with the text "An illegal value was provided for the argument"
     When I change the account "TestAccount" name to "TestAccount1"
@@ -1248,7 +1248,7 @@ Scenario: Init Security Context for all scenarios
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
     And I create endpoint with schema "TestEndpoint", domain "com" and port 8000
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1292,7 +1292,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1333,7 +1333,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1377,7 +1377,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1434,7 +1434,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "organization" and email adress "organization@gmail.com"
+    And I create an account with name "SubAccount", organization name "organization" and email address "organization@gmail.com"
     And I configure user service
       | type    | name                       | value |
       | boolean | infiniteChildEntities      | true  |
@@ -1492,7 +1492,7 @@ Scenario: Init Security Context for all scenarios
     And I find a role with name "admin"
     And I count the roles in scope 1
     And I count 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -1552,7 +1552,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I create role "SubRole" in account "SubAccount"
     And I configure user service
       | type    | name                   | value |
@@ -1578,7 +1578,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I create role "TestRole" in account "SubAccount"
     And I configure account service
       | type    | name                   | value |
@@ -1588,7 +1588,7 @@ Scenario: Init Security Context for all scenarios
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
       | integer | maxNumberChildEntities | 50    |
-    And I create an account with name "SubSubAccount", organization name "Organization" and email adress "test1@test.com" and child account
+    And I create an account with name "SubSubAccount", organization name "Organization" and email address "test1@test.com" and child account
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -1606,7 +1606,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |
@@ -1626,7 +1626,7 @@ Scenario: Init Security Context for all scenarios
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And Scope with ID 1
-    And I create an account with name "SubAccount", organization name "Organization" and email adress "test@test.com"
+    And I create an account with name "SubAccount", organization name "Organization" and email address "test@test.com"
     And I configure user service
       | type    | name                   | value |
       | boolean | infiniteChildEntities  | true  |

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -198,7 +198,7 @@ Scenario: Init Security Context for all scenarios
       | integer | lockoutPolicy.resetAfter   | 300   |
       | integer | lockoutPolicy.lockDuration | 3     |
     And I create user with name "TestUser"
-    And I create an account with name "SubAccount", organization name "TestOrganization" and email adress "test@gmail.com"
+    And I create an account with name "SubAccount", organization name "TestOrganization" and email address "test@gmail.com"
     And The account with name "kapua-sys" has 1 subaccount
     And I find account with name "SubAccount"
     And I configure account service

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -933,8 +933,8 @@ public class AccountServiceSteps extends TestBase {
         }
     }
 
-    @And("^I create an account with name \"([^\"]*)\", organization name \"([^\"]*)\" and email adress \"([^\"]*)\"$")
-    public void iCreateAAccountWithNameOrganizationNameAndEmailAdress(String accountName, String organizationName, String email) throws Exception {
+    @And("^I create an account with name \"([^\"]*)\", organization name \"([^\"]*)\" and email address \"([^\"]*)\"$")
+    public void iCreateAAccountWithNameOrganizationNameAndEmailaddress(String accountName, String organizationName, String email) throws Exception {
         AccountCreator accountCreator = accountFactory.newCreator(getCurrentScopeId());
         accountCreator.setName(accountName);
         accountCreator.setOrganizationName(organizationName);
@@ -978,8 +978,8 @@ public class AccountServiceSteps extends TestBase {
         assertNotNull(stepData.get(LAST_ACCOUNT));
     }
 
-    @And("^I create an account with name \"([^\"]*)\", organization name \"([^\"]*)\" and email adress \"([^\"]*)\" and child account$")
-    public void iCreateAccountWithNameOrganizationNameAndEmailAdressAndChildAccount(String accountName, String organizationName, String email) throws Exception {
+    @And("^I create an account with name \"([^\"]*)\", organization name \"([^\"]*)\" and email address \"([^\"]*)\" and child account$")
+    public void iCreateAccountWithNameOrganizationNameAndEmailaddressAndChildAccount(String accountName, String organizationName, String email) throws Exception {
         Account lastAccount = (Account) stepData.get(LAST_ACCOUNT);
 
         AccountCreator accountCreator = accountFactory.newCreator(lastAccount.getId());


### PR DESCRIPTION
**Description**
This PR simply fixes the typos "adress" and "loged" present in the integration test.

**Description of the solution adopted**
Replaced "address" with "address" and "loged" with "logged".
