### PR TITLE
CORS filter is now configurable for users in kapua-sys child account

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsToolbarGrid.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/client/cors/CorsToolbarGrid.java
@@ -56,12 +56,10 @@ public class CorsToolbarGrid extends EntityCRUDToolbar<GwtEndpoint> {
     @Override
     protected void updateButtonEnablement() {
         super.updateButtonEnablement();
-
         //
         // Force disabled if entity is inherited from parent scopes
-        addEntityButton.setEnabled(currentSession.hasPermission(EndpointSessionPermission.writeAll()));
-
-        editEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.writeAll()));
-        deleteEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.deleteAll()));
+        addEntityButton.setEnabled(currentSession.hasPermission(EndpointSessionPermission.write()));
+        editEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.write()));
+        deleteEntityButton.setEnabled(selectedEntity != null && currentSession.hasPermission(EndpointSessionPermission.delete()));
     }
 }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/endpoint/RunEndpointServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/endpoint/RunEndpointServiceI9nTest.java
@@ -24,7 +24,8 @@ import org.junit.runner.RunWith;
                 "org.eclipse.kapua.service.user.steps",
                 "org.eclipse.kapua.service.endpoint.steps",
                 "org.eclipse.kapua.qa.common",
-                "org.eclipse.kapua.service.account.steps"
+                "org.eclipse.kapua.service.account.steps",
+                "org.eclipse.kapua.service.authorization.steps"
         },
         plugin = { "pretty",
                 "html:target/cucumber/EndpointServiceI9n",

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -891,5 +891,6 @@ Scenario: Init Security Context for all scenarios
     And I delete all CORS filters
     And I logout
 
+@teardown
 Scenario: Reset Security Context for all scenarios
     Given Reset Security Context

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -756,6 +756,137 @@ Scenario: Init Security Context for all scenarios
     And I delete endpoint with schema "Schema2", domain "abc.com" and port 2222
     And I logout
 
-@teardown
-  Scenario: Reset Security Context for all scenarios
+  Scenario: List CORS filters from kapua-sys account
+  Login as kapua-sys, create a CORS filter, then get all CORS filter.
+  There should be 1 CORS filter and no exceptions throw.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create a CORS filter with schema "http", domain "localhost" and port 8080
+    Then I have 1 CORS filter
+    And I delete all CORS filters
+    And I logout
+
+  Scenario: List CORS filters from kapua-sys account
+  Login as kapua-sys, create 5 CORS filter, then get all CORS filter.
+  There should be 5 CORS filters and no exceptions throw.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    When I create the following CORS filters
+      | http | localhost | 8080 |
+      | http | localhost | 8081 |
+      | http | localhost | 8082 |
+      | http | localhost | 8090 |
+      | http | localhost | 42   |
+    Then I have 5 CORS filter
+    And I delete all CORS filters
+    And I logout
+
+  Scenario: List CORS filters from a newer created user of kapua-sys account
+  Login as kapua-sys, create a new user user1 and do not give him the permission to creates
+  new CORS filters. Then login as user1 and try to create a CORS filter, an exception should be
+  thrown and no filter should be created.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I create user with name "user1"
+    And I add credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I select the domain "domain"
+    And I create the access info entity
+    And I create role "test_role" in account "kapua-sys"
+    And I create the following role permissions
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | delete     |
+    And I add access role "test_role" to user "user1"
+    And I logout
+    Given I login as user with name "user1" and password "User@10031995"
+    And I expect the exception "SubjectUnauthorizedException" with the text "*"
+    When I create a CORS filter with schema "http", domain "localhost" and port 8080
+    Then An exception was thrown
+    And I have 0 CORS filter
+    And I logout
+
+  Scenario: List CORS filters from a newer created user of kapua-sys account
+  Login as kapua-sys, create a new user user1 and do not give him the permission to creates
+  new CORS filters (give him instead the domain write permission). Then login as user1 and try to
+  create a CORS filter, no exception should be thrown and 1 filter should be created.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    And I select account "kapua-sys"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I create user with name "user1"
+    And I add credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I select the domain "domain"
+    And I create the access info entity
+    And I create role "test_role" in account "kapua-sys"
+    And I create the following role permissions
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write       |
+      | 1       | delete     |
+    And I add access role "test_role" to user "user1"
+    And I logout
+    Given I login as user with name "user1" and password "User@10031995"
+    And I expect the exception "SubjectUnauthorizedException" with the text "*"
+    When I create a CORS filter with schema "http", domain "localhost" and port 8080
+    Then An exception was thrown
+    And I have 0 CORS filter
+    And I logout
+
+  Scenario: List CORS filters from a newer created user of kapua-sys account
+  Login as kapua-sys, create a new user user1 and give him the permission to creates
+  new CORS filters. Then login as user1 and try to create 5 CORS filters, no exception should be
+  thrown and 5 new filters should be created.
+    Given I login as user with name "kapua-sys" and password "kapua-password"
+    Given I create a generic account with name "kapua-sub"
+    And I select account "kapua-sub"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And I create user with name "user1" in account "kapua-sub"
+    And I add credentials
+      | name  | password      | enabled |
+      | user1 | User@10031995 | true    |
+    And I select the domain "endpoint_info"
+    And I create the access info entity in account "kapua-sub"
+    And I create role "test_role" in account "kapua-sub"
+    And I create the following role permissions in account "kapua-sub"
+      | scopeId | actionName |
+      | 1       | read       |
+      | 1       | write      |
+      | 1       | delete     |
+    And I add access role "test_role" to user "user1" in account "kapua-sub"
+    And I logout
+    Given I login as user with name "user1" and password "User@10031995"
+    When I create the following CORS filters
+      | http | localhost | 8080 |
+      | http | localhost | 8081 |
+      | http | localhost | 8082 |
+      | http | localhost | 8090 |
+      | http | localhost | 42   |
+    Then I have 5 CORS filter
+    And I delete all CORS filters
+    And I logout
+
+Scenario: Reset Security Context for all scenarios
     Given Reset Security Context

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -62,6 +62,7 @@ Scenario: Init Security Context for all scenarios
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I create endpoint with schema "YUrdWClCWvg98SN11A1TuFEgjobJLtPxOwaNkdHAj1z7vs0GncKhNuSsJr9aAopl", domain "abc.com" and port 2221
     Then No exception was thrown
+    Then I delete endpoint with schema "YUrdWClCWvg98SN11A1TuFEgjobJLtPxOwaNkdHAj1z7vs0GncKhNuSsJr9aAopl", domain "abc.com" and port 2221
     And I logout
 
   Scenario: Creating Endpoint With Too Long "Schema"
@@ -173,6 +174,7 @@ Scenario: Init Security Context for all scenarios
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I create endpoint with schema "Schema1", domain "IApYdQLo4WGsvQ9gSPOIIFFOmkQeIYiGlCEU9zK7e3a9qmMyVSADuM5cJ68H1uEZj4JAML0FbYBXwO32o9AAoqSTsRs3n8tqp4E6YLJUhOnLsGMxrPZ1Rmha4DbNOqweNuvziFkmwTaAc9rIJlUr0VpJEi567JYNvVHSVtK1SdMKAfuLiTQTLOKoGZZIVdp7jwXyhgAEFJxUl3swT1uNz8MOiJHT4ToKCKZ5rwWcN6kYi55XnkMESrjdRKTcSDZmzt8wut7USdPNouIYIMGIzsw1bKDwA2fNx8b9ISsEcDAbX1EWER8GeWkqUAnKBNvNacjYHNEHceeacx72Wchd8uD8Y17w55vdAi98mmA8x7F8fFNZmC4b446Jy8HEgtE42TTOglcgeb0nGCGeUicWqxSeH0DaHf1QFvd7f05NZNli5PYPmeN5WqlVQT6b5bLEala1UD94t5PqWC01o59hHCSAJyD7Zj01gWbyuDy5LmkuARZybDdxige6CzDVWvKBYxLthaLqqE3E7cWQA6wsDPqtyEsfoCycYXuPYGx81M7f1JVvh0I5oj2Eg0VHvYcvGnfUUBXUY3abYzCyvEBf2kZ6pQUkwgJHBaA2p7UBYTqpqt5zfc5w3qn1n6uD1QzyQukvqBvuaVPlXqVobmyz7VTgGBT45cMGevJhs5Td4UrtjifSmzEDbuzBZbQub3cbutLLmJqH2pctG4gtBPz2GNNRCC2Lsx2PsYynkUr5c9aBeENFXmR41BDRLlyEzpKRtzJ6QLEVrZKAvNahm8wvlmzI6JkLB9YZpEm7diq54bmm4EaolSBvs2X9e5EEGPosoIjyQfNsbasognvYY4fGCiNuTchmxnHnPlMyfRcGPas8SWYH7fvQFDWLquEXqX3kHGAn4KsShiyAvbj9OeJ4ao2QmJSHOtP0212nx4iooHGPpMOM8difFRt0i4AYdb68q51cs8OtHaW41IZSlJai6FttoiMl3ln7uAIHp6FrPXNBmwoMxAvUgdn60mXPs1XK" and port 2221
     Then No exception was thrown
+    Then I delete endpoint with schema "Schema1", domain "IApYdQLo4WGsvQ9gSPOIIFFOmkQeIYiGlCEU9zK7e3a9qmMyVSADuM5cJ68H1uEZj4JAML0FbYBXwO32o9AAoqSTsRs3n8tqp4E6YLJUhOnLsGMxrPZ1Rmha4DbNOqweNuvziFkmwTaAc9rIJlUr0VpJEi567JYNvVHSVtK1SdMKAfuLiTQTLOKoGZZIVdp7jwXyhgAEFJxUl3swT1uNz8MOiJHT4ToKCKZ5rwWcN6kYi55XnkMESrjdRKTcSDZmzt8wut7USdPNouIYIMGIzsw1bKDwA2fNx8b9ISsEcDAbX1EWER8GeWkqUAnKBNvNacjYHNEHceeacx72Wchd8uD8Y17w55vdAi98mmA8x7F8fFNZmC4b446Jy8HEgtE42TTOglcgeb0nGCGeUicWqxSeH0DaHf1QFvd7f05NZNli5PYPmeN5WqlVQT6b5bLEala1UD94t5PqWC01o59hHCSAJyD7Zj01gWbyuDy5LmkuARZybDdxige6CzDVWvKBYxLthaLqqE3E7cWQA6wsDPqtyEsfoCycYXuPYGx81M7f1JVvh0I5oj2Eg0VHvYcvGnfUUBXUY3abYzCyvEBf2kZ6pQUkwgJHBaA2p7UBYTqpqt5zfc5w3qn1n6uD1QzyQukvqBvuaVPlXqVobmyz7VTgGBT45cMGevJhs5Td4UrtjifSmzEDbuzBZbQub3cbutLLmJqH2pctG4gtBPz2GNNRCC2Lsx2PsYynkUr5c9aBeENFXmR41BDRLlyEzpKRtzJ6QLEVrZKAvNahm8wvlmzI6JkLB9YZpEm7diq54bmm4EaolSBvs2X9e5EEGPosoIjyQfNsbasognvYY4fGCiNuTchmxnHnPlMyfRcGPas8SWYH7fvQFDWLquEXqX3kHGAn4KsShiyAvbj9OeJ4ao2QmJSHOtP0212nx4iooHGPpMOM8difFRt0i4AYdb68q51cs8OtHaW41IZSlJai6FttoiMl3ln7uAIHp6FrPXNBmwoMxAvUgdn60mXPs1XK" and port 2221
     And I logout
 
   Scenario: Creating Endpoint With Too Long "Domain Name"
@@ -262,6 +264,7 @@ Scenario: Init Security Context for all scenarios
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I create endpoint with schema "Schema1", domain "abc.com" and port 65535
     Then No exception was thrown
+    Then I delete endpoint with schema "Schema1", domain "abc.com" and port 65535
     And I logout
 
   Scenario: Creating Endpoint With Small Number "Port"

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -95,7 +95,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, null));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, endpointInfoCreator.getScopeId())
+        );
 
         //
         // Check duplicate endpoint
@@ -129,7 +131,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, null));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, endpointInfo.getScopeId())
+        );
 
         //
         // Check duplicate endpoint
@@ -152,7 +156,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.delete, null));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.delete, scopeId)
+        );
 
         //
         // Do delete
@@ -167,7 +173,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, scopeId));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, scopeId)
+        );
 
         //
         // Do find
@@ -186,7 +194,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, query.getScopeId())
+        );
         addSectionToPredicate(query, section);
 
         //
@@ -239,7 +249,9 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        AUTHORIZATION_SERVICE.checkPermission(PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, query.getScopeId()));
+        AUTHORIZATION_SERVICE.checkPermission(
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, query.getScopeId())
+        );
 
         //
         // Do count

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -95,8 +95,10 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
+        KapuaId scopeIdPermission = endpointInfoCreator.getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ?
+                endpointInfoCreator.getScopeId() : null;
         AUTHORIZATION_SERVICE.checkPermission(
-                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, endpointInfoCreator.getScopeId())
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, scopeIdPermission)
         );
 
         //
@@ -131,8 +133,10 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
+        KapuaId scopeIdPermission = endpointInfo.getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ?
+                endpointInfo.getScopeId() : null;
         AUTHORIZATION_SERVICE.checkPermission(
-                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, endpointInfo.getScopeId())
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.write, scopeIdPermission)
         );
 
         //
@@ -156,8 +160,11 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
+        KapuaId scopeIdPermission = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId))
+                .getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ? scopeId : null;
+
         AUTHORIZATION_SERVICE.checkPermission(
-                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.delete, scopeId)
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.delete, scopeIdPermission)
         );
 
         //
@@ -173,8 +180,10 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
+        KapuaId scopeIdPermission = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId))
+                .getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ? scopeId : null;
         AUTHORIZATION_SERVICE.checkPermission(
-                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, scopeId)
+                PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, scopeIdPermission)
         );
 
         //

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -160,8 +160,11 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        KapuaId scopeIdPermission = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId))
-                .getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ? scopeId : null;
+        EndpointInfo endpointInfoToDelete = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId));
+        KapuaId scopeIdPermission = null;
+        if (endpointInfoToDelete != null && endpointInfoToDelete.getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS)) {
+            scopeIdPermission = scopeId;
+        }
 
         AUTHORIZATION_SERVICE.checkPermission(
                 PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.delete, scopeIdPermission)
@@ -180,8 +183,12 @@ public class EndpointInfoServiceImpl
 
         //
         // Check Access
-        KapuaId scopeIdPermission = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId))
-                .getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS) ? scopeId : null;
+        EndpointInfo endpointInfoToFind = entityManagerSession.doAction(em -> EndpointInfoDAO.find(em, scopeId, endpointInfoId));
+        KapuaId scopeIdPermission = null;
+        if (endpointInfoToFind != null && endpointInfoToFind.getEndpointType().equals(EndpointInfo.ENDPOINT_TYPE_CORS)) {
+            scopeIdPermission = scopeId;
+        }
+
         AUTHORIZATION_SERVICE.checkPermission(
                 PERMISSION_FACTORY.newPermission(EndpointInfoDomains.ENDPOINT_INFO_DOMAIN, Actions.read, scopeIdPermission)
         );

--- a/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
+++ b/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
@@ -12,12 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.endpoint.steps;
 
+
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.qa.common.StepData;
 import org.eclipse.kapua.qa.common.TestBase;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.service.endpoint.EndpointInfo;
 import org.eclipse.kapua.service.endpoint.EndpointInfoAttributes;
 import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
@@ -35,8 +37,9 @@ import io.cucumber.java.Scenario;
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Then;
 import io.cucumber.java.en.When;
-
 import javax.inject.Inject;
+import java.util.List;
+import java.util.concurrent.Callable;
 
 @Singleton
 public class EndpointServiceSteps extends TestBase {
@@ -463,6 +466,58 @@ public class EndpointServiceSteps extends TestBase {
             endpointInfoService.update(endpointInfo);
         } catch (Exception e) {
             verifyException(e);
+        }
+    }
+
+    @When("^I create a CORS filter with schema \"([^\"]*)\", domain \"([^\"]*)\" and port (\\d+)$")
+    public void iCreateCORSFilter(String schema, String domain, int port) throws Exception {
+        EndpointInfoCreator endpointInfoCreator = endpointInfoFactory.newCreator(getCurrentScopeId());
+        endpointInfoCreator.setSchema(schema);
+        endpointInfoCreator.setDns(domain);
+        endpointInfoCreator.setPort(port);
+        endpointInfoCreator.setEndpointType(EndpointInfo.ENDPOINT_TYPE_CORS);
+
+        try {
+            EndpointInfo endpointInfo = endpointInfoService.create(endpointInfoCreator);
+        } catch (KapuaException ex) {
+            verifyException(ex);
+        }
+    }
+
+    @And("^I create the following CORS filters$")
+    public void iCreateMultipleCORSFilter(DataTable corsFilters) throws Throwable {
+        for (List<String> config : corsFilters.raw()) {
+            iCreateCORSFilter(config.get(0), config.get(1), Integer.parseInt(config.get(2)));
+        }
+    }
+
+    @Then("I have (\\d+) CORS filters?$")
+    public void iHaveCORSFilter(int expectedNum) throws KapuaException {
+        int corsFilter = KapuaSecurityUtils.doPrivileged(new Callable<Integer>() {
+            @Override
+            public Integer call() throws Exception {
+                EndpointInfoQuery endpointInfoQuery = endpointInfoFactory.newQuery(getCurrentScopeId());
+                EndpointInfoListResult corsFilters = endpointInfoService.query(endpointInfoQuery, EndpointInfo.ENDPOINT_TYPE_CORS);
+                return corsFilters.getSize();
+            }
+        });
+        assertEquals(expectedNum, corsFilter);
+    }
+
+    @And("^I delete all CORS filters")
+    public void iDeleteAllCORSFilters() throws Exception {
+        primeException();
+
+        try {
+            EndpointInfoQuery endpointInfoQuery = endpointInfoFactory.newQuery(getCurrentScopeId());
+            EndpointInfoListResult endpointsToDelete = endpointInfoService.query(endpointInfoQuery, EndpointInfo.ENDPOINT_TYPE_CORS);
+
+            for (int i = 0; i < endpointsToDelete.getSize(); i++) {
+                endpointInfoService.delete(getCurrentScopeId(), endpointsToDelete.getItem(i).getId());
+            }
+
+        } catch (KapuaException ex) {
+            verifyException(ex);
         }
     }
 }

--- a/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
+++ b/service/endpoint/test-steps/src/main/java/org/eclipse/kapua/service/endpoint/steps/EndpointServiceSteps.java
@@ -13,13 +13,21 @@
 package org.eclipse.kapua.service.endpoint.steps;
 
 
+import com.google.inject.Singleton;
+import io.cucumber.datatable.DataTable;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalNullArgumentException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.qa.common.StepData;
 import org.eclipse.kapua.qa.common.TestBase;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.service.endpoint.EndpointInfo;
 import org.eclipse.kapua.service.endpoint.EndpointInfoAttributes;
 import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
@@ -29,14 +37,6 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointInfoService;
 import org.junit.Assert;
 
-import com.google.inject.Singleton;
-
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.Scenario;
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 import javax.inject.Inject;
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -486,7 +486,7 @@ public class EndpointServiceSteps extends TestBase {
 
     @And("^I create the following CORS filters$")
     public void iCreateMultipleCORSFilter(DataTable corsFilters) throws Throwable {
-        for (List<String> config : corsFilters.raw()) {
+        for (List<String> config : corsFilters.asLists()) {
             iCreateCORSFilter(config.get(0), config.get(1), Integer.parseInt(config.get(2)));
         }
     }
@@ -501,7 +501,7 @@ public class EndpointServiceSteps extends TestBase {
                 return corsFilters.getSize();
             }
         });
-        assertEquals(expectedNum, corsFilter);
+        Assert.assertEquals(expectedNum, corsFilter);
     }
 
     @And("^I delete all CORS filters")


### PR DESCRIPTION
**Related Issue**
This PR fixes the following problem:
users of one kapua-sys child account cannot configure CORS filters even if they have the permission to do it.

**Description of the solution adopted**
* change the `CorsToolbarGrid`class in order to enable the buttons to add/edit/remove CORS filter correctly
* change the `EndpointInfoServiceImpl` in order to fix the permissions' check
* add integration test regarding CORS filter configuration