### PR TITLE
Added missing JobEngineException error messages

### DIFF
--- a/job-engine/api/src/main/resources/job-engine-service-error-messages.properties
+++ b/job-engine/api/src/main/resources/job-engine-service-error-messages.properties
@@ -12,5 +12,15 @@
 #
 ###############################################################################
 INTERNAL_ERROR=An internal error occurred: {0}.
-JOB_STEP_MISSING=The Job does not have step configured.
-JOB_TARGET_MISSING=The Job does not have target configured.
+JOB_STEP_MISSING=The Job {0} in scope {1} does not have steps configured.
+JOB_TARGET_MISSING=The Job {0} in scope {1} does not have targets configured.
+JOB_TARGET_INVALID=The Job {0} in scope {1} cannot be started because at least one of the {2} Job Target is not a current Job Target. 
+JOB_ALREADY_RUNNING=The Job {0} in scope {1} cannot be started because it is already is already running.
+JOB_STARTING=The Job {0} in scope {1} cannot be started.
+JOB_RESUMING=The Job Execution {2} of Job {0} in scope {1} cannot be resumed.
+JOB_RUNNING=The Job {0} in scope {1} is running and the operation cannot be performed.
+JOB_CHECK_RUNNING=The Job {0} in scope {1} cannot be checked for running status.
+JOB_STOPPING=The Job {0} in scope {1} cannot be stopped.
+JOB_EXECUTION_STOPPING=The Job Execution {2} of Job {0} in scope {1} cannot be stopped.
+JOB_NOT_RUNNING=The Job {0} in scope {1} cannot be stopped because it is not running.
+CANNOT_CLEANUP_JOB_DATA=The Job Engine data for Job {0} in scope {1} cannot be cleaned up.


### PR DESCRIPTION
This PR adds the missing error messages to `job-engine-service-error-messages` resource bundle.

**Related Issue**
This PR completes #3382 

**Description of the solution adopted**
Just added the missing entries.

**Screenshots**
_None_

**Any side note on the changes made**
_None_