### PR TITLE
Increased wait times for job operations to complete

### DIFF
--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -50,7 +50,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob - Keystore Steps" and I find it
     And I query for the execution items for the current job and I count 1
@@ -87,7 +87,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob - Keystore Steps" and I find it
     And I query for the execution items for the current job and I count 1
@@ -151,7 +151,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 3 and status "PROCESS_OK"
     And I query for the job with the name "TestJob - Keystore Steps" and I find it
     And I query for the execution items for the current job and I count 1

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -51,7 +51,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -85,7 +85,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -119,7 +119,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -153,7 +153,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -187,7 +187,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -221,7 +221,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -255,7 +255,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -300,7 +300,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -341,7 +341,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -381,7 +381,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -421,7 +421,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -461,7 +461,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -501,7 +501,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -541,7 +541,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -581,7 +581,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -617,7 +617,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -653,7 +653,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -689,7 +689,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -725,7 +725,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -761,7 +761,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -797,7 +797,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -844,7 +844,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -887,7 +887,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -930,7 +930,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -973,7 +973,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -1016,7 +1016,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -1059,7 +1059,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -1102,7 +1102,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -50,13 +50,13 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -94,13 +94,13 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -140,13 +140,13 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -184,13 +184,13 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -237,13 +237,13 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -289,13 +289,13 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -337,13 +337,13 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -379,13 +379,13 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -423,13 +423,13 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -465,13 +465,13 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -516,13 +516,13 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -567,13 +567,13 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -52,13 +52,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 2
@@ -96,13 +96,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -140,13 +140,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -194,13 +194,13 @@ Feature: JobEngineService restart job tests with online device - second part
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -245,13 +245,13 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -293,13 +293,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -333,13 +333,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     When I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Then I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more
@@ -375,13 +375,13 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
@@ -428,13 +428,13 @@ Feature: JobEngineService restart job tests with online device - second part
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2
     And I confirm the executed job is finished
@@ -477,13 +477,13 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
     And I confirm the executed job is finished
     Then I restart a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 2 or more

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -51,7 +51,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -85,7 +85,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -121,7 +121,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -165,7 +165,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -206,7 +206,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -241,7 +241,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -283,7 +283,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -335,7 +335,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -384,7 +384,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -433,7 +433,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -484,7 +484,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -534,7 +534,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -584,7 +584,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -636,7 +636,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
     And I confirm the executed job is finished
@@ -680,7 +680,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -717,7 +717,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -755,7 +755,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -797,7 +797,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -834,7 +834,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -871,7 +871,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -908,7 +908,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -956,7 +956,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1001,7 +1001,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1046,7 +1046,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1095,7 +1095,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1139,7 +1139,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1183,7 +1183,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -1227,7 +1227,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -51,7 +51,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -89,7 +89,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -129,7 +129,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -168,7 +168,7 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new step entity from the existing creator
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -208,7 +208,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1 or more
@@ -247,7 +247,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -286,7 +286,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1 or more
@@ -333,7 +333,7 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1 or more
@@ -379,7 +379,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
@@ -424,7 +424,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
@@ -468,7 +468,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
@@ -511,7 +511,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     Then I query for the execution items for the current job and I count 1
@@ -547,7 +547,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -585,7 +585,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_FAILED"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -623,7 +623,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -658,7 +658,7 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new step entity from the existing creator
     Then I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
@@ -696,7 +696,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1
@@ -732,7 +732,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more
@@ -767,7 +767,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 0 and status "PROCESS_OK"
     And  I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1 or more
@@ -812,7 +812,7 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     And I query for the execution items for the current job and I count 1 or more
@@ -856,7 +856,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     Given I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
@@ -899,7 +899,7 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1
@@ -942,7 +942,7 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     And I query for the job with the name "TestJob" and I find it
     When I query for the execution items for the current job and I count 1 or more

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -70,7 +70,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 2 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -123,7 +123,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 2 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -175,7 +175,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 2 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -226,7 +226,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 2 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -277,7 +277,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 2 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -330,7 +330,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -381,7 +381,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -431,7 +431,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -480,7 +480,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished
@@ -531,7 +531,7 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
+    And I wait 14 seconds
     And I confirm job target has step index 1 and status "PROCESS_OK"
     When I query for the execution items for the current job and I count 2 or more
     And I confirm the executed job is finished

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -16,7 +16,7 @@
 
 Feature: JobEngineService execute job on device connect
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -59,9 +59,9 @@ Feature: JobEngineService execute job on device connect
     And The trigger is set to start today at "00:00"
     Then I create a new trigger from the existing creator with previously defined date properties
     And I restart the Kura Mock
-    And I wait 3 seconds
+    And I wait 6 seconds
     When Device is connected
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -109,9 +109,9 @@ Feature: JobEngineService execute job on device connect
     And The trigger is set to start tomorrow at "06:00"
     Then I create a new trigger from the existing creator with previously defined date properties
     And I restart the Kura Mock
-    And I wait 3 seconds
+    And I wait 6 seconds
     When Device is connected
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 0
@@ -159,9 +159,9 @@ Feature: JobEngineService execute job on device connect
     And The trigger is set to end tomorrow at "20:00"
     Then I create a new trigger from the existing creator with previously defined date properties
     And I restart the Kura Mock
-    And I wait 3 seconds
+    And I wait 6 seconds
     When Device is connected
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -211,7 +211,7 @@ Feature: JobEngineService execute job on device connect
     Then I create a new trigger from the existing creator with previously defined date properties
     And I wait 11 seconds
     And I restart the Kura Mock
-    And I wait 3 seconds
+    And I wait 6 seconds
     When Device is connected
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
@@ -261,15 +261,15 @@ Feature: JobEngineService execute job on device connect
     Then I create a new trigger from the existing creator with previously defined date properties
     And I restart the Kura Mock
     When Device is connected
-    And I wait 3 seconds
+    And I wait 6 seconds
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 4 device events
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
-    And I wait 3 seconds
+    And I wait 6 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 1
@@ -311,15 +311,15 @@ Feature: JobEngineService execute job on device connect
     Then I create a new trigger from the existing creator with previously defined date properties
     And I restart the Kura Mock
     When Device is connected
-    And I wait 3 seconds
+    And I wait 6 seconds
     When I search for events from device "rpione3" in account "kapua-sys"
     Then I find 3 device events
     And The type of the last event is "BIRTH"
     Then KuraMock is disconnected
-    And I wait 3 seconds
+    And I wait 6 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
+    And I wait 14 seconds
     Given I query for the job with the name "TestJob"
     When I query for the execution items for the current job
     Then I count 0
@@ -330,6 +330,6 @@ Feature: JobEngineService execute job on device connect
     And The type of the last event is "BIRTH"
     And I logout
 
-@teardown
+  @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/DeviceRegistrySteps.java
@@ -98,6 +98,8 @@ import org.eclipse.kapua.service.tag.TagService;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserService;
 import org.junit.Assert;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
 import java.math.BigInteger;
@@ -120,6 +122,8 @@ import java.util.Vector;
  */
 @Singleton
 public class DeviceRegistrySteps extends TestBase {
+
+    private static final Logger LOG = LoggerFactory.getLogger(DeviceRegistrySteps.class);
 
     private static final String TEST_DEVICE_NAME = "test_name";
     private static final String TEST_BIOS_VERSION_1 = "bios_version_1";
@@ -200,12 +204,12 @@ public class DeviceRegistrySteps extends TestBase {
     // * Setup and tear-down steps                                                        *
     // ************************************************************************************
 
-    @Before(value="@env_docker or @env_embedded_minimal or @env_none", order=10)
+    @Before(value = "@env_docker or @env_embedded_minimal or @env_none", order = 10)
     public void beforeScenarioNone(Scenario scenario) {
         updateScenario(scenario);
     }
 
-    @After(value="@setup")
+    @After(value = "@setup")
     public void setServices() {
         KapuaLocator locator = KapuaLocator.getInstance();
         deviceRegistryService = locator.getService(DeviceRegistryService.class);
@@ -1440,8 +1444,18 @@ public class DeviceRegistrySteps extends TestBase {
 
     @Then("I find {int} device event(s)")
     public void checkEventListForNumberOfItems(int numberOfEvents) {
-        DeviceEventListResult eventList = (DeviceEventListResult) stepData.get(DEVICE_EVENT_LIST);
-        Assert.assertEquals(numberOfEvents, eventList.getSize());
+
+        DeviceEventListResult deviceEvents = (DeviceEventListResult) stepData.get(DEVICE_EVENT_LIST);
+        try {
+            Assert.assertEquals(numberOfEvents, deviceEvents.getSize());
+        } catch (AssertionError ae) {
+            LOG.info("Device Events Found:");
+            for (DeviceEvent deviceEvent : deviceEvents.getItems()) {
+                LOG.info("\t{} - {} - {} - {}", deviceEvent.getCreatedOn(), deviceEvent.getReceivedOn(), deviceEvent.getResource(), deviceEvent.getResponseCode());
+            }
+
+            throw ae;
+        }
     }
 
     @Then("I find {int} or more device event(s)")
@@ -2358,7 +2372,7 @@ public class DeviceRegistrySteps extends TestBase {
         Group group = (Group) stepData.get("Group");
         Assert.assertEquals(group.getName(), groupName);
         try {
-            for(int i = 0; i < numberOfDevices; i++) {
+            for (int i = 0; i < numberOfDevices; i++) {
                 iCreateADeviceWithName(String.format("Device%02d", i));
                 iAddDeviceToGroup(String.format("Device%02d", i), group.getName());
             }
@@ -2488,73 +2502,73 @@ public class DeviceRegistrySteps extends TestBase {
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() == null && deviceParams.getStatus() == null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() == null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() == null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() == null && deviceParams.getSerialNumber() == null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() == null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() == null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() == null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() == null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() == null && deviceParams.getDisplayName() == null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() == null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() == null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() == null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() == null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         } else if (deviceParams.getClientId() != null && deviceParams.getDisplayName() != null && deviceParams.getSerialNumber() != null && deviceParams.getStatus() != null) {
             DeviceQuery tmpQuery = deviceFactory.newQuery(getCurrentScopeId());
             tmpQuery.setPredicate(tmpQuery.andPredicate(tmpQuery.attributePredicate(DeviceAttributes.SERIAL_NUMBER, deviceParams.getSerialNumber(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
-                                                        tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
+                    tmpQuery.attributePredicate(DeviceAttributes.DISPLAY_NAME, deviceParams.getDisplayName(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.CLIENT_ID, deviceParams.getClientId(), AttributePredicate.Operator.LIKE),
+                    tmpQuery.attributePredicate(DeviceAttributes.STATUS, deviceParams.getStatus(), AttributePredicate.Operator.LIKE)));
             devices = deviceRegistryService.query(tmpQuery);
             stepData.put("DeviceList", devices);
         }


### PR DESCRIPTION
This is a tentative change to avoid random failures on the job engine tests.

**Related Issue**
_None_

**Description of the solution adopted**
Increased the wait time and added some log lines in case of error to help diagnose the problem.

**Screenshots**
_None_

**Any side note on the changes made**
_None_