### PR TITLE
Fixed "limitExceed" value always false

### DIFF
--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/RestClientSteps.java
@@ -207,6 +207,27 @@ public class RestClientSteps extends Assert {
         Assert.assertEquals("Wrong response code.", expeted, restResponseCode);
     }
 
+    @Then("^REST response contains limitExceed field with value (true|false)$")
+    public void restResponseContainsLimitExceedValueWithValue(String value) throws Exception {
+        String restResponse = (String) stepData.get(REST_RESPONSE);
+        UserListResult userList = XmlUtil.unmarshalJson(restResponse, UserListResult.class, null);
+        Assert.assertEquals(Boolean.parseBoolean(value), userList.isLimitExceeded());
+    }
+
+    @Given("^An authenticated user$")
+    public void anAuthenticationToken() throws Exception {
+        restPostCallWithJson("/v1/authentication/user",
+                "{\"password\": \"kapua-password\", \"username\": \"kapua-sys\"}");
+        restResponseContainingAccessToken();
+    }
+
+    @Given("^(\\d+) new users? created$")
+    public void newUsersCreated(int howManyUser) throws Exception {
+        for (int i = 0; i < howManyUser; ++i) {
+            restPostCallWithJson("/_/users", String.format("{\"name\": \"new-user-%d\"}", i));
+        }
+    }
+
     /**
      * Take input parameter and replace its $var$ with value of var that is stored
      * in step data.

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -1245,7 +1245,7 @@ Feature: Datastore tests
     And I set the database to device timestamp indexing
     When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
       | clientId      | topic               | count | startDate                | endDate                  |
-      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+      | test-client-1 | delete/by/date/test | 4     | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all indices
     When I query for the current account messages with limit 1 and offset 0 and store them as "MessageInfo"
@@ -1261,7 +1261,7 @@ Feature: Datastore tests
     And I set the database to device timestamp indexing
     When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
       | clientId      | topic               | count | startDate                | endDate                  |
-      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+      | test-client-1 | delete/by/date/test | 4    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all indices
     When I query for the current account messages with limit 4 and offset 0 and store them as "MessageInfo"
@@ -1277,7 +1277,7 @@ Feature: Datastore tests
     And I set the database to device timestamp indexing
     When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
       | clientId      | topic               | count | startDate                | endDate                  |
-      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+      | test-client-1 | delete/by/date/test | 4    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all indices
     When I query for the current account messages with limit 1 and offset 2 and store them as "MessageInfo"
@@ -1293,7 +1293,7 @@ Feature: Datastore tests
     And I set the database to device timestamp indexing
     When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
       | clientId      | topic               | count | startDate                | endDate                  |
-      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+      | test-client-1 | delete/by/date/test | 4    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
     Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
     And I refresh all indices
     When I query for the current account messages with limit 1 and offset 3 and store them as "MessageInfo"

--- a/qa/integration/src/test/resources/features/datastore/Datastore.feature
+++ b/qa/integration/src/test/resources/features/datastore/Datastore.feature
@@ -976,6 +976,330 @@ Feature: Datastore tests
     Then An assertion error was thrown
     And I logout
 
+  Scenario: Create 4 clients, query all clients with offset 0 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I delete all indices
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic                     |
+      | test-client-1 | ci_topic_by_account/1/2/3 |
+      | test-client-1 | ci_topic_by_account/1/2/4 |
+      | test-client-1 | ci_topic_by_account/1/2/5 |
+      | test-client-1 | ci_topic_by_account/1/2/6 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account channels with limit 1 and offset 0 and store them as "AccountChannelList"
+    Then The channel list "AccountChannelList" have limitExceed value true
+    And I delete all indices
+    And I logout
+
+  Scenario: Create 4 clients, query all clients with offset 0 and limit 4
+    Check if value of limitExceed is false.
+
+    Given I delete all indices
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic                     |
+      | test-client-1 | ci_topic_by_account/1/2/3 |
+      | test-client-1 | ci_topic_by_account/1/2/4 |
+      | test-client-1 | ci_topic_by_account/1/2/5 |
+      | test-client-1 | ci_topic_by_account/1/2/6 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account channels with limit 4 and offset 0 and store them as "AccountChannelList"
+    Then The channel list "AccountChannelList" have limitExceed value false
+    And I delete all indices
+    And I logout
+
+  Scenario: Create 4 clients, query all clients with offset 2 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I delete all indices
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic                     |
+      | test-client-1 | ci_topic_by_account/1/2/3 |
+      | test-client-1 | ci_topic_by_account/1/2/4 |
+      | test-client-1 | ci_topic_by_account/1/2/5 |
+      | test-client-1 | ci_topic_by_account/1/2/6 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account channels with limit 1 and offset 2 and store them as "AccountChannelList"
+    Then The channel list "AccountChannelList" have limitExceed value true
+    And I delete all indices
+    And I logout
+
+  Scenario: Create 4 clients, query all clients with offset 1 and limit 3
+    Check if value of limitExceed is false.
+
+    Given I delete all indices
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic                     |
+      | test-client-1 | ci_topic_by_account/1/2/3 |
+      | test-client-1 | ci_topic_by_account/1/2/4 |
+      | test-client-1 | ci_topic_by_account/1/2/5 |
+      | test-client-1 | ci_topic_by_account/1/2/6 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account channels with limit 3 and offset 1 and store them as "AccountChannelList"
+    Then The channel list "AccountChannelList" have limitExceed value false
+    And I delete all indices
+    And I logout
+
+  Scenario: Create 4 metrics, query all metrics with offset 0 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-1 | double | 123   |
+      | tst-metric-2 | int    | 123   |
+    And I set the following metrics to the message 1 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-3 | string | 123   |
+      | tst-metric-4 | bool   | true  |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics with limit 1 and offset 0 and store them as "AccountMetrics"
+    Then The metric list "AccountMetrics" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 metrics, query all metrics with offset 0 and limit 4
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-1 | double | 123   |
+      | tst-metric-2 | int    | 123   |
+    And I set the following metrics to the message 1 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-3 | string | 123   |
+      | tst-metric-4 | bool   | true  |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics with limit 4 and offset 0 and store them as "AccountMetrics"
+    Then The metric list "AccountMetrics" have limitExceed value false
+    And I delete all indices
+
+  Scenario: Create 4 metrics, query all metrics with offset 2 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-1 | double | 123   |
+      | tst-metric-2 | int    | 123   |
+    And I set the following metrics to the message 1 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-3 | string | 123   |
+      | tst-metric-4 | bool   | true  |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics with limit 1 and offset 2 and store them as "AccountMetrics"
+    Then The metric list "AccountMetrics" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 metrics, query all metrics with offset 3 and limit 1
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    Then I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/3 |
+    And I set the following metrics to the message 0 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-1 | double | 123   |
+      | tst-metric-2 | int    | 123   |
+    And I set the following metrics to the message 1 from the list "TestMessages"
+      | metric       | type   | value |
+      | tst-metric-3 | string | 123   |
+      | tst-metric-4 | bool   | true  |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account metrics with limit 1 and offset 3 and store them as "AccountMetrics"
+    Then The metric list "AccountMetrics" have limitExceed value false
+    And I delete all indices
+
+  Scenario: Create 4 clients, query all clients with offset 0 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/4 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/4 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account clients with limit 1 and offset 0 and store them as "ClientInfo"
+    Then The client list "ClientInfo" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 clients, query all clients with offset 0 and limit 4
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/4 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/4 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account clients with limit 4 and offset 0 and store them as "ClientInfo"
+    Then The client list "ClientInfo" have limitExceed value false
+    And I delete all indices
+
+  Scenario: Create 4 clients, query all clients with offset 2 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/4 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/4 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account clients with limit 1 and offset 2 and store them as "ClientInfo"
+    Then The client list "ClientInfo" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 clients, query all clients with offset 3 and limit 1
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-device-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages with the following details and remember the list as "TestMessages"
+      | clientId      | topic            |
+      | test-client-1 | test_topic/1/2/3 |
+      | test-client-2 | test_topic/1/2/4 |
+      | test-client-3 | test_topic/1/2/3 |
+      | test-client-4 | test_topic/1/2/4 |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account clients with limit 1 and offset 3 and store them as "ClientInfo"
+    Then The client list "ClientInfo" have limitExceed value false
+    And I delete all indices
+
+  Scenario: Create 4 messages, query all messages with offset 0 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
+      | clientId      | topic               | count | startDate                | endDate                  |
+      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account messages with limit 1 and offset 0 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 messages, query all messages with offset 0 and limit 4
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
+      | clientId      | topic               | count | startDate                | endDate                  |
+      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account messages with limit 4 and offset 0 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value false
+    And I delete all indices
+
+  Scenario: Create 4 messages, query all messages with offset 2 and limit 1
+    Check if value of limitExceed is true.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
+      | clientId      | topic               | count | startDate                | endDate                  |
+      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account messages with limit 1 and offset 2 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value true
+    And I delete all indices
+
+  Scenario: Create 4 messages, query all messages with offset 3 and limit 1
+    Check if value of limitExceed is false.
+
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And The device "test-client-1"
+    And I set the database to device timestamp indexing
+    When I prepare a number of messages in the specified ranges and remember the list as "TestMessages"
+      | clientId      | topic               | count | startDate                | endDate                  |
+      | test-client-1 | delete/by/date/test | 3    | 2018-10-01T12:00:00.000Z | 2018-12-31T12:00:00.000Z |
+    Then I store the messages from list "TestMessages" and remember the IDs as "StoredMessageIDs"
+    And I refresh all indices
+    When I query for the current account messages with limit 1 and offset 3 and store them as "MessageInfo"
+    Then The message list "MessageInfo" have limitExceed value false
+    And I delete all indices
+
   Scenario: Stop broker after all scenarios
 
     Given Stop Broker

--- a/qa/integration/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/integration/src/test/resources/features/rest/user/RestUser.feature
@@ -132,6 +132,76 @@ Feature: REST API tests for User
     And REST GET call at "/v1/$accountBCompactId$/users/$lastUserCompactId$"
     Then REST response code is 404
 
+  Scenario: Retrieve all users and check if limitExceed value is true
+    Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 0 entries,
+    then the limitExceed value must be true.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    When REST GET call at "/v1/_/users?offset=0&limit=0"
+    Then REST response contains limitExceed field with value true
+
+  Scenario: Retrieve all users and check if limitExceed value is false
+  Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 50 entries,
+  then the limitExceed value must be false.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    When REST GET call at "/v1/_/users?offset=0&limit=50"
+    Then REST response contains limitExceed field with value false
+
+  Scenario: Create a new user, then retrieve all users and check if limitExceed value is false
+  Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 2 entries,
+  then the limitExceed value must be false.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    Given 1 new user created
+    When REST GET call at "/v1/_/users?offset=0&limit=2"
+    Then REST response contains limitExceed field with value false
+
+  Scenario: Create two new users, then retrieve all users and check if limitExceed value is true
+  Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 3 entries
+  then the limitExceed value must be true.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    Given 2 new users created
+    When REST GET call at "/v1/_/users?offset=0&limit=3"
+    Then REST response contains limitExceed field with value false
+
+  Scenario: Create two new users, then retrieve all users specifying a offset of 2, then check if
+  limitExceed value is false.
+  Login with sys user and call GET on users to retrieve list of all users. Specify a offset of 2
+  then the limitExceed value must be false.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    Given 2 new users created
+    When REST GET call at "/v1/_/users?offset=2"
+    Then REST response contains limitExceed field with value false
+
+  Scenario: Create three new users, then retrieve all users specifying a offset of 2 and a limit of 1,
+  then check if limitExceed value is true.
+  Login with sys user and call GET on users to retrieve list of all users. Specify a offset of 2
+  and a limit of 1, then the limitExceed value must be false.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    Given 3 new users created
+    When REST GET call at "/v1/_/users?offset=2&limit=1"
+    Then REST response contains limitExceed field with value false
+
+  Scenario: Create 119 new users, then retrieve all users specifying a offset of 100 and limit of 50,
+  then check if limitExceed value is false. Login with sys user and call GET on users to retrieve list
+  of all users. Specify a offset of 100 and a limit of 50 entries then the limitExceed value must be false.
+
+    Given Server with host "127.0.0.1" on port "8081"
+    Given An authenticated user
+    Given 119 new users created
+    When REST GET call at "/v1/_/users?limit=50&offset=100"
+    Then REST response contains limitExceed field with value false
+
   Scenario: Stop Jetty server for all scenarios
 
     Given Stop Jetty Server

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/AbstractRegistryFacade.java
@@ -18,6 +18,9 @@ import org.eclipse.kapua.service.datastore.internal.mediator.ConfigurationExcept
 import org.eclipse.kapua.service.datastore.internal.mediator.MessageStoreConfiguration;
 import org.eclipse.kapua.service.elasticsearch.client.ElasticsearchClient;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientUnavailableException;
+import org.eclipse.kapua.service.storable.model.Storable;
+import org.eclipse.kapua.service.storable.model.StorableListResult;
+import org.eclipse.kapua.service.storable.model.query.StorableQuery;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,5 +47,12 @@ public abstract class AbstractRegistryFacade {
 
     protected ElasticsearchClient<?> getElasticsearchClient() throws ClientUnavailableException {
         return DatastoreClientFactory.getElasticsearchClient();
+    }
+
+    protected <T extends Storable> void setLimitExceed(StorableQuery query, StorableListResult<T> list) {
+        int offset = query.getOffset() != null ? query.getOffset() : 0;
+        if (query.getLimit() != null && list.getTotalCount() > offset + query.getLimit()) {
+            list.setLimitExceeded(true);
+        }
     }
 }

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryFacade.java
@@ -193,7 +193,9 @@ public class ChannelInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexName = SchemaUtil.getChannelIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ChannelInfoSchema.CHANNEL_TYPE_NAME);
-        return new ChannelInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ChannelInfo.class));
+        ChannelInfoListResult result = new ChannelInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ChannelInfo.class));
+        setLimitExceed(query, result);
+        return result;
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryFacade.java
@@ -188,7 +188,9 @@ public class ClientInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexName = SchemaUtil.getClientIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexName, ClientInfoSchema.CLIENT_TYPE_NAME);
-        return new ClientInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ClientInfo.class));
+        ClientInfoListResultImpl result = new ClientInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, ClientInfo.class));
+        setLimitExceed(query, result);
+        return result;
     }
 
     /**

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFacade.java
@@ -293,8 +293,7 @@ public final class MessageStoreFacade extends AbstractRegistryFacade {
         String dataIndexName = SchemaUtil.getDataIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(dataIndexName, MessageSchema.MESSAGE_TYPE_NAME);
         MessageListResult result = new MessageListResultImpl(getElasticsearchClient().query(typeDescriptor, query, DatastoreMessage.class));
-        Integer offset = query.getOffset();
-        result.setLimitExceeded((offset == null ? 0 : offset) + result.getSize() < result.getTotalCount());
+        setLimitExceed(query, result);
         return result;
     }
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryFacade.java
@@ -30,7 +30,6 @@ import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 import org.eclipse.kapua.service.elasticsearch.client.exception.ClientException;
 import org.eclipse.kapua.service.elasticsearch.client.model.BulkUpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.BulkUpdateResponse;
-import org.eclipse.kapua.service.elasticsearch.client.model.ResultList;
 import org.eclipse.kapua.service.elasticsearch.client.model.TypeDescriptor;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateRequest;
 import org.eclipse.kapua.service.elasticsearch.client.model.UpdateResponse;
@@ -258,8 +257,9 @@ public class MetricInfoRegistryFacade extends AbstractRegistryFacade {
 
         String indexNme = SchemaUtil.getMetricIndexName(query.getScopeId());
         TypeDescriptor typeDescriptor = new TypeDescriptor(indexNme, MetricInfoSchema.METRIC_TYPE_NAME);
-        ResultList<MetricInfo> result = getElasticsearchClient().query(typeDescriptor, query, MetricInfo.class);
-        return new MetricInfoListResultImpl(result);
+        MetricInfoListResult result = new MetricInfoListResultImpl(getElasticsearchClient().query(typeDescriptor, query, MetricInfo.class));
+        setLimitExceed(query, result);
+        return result;
     }
 
     /**

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -589,7 +589,7 @@ public class DatastoreSteps extends TestBase {
             long stepSeconds = (endDate.getTime() - startDate.getTime()) / (1000L * (tmpMessage.getCount().longValue() - 1));
 
             tmpCal.setTime(startDate);
-            for (int cnt = 0; cnt <= tmpMessage.getCount(); cnt++) {
+            for (int cnt = 0; cnt < tmpMessage.getCount(); cnt++) {
                 tmpMsg = createTestMessage(
                         ((Account) stepData.get(LAST_ACCOUNT)).getId(),
                         ((Device) stepData.get(LAST_DEVICE)).getId(),

--- a/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
+++ b/service/datastore/test-steps/src/main/java/org/eclipse/kapua/service/datastore/steps/DatastoreSteps.java
@@ -959,6 +959,74 @@ public class DatastoreSteps extends TestBase {
         }
     }
 
+    @Then("^The channel list \"(.+)\" have limitExceed value (true|false)$")
+    public void theChannelListHaveLimitExceedValue(String lstKey, String limitExceedVal) {
+
+        theListHaveLimitExceedValue(ChannelInfoListResult.class, lstKey, limitExceedVal);
+    }
+
+    @Then("^The metric list \"(.+)\" have limitExceed value (true|false)$")
+    public void theMetricListHaveLimitExceedValue(String lstKey, String limitExceedVal) {
+
+        theListHaveLimitExceedValue(MetricInfoListResult.class, lstKey, limitExceedVal);
+    }
+
+    @Then("^The message list \"(.+)\" have limitExceed value (true|false)$")
+    public void theMessageListHaveLimitExceedValue(String lstKey, String limitExceedVal) {
+
+        theListHaveLimitExceedValue(MessageListResult.class, lstKey, limitExceedVal);
+    }
+
+    @Then("^The client list \"(.+)\" have limitExceed value (true|false)$")
+    public void theClientListHaveLimitExceedValue(String lstKey, String limitExceedVal) {
+
+        theListHaveLimitExceedValue(ClientInfoListResult.class, lstKey, limitExceedVal);
+    }
+
+    @When("^I query for the current account channels with limit (\\d+) and offset (\\d+) and store them as \"(.+)\"$")
+    public void queryChannelWithOffsetAndLimit(int limit, int offset, String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get(LAST_ACCOUNT);
+        ChannelInfoQuery tmpQuery = createBaseChannelInfoQuery(account.getId(), limit);
+        tmpQuery.setOffset(offset);
+        tmpQuery.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
+        ChannelInfoListResult tmpList = channelInfoRegistryService.query(tmpQuery);
+        stepData.put(lstKey, tmpList);
+    }
+
+    @When("^I query for the current account metrics with limit (\\d+) and offset (\\d+) and store them as \"(.+)\"$")
+    public void queryMetricWithOffsetAndLimit(int limit, int offset, String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get(LAST_ACCOUNT);
+        MetricInfoQuery tmpQuery = createBaseMetricInfoQuery(account.getId(), limit);
+        tmpQuery.setOffset(offset);
+        tmpQuery.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
+        MetricInfoListResult tmpList = metricInfoRegistryService.query(tmpQuery);
+        stepData.put(lstKey, tmpList);
+    }
+
+    @When("^I query for the current account messages with limit (\\d+) and offset (\\d+) and store them as \"(.+)\"$")
+    public void queryMessageWithOffsetAndLimit(int limit, int offset, String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get(LAST_ACCOUNT);
+        MessageQuery tmpQuery = createBaseMessageQuery(account.getId(), limit);
+        tmpQuery.setOffset(offset);
+        tmpQuery.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
+        MessageListResult tmpList = messageStoreService.query(tmpQuery);
+        stepData.put(lstKey, tmpList);
+    }
+
+    @When("^I query for the current account clients with limit (\\d+) and offset (\\d+) and store them as \"(.+)\"$")
+    public void queryClientWithOffsetAndLimit(int limit, int offset, String lstKey) throws KapuaException {
+
+        Account account = (Account) stepData.get(LAST_ACCOUNT);
+        ClientInfoQuery tmpQuery = createBaseClientInfoQuery(account.getId(), limit);
+        tmpQuery.setOffset(offset);
+        tmpQuery.addFetchAttributes(ChannelInfoField.TIMESTAMP.field());
+        ClientInfoListResult tmpList = clientInfoRegistryService.query(tmpQuery);
+        stepData.put(lstKey, tmpList);
+    }
+
     @When("^I count the current account channels and store the count as \"(.*)\"$")
     public void countAccountChannels(String countKey) throws KapuaException {
 
@@ -2430,6 +2498,11 @@ public class DatastoreSteps extends TestBase {
 
     private void setDatastoreIndexingWindowOption(String windowOption) {
         System.setProperty(DatastoreSettingsKey.INDEXING_WINDOW_OPTION.key(), windowOption.trim().toLowerCase());
+    }
+
+    private <T extends StorableListResult> void theListHaveLimitExceedValue(Class<T> bar, String lstKey, String limitExceedVal) {
+        T tmpList = (T) stepData.get(lstKey);
+        assertEquals(tmpList.isLimitExceeded(), Boolean.parseBoolean(limitExceedVal));
     }
 
     /**


### PR DESCRIPTION
**Description**
This PR fixes the following problem: when a rest api response contains the `limitExceeded` field, its value is always `false`.

**Description of the solution adopted**
* Added the method to set the correct `limitExceeded` value in the `AbstractRegistryFacade`, then use it in all concrete subclasses
* Added tests
