### PR TITLE
Authorization - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -26,23 +26,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -26,23 +26,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -27,23 +27,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -22,23 +22,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -22,23 +22,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -25,23 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -24,25 +24,6 @@
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
         <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -25,23 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -25,23 +25,6 @@
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
         <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessInfoService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessPermissionService</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.access.AccessRoleService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupFactory</api>
-        <api>org.eclipse.kapua.service.authorization.group.GroupService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionFactory</api>
-        <api>org.eclipse.kapua.service.authorization.role.RolePermissionService</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -15,11 +15,8 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -17,11 +17,6 @@
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
 
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
-
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
 

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -15,9 +15,7 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -18,12 +18,10 @@
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
+
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authorization.access.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessInfo;
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
 import org.eclipse.kapua.service.authorization.access.AccessInfoListResult;
 import org.eclipse.kapua.service.authorization.access.AccessInfoQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccessInfoFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessInfoFactoryImpl implements AccessInfoFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessInfoServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -48,12 +47,14 @@ import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizatio
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccessInfoService} implementation based on JPA.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessInfoServiceImpl extends AbstractKapuaService implements AccessInfoService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AccessInfoServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.access.shiro;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionCreator;
@@ -20,12 +19,14 @@ import org.eclipse.kapua.service.authorization.access.AccessPermissionFactory;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionListResult;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccessPermissionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessPermissionFactoryImpl implements AccessPermissionFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -38,6 +37,7 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.authorization.permission.shiro.PermissionValidator;
 import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerFactory;
 
+import javax.inject.Singleton;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -48,7 +48,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessPermissionServiceImpl extends AbstractKapuaService implements AccessPermissionService {
 
     public AccessPermissionServiceImpl() {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authorization.access.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.access.AccessRole;
 import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.authorization.access.AccessRoleFactory;
 import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
 import org.eclipse.kapua.service.authorization.access.AccessRoleQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccessRoleFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessRoleFactoryImpl implements AccessRoleFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -41,12 +40,14 @@ import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerF
 import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizationErrorCodes;
 import org.eclipse.kapua.service.authorization.shiro.exception.KapuaAuthorizationException;
 
+import javax.inject.Singleton;
+
 /**
  * {@link AccessRole} service implementation.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class AccessRoleServiceImpl extends AbstractKapuaService implements AccessRoleService {
 
     public AccessRoleServiceImpl() {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authorization.domain.shiro;
 
 import org.apache.commons.lang.NotImplementedException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.domain.Domain;
 import org.eclipse.kapua.service.authorization.domain.DomainCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.authorization.domain.DomainFactory;
 import org.eclipse.kapua.service.authorization.domain.DomainListResult;
 import org.eclipse.kapua.service.authorization.domain.DomainQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DomainFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DomainFactoryImpl implements DomainFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainRegistryServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -35,12 +34,14 @@ import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerF
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DomainRegistryService} implementation.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DomainRegistryServiceImpl extends AbstractKapuaService implements DomainRegistryService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DomainRegistryServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authorization.group.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.authorization.group.GroupCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.authorization.group.GroupFactory;
 import org.eclipse.kapua.service.authorization.group.GroupListResult;
 import org.eclipse.kapua.service.authorization.group.GroupQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link GroupFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class GroupFactoryImpl implements GroupFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/group/shiro/GroupServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResource
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -40,13 +39,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link GroupService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class GroupServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Group, GroupCreator, GroupService, GroupListResult, GroupQuery, GroupFactory> implements GroupService {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/permission/shiro/PermissionFactoryImpl.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.permission.shiro;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.domain.Domain;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 
+import javax.inject.Singleton;
+
 /**
  * {@link PermissionFactory} implementation.
  */
-@KapuaProvider
+@Singleton
 public class PermissionFactoryImpl implements PermissionFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authorization.role.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.role.Role;
 import org.eclipse.kapua.service.authorization.role.RoleCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.authorization.role.RoleListResult;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
 import org.eclipse.kapua.service.authorization.role.RoleQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link RoleFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class RoleFactoryImpl implements RoleFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.role.shiro;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authorization.role.RolePermission;
 import org.eclipse.kapua.service.authorization.role.RolePermissionCreator;
@@ -20,12 +19,14 @@ import org.eclipse.kapua.service.authorization.role.RolePermissionFactory;
 import org.eclipse.kapua.service.authorization.role.RolePermissionListResult;
 import org.eclipse.kapua.service.authorization.role.RolePermissionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link RolePermissionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class RolePermissionFactoryImpl implements RolePermissionFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -40,6 +39,7 @@ import org.eclipse.kapua.service.authorization.role.RolePermissionService;
 import org.eclipse.kapua.service.authorization.role.RoleService;
 import org.eclipse.kapua.service.authorization.shiro.AuthorizationEntityManagerFactory;
 
+import javax.inject.Singleton;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -50,7 +50,7 @@ import java.util.Map;
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class RolePermissionServiceImpl extends AbstractKapuaService implements RolePermissionService {
 
     private static final RoleService ROLE_SERVICE = KapuaLocator.getInstance().getService(RoleService.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/role/shiro/RoleServiceImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -46,13 +45,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link RoleService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class RoleServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Role, RoleCreator, RoleService, RoleListResult, RoleQuery, RoleFactory> implements RoleService {
 
     private static final Logger LOG = LoggerFactory.getLogger(RoleServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationModule.java
@@ -1,0 +1,74 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authorization.shiro;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.authorization.AuthorizationService;
+import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
+import org.eclipse.kapua.service.authorization.access.AccessInfoService;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionFactory;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionService;
+import org.eclipse.kapua.service.authorization.access.AccessRoleFactory;
+import org.eclipse.kapua.service.authorization.access.AccessRoleService;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessInfoServiceImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionServiceImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleFactoryImpl;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleServiceImpl;
+import org.eclipse.kapua.service.authorization.domain.DomainFactory;
+import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
+import org.eclipse.kapua.service.authorization.domain.shiro.DomainFactoryImpl;
+import org.eclipse.kapua.service.authorization.domain.shiro.DomainRegistryServiceImpl;
+import org.eclipse.kapua.service.authorization.group.GroupFactory;
+import org.eclipse.kapua.service.authorization.group.GroupService;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupFactoryImpl;
+import org.eclipse.kapua.service.authorization.group.shiro.GroupServiceImpl;
+import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.authorization.permission.shiro.PermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.RoleFactory;
+import org.eclipse.kapua.service.authorization.role.RolePermissionFactory;
+import org.eclipse.kapua.service.authorization.role.RolePermissionService;
+import org.eclipse.kapua.service.authorization.role.RoleService;
+import org.eclipse.kapua.service.authorization.role.shiro.RoleFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionFactoryImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RolePermissionServiceImpl;
+import org.eclipse.kapua.service.authorization.role.shiro.RoleServiceImpl;
+
+public class AuthorizationModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(AuthorizationService.class).to(AuthorizationServiceImpl.class);
+
+        bind(RoleService.class).to(RoleServiceImpl.class);
+        bind(RoleFactory.class).to(RoleFactoryImpl.class);
+
+        bind(DomainRegistryService.class).to(DomainRegistryServiceImpl.class);
+        bind(DomainFactory.class).to(DomainFactoryImpl.class);
+
+        bind(PermissionFactory.class).to(PermissionFactoryImpl.class);
+
+        bind(AccessInfoService.class).to(AccessInfoServiceImpl.class);
+        bind(AccessInfoFactory.class).to(AccessInfoFactoryImpl.class);
+        bind(AccessPermissionService.class).to(AccessPermissionServiceImpl.class);
+        bind(AccessPermissionFactory.class).to(AccessPermissionFactoryImpl.class);
+        bind(AccessRoleService.class).to(AccessRoleServiceImpl.class);
+        bind(AccessRoleFactory.class).to(AccessRoleFactoryImpl.class);
+
+        bind(RolePermissionService.class).to(RolePermissionServiceImpl.class);
+        bind(RolePermissionFactory.class).to(RolePermissionFactoryImpl.class);
+
+        bind(GroupService.class).to(GroupServiceImpl.class);
+        bind(GroupFactory.class).to(GroupFactoryImpl.class);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
@@ -12,26 +12,26 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authorization.shiro;
 
-import java.util.Arrays;
-import java.util.List;
-import java.util.stream.Collectors;
-
 import org.apache.shiro.SecurityUtils;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaUnauthenticatedException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.shiro.exception.SubjectUnauthorizedException;
+
+import javax.inject.Singleton;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 
 /**
  * {@link AuthorizationService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AuthorizationServiceImpl implements AuthorizationService {
 
     @Override

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -14,14 +14,9 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authorization.role.RoleService</api>
-        <api>org.eclipse.kapua.service.authorization.role.RoleFactory</api>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -15,11 +15,8 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permission.PermissionFactory</api>
+
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -16,10 +16,6 @@
     <provided>
         <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authorization.AuthorizationService</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainFactory</api>
-        <api>org.eclipse.kapua.service.authorization.domain.DomainRegistryService</api>
-        <api>org.eclipse.kapua.service.authorization.permissio.PermissionFactory</api>
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3397, i.e. move Authorization bindings from the `locator.xml` file to local module.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding authorization services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations