### PR TITLE
Tag - Move bindings to local module 

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -74,9 +74,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -64,9 +64,6 @@
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
         <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -126,9 +126,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -76,9 +76,6 @@
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
         <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -71,9 +71,6 @@
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -130,8 +130,6 @@
                                         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
                                         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 -->
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
 
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -135,9 +135,6 @@
 
         <api>org.eclipse.kapua.service.stream.StreamService</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.job.JobFactory</api>
         <api>org.eclipse.kapua.service.job.JobService</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -135,9 +135,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-
         <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.user.UserService</api>
 

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagFactoryImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.tag.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.tag.Tag;
 import org.eclipse.kapua.service.tag.TagCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.tag.TagFactory;
 import org.eclipse.kapua.service.tag.TagListResult;
 import org.eclipse.kapua.service.tag.TagQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link TagFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class TagFactoryImpl implements TagFactory {
 
     @Override

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagModule.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.tag.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.tag.TagFactory;
+import org.eclipse.kapua.service.tag.TagService;
+
+public class TagModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(TagService.class).to(TagServiceImpl.class);
+        bind(TagFactory.class).to(TagFactoryImpl.class);
+    }
+}

--- a/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
+++ b/service/tag/internal/src/main/java/org/eclipse/kapua/service/tag/internal/TagServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaMaxNumberOfItemsReachedException;
 import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResourceLimitedService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -35,6 +34,7 @@ import org.eclipse.kapua.service.tag.TagQuery;
 import org.eclipse.kapua.service.tag.TagService;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 //import org.eclipse.kapua.locator.KapuaLocator;
 
@@ -43,7 +43,7 @@ import javax.inject.Inject;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class TagServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Tag, TagCreator, TagService, TagListResult, TagQuery, TagFactory> implements TagService {
 
     @Inject

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.tag.TagService</api>
-        <api>org.eclipse.kapua.service.tag.TagFactory</api>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3391, i.e. move Tag bindings from the `locator.xml` file to local module.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding `TagService` and `TagFactory`
* replaced the deprecated `@KapuaProvider` annotation with the inject annotation `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations