### PR TITLE
Hide Device Tabs if feature is not supported by device

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/assets/DeviceTabAssets.java
@@ -48,12 +48,13 @@ public class DeviceTabAssets extends KapuaTabItem<GwtDevice> {
     @Override
     public void setEntity(GwtDevice gwtDevice) {
         super.setEntity(gwtDevice);
-
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_ASSET_V1));
-
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_ASSET_V1));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
         assetsValues.setDevice(gwtDevice);
         doRefresh();
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/bundles/DeviceTabBundles.java
@@ -94,17 +94,19 @@ public class DeviceTabBundles extends KapuaTabItem<GwtDevice> {
         this.devicesView = devicesView;
         initialized = false;
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
     public void setEntity(GwtDevice gwtDevice) {
         super.setEntity(gwtDevice);
-
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V1) || (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V2))));
-
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V1) || (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V2)));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
         doRefresh();
     }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/command/DeviceTabCommand.java
@@ -96,17 +96,19 @@ public class DeviceTabCommand extends KapuaTabItem<GwtDevice> {
         super(currentSession, DEVICE_MSGS.tabCommand(), new KapuaIcon(IconSet.TERMINAL));
         initialized = false;
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
     public void setEntity(GwtDevice gwtDevice) {
         super.setEntity(gwtDevice);
-
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.execute()) &&
-                gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_COMMAND));
-
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.execute()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_COMMAND));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
         doRefresh();
     }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/configuration/DeviceTabConfiguration.java
@@ -46,16 +46,19 @@ public class DeviceTabConfiguration extends KapuaTabItem<GwtDevice> {
         configComponents = new DeviceConfigComponents(currentSession, this);
         configSnapshots = new DeviceConfigSnapshots(currentSession, this);
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
     public void setEntity(GwtDevice gwtDevice) {
         super.setEntity(gwtDevice);
-
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_CONFIGURATION));
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_CONFIGURATION));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
         doRefresh();
     }
 

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventory.java
@@ -58,6 +58,7 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
 
         this.deviceTabs = deviceTabs;
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
@@ -65,15 +66,16 @@ public class DeviceTabInventory extends KapuaTabItem<GwtDevice> {
         super.setEntity(gwtDevice);
 
         setDirty();
-
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_INVENTORY_V1));
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_INVENTORY_V1));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
 
         if (initialized && tabsPanel.getSelectedItem() == null) {
             tabsPanel.setSelection(inventoryDeploymentPackageTab);
-
         }
 
         if (toolBar != null) {

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/keystore/DeviceTabKeystore.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/keystore/DeviceTabKeystore.java
@@ -86,16 +86,20 @@ public class DeviceTabKeystore extends KapuaTabItem<GwtDevice> {
         super(currentSession, "Keystore", new KapuaIcon(IconSet.KEY));
 
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
     public void setEntity(GwtDevice gwtDevice) {
         super.setEntity(gwtDevice);
 
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_KEYS_V1));
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_KEYS_V1));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
 
         refresh();
     }

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/packages/DeviceTabPackages.java
@@ -81,6 +81,7 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
 
         this.deviceTabs = deviceTabs;
         setEnabled(false);
+        getHeader().setVisible(false);
     }
 
     @Override
@@ -88,10 +89,13 @@ public class DeviceTabPackages extends KapuaTabItem<GwtDevice> {
         super.setEntity(gwtDevice);
         setDirty();
 
-        setEnabled(gwtDevice != null &&
-                gwtDevice.isOnline() &&
-                currentSession.hasPermission(DeviceManagementSessionPermission.read()) &&
-                (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V1) || (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V2))));
+        if (gwtDevice != null) {
+            setEnabled(gwtDevice.isOnline() && currentSession.hasPermission(DeviceManagementSessionPermission.read()));
+            getHeader().setVisible(gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V1) || (gwtDevice.hasApplication(GwtDevice.GwtDeviceApplication.APP_DEPLOY_V2)));
+        } else {
+            setEnabled(false);
+            getHeader().setVisible(false);
+        }
 
         if (initialized && tabsPanel.getSelectedItem() == null) {
             tabsPanel.setSelection(installedPackageTab);


### PR DESCRIPTION
Currently, if a Device does not support a specific application, the tab is shown disabled. After this PR it will be hidden altogether, while it will be shown disabled if the application is supported but the device is offline or the user lacks proper permission

**Related Issue**
No related issues
