### PR TITLE
Account - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -15,9 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -15,9 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -15,9 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -15,9 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -15,9 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -14,9 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -43,9 +43,6 @@
         <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
         <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
 
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -15,9 +15,6 @@
 <locator-config>
     <provided>
 
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -14,9 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountFactoryImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.account.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.Account;
 import org.eclipse.kapua.service.account.AccountCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.account.AccountListResult;
 import org.eclipse.kapua.service.account.AccountQuery;
 import org.eclipse.kapua.service.account.Organization;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccountFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccountFactoryImpl implements AccountFactory {
 
     @Override

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.account.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.account.AccountFactory;
+import org.eclipse.kapua.service.account.AccountService;
+
+public class AccountModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(AccountService.class).to(AccountServiceImpl.class);
+        bind(AccountFactory.class).to(AccountFactoryImpl.class);
+    }
+}

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -29,7 +29,6 @@ import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.KapuaNamedEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
@@ -48,6 +47,7 @@ import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.persistence.TypedQuery;
 import java.util.Map;
 import java.util.Objects;
@@ -57,7 +57,7 @@ import java.util.Objects;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Account, AccountCreator, AccountService, AccountListResult, AccountQuery, AccountFactory>
         implements AccountService {
 

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -22,9 +22,6 @@
         <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
         <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
 
-        <api>org.eclipse.kapua.service.account.AccountFactory</api>
-        <api>org.eclipse.kapua.service.account.AccountService</api>
-
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
 


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3390, i.e. move Account bindings from the locator.xml file to local module.

**Description of the solution adopted**
* removed all references in the locator.xml files regarding AccountService and AccountFactory
* replaced the deprecated `@KapuaProvider` annotation with the inject annotation `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations