### PR TITLE
Fixed Keystore Keypair creation from console

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/keystore/GwtDeviceKeystoreKeypair.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/shared/model/management/keystore/GwtDeviceKeystoreKeypair.java
@@ -57,7 +57,7 @@ public class GwtDeviceKeystoreKeypair extends GwtEntityModel {
     }
 
     public String getAttributes() {
-        return get("algorithm");
+        return get("attributes");
     }
 
     public void setAttributes(String attributes) {


### PR DESCRIPTION
This PR fixes an issue whne creating a new Keypair from the console

**Related Issue**
_None_

**Description of the solution adopted**
Just fixed the property for the `getAttributes()` which was wrong.

**Screenshots**
_None_

**Any side note on the changes made**
_None_