### PR TITLE
Implemented JobStepProperty.secret 

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/client/steps/JobStepAddDialog.java
@@ -343,6 +343,7 @@ public class JobStepAddDialog extends EntityAddEditDialog {
 
         textField.setAllowBlank(!property.getRequired());
         textField.setFieldLabel(property.getRequired() ? "* " + fieldLabel : fieldLabel);
+        textField.setPassword(property.getSecret());
 
         if (property.getMinLength() != null) {
             textField.setMinLength(property.getMinLength());

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/model/GwtJobStepProperty.java
@@ -48,6 +48,14 @@ public class GwtJobStepProperty extends KapuaBaseModel {
         set("required", required);
     }
 
+    public Boolean getSecret() {
+        return get("secret");
+    }
+
+    public void setSecret(Boolean secret) {
+        set("secret", secret);
+    }
+
     public String getExampleValue() {
         return get("exampleValue");
     }

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/shared/util/KapuaGwtJobModelConverter.java
@@ -86,6 +86,7 @@ public class KapuaGwtJobModelConverter {
             gwtJobStepProperty.setPropertyType(jobStepProperty.getPropertyType());
             gwtJobStepProperty.setPropertyValue(jobStepProperty.getPropertyValue());
             gwtJobStepProperty.setRequired(jobStepProperty.getRequired());
+            gwtJobStepProperty.setSecret(jobStepProperty.getSecret());
             gwtJobStepProperty.setExampleValue(jobStepProperty.getExampleValue());
             gwtJobStepProperty.setMinLength(jobStepProperty.getMinLength());
             gwtJobStepProperty.setMaxLength(jobStepProperty.getMaxLength());

--- a/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
+++ b/rest-api/resources/src/main/resources/openapi/jobStepDefinition/jobStepDefinition.yaml
@@ -34,6 +34,8 @@ components:
           type: string
         required:
           type: boolean
+        secret:
+          type: boolean
         exampleValue:
           type: string
           readOnly: true
@@ -98,10 +100,16 @@ components:
             name: assets
             propertyType: org.eclipse.kapua.service.device.management.asset.DeviceAssets
             required: true
+            secret: false
+          - name: password
+            propertyType: java.lang.String
+            required: true
+            secret: true
           - name: timeout
             propertyType: java.lang.Long
             propertyValue: '30000'
             required: false
+            secret: false
         stepType: TARGET
     jobStepDefinitionListResult:
       allOf:
@@ -145,10 +153,12 @@ components:
                     name: assets
                     propertyType: org.eclipse.kapua.service.device.management.asset.DeviceAssets
                     required: true
+                    secret: false
                   - name: timeout
                     propertyType: java.lang.Long
                     propertyValue: '30000'
                     required: false
+                    secret: false
                 stepType: TARGET
               - type: jobStepDefinition
                 id: Ag
@@ -164,8 +174,14 @@ components:
                   - name: bundleId
                     propertyType: java.lang.String
                     required: true
+                    secret: false
+                  - name: password
+                    propertyType: java.lang.String
+                    required: true
+                    secret: true
                   - name: timeout
                     propertyType: java.lang.Long
                     propertyValue: '30000'
                     required: false
+                    secret: false
                 stepType: TARGET

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -78,7 +78,7 @@ public interface JobStepProperty {
     void setExampleValue(String exampleValue);
 
     /**
-     * Gets whether or not this must have a {@link #getPropertyValue()}
+     * Gets whether this must have a {@link #getPropertyValue()}
      *
      * @return {@code true} if must have a {@link #getPropertyValue()}, {@code false} otherwise.
      * @since 1.5.0
@@ -86,12 +86,28 @@ public interface JobStepProperty {
     Boolean getRequired();
 
     /**
-     * Whether or not this must have a {@link #getPropertyValue()}
+     * Whether this must have a {@link #getPropertyValue()}
      *
      * @param required {@code true} if must have a {@link #getPropertyValue()}, {@code false} otherwise.
      * @since 1.5.0
      */
     void setRequired(Boolean required);
+
+    /**
+     * Gets whether this {@link #getPropertyValue()} is a secret that shouldn't be shown (i.e. passwords).
+     *
+     * @return {@code true} if {@link #getPropertyValue()} is a secret that shouldn't be shown, {@code false} otherwise.
+     * @since 1.6.0
+     */
+    Boolean getSecret();
+
+    /**
+     * Whether t{@link #getPropertyValue()} is a secret that shouldn't be shown (i.e. passwords).
+     *
+     * @param se {@code true} if {@link #getPropertyValue()} is a secret that shouldn't be shown, {@code false} otherwise.
+     * @since 1.6.0
+     */
+    void setSecret(Boolean se);
 
     /**
      * @return

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/definition/internal/JobStepPropertyImpl.java
@@ -38,6 +38,10 @@ public class JobStepPropertyImpl implements JobStepProperty {
     private Boolean required;
 
     @Basic
+    @Column(name = "secret", nullable = true, updatable = true)
+    private Boolean secret;
+
+    @Basic
     @Column(name = "example_value", nullable = true, updatable = true)
     private String propertyExampleValue;
 
@@ -69,6 +73,7 @@ public class JobStepPropertyImpl implements JobStepProperty {
         setPropertyType(jobStepProperty.getPropertyType());
         setPropertyValue(jobStepProperty.getPropertyValue());
         setRequired(jobStepProperty.getRequired());
+        setSecret(jobStepProperty.getSecret());
         setExampleValue(jobStepProperty.getExampleValue());
         setMinLength(jobStepProperty.getMinLength());
         setMaxLength(jobStepProperty.getMaxLength());
@@ -121,6 +126,20 @@ public class JobStepPropertyImpl implements JobStepProperty {
     @Override
     public void setRequired(Boolean required) {
         this.required = required;
+    }
+
+    @Override
+    public Boolean getSecret() {
+        if (secret == null) {
+            secret = Boolean.FALSE;
+        }
+
+        return secret;
+    }
+
+    @Override
+    public void setSecret(Boolean secret) {
+        this.secret = secret;
     }
 
     @Override

--- a/service/job/internal/src/main/resources/liquibase/1.6.0/changelog-job-1.6.0.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.6.0/changelog-job-1.6.0.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+        logicalFilePath="KapuaDB/changelog-job-1.6.0.xml">
+
+    <include relativeToChangelogFile="true" file="job_job_step_properties-secret.xml"/>
+    <include relativeToChangelogFile="true" file="job_job_step_definition_properties-secret.xml"/>
+
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_step_definition_properties-secret.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_step_definition_properties-secret.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-1.6.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_step_definition_properties-1.6.0_addSecret" author="eurotech">
+        <addColumn tableName="job_job_step_definition_properties">
+            <column name="secret" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_step_properties-secret.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_step_properties-secret.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2021 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                            http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
+
+        logicalFilePath="KapuaDB/changelog-job-1.6.0.xml">
+
+    <include relativeToChangelogFile="true" file="../common-properties.xml"/>
+
+    <changeSet id="changelog-job_step_properties-1.6.0_addSecret" author="eurotech">
+        <addColumn tableName="job_job_step_properties">
+            <column name="secret" type="boolean" defaultValueBoolean="false"/>
+        </addColumn>
+    </changeSet>
+</databaseChangeLog>

--- a/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
+++ b/service/job/internal/src/main/resources/liquibase/changelog-job-master.xml
@@ -21,5 +21,6 @@
     <include relativeToChangelogFile="true" file="./1.1.0/changelog-job-1.1.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.2.0/changelog-job-1.2.0.xml"/>
     <include relativeToChangelogFile="true" file="./1.5.0/changelog-job-1.5.0.xml"/>
+    <include relativeToChangelogFile="true" file="./1.6.0/changelog-job-1.6.0.xml"/>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR add a new field to the `JobStepProperty` named `secret` to allow defining that `JobStepProperty.value` should not be displayed when read from Web Console or REST API (i.e.: password, access keys etc)

**Related Issue**
_None_

**Description of the solution adopted**
Implemented the new field and changed the behaviour of the UI to hide the value inserted when `secret` is `true`

**Screenshots**
_None_

**Any side note on the changes made**
_None_
