### PR TITLE
Remove dependencies from ActiveMQ tar.gz

### DIFF
--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -275,6 +275,22 @@
                     <groupId>com.fasterxml.jackson.core</groupId>
                     <artifactId>jackson-annotations</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>jrms</groupId>
+                    <artifactId>jrms</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>activesoap</groupId>
+                    <artifactId>jaxp-api</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.json</groupId>
+                    <artifactId>json</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.apache.hadoop</groupId>
+                    <artifactId>hadoop-core</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 


### PR DESCRIPTION
Some dependencies (jrms:jrms, activesoap:jaxp-api, org.json:json, org.apache.hadoop:hadoop-core) are present in the ActiveMQ pom.xml but are not actually present in the tar.gz artifact we use, so there's no need to have them around.

**Related Issue**
No related issues
