### PR TITLE
Feature kapua list result get items enachements

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/KapuaListResultImpl.java
@@ -19,11 +19,15 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
+import java.util.stream.Collectors;
 
 /**
  * {@link KapuaListResult} implementation.
  *
- * @param <E> {@link KapuaEntity} domain
+ * @param <E> {@link KapuaEntity} type.
  * @since 1.0.0
  */
 public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResult<E> {
@@ -54,6 +58,30 @@ public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResu
     }
 
     @Override
+    public List<E> getItems() {
+        if (items == null) {
+            items = new ArrayList<>();
+        }
+
+        return items;
+    }
+
+    @Override
+    public List<E> getItems(Predicate<E> filter) {
+        return getItems().stream().filter(filter).collect(Collectors.toList());
+    }
+
+    @Override
+    public <K> Map<K, E> getItemsAsMap(Function<E, K> keyMapper) {
+        return getItems().stream().collect(Collectors.toMap(keyMapper, e -> e));
+    }
+
+    @Override
+    public <K, V> Map<K, V> getItemsAsMap(Function<E, K> keyMapper, Function<E, V> valueMapper) {
+        return getItems().stream().collect(Collectors.toMap(keyMapper, valueMapper));
+    }
+
+    @Override
     public E getItem(int index) {
         return getItems().get(index);
     }
@@ -71,15 +99,6 @@ public class KapuaListResultImpl<E extends KapuaEntity> implements KapuaListResu
     @Override
     public boolean isEmpty() {
         return getItems().isEmpty();
-    }
-
-    @Override
-    public List<E> getItems() {
-        if (items == null) {
-            items = new ArrayList<>();
-        }
-
-        return items;
     }
 
     @Override

--- a/commons/src/test/java/org/eclipse/kapua/commons/model/query/KapuaListResultImplTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/model/query/KapuaListResultImplTest.java
@@ -15,6 +15,7 @@ package org.eclipse.kapua.commons.model.query;
 import org.eclipse.kapua.commons.model.AbstractKapuaEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.RandomUtils;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
 import org.junit.Test;
@@ -25,151 +26,261 @@ import java.math.BigInteger;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
 
-
 @Category(JUnitTests.class)
-public class KapuaListResultImplTest extends Assert {
+public class KapuaListResultImplTest {
 
     private final static Random RANDOM = RandomUtils.getInstance();
 
-    KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
-
     @Test
     public void kapuaListResultImplTest() {
-        assertFalse(kapuaListResult.isLimitExceeded());
-    }
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
 
-    @Test
-    public void setTrueAndFalseLimitExceededTest() {
-        kapuaListResult.setLimitExceeded(true);
-        assertTrue(kapuaListResult.isLimitExceeded());
-        kapuaListResult.setLimitExceeded(false);
-        assertFalse(kapuaListResult.isLimitExceeded());
-    }
-
-    @Test
-    public void getItemTest() {
-        AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntity);
-        assertEquals("Actual and expected values are not the same!", kapuaEntity, kapuaListResult.getItem(0));
-    }
-
-    @Test
-    public void getFirstItemTest() {
-        AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntity);
-        assertEquals("Actual and expected values are not the same!", kapuaEntity, kapuaListResult.getFirstItem());
-    }
-
-    @Test
-    public void getSizeTest() {
-        assertEquals("Actual and expected values are not the same!", 0, kapuaListResult.getSize());
-        List<AbstractKapuaEntity> items = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            items.add(Mockito.mock(AbstractKapuaEntity.class));
-        }
-        kapuaListResult.addItems(items);
-        assertEquals("Actual and expected values are not the same!", 10, kapuaListResult.getSize());
-    }
-
-    @Test
-    public void isEmptyTest() {
-        assertTrue(kapuaListResult.isEmpty());
-        AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntity);
-        assertFalse(kapuaListResult.isEmpty());
-    }
-
-    @Test
-    public void getItemsTest() {
-        List<AbstractKapuaEntity> items = new ArrayList<>();
-        assertEquals("Actual and expected values are not the same!", items, kapuaListResult.getItems());
+        Assert.assertNotNull(kapuaListResult.getItems());
+        Assert.assertTrue(kapuaListResult.getItems().isEmpty());
+        Assert.assertFalse(kapuaListResult.isLimitExceeded());
+        Assert.assertNull(kapuaListResult.getTotalCount());
     }
 
     @Test
     public void addItemsTest() {
+        AbstractKapuaEntity kapuaEntity1 = Mockito.mock(AbstractKapuaEntity.class);
+        AbstractKapuaEntity kapuaEntity2 = Mockito.mock(AbstractKapuaEntity.class);
+
         List<AbstractKapuaEntity> items = new ArrayList<>();
+        items.add(kapuaEntity1);
+        items.add(kapuaEntity2);
+
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
         kapuaListResult.addItems(items);
-        assertEquals("Actual and expected values are not the same!", items, kapuaListResult.getItems());
+
+        Assert.assertEquals(2, kapuaListResult.getItems().size());
+        Assert.assertEquals(kapuaEntity1, kapuaListResult.getItems().get(0));
+        Assert.assertEquals(kapuaEntity2, kapuaListResult.getItems().get(1));
+        Assert.assertEquals(items, kapuaListResult.getItems());
     }
 
     @Test
     public void addItemTest() {
-        AbstractKapuaEntity kapuaEntityFirst = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntityFirst);
-        assertEquals("Actual and expected values are not the same!", kapuaEntityFirst, kapuaListResult.getFirstItem());
-        AbstractKapuaEntity kapuaEntitySecond = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntitySecond);
-        AbstractKapuaEntity kapuaEntityThird = Mockito.mock(AbstractKapuaEntity.class);
-        kapuaListResult.addItem(kapuaEntityThird);
-        for (AbstractKapuaEntity item : kapuaListResult.getItems()) {
-            assertTrue(kapuaListResult.getItems().contains(item));
-        }
+        AbstractKapuaEntity kapuaEntity1 = Mockito.mock(AbstractKapuaEntity.class);
+        AbstractKapuaEntity kapuaEntity2 = Mockito.mock(AbstractKapuaEntity.class);
+
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+        kapuaListResult.addItem(kapuaEntity1);
+        kapuaListResult.addItem(kapuaEntity2);
+
+        Assert.assertEquals(2, kapuaListResult.getItems().size());
+        Assert.assertEquals(kapuaEntity1, kapuaListResult.getItems().get(0));
+        Assert.assertEquals(kapuaEntity2, kapuaListResult.getItems().get(1));
     }
 
     @Test
     public void clearItemsTest() {
-        List<AbstractKapuaEntity> items = new ArrayList<>();
-        for (int i = 0; i < 10; i++) {
-            items.add(Mockito.mock(AbstractKapuaEntity.class));
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        for (int i = 0; i < testSize; i++) {
+            kapuaListResult.addItem(Mockito.mock(AbstractKapuaEntity.class));
         }
-        kapuaListResult.addItems(items);
-        for (int i = 0; i < 10; i++) {
-            assertEquals("Actual and expected values are not the same!", items.get(i), kapuaListResult.getItems().get(i));
-        }
+
+        Assert.assertEquals(testSize, kapuaListResult.getSize());
+
         kapuaListResult.clearItems();
-        assertEquals("Actual and expected values are not the same!", 0, kapuaListResult.getSize());
+
+        Assert.assertEquals(0, kapuaListResult.getSize());
     }
 
     @Test
-    public void sortTest() {
-        List<AbstractKapuaEntity> items = new ArrayList<>();
-        BigInteger eid1 = new BigInteger(64, RANDOM);
-        BigInteger eid2 = new BigInteger(64, RANDOM);
-        BigInteger eid3 = new BigInteger(64, RANDOM);
+    public void getFirstItemTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
 
-        AbstractKapuaEntity item1 = Mockito.mock(AbstractKapuaEntity.class);
-        Mockito.when(item1.getScopeId()).thenReturn(new KapuaEid(eid1));
-        items.add(item1);
+        AbstractKapuaEntity kapuaEntity1 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity1);
 
-        AbstractKapuaEntity item2 = Mockito.mock(AbstractKapuaEntity.class);
-        Mockito.when(item2.getScopeId()).thenReturn(new KapuaEid(eid2));
-        items.add(item2);
+        AbstractKapuaEntity kapuaEntity2 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity2);
 
-        AbstractKapuaEntity item3 = Mockito.mock(AbstractKapuaEntity.class);
-        Mockito.when(item3.getScopeId()).thenReturn(new KapuaEid(eid3));
-        items.add(item3);
+        Assert.assertEquals(kapuaEntity1, kapuaListResult.getFirstItem());
+        Assert.assertNotEquals(kapuaEntity2, kapuaListResult.getFirstItem());
+    }
 
-        kapuaListResult.addItem(items.get(0));
-        kapuaListResult.addItem(items.get(1));
-        kapuaListResult.addItem(items.get(2));
+    @Test
+    public void getItemsTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
 
-        kapuaListResult.sort(new SortByHashCode());
-        items.sort(new SortByHashCode());
+        AbstractKapuaEntity kapuaEntity1 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity1);
 
-        for (int i = 0; i < items.size(); i++) {
-            assertEquals("Actual and expected values are not the same!", items.get(i), kapuaListResult.getItem(i));
+        AbstractKapuaEntity kapuaEntity2 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity2);
+
+        Assert.assertEquals(2, kapuaListResult.getItems().size());
+        Assert.assertEquals(kapuaEntity1, kapuaListResult.getItems().get(0));
+        Assert.assertEquals(kapuaEntity2, kapuaListResult.getItems().get(1));
+    }
+
+    @Test
+    public void getItemsPredicateTest() {
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        for (int i = 0; i < testSize; i++) {
+            AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
+            Mockito.when(kapuaEntity.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(i))));
+
+            kapuaListResult.addItem(kapuaEntity);
+        }
+
+        List<AbstractKapuaEntity> filteredItems = kapuaListResult.getItems(i -> i.getId().getId().longValue() % 2 == 0);
+
+        Assert.assertEquals(5, filteredItems.size());
+        for (AbstractKapuaEntity filteredItem : filteredItems) {
+            Assert.assertEquals(0, filteredItem.getId().getId().longValue() % 2);
         }
     }
 
     @Test
-    public void getTotalCountTest() {
-        Long totalCount = null;
-        kapuaListResult.setTotalCount(totalCount);
-        assertNull(kapuaListResult.getTotalCount());
-        Long totalCountMax = Long.MAX_VALUE;
-        kapuaListResult.setTotalCount(totalCountMax);
-        assertEquals("Actual and expected values are not the same!", totalCountMax, kapuaListResult.getTotalCount());
-        Long totalCountMin = Long.MIN_VALUE;
-        kapuaListResult.setTotalCount(totalCountMin);
-        assertEquals("Actual and expected values are not the same!", totalCountMin, kapuaListResult.getTotalCount());
+    public void getItemsAsMapKeyTest() {
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        for (int i = 0; i < testSize; i++) {
+            AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
+            Mockito.when(kapuaEntity.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(i))));
+
+            kapuaListResult.addItem(kapuaEntity);
+        }
+
+        Map<KapuaId, AbstractKapuaEntity> itemsAsMap = kapuaListResult.getItemsAsMap(AbstractKapuaEntity::getId);
+
+        Assert.assertEquals(kapuaListResult.getSize(), itemsAsMap.size());
+        for (Map.Entry<KapuaId, AbstractKapuaEntity> entry : itemsAsMap.entrySet()) {
+            Assert.assertEquals(entry.getKey(), entry.getValue().getId());
+        }
     }
-}
 
-class SortByHashCode implements Comparator<AbstractKapuaEntity> {
+    @Test
+    public void getItemsAsMapKeyValueTest() {
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
 
-    public int compare(AbstractKapuaEntity a, AbstractKapuaEntity b) {
-        return (a.getScopeId().hashCode() - b.getScopeId().hashCode());
+        for (int i = 0; i < testSize; i++) {
+            AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
+            Mockito.when(kapuaEntity.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(i))));
+
+            kapuaListResult.addItem(kapuaEntity);
+        }
+
+        Map<KapuaId, KapuaId> itemsAsMap = kapuaListResult.getItemsAsMap(AbstractKapuaEntity::getId, AbstractKapuaEntity::getId);
+
+        Assert.assertEquals(kapuaListResult.getSize(), itemsAsMap.size());
+        for (Map.Entry<KapuaId, KapuaId> entry : itemsAsMap.entrySet()) {
+            Assert.assertEquals(entry.getKey(), entry.getValue());
+        }
+    }
+
+
+    @Test
+    public void getItemTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        AbstractKapuaEntity kapuaEntity1 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity1);
+
+        AbstractKapuaEntity kapuaEntity2 = Mockito.mock(AbstractKapuaEntity.class);
+        kapuaListResult.addItem(kapuaEntity2);
+
+        Assert.assertEquals(kapuaEntity1, kapuaListResult.getItem(0));
+        Assert.assertEquals(kapuaEntity2, kapuaListResult.getItem(1));
+    }
+
+    @Test
+    public void getSizeTest() {
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        for (int i = 0; i < testSize; i++) {
+            kapuaListResult.addItem(Mockito.mock(AbstractKapuaEntity.class));
+        }
+
+        Assert.assertEquals(testSize, kapuaListResult.getSize());
+    }
+
+    @Test
+    public void isEmptyTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+        Assert.assertTrue(kapuaListResult.isEmpty());
+
+        kapuaListResult.addItem(Mockito.mock(AbstractKapuaEntity.class));
+        Assert.assertFalse(kapuaListResult.isEmpty());
+    }
+
+    @Test
+    public void setGetLimitExceededTrueTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+        kapuaListResult.setLimitExceeded(true);
+
+        Assert.assertTrue(kapuaListResult.isLimitExceeded());
+    }
+
+    @Test
+    public void setGetLimitExceededFalseTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+        kapuaListResult.setLimitExceeded(false);
+
+        Assert.assertFalse(kapuaListResult.isLimitExceeded());
+    }
+
+    @Test
+    public void setGetTotalCountDefaultTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        Assert.assertNull(kapuaListResult.getTotalCount());
+    }
+
+    @Test
+    public void setGetTotalCountValueTest() {
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+        kapuaListResult.setTotalCount(10L);
+
+        Assert.assertEquals(new Long(10L), kapuaListResult.getTotalCount());
+    }
+
+    @Test
+    public void sortComparatorTest() {
+        int testSize = 10;
+        KapuaListResultImpl<AbstractKapuaEntity> kapuaListResult = new KapuaListResultImpl<>();
+
+        // Add the max value
+        AbstractKapuaEntity kapuaEntityMax = Mockito.mock(AbstractKapuaEntity.class);
+        Mockito.when(kapuaEntityMax.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(Long.MAX_VALUE))));
+        kapuaListResult.addItem(kapuaEntityMax);
+
+        // Add values between
+        for (int i = 0; i < testSize; i++) {
+            AbstractKapuaEntity kapuaEntity = Mockito.mock(AbstractKapuaEntity.class);
+            Mockito.when(kapuaEntity.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(RANDOM.nextLong()))));
+
+            kapuaListResult.addItem(kapuaEntity);
+        }
+
+        // Add the min value
+        AbstractKapuaEntity kapuaEntityMin = Mockito.mock(AbstractKapuaEntity.class);
+        Mockito.when(kapuaEntityMin.getId()).thenReturn(new KapuaEid(new BigInteger(String.valueOf(Long.MIN_VALUE))));
+        kapuaListResult.addItem(kapuaEntityMin);
+
+        // Check result are not sorted by `.getId()` ascending
+        Assert.assertTrue(kapuaListResult.getItem(0).getId().getId().compareTo(kapuaListResult.getItem(1).getId().getId()) > 0);
+        Assert.assertTrue(kapuaListResult.getItem(0).getId().getId().compareTo(kapuaListResult.getItem(kapuaListResult.getSize() - 1).getId().getId()) > 0);
+
+        // Sort
+        kapuaListResult.sort(Comparator.comparing(i -> i.getId().getId()));
+
+        // Check result are sorted
+        for (int i = 0; i < kapuaListResult.getSize() - 1; i++) {
+            Assert.assertTrue(kapuaListResult.getItem(i).getId().getId().compareTo(kapuaListResult.getItem(i + 1).getId().getId()) < 0);
+        }
     }
 }

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -25,12 +25,15 @@ import javax.xml.bind.annotation.XmlType;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+import java.util.function.Predicate;
 
 /**
  * {@link KapuaListResult} definition.
  *
- * @param <E> {@link KapuaEntity} domain
- * @since 1.0
+ * @param <E> {@link KapuaEntity} type.
+ * @since 1.0.0
  */
 @XmlRootElement(name = "result")
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -70,6 +73,43 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
     @XmlElementWrapper(name = "items")
     @XmlElement(name = "item")
     List<E> getItems();
+
+    /**
+     * Gets the {@link KapuaEntity}s that matched the {@link KapuaQuery#getPredicate()} and applies even more filtering.
+     * <p>
+     * This is meant to be used to filter result when is not possible to do so with {@link KapuaQuery#getPredicate()}s.
+     *
+     * @param filter The filter to apply to select results.
+     * @return The filtered {@link KapuaEntity}s that matched the {@link KapuaQuery#getPredicate()}.
+     * @since 1.6.0
+     */
+    List<E> getItems(@NotNull Predicate<E> filter);
+
+    /**
+     * Gets a {@link Map} whose {@link Map#keySet()} are generated from the given {@link Map.Entry#getKey()} mapper {@link Function}.
+     * The {@link Map#values()} are the {@link KapuaEntity}s themself.
+     * <p>
+     * This is like invoking {@link #getItemsAsMap(Function, Function)} whose value mapper returns the {@link KapuaEntity} itself.
+     *
+     * @param keyMapper The {@link Function} which defines the {@link Map.Entry#getKey()} for each {@link Map.Entry}
+     * @param <K>       The type of the {@link Map.Entry#getKey()}
+     * @return The {@link Map} generated according to the mapping {@link Map.Entry#getKey()} {@link Function}.
+     * @since 1.6.0
+     */
+    <K> Map<K, E> getItemsAsMap(@NotNull Function<E, K> keyMapper);
+
+    /**
+     * Gets a {@link Map} whose {@link Map#keySet()} are generated from the given {@link Map.Entry#getKey()} mapper {@link Function}.
+     * The {@link Map#values()} are generated from the given {@link Map.Entry#getValue()} mapper {@link Function}.
+     *
+     * @param keyMapper   The {@link Function} which defines the {@link Map.Entry#getKey()} for each {@link Map.Entry}
+     * @param valueMapper The {@link Function} which defines the {@link Map.Entry#getValue()} for each {@link Map.Entry}
+     * @param <K>         The type of the {@link Map.Entry#getKey()}
+     * @param <V>         The type of the {@link Map.Entry#getValue()}
+     * @return The {@link Map} generated according to the mapping {@link Function}s.
+     * @since 1.6.0
+     */
+    <K, V> Map<K, V> getItemsAsMap(@NotNull Function<E, K> keyMapper, @NotNull Function<E, V> valueMapper);
 
     /**
      * Gets the {@link KapuaEntity} at the given position in the {@link KapuaListResult}.


### PR DESCRIPTION
This PR improves features offered by the `KapuaListResult` to allow common filtering operations on `KapuaListResultItem`s, like filtering for a field or obtain a key-value map from the items (like resolution of User.id - User.name).

**Related Issue**
_None_

**Description of the solution adopted**
Added few `interface` methods and implemented them using Java Streams.

**Screenshots**
_None_

**Any side note on the changes made**
Improved test on the `KapuaListResultImpl`.