### PR TITLE
Add sortDir and sortParam to REST APIs - Round 1

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/AccessPermissions.java
@@ -20,6 +20,7 @@ import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
@@ -43,6 +44,8 @@ import javax.ws.rs.QueryParam;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
+import com.google.common.base.Strings;
+
 /**
  * {@link AccessPermission} REST API resource.
  *
@@ -62,6 +65,8 @@ public class AccessPermissions extends AbstractKapuaResource {
      * @param accessInfoId The optional {@link AccessInfo} id to filter results.
      * @param offset       The result set offset.
      * @param limit        The result set limit.
+     * @param sortParam    The name of the parameter that will be used as a sorting key
+     * @param sortDir      The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
      * @return The {@link AccessPermissionListResult} of all the {@link AccessPermission}s associated to the current selected scope.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -71,11 +76,16 @@ public class AccessPermissions extends AbstractKapuaResource {
     public AccessPermissionListResult simpleQuery(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("accessInfoId") EntityId accessInfoId,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         AccessPermissionQuery query = accessPermissionFactory.newQuery(scopeId);
 
         query.setPredicate(query.attributePredicate(AccessPermissionAttributes.ACCESS_INFO_ID, accessInfoId));
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
+        }
 
         query.setOffset(offset);
         query.setLimit(limit);

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Accounts.java
@@ -21,6 +21,7 @@ import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.account.Account;
@@ -56,6 +57,8 @@ public class Accounts extends AbstractKapuaResource {
      * @param scopeId       The {@link ScopeId} in which to search results.
      * @param name          The {@link Account} name in which to search results.
      * @param recursive     The {@link Account} name in which to search results.
+     * @param sortParam     The name of the parameter that will be used as a sorting key
+     * @param sortDir       The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
      * @param offset        The result set offset.
      * @param limit         The result set limit.
      * @return              The {@link AccountListResult} of all the accounts associated to the current selected scope.
@@ -67,6 +70,8 @@ public class Accounts extends AbstractKapuaResource {
     public AccountListResult simpleQuery(@PathParam("scopeId") ScopeId scopeId, //
                                          @QueryParam("name") String name, //
                                          @QueryParam("recursive") boolean recursive, //
+                                         @QueryParam("sortParam") String sortParam,
+                                         @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
                                          @QueryParam("offset") @DefaultValue("0") int offset, //
                                          @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
 
@@ -79,6 +84,9 @@ public class Accounts extends AbstractKapuaResource {
         AndPredicate andPredicate = query.andPredicate();
         if (!Strings.isNullOrEmpty(name)) {
             andPredicate.and(query.attributePredicate(KapuaNamedEntityAttributes.NAME, name));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceEvents.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
 import org.eclipse.kapua.service.KapuaService;
@@ -58,11 +59,13 @@ public class DeviceEvents extends AbstractKapuaResource {
     /**
      * Gets the {@link DeviceEvent} list in the scope.
      *
-     * @param scopeId  The {@link ScopeId} in which to search results.
-     * @param deviceId The id of the {@link Device} in which to search results
-     * @param resource The resource of the {@link DeviceEvent} in which to search results
-     * @param offset   The result set offset.
-     * @param limit    The result set limit.
+     * @param scopeId   The {@link ScopeId} in which to search results.
+     * @param deviceId  The id of the {@link Device} in which to search results
+     * @param resource  The resource of the {@link DeviceEvent} in which to search results
+     * @param sortParam The name of the parameter that will be used as a sorting key
+     * @param sortDir   The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
+     * @param offset    The result set offset.
+     * @param limit     The result set limit.
      * @return The {@link DeviceEventListResult} of all the deviceEvents associated to the current selected scope.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -75,6 +78,8 @@ public class DeviceEvents extends AbstractKapuaResource {
             @QueryParam("resource") String resource,
             @QueryParam("startDate") DateParam startDateParam,
             @QueryParam("endDate") DateParam endDateParam,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         DeviceEventQuery query = deviceEventFactory.newQuery(scopeId);

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/DeviceManagementBundles.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
@@ -26,10 +27,14 @@ import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.service.KapuaService;
+import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
 import org.eclipse.kapua.service.device.registry.Device;
+
+import com.google.common.base.Strings;
 
 @Path("{scopeId}/devices/{deviceId}/bundles")
 public class DeviceManagementBundles extends AbstractKapuaResource {
@@ -44,6 +49,10 @@ public class DeviceManagementBundles extends AbstractKapuaResource {
      *            The {@link ScopeId} of the {@link Device}.
      * @param deviceId
      *            The id of the device
+     * @param sortParam
+     *            The name of the parameter that will be used as a sorting key
+     * @param sortDir
+     *            The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
      * @param timeout
      *            The timeout of the operation in milliseconds
      * @return The list of Bundles
@@ -56,8 +65,28 @@ public class DeviceManagementBundles extends AbstractKapuaResource {
     public DeviceBundles get(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("deviceId") EntityId deviceId,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("timeout") Long timeout) throws KapuaException {
-        return bundleService.get(scopeId, deviceId, timeout);
+        DeviceBundles deviceBundles = bundleService.get(scopeId, deviceId, timeout);
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            deviceBundles.getBundles().sort((b1, b2) -> sortBundles(sortParam, sortDir, b1, b2));
+        }
+        return deviceBundles;
+    }
+
+    private int sortBundles(String sortParam, SortOrder sortDir, DeviceBundle b1, DeviceBundle b2) {
+        switch(sortParam.toUpperCase()) {
+            default:
+            case "ID":
+                return (sortDir == SortOrder.DESCENDING ? (int) (b2.getId() - b1.getId()) : (int) (b1.getId() - b2.getId()));
+            case "NAME":
+                return (sortDir == SortOrder.DESCENDING ? b2.getName().compareToIgnoreCase(b1.getName()) : b1.getName().compareToIgnoreCase(b2.getName()));
+            case "STATE":
+                return (sortDir == SortOrder.DESCENDING ? b2.getState().compareToIgnoreCase(b1.getState()) : b1.getState().compareToIgnoreCase(b2.getState()));
+            case "VERSION":
+                return (sortDir == SortOrder.DESCENDING ? b2.getVersion().compareToIgnoreCase(b1.getVersion()) : b1.getVersion().compareToIgnoreCase(b2.getVersion()));
+        }
     }
 
     /**

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Roles.java
@@ -35,6 +35,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
@@ -240,10 +241,12 @@ public class Roles extends AbstractKapuaResource {
     /**
      * Gets all the {@link User}s for a given {@link Role}
      *
-     * @param scopeId The ScopeId of the requested {@link Role}.
-     * @param roleId The id of the Role to be deleted.
-     * @param offset  The result set offset.
-     * @param limit   The result set limit.
+     * @param scopeId       The ScopeId of the requested {@link Role}.
+     * @param roleId        The id of the Role to be deleted.
+     * @param offset        The result set offset.
+     * @param limit         The result set limit.
+     * @param sortParam     The name of the parameter that will be used as a sorting key for the users
+     * @param sortDir       The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
      * @return An {@link UserListResult} containing the {@link User}s for the given {@link Role}
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.2.0
@@ -253,6 +256,8 @@ public class Roles extends AbstractKapuaResource {
     public UserListResult usersForRole(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("roleId") EntityId roleId,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         AccessRoleQuery accessRoleQuery = accessRoleFactory.newQuery(scopeId);
@@ -271,6 +276,9 @@ public class Roles extends AbstractKapuaResource {
         userQuery.setPredicate(userQuery.attributePredicate(KapuaEntityAttributes.ENTITY_ID, accessInfoListResult.getItems().stream().map(AccessInfo::getUserId).toArray(KapuaId[]::new)));
         userQuery.setLimit(limit);
         userQuery.setOffset(offset);
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            userQuery.setSortCriteria(userQuery.fieldSortCriteria(sortParam, sortDir));
+        }
         return userService.query(userQuery);
     }
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/RolesPermissions.java
@@ -22,6 +22,7 @@ import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authorization.role.Role;
@@ -55,12 +56,14 @@ public class RolesPermissions extends AbstractKapuaResource {
     /**
      * Gets the {@link RolePermission} list in the scope.
      *
-     * @param scopeId The {@link ScopeId} in which to search results.
-     * @param roleId  The id of the {@link Role} in which to search results.
-     * @param domain  The domain name to filter results.
-     * @param action  The action to filter results.
-     * @param offset  The result set offset.
-     * @param limit   The result set limit.
+     * @param scopeId   The {@link ScopeId} in which to search results.
+     * @param roleId    The id of the {@link Role} in which to search results.
+     * @param domain    The domain name to filter results.
+     * @param action    The action to filter results.
+     * @param sortParam The name of the parameter that will be used as a sorting key
+     * @param sortDir   The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
+     * @param offset    The result set offset.
+     * @param limit     The result set limit.
      * @return The {@link RolePermissionListResult} of all the rolePermissions associated to the current selected scope.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -72,6 +75,8 @@ public class RolesPermissions extends AbstractKapuaResource {
             @PathParam("roleId") EntityId roleId,
             @QueryParam("name") String domain,
             @QueryParam("action") Actions action,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
         RolePermissionQuery query = rolePermissionFactory.newQuery(scopeId);
@@ -83,6 +88,9 @@ public class RolesPermissions extends AbstractKapuaResource {
         }
         if (action != null) {
             andPredicate.and(query.attributePredicate(RolePermissionAttributes.PERMISSION_ACTION, action));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
         query.setPredicate(andPredicate);
 

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Users.java
@@ -21,6 +21,7 @@ import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
@@ -59,6 +60,8 @@ public class Users extends AbstractKapuaResource {
      *
      * @param scopeId       The {@link ScopeId} in which to search results.
      * @param name          The {@link User} name in which to search results.
+     * @param sortParam     The name of the parameter that will be used as a sorting key
+     * @param sortDir       The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
      * @param matchTerm     A term to be matched in at least one of the configured fields of this entity
      * @param askTotalCount Ask for the total count of the matched entities in the result
      * @param offset        The result set offset.
@@ -73,6 +76,8 @@ public class Users extends AbstractKapuaResource {
             @PathParam("scopeId") ScopeId scopeId,
             @QueryParam("name") String name,
             @QueryParam("matchTerm") String matchTerm,
+            @QueryParam("sortParam") String sortParam,
+            @QueryParam("sortDir") @DefaultValue("ASCENDING") SortOrder sortDir,
             @QueryParam("askTotalCount") boolean askTotalCount,
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
@@ -84,6 +89,9 @@ public class Users extends AbstractKapuaResource {
         }
         if (matchTerm != null && !matchTerm.isEmpty()) {
             andPredicate.and(query.matchPredicate(matchTerm));
+        }
+        if (!Strings.isNullOrEmpty(sortParam)) {
+            query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
         }
 
         query.setPredicate(andPredicate);

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
@@ -21,6 +21,8 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: './accessInfo.yaml#/components/parameters/accessInfoId'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId.yaml
@@ -32,6 +32,8 @@ paths:
             Setting this to `true` and also using the `name` parameter will result in this last one beign ignored.
           schema:
             type: boolean
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceBundle/deviceBundle-scopeId-deviceId.yaml
@@ -21,6 +21,8 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../device/device.yaml#/components/parameters/timeout'
       responses:
         200:

--- a/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceEvent/deviceEvent-scopeId-deviceId.yaml
@@ -38,6 +38,8 @@ paths:
           schema:
             type: string
             format: 'date-time'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role-scopeId-roleId-users.yaml
@@ -21,6 +21,8 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: './role.yaml#/components/parameters/roleId'
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
@@ -31,6 +31,8 @@ paths:
           description: The action to filter results
           schema:
             type: string
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'
       responses:

--- a/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user-scopeId.yaml
@@ -39,6 +39,8 @@ paths:
             - DESCRIPTION
           schema:
             type: string
+        - $ref: '../openapi.yaml#/components/parameters/sortParam'
+        - $ref: '../openapi.yaml#/components/parameters/sortDir'
         - $ref: '../openapi.yaml#/components/parameters/askTotalCount'
         - $ref: '../openapi.yaml#/components/parameters/limit'
         - $ref: '../openapi.yaml#/components/parameters/offset'


### PR DESCRIPTION
Add the `sortParam` and `sortDir` params to the following REST APIs:

- Accounts simple query
- DeviceBundles simple query
- Users simple query
- Roles->Users simple query
- Permissions (users and roles) simple query
- DeviceEvents simple query

**Related Issue**
No related issue

