### PR TITLE
Do not increase lockout counter error when credentials are correct but no otp is provided

### DIFF
--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -503,7 +503,7 @@ Scenario: Init Security Context for all scenarios
     Then No exception was thrown
     And I logout
 
-  Scenario: User is just created and its credentials are not used to login.
+  Scenario: User is just created and its credentials are not used to login
   Its lockout error counter is equals to 0.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
@@ -530,7 +530,7 @@ Scenario: Init Security Context for all scenarios
     And I logout
     Then The lockout error counter for user "kapua-a" is 0
 
-  Scenario: User tying to login one time with wrong password.
+  Scenario: User tying to login one time with wrong password
   The user cannot login in, and the lockout error counter is equals to 1.
     When I login as user with name "kapua-sys" and password "kapua-password"
     And I configure user service
@@ -622,6 +622,7 @@ Scenario: Init Security Context for all scenarios
     Then I have mfa enable
     And I logout
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
     Then The lockout error counter for user "kapua-a" is 0
 
   Scenario: User login with wrong username and password, after that it login with correct username and password
@@ -657,6 +658,7 @@ Scenario: Init Security Context for all scenarios
     Then An exception was thrown
     Then The lockout error counter for user "kapua-a" is 1
     When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then No exception was thrown
     Then The lockout error counter for user "kapua-a" is 0
 
   Scenario: Reset Security Context for all scenarios

--- a/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/user/LockoutExpirationI9n.feature
@@ -503,6 +503,162 @@ Scenario: Init Security Context for all scenarios
     Then No exception was thrown
     And I logout
 
+  Scenario: User is just created and its credentials are not used to login.
+  Its lockout error counter is equals to 0.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    Then The lockout error counter for user "kapua-a" is 0
+
+  Scenario: User tying to login one time with wrong password.
+  The user cannot login in, and the lockout error counter is equals to 1.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
+    When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
+    Then The lockout error counter for user "kapua-a" is 1
+
+  Scenario: User login with wrong password and it doesn't provide any otp code
+  even if the mfa is activated.
+  The user cannot login in, and the lockout error counter is equals to 1.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I enable mfa
+    Then I have mfa enable
+    And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
+    When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
+    Then The lockout error counter for user "kapua-a" is 1
+
+  Scenario: User login with correct username and password, but it doesn't provide any otp code
+  even if the mfa is activated.
+  The user cannot login in, but the lockout error counter is not increased.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I enable mfa
+    Then I have mfa enable
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then The lockout error counter for user "kapua-a" is 0
+
+  Scenario: User login with wrong username and password, after that it login with correct username and password
+  but it doesn't provide any otp code even if the mfa is activated.
+  The user cannot login in. The lockout error counter is first set to 1, then set to 0.
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    Given Account
+      | name      | scopeId |
+      | account-a | 1       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  5    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType | expirationDate |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL | tomorrow       |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And I enable mfa
+    Then I have mfa enable
+    And I logout
+    Given I expect the exception "KapuaAuthenticationException" with the text "Error: kapua-a"
+    When I login as user with name "kapua-a" and password "WrongPassword123#"
+    Then An exception was thrown
+    Then The lockout error counter for user "kapua-a" is 1
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Then The lockout error counter for user "kapua-a" is 0
+
   Scenario: Reset Security Context for all scenarios
 
     Given Reset Security Context

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -297,8 +297,8 @@ public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
         }
         Subject currentSubject = SecurityUtils.getSubject();
         Session session = currentSubject.getSession();
-        session.setAttribute("scopeId", userId);
-        session.setAttribute("userId", scopeId);
+        session.setAttribute("scopeId", scopeId);
+        session.setAttribute("userId", userId);
     }
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -229,8 +229,8 @@ public class UserPassAuthenticatingRealm extends AuthenticatingRealm {
                 hasMfa = true;
             }
         } catch (KapuaException e) {
-            logger.warn(e.toString());
-            throw new ShiroException("Error while find user!", e);
+            logger.warn("Error while finding User. Error: {}", e.getMessage());
+            throw new ShiroException("Error while finding user!", e);
         }
 
         try {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -166,4 +166,16 @@ public class UserPassCredentialsMatcher implements CredentialsMatcher {
         return credentialMatch;
     }
 
+    public boolean doUsernameAndPasswordMatch(AuthenticationToken authenticationToken, AuthenticationInfo authenticationInfo) {
+        UsernamePasswordCredentials token = (UsernamePasswordCredentials) authenticationToken;
+        String tokenUsername = token.getUsername();
+        String tokenPassword = token.getPassword();
+        LoginAuthenticationInfo loginAuthInfo = (LoginAuthenticationInfo) authenticationInfo;
+        User infoUser = (User) loginAuthInfo.getPrincipals().getPrimaryPrincipal();
+        Credential infoCredential = (Credential) loginAuthInfo.getCredentials();
+        return tokenUsername.equals(infoUser.getName()) &&
+                CredentialType.PASSWORD.equals(infoCredential.getCredentialType()) &&
+                BCrypt.checkpw(tokenPassword, infoCredential.getCredentialKey());
+    }
+
 }

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -54,6 +54,12 @@ import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionFactoryImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionServiceImpl;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialQueryImpl;
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
 import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
@@ -93,6 +99,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.Callable;
 
 /**
  * Implementation of Gherkin steps used in user test scenarios.
@@ -1318,6 +1325,74 @@ public class UserServiceSteps extends TestBase {
            assertEquals(user.getEmail(), (email));
        }
        stepData.put(USER_LIST, users);
+    }
+
+    @And("^I enable mfa$")
+    public void iEnableMfa() {
+        KapuaId userId = KapuaSecurityUtils.getSession().getUserId();
+        KapuaId scopeId = KapuaSecurityUtils.getSession().getScopeId();
+
+        MfaOptionFactory mfaFactory = locator.getFactory(MfaOptionFactoryImpl.class);
+        MfaOptionCreator mfaCreator = mfaFactory.newCreator(scopeId, userId, "mfaSecretKey");
+        MfaOptionService mfaOptionService = locator.getService(MfaOptionServiceImpl.class);
+        try {
+            mfaOptionService.create(mfaCreator);
+        } catch (KapuaException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Then("^I have mfa enable$")
+    public void iHaveMfaIsEnable() {
+        KapuaId userId = KapuaSecurityUtils.getSession().getUserId();
+        KapuaId scopeId = KapuaSecurityUtils.getSession().getScopeId();
+
+        MfaOptionService mfaOptionService = locator.getService(MfaOptionServiceImpl.class);
+        MfaOption mfaOption = null;
+        try {
+            mfaOption = mfaOptionService.findByUserId(scopeId, userId);
+        } catch (KapuaException e) {
+            e.printStackTrace();
+        }
+        assertNotNull(mfaOption);
+    }
+
+    @Then("^The lockout error counter for user \"([^\"]*)\" is (\\d+)$")
+    public void theLockoutErrorCounterForUserIs(String username, int expectedCounter) {
+        KapuaId userIdTmp = null;
+        KapuaId scopeIdTmp = null;
+        try {
+            userIdTmp = KapuaSecurityUtils.doPrivileged(new Callable<KapuaId>() {
+                @Override
+                public KapuaId call() throws Exception {
+                    return userService.findByName(username).getId();
+                }
+            });
+            scopeIdTmp = KapuaSecurityUtils.doPrivileged(new Callable<KapuaId>() {
+                @Override
+                public KapuaId call() throws Exception {
+                    return userService.findByName(username).getScopeId();
+                }
+            });
+        } catch (KapuaException e) {
+            e.printStackTrace();
+        }
+
+        Credential credential = null;
+        final KapuaId userId = userIdTmp;
+        final KapuaId scopeId = scopeIdTmp;
+        try {
+            credential = KapuaSecurityUtils.doPrivileged(new Callable<Credential>() {
+                @Override
+                public Credential call() throws Exception {
+                    return credentialService.findByUserId(scopeId, userId).getFirstItem();
+                }
+            });
+        } catch (KapuaException e) {
+            e.printStackTrace();
+        }
+
+        assertEquals(expectedCounter, credential.getLoginFailures());
     }
 
     // *****************


### PR DESCRIPTION
**Description**
This PR fixes the following problem:
when mfa is enable for an account and the user try to login with correct username and password but without provide any otp code, the lockout counter error is increased.
This is not the intended behavior because this situation happen when a user provide the correct credentials but use the wrong rest api. Also this is the workflow used by the console in order to check if the mfa is enable for an account.

**Description of the solution adopted**
* In the `UserPassCredentialsMatcher` class is created a new method `doUsernameAndPasswordMatch` which check if provided password is correct for the selected user without consider the otp.
* In the method `assertCredentialsMatch` of the `UserPassAuthenticatingRealm` class it's added the case with correct credentials but no mandatory otp sent.
* New integration test are created.