### PR TITLE
Return 409 Conflict in REST API for ENITY_UNIQUENESS exceptions

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaEntityUniquenessExceptionMapper.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/mapper/KapuaEntityUniquenessExceptionMapper.java
@@ -1,0 +1,40 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.mapper;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import javax.ws.rs.ext.ExceptionMapper;
+import javax.ws.rs.ext.Provider;
+
+import org.eclipse.kapua.KapuaEntityUniquenessException;
+import org.eclipse.kapua.app.api.core.exception.model.EntityUniquenessExceptionInfo;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Provider
+public class KapuaEntityUniquenessExceptionMapper implements ExceptionMapper<KapuaEntityUniquenessException> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(KapuaEntityUniquenessExceptionMapper.class);
+
+    @Override
+    public Response toResponse(KapuaEntityUniquenessException kapuaException) {
+        LOG.error("Entity uniqueness exception!", kapuaException);
+        return Response//
+                       .status(Status.fromStatusCode(409)) //
+                       .entity(new EntityUniquenessExceptionInfo(Status.fromStatusCode(409), kapuaException)) //
+                       .build();
+    }
+
+}

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityUniquenessExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityUniquenessExceptionInfo.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2017, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.api.core.exception.model;
+
+import javax.ws.rs.core.Response.Status;
+import javax.xml.bind.annotation.XmlAccessType;
+import javax.xml.bind.annotation.XmlAccessorType;
+import javax.xml.bind.annotation.XmlElement;
+import javax.xml.bind.annotation.XmlRootElement;
+
+import org.eclipse.kapua.KapuaEntityUniquenessException;
+
+@XmlRootElement(name = "entityUniquenessExceptionInfo")
+@XmlAccessorType(XmlAccessType.FIELD)
+public class EntityUniquenessExceptionInfo extends ExceptionInfo {
+
+    @XmlElement(name = "entityType")
+    private String entityType;
+
+    protected EntityUniquenessExceptionInfo() {
+        super();
+    }
+
+    public EntityUniquenessExceptionInfo(Status httpStatus, KapuaEntityUniquenessException kapuaException) {
+        super(httpStatus, kapuaException.getCode(), kapuaException);
+
+        setEntityType(kapuaException.getEntityType());
+    }
+
+    public String getEntityType() {
+        return entityType;
+    }
+
+    private void setEntityType(String entityType) {
+        this.entityType = entityType;
+    }
+
+}

--- a/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
+++ b/rest-api/resources/src/main/resources/openapi/accessInfo/accessInfo-scopeId-accessInfoId-permissions.yaml
@@ -62,5 +62,7 @@ paths:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceOperation/deviceOperation-scopeId-deviceId.yaml
@@ -39,5 +39,7 @@ paths:
           $ref: '../openapi.yaml#/components/responses/unauthenticated'
         403:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId-endpointInfoId.yaml
@@ -74,6 +74,8 @@ paths:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
         404:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
     delete:

--- a/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/endpointInfo/endpointInfo-scopeId.yaml
@@ -68,5 +68,7 @@ paths:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
         404:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStep/job-scopeId-jobId-steps.yaml
@@ -72,5 +72,7 @@ paths:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
         404:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'

--- a/rest-api/resources/src/main/resources/openapi/openapi.yaml
+++ b/rest-api/resources/src/main/resources/openapi/openapi.yaml
@@ -991,6 +991,8 @@ components:
                     type: string
     unauthenticated:
       description: The provided AccessToken could not be found, or no AccessToken has been provided
+    entityUniqueness:
+      description: An Entity with the same unique fields is already present in the system
   securitySchemes:
     kapuaToken:
       description: The default AccessToken Security Scheme. A [JWT](https://jwt.io) is used to represent the claims of a user

--- a/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/rolePermission-scopeId-roleId.yaml
@@ -92,5 +92,7 @@ paths:
           $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
         404:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        409:
+          $ref: '../openapi.yaml#/components/responses/entityUniqueness'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'


### PR DESCRIPTION
Return 409 Conflict instead of 500 when a duplicate entity is created

**Related Issue**
No related issues
