### PR TITLE
Fix timeout and random failures on QAs

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -24,13 +24,7 @@ jobs:
             ${{ runner.os }}-maven-
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
-      - uses: satackey/action-docker-layer-caching@v0.0.11  # docker images cache
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}  # cache is valid only for current run on the current repository
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
+      - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build-kapua
@@ -46,19 +40,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@brokerAcl" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-tag:
@@ -79,7 +67,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@tag" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-broker:
@@ -96,19 +84,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@broker" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-device:
@@ -125,17 +107,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
+      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@device" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-device-management:
@@ -152,19 +130,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@deviceManagement" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-connection:
@@ -181,19 +153,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@connection" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-datastore:
@@ -210,19 +176,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@datastore" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-user:
@@ -243,7 +203,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@user" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-userIntegrationBase:
@@ -260,19 +220,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-userIntegration:
@@ -289,19 +243,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-security:
@@ -322,7 +270,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@security" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobs:
@@ -343,7 +291,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobs" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobsIntegrationBase:
@@ -360,19 +308,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobsIntegration:
@@ -389,19 +331,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerService:
@@ -418,19 +354,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerService" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerServiceIntegrationBase:
@@ -447,19 +377,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerServiceIntegration:
@@ -476,19 +400,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-account:
@@ -509,7 +427,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@account" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStepDefinitions:
@@ -526,19 +444,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStepDefinitions" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStartOfflineDevice:
@@ -555,19 +467,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOfflineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStartOnlineDevice:
@@ -584,19 +490,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOnlineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOfflineDevice:
@@ -613,19 +513,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOfflineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOnlineDevice:
@@ -642,19 +536,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOnlineDeviceSecondPart:
@@ -671,19 +559,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDeviceSecondPart" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineServiceStop:
@@ -700,19 +582,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineServiceStop" verify
       - run: bash <(curl -s https://codecov.io/bash)
   junit-tests:
@@ -733,7 +609,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - run: bash <(curl -s https://codecov.io/bash)
   build-javadoc:

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -49,8 +49,7 @@ Feature: Device Registry Integration
     And A birth message from device "device_1"
     When I search for the device "device_1" in account "AccountA"
     Then I find 1 device
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 1 device event
+    When I search for events from device "device_1" in account "AccountA" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -81,8 +80,7 @@ Feature: Device Registry Integration
       | clientId | displayName | modelId         | serialNumber |
       | device_1 | testGateway | ReliaGate 10-20 | 12341234ABC  |
     And A birth message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 1 device event
+    When I search for events from device "device_1" in account "AccountA" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -111,8 +109,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     And A birth message from device "device_1"
     And A birth message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -170,8 +167,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And A disconnect message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     And I logout
 
@@ -202,8 +198,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And A missing message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "MISSING"
     And I logout
 
@@ -234,8 +229,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And An application message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "APPLICATION"
     And I logout
 

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -134,5 +134,5 @@ Scenario: Job execution factory sanity checks
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -252,5 +252,5 @@ Scenario: Init Security Context for all scenarios
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobStepServiceI9n.feature
@@ -172,5 +172,5 @@ Scenario: Step factory sanity checks
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -162,5 +162,5 @@ Scenario: Job target factory sanity checks
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -35,8 +35,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
@@ -50,13 +49,9 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -69,8 +64,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
@@ -87,13 +81,9 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -108,8 +98,7 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
@@ -151,13 +140,9 @@ Feature: Job Engine Service - Keystore Step Definitions
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 3 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    And I confirm job target has step index 3 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -51,10 +51,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -85,10 +82,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -119,10 +113,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -153,10 +144,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -187,10 +175,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -221,10 +206,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -255,10 +237,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -300,10 +279,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -341,10 +317,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -381,10 +354,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -421,10 +391,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -461,10 +428,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -501,10 +465,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -541,10 +502,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -581,10 +539,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -617,10 +572,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -653,10 +605,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -689,10 +638,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -725,10 +671,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -761,10 +704,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -797,10 +737,7 @@ Feature: JobEngineService tests for restarting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -844,10 +781,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -887,10 +821,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -930,10 +861,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -973,10 +901,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1016,10 +941,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1059,10 +981,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1102,10 +1021,7 @@ Feature: JobEngineService tests for restarting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -38,8 +38,7 @@ Feature: JobEngineService restart job tests with online device
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -50,19 +49,12 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then KuraMock is disconnected
     And I logout
 
@@ -81,8 +73,7 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -94,19 +85,12 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And KuraMock is disconnected
@@ -127,8 +111,7 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -140,19 +123,12 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And KuraMock is disconnected
@@ -172,8 +148,7 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     Then Packages are requested and 1 package is received
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -184,19 +159,12 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then Packages are requested and 0 packages are received
     And KuraMock is disconnected
     And I logout
@@ -220,8 +188,7 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -237,19 +204,12 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then KuraMock is disconnected
     And I logout
 
@@ -269,8 +229,7 @@ Feature: JobEngineService restart job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -289,19 +248,12 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 or more events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -337,17 +289,11 @@ Feature: JobEngineService restart job tests with online device
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
     And I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then KuraMock is disconnected
     And I logout
@@ -379,17 +325,11 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -423,17 +363,11 @@ Feature: JobEngineService restart job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -465,17 +399,11 @@ Feature: JobEngineService restart job tests with online device
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 2 or more events are found
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
@@ -516,17 +444,11 @@ Feature: JobEngineService restart job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
     Then KuraMock is disconnected
@@ -567,17 +489,11 @@ Feature: JobEngineService restart job tests with online device
     Then No exception was thrown
     And I search the database for created job steps and I find 2
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 4 or more events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -40,8 +40,7 @@ Feature: JobEngineService restart job tests with online device - second part
     And I get the KuraMock device after 5 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -52,19 +51,12 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     And KuraMock is disconnected
@@ -84,8 +76,7 @@ Feature: JobEngineService restart job tests with online device - second part
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -96,19 +87,12 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     When I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
     And I logout
@@ -128,8 +112,7 @@ Feature: JobEngineService restart job tests with online device - second part
     And I get the KuraMock device after 5 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "ASSET"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -140,19 +123,12 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     Then KuraMock is disconnected
@@ -178,8 +154,7 @@ Feature: JobEngineService restart job tests with online device - second part
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Command "pwd" is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "COMMAND"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -194,19 +169,12 @@ Feature: JobEngineService restart job tests with online device - second part
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     When KuraMock is disconnected
@@ -228,8 +196,7 @@ Feature: JobEngineService restart job tests with online device - second part
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -245,19 +212,12 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 14 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
@@ -293,17 +253,11 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -333,17 +287,11 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
     When I create a new step entity from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
@@ -375,17 +323,11 @@ Feature: JobEngineService restart job tests with online device - second part
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
     When I create a new step entity from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -428,17 +370,11 @@ Feature: JobEngineService restart job tests with online device - second part
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I confirm job target has step index 1 and status "PROCESS_OK"
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -477,17 +413,11 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 14 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -51,10 +51,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -85,10 +82,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -121,10 +115,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -165,10 +156,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -206,10 +194,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -241,10 +226,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -283,10 +265,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -335,10 +314,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -384,10 +360,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -434,9 +407,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     And I start a job
     And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -484,10 +455,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -534,10 +502,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -584,10 +549,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -636,10 +598,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -680,11 +639,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -717,11 +672,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -755,11 +706,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I add 2 devices to Kura Mock
@@ -797,11 +744,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -834,11 +777,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -871,11 +810,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -908,11 +843,7 @@ Feature: JobEngineService tests for starting job with offline device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -956,11 +887,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1001,11 +928,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1046,11 +969,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I add 2 devices to Kura Mock
@@ -1095,11 +1014,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1139,11 +1054,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1183,11 +1094,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1227,11 +1134,7 @@ Feature: JobEngineService tests for starting job with offline device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -38,8 +38,7 @@ Feature: JobEngineService start job tests with online device
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob"
     And I create a new job target item
@@ -51,13 +50,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -76,8 +71,7 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -89,13 +83,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
     And A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     When KuraMock is disconnected
@@ -116,8 +106,7 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -129,13 +118,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And KuraMock is disconnected
@@ -156,8 +141,7 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     When Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -168,13 +152,9 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     Then I create a new step entity from the existing creator
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     And Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -195,8 +175,7 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -208,13 +187,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
     And KuraMock is disconnected
     And I logout
@@ -234,8 +209,7 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "ASSET"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -247,13 +221,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And KuraMock is disconnected
@@ -273,8 +243,7 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -286,13 +255,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
     And I logout
@@ -316,8 +281,7 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     Then The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -333,13 +297,9 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
     When KuraMock is disconnected
     And I logout
@@ -360,8 +320,7 @@ Feature: JobEngineService start job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -379,13 +338,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -408,8 +363,7 @@ Feature: JobEngineService start job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Command "pwd" is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -424,13 +378,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     When KuraMock is disconnected
@@ -452,8 +402,7 @@ Feature: JobEngineService start job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
@@ -468,13 +417,9 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
@@ -511,11 +456,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    Then I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     When KuraMock is disconnected
     And I logout
@@ -547,11 +489,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -585,11 +524,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_FAILED" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 2 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
@@ -623,11 +559,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -658,11 +591,8 @@ Feature: JobEngineService start job tests with online device
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
     When I create a new step entity from the existing creator
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -696,11 +626,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items and I confirm the executed jobs is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -732,11 +659,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
@@ -767,11 +691,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And  I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
@@ -812,11 +733,8 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
     When KuraMock is disconnected
@@ -856,11 +774,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entity from the existing creator
     And I search the database for created job steps and I find 2
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 4 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -899,11 +814,8 @@ Feature: JobEngineService start job tests with online device
     When I create a new step entities from the existing creator
     And I search the database for created job steps and I find 2
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 5 events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -942,11 +854,8 @@ Feature: JobEngineService start job tests with online device
     And I search the database for created job steps and I find 2
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -44,8 +44,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -70,10 +69,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And Packages are requested and 2 packages are received
@@ -97,8 +94,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -123,10 +119,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And Packages are requested and 2 packages are received
@@ -149,8 +143,7 @@ Feature: JobEngineService stop job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -175,10 +168,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     And Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -200,8 +191,7 @@ Feature: JobEngineService stop job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Packages are requested and 1 packages is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -226,10 +216,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     Then Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -251,8 +239,7 @@ Feature: JobEngineService stop job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -277,10 +264,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 2 packages are received
@@ -308,8 +293,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -330,10 +314,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And Packages are requested and 2 packages are received
@@ -357,8 +339,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -381,10 +362,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And Packages are requested and 0 packages are received
@@ -407,8 +386,7 @@ Feature: JobEngineService stop job tests with online device
     And I get the KuraMock devices after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -431,10 +409,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -456,8 +432,7 @@ Feature: JobEngineService stop job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Packages are requested and 1 packages is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -480,10 +455,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     And Packages are requested and 0 packages are received
@@ -507,8 +480,7 @@ Feature: JobEngineService stop job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -531,10 +503,8 @@ Feature: JobEngineService stop job tests with online device
     And I search for the last job target in the database
     And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 2 packages are received

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -42,8 +42,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -61,15 +60,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I logout
 
@@ -92,8 +86,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -111,14 +104,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -141,8 +130,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -161,15 +149,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I logout
 
@@ -192,8 +175,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -213,13 +195,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -243,8 +222,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -262,22 +240,16 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     When Device is connected
     And I wait 14 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
     And I wait 3 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 6 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 6 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -300,8 +272,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -312,21 +283,16 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     When Device is connected
     And I wait 3 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     Then KuraMock is disconnected
     And I wait 3 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -787,5 +787,5 @@ Scenario: Init Security Context for all scenarios
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -192,8 +192,7 @@ Scenario: Initialize test environment
       | 1       | delete     |
     And I logout
     Given I login as user with name "user1" and password "User@10031995"
-    When I search for events from device "device_1" in account "kapua-sys"
-    Then I find 1 device events
+    When I search for events from device "device_1" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And No exception was thrown
     And I logout
@@ -1643,5 +1642,5 @@ Scenario: Initialize test environment
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -214,5 +214,5 @@ Scenario: Initialize test environment
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context


### PR DESCRIPTION
**Brief description of the PR.**
see description

**Related Issue**
fix #3393

**Description of the solution adopted**
Removed docker cache to make available containers to test steps since this causes random failures (429 error)
Job steps widely used wait steps with fixed amount of time. The major part of them are no more present and replaced with a while loop with a timeout. In this way the stability of the tests is improved.

**Screenshots**
none

**Any side note on the changes made**
none
