### PR TITLE
Fixed example of model DeviceKeystoreCertificateInfo

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore.yaml
+++ b/rest-api/resources/src/main/resources/openapi/deviceKeystore/deviceKeystore.yaml
@@ -196,7 +196,7 @@ components:
       example:
         keystoreId: SSLKeystore
         alias: ssl-eclipse
-        certificate: IaIA6xbNR7C
+        certificateInfoId: IaIA6xbNR7C
     deviceKeystoreCertificate:
       type: object
       properties:


### PR DESCRIPTION
This PR fixes the example for the Keystore `deviceKeystoreCertificateInfo` OpenAPI  definition.

**Related Issue**
_None_

**Description of the solution adopted**
Just fixed the value 😁 

**Screenshots**
_None_

**Any side note on the changes made**
_None_