### PR TITLE
Distributed locator and package exclusions

### DIFF
--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -59,6 +59,10 @@
             <artifactId>guice</artifactId>
         </dependency>
         <dependency>
+            <groupId>com.google.inject.extensions</groupId>
+            <artifactId>guice-multibindings</artifactId>
+        </dependency>
+        <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>
         </dependency>

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/AbstractKapuaModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/AbstractKapuaModule.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.core;
+
+import com.google.inject.AbstractModule;
+
+public abstract class AbstractKapuaModule extends AbstractModule {
+
+    public AbstractKapuaModule() {}
+
+    @Override
+    protected final void configure() {
+        configureModule();
+    }
+
+    protected abstract void configureModule();
+}

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -13,17 +13,26 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
+import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.core.ServiceModuleConfiguration;
 import org.eclipse.kapua.commons.core.ServiceModuleProvider;
+import org.eclipse.kapua.commons.util.ResourceUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaLocatorErrorCodes;
 import org.eclipse.kapua.model.KapuaObjectFactory;
 import org.eclipse.kapua.service.KapuaService;
+import org.reflections.Reflections;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import com.google.inject.Binding;
 import com.google.inject.ConfigurationException;
@@ -36,20 +45,26 @@ import com.google.inject.Key;
  */
 public class GuiceLocatorImpl extends KapuaLocator {
 
-    private final Injector injector;
+    private static final Logger LOGGER = LoggerFactory.getLogger(GuiceLocatorImpl.class);
+
+    // Default service resource file from which the managed services are read
+    private static final String SERVICE_RESOURCE = "locator.xml";
+
+    private Injector injector;
 
     public GuiceLocatorImpl() {
-        injector = Guice.createInjector(new KapuaModule());
-        ServiceModuleConfiguration.setConfigurationProvider(() -> {
-            return injector.getInstance(ServiceModuleProvider.class);
-        });
+        this(SERVICE_RESOURCE);
     }
 
     public GuiceLocatorImpl(String resourceName) {
-        injector = Guice.createInjector(new KapuaModule(resourceName));
-        ServiceModuleConfiguration.setConfigurationProvider(() -> {
-            return injector.getInstance(ServiceModuleProvider.class);
-        });
+        try {
+            injector = init(resourceName);
+            ServiceModuleConfiguration.setConfigurationProvider(() -> {
+                return injector.getInstance(ServiceModuleProvider.class);
+            });
+        } catch (Exception exc) {
+            throw new KapuaRuntimeException(KapuaLocatorErrorCodes.INVALID_CONFIGURATION, exc);
+        }
     }
 
     @Override
@@ -91,4 +106,54 @@ public class GuiceLocatorImpl extends KapuaLocator {
         return servicesList;
     }
 
+    private Injector init(String resourceName) throws Exception {
+        // Find locator configuration file. Exactly one non empty is expected.
+        List<URL> locatorConfigurations = Arrays.asList(ResourceUtils.getResource(resourceName));
+        if (locatorConfigurations.isEmpty()) {
+            throw new Exception(String.format("Locator configurations in %s are empty"));
+        }
+
+        // Read configurations from locator file
+        URL locatorConfigURL = locatorConfigurations.get(0);
+        LocatorConfig locatorConfig = LocatorConfig.fromURL(locatorConfigURL);
+
+        // Scan packages listed in to find Kapua modules
+        Collection<String> packageNames = locatorConfig.getIncludedPackageNames();
+        Reflections reflections = new Reflections(packageNames);
+        Set<Class<? extends AbstractKapuaModule>> moduleClazzes = reflections.getSubTypesOf(AbstractKapuaModule.class);
+        // Instantiate Kapua modules 
+        List<AbstractKapuaModule> modules = new ArrayList<>();
+        LOGGER.info("====== Loading Kapua Modules =====");
+        for(Class<? extends AbstractKapuaModule> moduleClazz:moduleClazzes) {
+            if (isExcluded(moduleClazz.getName(), locatorConfig.getExcludedPackageNames())) {
+                LOGGER.debug("Module: {}, found .... EXCLUDED", moduleClazz.getSimpleName());
+                continue;
+            }
+            LOGGER.info("Module: {}, found ....", moduleClazz.getSimpleName());
+            modules.add(moduleClazz.newInstance());
+            LOGGER.info("Module: {}, load DONE", moduleClazz.getSimpleName());
+        }
+        // KapuaModule will be removed as soon as bindings will be moved to local modules
+        LOGGER.info("Module: {}, found ....", KapuaModule.class.getSimpleName());
+        modules.add(new KapuaModule(resourceName));
+        LOGGER.info("Module: {}, load DONE", KapuaModule.class.getSimpleName());
+        LOGGER.info("==================================");
+        return Guice.createInjector(modules);
+    }
+
+    private boolean isExcluded(String className, Collection<String> excludedPkgs) {
+        if (className == null || className.isEmpty()) {
+            return true;
+        }
+        if (excludedPkgs == null || excludedPkgs.isEmpty()) {
+            return false;
+        }
+        for(String pkg:excludedPkgs) {
+            LOGGER.info("Excluded: {}", pkg);
+            if (className.startsWith(pkg)) {
+                return true;
+            }
+        }
+        return false;
+    }
 }

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/KapuaModule.java
@@ -13,17 +13,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.guice;
 
-import com.google.common.collect.ImmutableSet;
-import com.google.common.reflect.ClassPath;
-import com.google.common.reflect.ClassPath.ClassInfo;
-import com.google.inject.AbstractModule;
-import com.google.inject.Singleton;
-import com.google.inject.matcher.Matcher;
-import com.google.inject.matcher.Matchers;
-import com.google.inject.multibindings.Multibinder;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.net.URL;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
 import org.aopalliance.intercept.MethodInterceptor;
 import org.eclipse.kapua.KapuaErrorCodes;
 import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.commons.core.InterceptorBind;
 import org.eclipse.kapua.commons.core.ServiceModule;
 import org.eclipse.kapua.commons.core.ServiceModuleProvider;
@@ -35,18 +37,15 @@ import org.eclipse.kapua.service.KapuaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.lang.annotation.Annotation;
-import java.lang.reflect.Method;
-import java.net.URL;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.ImmutableSet;
+import com.google.common.reflect.ClassPath;
+import com.google.common.reflect.ClassPath.ClassInfo;
+import com.google.inject.Singleton;
+import com.google.inject.matcher.Matcher;
+import com.google.inject.matcher.Matchers;
+import com.google.inject.multibindings.Multibinder;
 
-public class KapuaModule extends AbstractModule {
+public class KapuaModule extends AbstractKapuaModule {
 
     private static final Logger logger = LoggerFactory.getLogger(KapuaModule.class);
 
@@ -55,19 +54,16 @@ public class KapuaModule extends AbstractModule {
      */
     private static final String SERVICE_RESOURCE = "locator.xml";
 
-    private String resourceName;
-    private Map<Class<?>, Multibinder<Class<?>>> multibinders;
+    private final String resourceName;
 
-    public KapuaModule() {
-        this(SERVICE_RESOURCE);
-    }
+    private Multibinder<ServiceModule> serviceModulesBindings;
 
     public KapuaModule(final String resourceName) {
         this.resourceName = resourceName;
     }
 
     @Override
-    protected void configure() {
+    protected void configureModule() {
         try {
             // Find locator configuration file
             List<URL> locatorConfigurations = Arrays.asList(ResourceUtils.getResource(resourceName));
@@ -80,7 +76,10 @@ public class KapuaModule extends AbstractModule {
             LocatorConfig locatorConfig = LocatorConfig.fromURL(locatorConfigURL);
 
             // Packages are supposed to contain service implementations
-            Collection<String> packageNames = locatorConfig.getPackageNames();
+            Collection<String> packageNames = locatorConfig.getIncludedPackageNames();
+
+            // Packages that are excluded
+            Collection<String> excludedPkgNames = locatorConfig.getExcludedPackageNames();
 
             ClassLoader classLoader = this.getClass().getClassLoader();
             ClassPath classPath = ClassPath.from(classLoader);
@@ -93,6 +92,10 @@ public class KapuaModule extends AbstractModule {
                 // Use the class loader of this (module) class
                 ImmutableSet<ClassInfo> classInfos = classPath.getTopLevelClassesRecursive(packageName);
                 for (ClassInfo classInfo : classInfos) {
+                    if (isExcluded(classInfo.getName(), excludedPkgNames)) {
+                         logger.trace("CLASS: {} ... excluded by configuration, skip", classInfo.getName());
+                         continue;
+                    }
                     logger.trace("CLASS: {}", classInfo.getName());
                     Class<?> theClass = Class.forName(classInfo.getName(), !initialize, classLoader);
                     KapuaProvider serviceProvider = theClass.getAnnotation(KapuaProvider.class);
@@ -152,7 +155,7 @@ public class KapuaModule extends AbstractModule {
             }
 
             // Bind interceptors
-            logger.info("Binding interceptors ..");
+            logger.info("Binding interceptors ...");
             for (Class<?> clazz : providers) {
                 if (MethodInterceptor.class.isAssignableFrom(clazz)) {
                     InterceptorBind annotation = clazz.getAnnotation(InterceptorBind.class);
@@ -169,21 +172,18 @@ public class KapuaModule extends AbstractModule {
                 }
             }
 
-            multibinders = new HashMap<>();
-
             bind(ServiceModuleProvider.class).to(ServiceModuleProviderImpl.class).in(Singleton.class);
+            serviceModulesBindings = Multibinder.newSetBinder(binder(), ServiceModule.class);
 
-            // Bind service modules
-            logger.info("Binding service modules ..");
+            logger.info("Binding service modules ...");
             //cast is safe by design
-            multibinders.put(ServiceModule.class, (Multibinder<Class<?>>) Multibinder.newSetBinder(binder(), (Class<?>) ServiceModule.class));
             for (Class<?> clazz : providers) {
                 if (ServiceModule.class.isAssignableFrom(clazz)) {
                     ComponentResolver resolver = ComponentResolver.newInstance(ServiceModule.class, clazz);
                     //cast is safe by design
                     if (resolver.getProvidedClass().isAssignableFrom(clazz)) {
                         logger.info("Assignable from {}", resolver.getProvidedClass(), clazz);
-                        multibinders.get(resolver.getProvidedClass()).addBinding().to(resolver.getImplementationClass());
+                        serviceModulesBindings.addBinding().to(resolver.getImplementationClass());
                     }
                     continue;
                 }
@@ -201,4 +201,20 @@ public class KapuaModule extends AbstractModule {
     protected void bindInterceptor(Matcher<? super Class<?>> classMatcher, Matcher<? super Method> methodMatcher, MethodInterceptor... interceptors) {
         super.bindInterceptor(classMatcher, Matchers.not(SyntheticMethodMatcher.getInstance()).and(methodMatcher), interceptors);
     }
+
+    private boolean isExcluded(String className, Collection<String> excludedPkgs) {
+        if (className == null || className.isEmpty()) {
+            return true;
+        }
+        if (excludedPkgs == null || excludedPkgs.isEmpty()) {
+            return false;
+        }
+        for(String pkg:excludedPkgs) {
+            if (className.startsWith(pkg)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
 }

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/LocatorConfig.java
@@ -27,15 +27,18 @@ import org.eclipse.kapua.locator.KapuaLocatorException;
 public class LocatorConfig {
 
     private static final String SERVICE_RESOURCE_INTERFACES = "provided.api";
-    private static final String SERVICE_RESOURCE_PACKAGES = "packages.package";
+    private static final String SERVICE_RESOURCE_INCLUDED_PACKAGES = "packages.package";
+    private static final String SERVICE_RESOURCE_EXCLUDED_PACKAGES = "packages.excludes.package";
 
     private final URL url;
-    private final List<String> packageNames;
+    private final List<String> includedPkgNames;
+    private final List<String> excludedPkgNames;
     private final List<String> providedInterfaceNames;
 
-    private LocatorConfig(final URL url, final List<String> packageNames, final List<String> providedInterfaceNames) {
+    private LocatorConfig(final URL url, final List<String> includedPkgNames, final List<String> excludedPkgNames, final List<String> providedInterfaceNames) {
         this.url = url;
-        this.packageNames = packageNames;
+        this.includedPkgNames = includedPkgNames;
+        this.excludedPkgNames = excludedPkgNames;
         this.providedInterfaceNames = providedInterfaceNames;
     }
 
@@ -45,7 +48,8 @@ public class LocatorConfig {
             throw new IllegalArgumentException("'url' must not be null");
         }
 
-        final List<String> packageNames = new ArrayList<>();
+        final List<String> includedPkgNames = new ArrayList<>();
+        final List<String> excludedPkgNames = new ArrayList<>();
         final List<String> providedInterfaceNames = new ArrayList<>();
 
         final XMLConfiguration xmlConfig;
@@ -55,12 +59,20 @@ public class LocatorConfig {
             throw new KapuaLocatorException(KapuaLocatorErrorCodes.INVALID_CONFIGURATION, e);
         }
 
-        Object props = xmlConfig.getProperty(SERVICE_RESOURCE_PACKAGES);
+        Object props = xmlConfig.getProperty(SERVICE_RESOURCE_INCLUDED_PACKAGES);
         if (props instanceof Collection<?>) {
-            addAllStrings(packageNames, (Collection<?>) props);
+            addAllStrings(includedPkgNames, (Collection<?>) props);
         }
         if (props instanceof String) {
-            packageNames.add((String) props);
+            includedPkgNames.add((String) props);
+        }
+
+        props = xmlConfig.getProperty(SERVICE_RESOURCE_EXCLUDED_PACKAGES);
+        if (props instanceof Collection<?>) {
+            addAllStrings(excludedPkgNames, (Collection<?>) props);
+        }
+        if (props instanceof String) {
+            excludedPkgNames.add((String) props);
         }
 
         props = xmlConfig.getProperty(SERVICE_RESOURCE_INTERFACES);
@@ -71,7 +83,7 @@ public class LocatorConfig {
             providedInterfaceNames.add((String) props);
         }
 
-        return new LocatorConfig(url, Collections.unmodifiableList(packageNames), Collections.unmodifiableList(providedInterfaceNames));
+        return new LocatorConfig(url, Collections.unmodifiableList(includedPkgNames), Collections.unmodifiableList(excludedPkgNames), Collections.unmodifiableList(providedInterfaceNames));
     }
 
     private static void addAllStrings(final List<String> list, Collection<?> other) {
@@ -86,8 +98,12 @@ public class LocatorConfig {
         return url;
     }
 
-    public Collection<String> getPackageNames() {
-        return packageNames;
+    public Collection<String> getIncludedPackageNames() {
+        return includedPkgNames;
+    }
+
+    public Collection<String> getExcludedPackageNames() {
+        return excludedPkgNames;
     }
 
     public Collection<String> getProvidedInterfaceNames() {

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -16,15 +16,19 @@ package org.eclipse.kapua.locator.internal;
 import java.util.List;
 
 import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.core.ServiceModuleConfiguration;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.locator.KapuaLocatorErrorCodes;
 import org.eclipse.kapua.locator.guice.GuiceLocatorImpl;
 import org.eclipse.kapua.locator.guice.TestService;
 import org.eclipse.kapua.locator.internal.guice.FactoryA;
 import org.eclipse.kapua.locator.internal.guice.FactoryB;
+import org.eclipse.kapua.locator.internal.guice.FactoryC;
+import org.eclipse.kapua.locator.internal.guice.FactoryD;
 import org.eclipse.kapua.locator.internal.guice.ServiceA;
 import org.eclipse.kapua.locator.internal.guice.ServiceB;
 import org.eclipse.kapua.locator.internal.guice.ServiceC;
+import org.eclipse.kapua.locator.internal.guice.extra.ServiceE;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.junit.Assert;
@@ -61,20 +65,45 @@ public class GuiceLocatorImplTest {
         Assert.assertNotNull(locator.getService(ServiceA.class));
     }
 
-    @Test(expected = KapuaRuntimeException.class)
-    public void shouldProvideServiceB() {
-        Assert.assertNotNull(locator.getService(ServiceB.class));
-    }
-
     @Test
     public void shouldProvideFactoryA() {
         Assert.assertNotNull(locator.getFactory(FactoryA.class));
     }
 
     @Test
-    public void shouldNotFindFactory() {
+    public void shouldProvideServiceB() {
+        Assert.assertNotNull(locator.getService(ServiceB.class));
+    }
+
+    @Test
+    public void shouldProvideFactoryB() {
+        Assert.assertNotNull(locator.getFactory(FactoryB.class));
+    }
+
+    @Test
+    public void shouldProvideOneServiceModule() {
+        Assert.assertEquals(1, ServiceModuleConfiguration.getServiceModules().size());
+    }
+
+    @Test(expected = KapuaRuntimeException.class)
+    public void shouldNotProvideServiceC() {
+        Assert.assertNotNull(locator.getService(ServiceC.class));
+    }
+
+    @Test(expected = KapuaRuntimeException.class)
+    public void shouldNotProvideFactoryC() {
+        Assert.assertNotNull(locator.getFactory(FactoryC.class));
+    }
+
+    @Test(expected = KapuaRuntimeException.class)
+    public void shouldNotProvideServiceD() {
+        Assert.assertNotNull(locator.getService(ServiceE.class));
+    }
+
+    @Test
+    public void shouldNotFindFactoryD() {
         try {
-            locator.getFactory(FactoryB.class);
+            locator.getFactory(FactoryD.class);
             Assert.fail("getFactory must throw an exception for un-bound factories");
         } catch (KapuaRuntimeException e) {
             Assert.assertEquals(KapuaLocatorErrorCodes.FACTORY_UNAVAILABLE, e.getCode());
@@ -86,12 +115,7 @@ public class GuiceLocatorImplTest {
     @Test
     public void shouldProvideAll() {
         List<KapuaService> result = locator.getServices();
-        Assert.assertEquals(1, result.size());
-
-        {
-            KapuaService service = result.get(0);
-            Assert.assertTrue(service instanceof ServiceA);
-        }
+        Assert.assertEquals(2, result.size());
     }
 
     @Test(expected = KapuaRuntimeException.class)

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryBImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryBImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Red Hat Inc and others
+ * Copyright (c) 2016, 2021 Red Hat Inc and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,23 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.locator.KapuaProvider;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
-
-    @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
-    }
-
+@KapuaProvider
+public class FactoryBImpl implements FactoryB {
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryD.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryD.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Red Hat Inc and others
+ * Copyright (c) 2016, 2021 Red Hat Inc and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,23 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.model.KapuaObjectFactory;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
-
-    @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
-    }
+public interface FactoryD extends KapuaObjectFactory {
 
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceLocatorModule.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceLocatorModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Red Hat Inc and others
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,27 +8,19 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *     Red Hat Inc - initial API and implementation
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
+public class GuiceLocatorModule extends AbstractKapuaModule {
 
     @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
+    protected void configureModule() {
+        bind(ServiceA.class).to(ServiceAImpl.class);
+        bind(FactoryA.class).to(FactoryAImpl.class);
     }
 
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceServiceModule.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceServiceModule.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.core.ServiceModule;
+import org.eclipse.kapua.locator.KapuaProvider;
+
+@KapuaProvider
+public class GuiceServiceModule implements ServiceModule {
+
+    @Override
+    public void start() throws KapuaException {
+        // TODO Auto-generated method stub
+    }
+
+    @Override
+    public void stop() throws KapuaException {
+        // TODO Auto-generated method stub
+    }
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceBImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceBImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Red Hat Inc and others
+ * Copyright (c) 2016, 2021 Red Hat Inc and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,23 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.locator.KapuaProvider;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
-
-    @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
-    }
-
+@KapuaProvider
+public class ServiceBImpl implements ServiceB {
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceD.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceD.java
@@ -12,23 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.service.KapuaService;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
-
-    @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
-    }
+public interface ServiceD extends KapuaService {
 
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceE.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceE.java
@@ -1,0 +1,19 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *     Red Hat Inc
+ *******************************************************************************/
+package org.eclipse.kapua.locator.internal.guice.extra;
+
+import org.eclipse.kapua.service.KapuaService;
+
+public interface ServiceE extends KapuaService {
+}

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceEImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceEImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2017, 2021 Red Hat Inc and others
+ * Copyright (c) 2016, 2021 Red Hat Inc and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,25 +10,10 @@
  * Contributors:
  *     Red Hat Inc - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.locator.internal.guice;
+package org.eclipse.kapua.locator.internal.guice.extra;
 
-import java.math.BigInteger;
+import org.eclipse.kapua.locator.KapuaProvider;
 
-import javax.inject.Singleton;
-
-import org.eclipse.kapua.model.id.KapuaId;
-
-@Singleton
-public class FactoryAImpl implements FactoryA {
-
-    @Override
-    public KapuaId newKapuaId(String shortId) {
-        return null;
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return null;
-    }
-
+@KapuaProvider
+public class ServiceEImpl implements ServiceE {
 }

--- a/locator/guice/src/test/resources/locator.xml
+++ b/locator/guice/src/test/resources/locator.xml
@@ -14,14 +14,38 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
+        <!-- 
+            Service/Factory A are bound via AbstractKapuaModule
+         -->
+        <!-- 
         <api>org.eclipse.kapua.locator.internal.guice.ServiceA</api>
         <api>org.eclipse.kapua.locator.internal.guice.FactoryA</api>
+         -->
+
+        <!-- 
+            Service/Factory B are bound via </api> element
+         -->
+        <api>org.eclipse.kapua.locator.internal.guice.ServiceB</api>
+        <api>org.eclipse.kapua.locator.internal.guice.FactoryB</api>
+        
+        <!-- 
+            Service/Factory E are excluded because of the package
+         -->
+        <api>org.eclipse.kapua.locator.internal.guice.extra.ServiceE</api>
+        
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>
         </provide>
     </provided>
     <packages>
-        <package>org.eclipse.kapua.locator.internal.guice</package>
+        <package>org.eclipse.kapua.locator.internal</package>
+        <excludes>
+         <!-- 
+            Service/Factory in org.eclipse.kapua.locator.internal.guice.extra
+            are excluded
+         -->
+         <package>org.eclipse.kapua.locator.internal.guice.extra</package>
+        </excludes>
     </packages>
 </locator-config>

--- a/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
+++ b/service/api/src/main/java/org/eclipse/kapua/locator/KapuaProvider.java
@@ -17,6 +17,15 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 
+/**
+ * A class annotated with @KapuaProvider is used by the KapuaLocator to 
+ * create a binding with its matching interface.
+ * @deprecated
+ * A new mechanism to create bindings between interfaces and implementations will
+ * be developed so that this annotation will be no longer necessary. It will be
+ * removed in a future version. 
+ */
+@Deprecated
 @Retention(RetentionPolicy.RUNTIME)
 @Target(ElementType.TYPE)
 public @interface KapuaProvider {


### PR DESCRIPTION
This pull request provides the capability to simplify the configuration of a Kapua application by defining Kapua services and factories in a single place in their own project and by removing the need to list implemented interfaces in the locator.xml file. It also allows exclusion of packages to be scanned. 

**Related Issue**
This PR fixes/closes _{#3370}_ _{#3371}_

**Description of the solution adopted**
Moved binding definition in multiple Guice modules located in each single project.

**Screenshots**
none

**Any side note on the changes made**
The solution has the benefit to increase the capabilities to use dependency injection within Kapua services and resources.