### PR TITLE
Fixed NPE on TriggerService.find when Trigger does not exist

### DIFF
--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -44,6 +44,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -313,7 +314,11 @@ public class TriggerServiceImpl extends AbstractKapuaService implements TriggerS
         //
         // Do find
         Trigger trigger = entityManagerSession.doAction(em -> TriggerDAO.find(em, scopeId, triggerId));
-        adaptTrigger(trigger);
+
+        if (trigger != null) {
+            adaptTrigger(trigger);
+        }
+
         return trigger;
     }
 
@@ -431,7 +436,7 @@ public class TriggerServiceImpl extends AbstractKapuaService implements TriggerS
      * @throws KapuaException In case that {@link TriggerDefinition} is not found.
      * @since 1.1.0
      */
-    private void adaptTrigger(Trigger trigger) throws KapuaException {
+    private void adaptTrigger(@NotNull Trigger trigger) throws KapuaException {
         boolean converted = false;
         if (trigger.getRetryInterval() != null) {
             trigger.setTriggerDefinitionId(getIntervalJobTriggerDefinition().getId());


### PR DESCRIPTION
This PR fixes a NPE occurring when looking for a Trigger that has been deleted.

**Related Issue**
_None_

**Description of the solution adopted**
Just added a `null` check

**Screenshots**
_None_

**Any side note on the changes made**
_None_