### PR TITLE
Job Step Properties required attribute

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -251,10 +251,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
         for (GwtJobStepProperty property : gwtJobStepDefinition.getStepProperties()) {
             String propertyType = property.getPropertyType();
-            String fieldLabel = camelCaseToNormalCase(property.getPropertyName());
-            if (property.getPropertyValue() == null) {
-                fieldLabel = "* " + fieldLabel;
-            }
+
             if (
                     (propertyType.equals(String.class.getName()) &&
                             (
@@ -266,19 +263,8 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                             KAPUA_ID_CLASS_NAME.equals(propertyType)
             ) {
                 KapuaTextField<String> textField = new KapuaTextField<String>();
-                if (property.getPropertyValue() == null) {
-                    textField.setAllowBlank(false);
-                }
-                textField.setFieldLabel(fieldLabel);
-                if (property.getMinLength() != null) {
-                    textField.setMinLength(property.getMinLength());
-                }
-                if (property.getMaxLength() != null) {
-                    textField.setMaxLength(property.getMaxLength());
-                }
-                if (property.getValidationRegex() != null) {
-                    textField.setValidator(new RegexFieldValidator(property.getValidationRegex(), "The value provided does not match regex: " + property.getValidationRegex()));
-                }
+
+                applyFieldLimits(property, textField);
 
                 textField.setEmptyText(KapuaSafeHtmlUtils.htmlUnescape(property.getPropertyValue()));
                 textField.setData(PROPERTY_TYPE, property.getPropertyType());
@@ -290,16 +276,9 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                             propertyType.equals(Float.class.getName()) ||
                             propertyType.equals(Double.class.getName())) {
                 KapuaNumberField numberField = new KapuaNumberField();
-                if (property.getPropertyValue() == null) {
-                    numberField.setAllowBlank(false);
-                }
-                numberField.setFieldLabel(fieldLabel);
-                if (property.getMinLength() != null) {
-                    numberField.setMinLength(property.getMinLength());
-                }
-                if (property.getMaxLength() != null) {
-                    numberField.setMaxLength(property.getMaxLength());
-                }
+
+                applyFieldLimits(property, numberField);
+
                 numberField.setEmptyText(KapuaSafeHtmlUtils.htmlUnescape(property.getPropertyValue()));
                 numberField.setData(PROPERTY_TYPE, property.getPropertyType());
                 numberField.setData(PROPERTY_NAME, property.getPropertyName());
@@ -320,27 +299,18 @@ public class JobStepAddDialog extends EntityAddEditDialog {
                 }
                 jobStepPropertiesPanel.add(numberField);
             } else if (propertyType.equals(Boolean.class.getName())) {
+                String fieldLabel = camelCaseToNormalCase(property.getPropertyName());
+
                 CheckBox checkBox = new CheckBox();
-                checkBox.setFieldLabel(fieldLabel);
+                checkBox.setFieldLabel(property.getRequired() ? "* " + fieldLabel : fieldLabel);
                 checkBox.setValue(Boolean.valueOf(property.getPropertyValue()));
                 checkBox.setData(PROPERTY_TYPE, property.getPropertyType());
                 checkBox.setData(PROPERTY_NAME, property.getPropertyName());
                 jobStepPropertiesPanel.add(checkBox);
             } else {
                 final KapuaTextArea textArea = new KapuaTextArea();
-                if (property.getPropertyValue() == null) {
-                    textArea.setAllowBlank(false);
-                }
-                textArea.setFieldLabel(fieldLabel);
-                if (property.getMinLength() != null) {
-                    textArea.setMinLength(property.getMinLength());
-                }
-                if (property.getMaxLength() != null) {
-                    textArea.setMaxLength(property.getMaxLength());
-                }
-                if (property.getValidationRegex() != null) {
-                    textArea.setValidator(new RegexFieldValidator(property.getValidationRegex(), "The value provided does not match regex: " + property.getValidationRegex()));
-                }
+
+                applyFieldLimits(property, textArea);
 
                 textArea.setData(PROPERTY_TYPE, property.getPropertyType());
                 textArea.setData(PROPERTY_NAME, property.getPropertyName());
@@ -366,6 +336,23 @@ public class JobStepAddDialog extends EntityAddEditDialog {
             jobStepPropertiesPanel.layout(true);
         }
         jobStepPropertiesPanel.layout(true);
+    }
+
+    private void applyFieldLimits(GwtJobStepProperty property, TextField<?> textField) {
+        String fieldLabel = camelCaseToNormalCase(property.getPropertyName());
+
+        textField.setAllowBlank(!property.getRequired());
+        textField.setFieldLabel(property.getRequired() ? "* " + fieldLabel : fieldLabel);
+
+        if (property.getMinLength() != null) {
+            textField.setMinLength(property.getMinLength());
+        }
+        if (property.getMaxLength() != null) {
+            textField.setMaxLength(property.getMaxLength());
+        }
+        if (property.getValidationRegex() != null) {
+            textField.setValidator(new RegexFieldValidator(property.getValidationRegex(), "The value provided does not match regex: " + property.getValidationRegex()));
+        }
     }
 
     protected List<GwtJobStepProperty> readStepProperties() {

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
@@ -40,6 +40,14 @@ public class GwtJobStepProperty extends KapuaBaseModel {
         set("propertyValue", propertyValue, false);
     }
 
+    public Boolean getRequired() {
+        return get("required");
+    }
+
+    public void setRequired(Boolean required) {
+        set("required", required);
+    }
+
     public String getExampleValue() {
         return get("exampleValue");
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -85,6 +85,7 @@ public class KapuaGwtJobModelConverter {
             gwtJobStepProperty.setPropertyName(jobStepProperty.getName());
             gwtJobStepProperty.setPropertyType(jobStepProperty.getPropertyType());
             gwtJobStepProperty.setPropertyValue(jobStepProperty.getPropertyValue());
+            gwtJobStepProperty.setRequired(jobStepProperty.getRequired());
             gwtJobStepProperty.setExampleValue(jobStepProperty.getExampleValue());
             gwtJobStepProperty.setMinLength(jobStepProperty.getMinLength());
             gwtJobStepProperty.setMaxLength(jobStepProperty.getMaxLength());

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JobDefinitionBuildUtils.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/utils/JobDefinitionBuildUtils.java
@@ -144,18 +144,18 @@ public class JobDefinitionBuildUtils {
 
         Map<String, Property> customStepProperties = new HashMap<>();
 
-        //
-        // Add default properties
-        for (JobStepProperty jobStepProperty : jobStepDefinition.getStepProperties()) {
-            Property jslStepProperty = new Property();
-            jslStepProperty.setName(jobStepProperty.getName());
-            jslStepProperty.setValue(jobStepProperty.getPropertyValue());
-            customStepProperties.put(jobStepProperty.getName(), jslStepProperty);
-        }
+        // Add properties from Job Step Definition
+        addPropertiesToCustomStepProperties(customStepProperties, jobStepDefinition.getStepProperties());
 
-        //
-        // Add custom values
-        for (JobStepProperty jobStepProperty : jobStep.getStepProperties()) {
+        // Add properties from Job Step
+        addPropertiesToCustomStepProperties(customStepProperties, jobStep.getStepProperties());
+
+        // Return only values
+        return customStepProperties.values();
+    }
+
+    private static void addPropertiesToCustomStepProperties(Map<String, Property> customStepProperties, List<JobStepProperty> stepProperties) {
+        for (JobStepProperty jobStepProperty : stepProperties) {
             if (jobStepProperty.getPropertyValue() != null) {
                 Property jslStepProperty = new Property();
                 jslStepProperty.setName(jobStepProperty.getName());
@@ -163,8 +163,6 @@ public class JobDefinitionBuildUtils {
                 customStepProperties.put(jobStepProperty.getName(), jslStepProperty);
             }
         }
-
-        return customStepProperties.values();
     }
 
     public static Batchlet buildGenericStep(@NotNull JobStepDefinition jobStepDefinition) {

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
@@ -32,6 +32,8 @@ components:
           type: string
         propertyValue:
           type: string
+        required:
+          type: boolean
         exampleValue:
           type: string
           readOnly: true
@@ -95,9 +97,11 @@ components:
               </deviceAssets>
             name: assets
             propertyType: org.eclipse.kapua.service.device.management.asset.DeviceAssets
+            required: true
           - name: timeout
             propertyType: java.lang.Long
             propertyValue: '30000'
+            required: false
         stepType: TARGET
     jobStepDefinitionListResult:
       allOf:
@@ -140,9 +144,11 @@ components:
                       </deviceAssets>
                     name: assets
                     propertyType: org.eclipse.kapua.service.device.management.asset.DeviceAssets
+                    required: true
                   - name: timeout
                     propertyType: java.lang.Long
                     propertyValue: '30000'
+                    required: false
                 stepType: TARGET
               - type: jobStepDefinition
                 id: Ag
@@ -157,7 +163,9 @@ components:
                 stepProperties:
                   - name: bundleId
                     propertyType: java.lang.String
+                    required: true
                   - name: timeout
                     propertyType: java.lang.Long
                     propertyValue: '30000'
+                    required: false
                 stepType: TARGET

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -19,44 +19,137 @@ import javax.xml.bind.annotation.XmlAccessorType;
 import javax.xml.bind.annotation.XmlRootElement;
 import javax.xml.bind.annotation.XmlType;
 
+/**
+ * {@link JobStepProperty} definition.
+ *
+ * @since 1.0.0
+ */
 @XmlRootElement(name = "jobStepProperty")
 @XmlAccessorType(XmlAccessType.PROPERTY)
 @XmlType(factoryClass = JobStepXmlRegistry.class, factoryMethod = "newJobStepProperty")
 public interface JobStepProperty {
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     String getName();
 
+    /**
+     * @param name
+     * @since 1.0.0
+     */
     void setName(String name);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     String getPropertyType();
 
+    /**
+     * @param propertyType
+     * @since 1.0.0
+     */
     void setPropertyType(String propertyType);
 
+    /**
+     * @return
+     * @since 1.0.0
+     */
     String getPropertyValue();
 
+    /**
+     * @param propertyValue
+     * @since 1.0.0
+     */
     void setPropertyValue(String propertyValue);
 
+    /**
+     * @return
+     * @since 1.1.0
+     */
     String getExampleValue();
 
+    /**
+     * @param exampleValue
+     * @since 1.1.0
+     */
     void setExampleValue(String exampleValue);
 
+    /**
+     * Gets whether or not this must have a {@link #getPropertyValue()}
+     *
+     * @return {@code true} if must have a {@link #getPropertyValue()}, {@code false} otherwise.
+     * @since 1.5.0
+     */
+    Boolean getRequired();
+
+    /**
+     * Whether or not this must have a {@link #getPropertyValue()}
+     *
+     * @param required {@code true} if must have a {@link #getPropertyValue()}, {@code false} otherwise.
+     * @since 1.5.0
+     */
+    void setRequired(Boolean required);
+
+    /**
+     * @return
+     * @since 1.5.0
+     */
     Integer getMinLength();
 
+    /**
+     * @param minLength
+     * @since 1.5.0
+     */
     void setMinLength(Integer minLength);
 
+    /**
+     * @return
+     * @since 1.5.0
+     */
     Integer getMaxLength();
 
+    /**
+     * @param maxLength
+     * @since 1.5.0
+     */
     void setMaxLength(Integer maxLength);
 
+    /**
+     * @return
+     * @since 1.5.0
+     */
     String getMinValue();
 
+    /**
+     * @param minValue
+     * @since 1.5.0
+     */
     void setMinValue(String minValue);
 
+    /**
+     * @return
+     * @since 1.5.0
+     */
     String getMaxValue();
 
+    /**
+     * @param maxValue
+     * @since 1.5.0
+     */
     void setMaxValue(String maxValue);
 
+    /**
+     * @return
+     * @since 1.5.0
+     */
     String getValidationRegex();
 
+    /**
+     * @param validationRegex
+     * @since 1.5.0
+     */
     void setValidationRegex(String validationRegex);
 }

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
@@ -34,6 +34,10 @@ public class JobStepPropertyImpl implements JobStepProperty {
     private String propertyValue;
 
     @Basic
+    @Column(name = "required", nullable = true, updatable = true)
+    private Boolean required;
+
+    @Basic
     @Column(name = "example_value", nullable = true, updatable = true)
     private String propertyExampleValue;
 
@@ -64,6 +68,7 @@ public class JobStepPropertyImpl implements JobStepProperty {
         setName(jobStepProperty.getName());
         setPropertyType(jobStepProperty.getPropertyType());
         setPropertyValue(jobStepProperty.getPropertyValue());
+        setRequired(jobStepProperty.getRequired());
         setExampleValue(jobStepProperty.getExampleValue());
         setMinLength(jobStepProperty.getMinLength());
         setMaxLength(jobStepProperty.getMaxLength());
@@ -106,6 +111,16 @@ public class JobStepPropertyImpl implements JobStepProperty {
     @Override
     public void setPropertyValue(String propertyValue) {
         this.propertyValue = propertyValue;
+    }
+
+    @Override
+    public Boolean getRequired() {
+        return required != null ? required : (propertyValue == null);
+    }
+
+    @Override
+    public void setRequired(Boolean required) {
+        this.required = required;
     }
 
     @Override

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -350,6 +350,10 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
             for (JobStepProperty jobStepDefinitionProperty : jobStepDefinition.getStepProperties()) {
                 if (jobStepProperty.getName().equals(jobStepDefinitionProperty.getName())) {
 
+                    if (jobStepDefinitionProperty.getRequired()) {
+                        ArgumentValidator.notNull(jobStepProperty.getPropertyValue(), "stepProperties[]." + jobStepProperty.getName());
+                    }
+
                     ArgumentValidator.areEqual(jobStepProperty.getPropertyType(), jobStepDefinitionProperty.getPropertyType(), "stepProperties[]." + jobStepProperty.getName());
                     ArgumentValidator.lengthRange(jobStepProperty.getPropertyValue(), jobStepDefinitionProperty.getMinLength(), jobStepDefinitionProperty.getMaxLength(), "stepProperties[]." + jobStepProperty.getName());
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -375,6 +375,9 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
                 if (String.class.equals(jobStepDefinitionPropertyClass) && !Strings.isNullOrEmpty(jobStepDefinitionProperty.getValidationRegex())) {
                     ArgumentValidator.match((String) propertyValue, () -> Pattern.compile(jobStepDefinitionProperty.getValidationRegex()), "stepProperties[]." + jobStepProperty.getName());
                 }
+            } else if (KapuaId.class.isAssignableFrom(jobStepDefinitionPropertyClass) ||
+                    (jobStepDefinitionPropertyClass == byte[].class || jobStepDefinitionPropertyClass == Byte[].class)) {
+                fromString(jobStepProperty.getPropertyValue(), jobStepDefinitionPropertyClass);
             } else if (jobStepDefinitionPropertyClass.isEnum()) {
                 Class<E> jobStepDefinitionPropertyClassEnum = (Class<E>) jobStepDefinitionPropertyClass;
                 Enum.valueOf(jobStepDefinitionPropertyClassEnum, jobStepProperty.getPropertyValue());

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_definition_properties-required.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_definition_properties-required.xml
@@ -10,18 +10,20 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
         logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
 
-    <include relativeToChangelogFile="true" file="./job-name_indexes.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_properties-limits.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_properties-required.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_definition_properties-limits.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_definition_properties-required.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
+    <changeSet id="changelog-job_step_definition_properties-1.5.0_addRequired" author="eurotech">
+        <addColumn tableName="job_job_step_definition_properties">
+            <column name="required" type="boolean"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_properties-required.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.5.0/job_job_step_properties-required.xml
@@ -10,18 +10,20 @@
 
     Contributors:
         Eurotech - initial API and implementation
- -->
+-->
 <databaseChangeLog
         xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
-                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
         logicalFilePath="KapuaDB/changelog-job-1.5.0.xml">
 
-    <include relativeToChangelogFile="true" file="./job-name_indexes.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_properties-limits.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_properties-required.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_definition_properties-limits.xml"/>
-    <include relativeToChangelogFile="true" file="./job_job_step_definition_properties-required.xml"/>
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
 
+    <changeSet id="changelog-job_step_properties-1.5.0_addRequired" author="eurotech">
+        <addColumn tableName="job_job_step_properties">
+            <column name="required" type="boolean"/>
+        </addColumn>
+    </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds `required` field to the JobStepProperty. 
Now the  mandatory-ness was determined by the JobStepProperty having a `propertyValue` or not, which prevents leaving parameters not defined.

**Related Issue**
This PR is an integration of #3318

**Description of the solution adopted**
Added a new field.

Old existing JobStepDefinitions.property gets the value of `required` based on the value of `propertyValue` which leaves the behaviour unchanged.

**Screenshots**
_None_

**Any side note on the changes made**
FIxed parsing of `KapuaId` and `byte[]`  JobStepProperties types