### PR TITLE
User - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -71,9 +71,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -61,9 +61,6 @@
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
         <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -123,9 +123,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -73,9 +73,6 @@
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
         <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -68,9 +68,6 @@
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -128,9 +128,6 @@
                                         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 -->
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <!--        <api>org.eclipse.kapua.service.stream.StreamService</api>-->
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -43,9 +43,6 @@
         <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
         <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -14,10 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -132,9 +132,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.service.stream.StreamService</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -27,9 +27,6 @@
 
         <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
 
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
     </provided>

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserFactoryImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.user.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link UserFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class UserFactoryImpl implements UserFactory {
 
     @Override

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.user.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.user.UserFactory;
+import org.eclipse.kapua.service.user.UserService;
+
+public class UserModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(UserService.class).to(UserServiceImpl.class);
+        bind(UserFactory.class).to(UserFactoryImpl.class);
+    }
+}

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -29,7 +29,6 @@ import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.event.ServiceEvent;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -49,12 +48,13 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import java.util.Objects;
 
 /**
  * {@link UserService} implementation.
  */
-@KapuaProvider
+@Singleton
 public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<User, UserCreator, UserService, UserListResult, UserQuery, UserFactory> implements UserService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(UserServiceImpl.class);

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.user.UserService</api>
-        <api>org.eclipse.kapua.service.user.UserFactory</api>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3392, i.e. move User bindings from the `locator.xml` file to local module.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding `UserService` and `UserFactory`
* replaced the deprecated `@KapuaProvider` annotation with the inject annotation `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations