### PR TITLE
Added DELETE keystore/item to OpenAPI definitions

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore-scopeId-deviceId.yaml
@@ -109,6 +109,38 @@ paths:
           $ref: '../openapi.yaml#/components/responses/entityNotFound'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
+    delete:
+      tags:
+        - Device Management - Keystore
+      summary: Delete a keystore item from a single Device
+      operationId: deviceKeystoreItemDelete
+      parameters:
+        - $ref: '../openapi.yaml#/components/parameters/scopeId'
+        - $ref: '../device/device.yaml#/components/parameters/deviceId'
+        - name: keystoreId
+          in: query
+          description: The keystore id of the item to delete.
+          required: true
+          schema:
+            type: string
+        - name: alias
+          in: query
+          description: The alias of the item to delete.
+          required: true
+          schema:
+            type: string
+        - $ref: '../device/device.yaml#/components/parameters/timeout'
+      responses:
+        204:
+          description: The keystore item has been deleted
+        401:
+          $ref: '../openapi.yaml#/components/responses/unauthenticated'
+        403:
+          $ref: '../openapi.yaml#/components/responses/subjectUnauthorized'
+        404:
+          $ref: '../openapi.yaml#/components/responses/entityNotFound'
+        500:
+          $ref: '../openapi.yaml#/components/responses/kapuaError'
   /{scopeId}/devices/{deviceId}/keystore/items/certificateInfo:
     post:
       tags:


### PR DESCRIPTION
This PR adds the missing mapping `keystore/item` `DELETE` on the OpenAPI file. 

**Related Issue**
_None_

**Description of the solution adopted**
Just added the mapping of the resource

**Screenshots**
_None_

**Any side note on the changes made**
_None_