### PR TITLE
Authentication - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -15,17 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -247,6 +247,7 @@
                 <include>${pom.groupId}:kapua-locator-guice</include>
                 <include>${pom.groupId}:kapua-message-api</include>
                 <include>${pom.groupId}:kapua-message-internal</include>
+                <include>${pom.groupId}:kapua-openid-api</include>
                 <include>${pom.groupId}:kapua-rest-api-core</include>
                 <include>${pom.groupId}:kapua-security-authentication-api</include>
                 <include>${pom.groupId}:kapua-security-authorization-api</include>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -229,12 +229,10 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-commons</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-openid-api</artifactId>
         </dependency>
-
     </dependencies>
     <build>
         <plugins>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -229,6 +229,12 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-commons</artifactId>
         </dependency>
+
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-openid-api</artifactId>
+        </dependency>
+
     </dependencies>
     <build>
         <plugins>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -15,17 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -15,18 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.registration.RegistrationService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -15,13 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -15,13 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -14,17 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -14,16 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -14,17 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -14,17 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.CredentialService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory</api>
-        <api>org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenService</api>
-        <api>org.eclipse.kapua.service.authentication.token.AccessTokenFactory</api>
-
         <api>org.eclipse.kapua.service.certificate.CertificateService</api>
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -14,9 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
-
         <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
         <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
 

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -19,7 +19,6 @@
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
 
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -19,8 +19,6 @@
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
 
-        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
@@ -21,10 +20,12 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link MfaOptionFactory} implementation.
  */
-@KapuaProvider
+@Singleton
 public class MfaOptionFactoryImpl implements MfaOptionFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -28,7 +28,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -67,6 +66,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.imageio.ImageIO;
+import javax.inject.Singleton;
 import java.awt.Color;
 import java.awt.Graphics;
 import java.awt.image.BufferedImage;
@@ -81,7 +81,7 @@ import java.util.UUID;
 /**
  * {@link MfaOptionService} implementation.
  */
-@KapuaProvider
+@Singleton
 public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOptionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MfaOptionServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeCreator;
@@ -21,10 +20,12 @@ import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactor
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeListResult;
 import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link ScratchCodeFactory} implementation.
  */
-@KapuaProvider
+@Singleton
 public class ScratchCodeFactoryImpl implements ScratchCodeFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/ScratchCodeServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -42,12 +41,13 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.List;
 
 /**
  * {@link ScratchCodeService} implementation.
  */
-@KapuaProvider
+@Singleton
 public class ScratchCodeServiceImpl extends AbstractKapuaService implements ScratchCodeService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(ScratchCodeServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.credential.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
@@ -23,6 +22,7 @@ import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -30,7 +30,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class CredentialFactoryImpl implements CredentialFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.commons.util.KapuaExceptionUtils;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.domain.Actions;
@@ -55,6 +54,7 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.security.SecureRandom;
 import java.util.Map;
 import java.util.NoSuchElementException;
@@ -64,7 +64,7 @@ import java.util.NoSuchElementException;
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class CredentialServiceImpl extends AbstractKapuaConfigurableService implements CredentialService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(CredentialServiceImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationModule.java
@@ -1,0 +1,56 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.authentication.shiro;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
+import org.eclipse.kapua.service.authentication.CredentialsFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialService;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeFactory;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCodeService;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionFactoryImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionServiceImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeFactoryImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeServiceImpl;
+import org.eclipse.kapua.service.authentication.credential.shiro.CredentialFactoryImpl;
+import org.eclipse.kapua.service.authentication.credential.shiro.CredentialServiceImpl;
+import org.eclipse.kapua.service.authentication.registration.RegistrationService;
+import org.eclipse.kapua.service.authentication.shiro.registration.RegistrationServiceImpl;
+import org.eclipse.kapua.service.authentication.token.AccessTokenFactory;
+import org.eclipse.kapua.service.authentication.token.AccessTokenService;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenFactoryImpl;
+import org.eclipse.kapua.service.authentication.token.shiro.AccessTokenServiceImpl;
+
+public class AuthenticationModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(AuthenticationService.class).to(AuthenticationServiceShiroImpl.class);
+
+        bind(CredentialFactory.class).to(CredentialFactoryImpl.class);
+        bind(CredentialService.class).to(CredentialServiceImpl.class);
+        bind(CredentialsFactory.class).to(CredentialsFactoryImpl.class);
+
+        bind(MfaOptionFactory.class).to(MfaOptionFactoryImpl.class);
+        bind(MfaOptionService.class).to(MfaOptionServiceImpl.class);
+        bind(ScratchCodeFactory.class).to(ScratchCodeFactoryImpl.class);
+        bind(ScratchCodeService.class).to(ScratchCodeServiceImpl.class);
+
+        bind(AccessTokenFactory.class).to(AccessTokenFactoryImpl.class);
+        bind(AccessTokenService.class).to(AccessTokenServiceImpl.class);
+
+        bind(RegistrationService.class).to(RegistrationServiceImpl.class);
+    }
+}

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -33,7 +33,6 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.util.KapuaDelayUtil;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.predicate.AndPredicate;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate.Operator;
@@ -97,6 +96,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 
+import javax.inject.Singleton;
 import java.util.Date;
 import java.util.UUID;
 
@@ -105,7 +105,7 @@ import java.util.UUID;
  * <p>
  * since 1.0
  */
-@KapuaProvider
+@Singleton
 public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/CredentialsFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.authentication.AccessTokenCredentials;
 import org.eclipse.kapua.service.authentication.ApiKeyCredentials;
 import org.eclipse.kapua.service.authentication.CredentialsFactory;
@@ -20,13 +19,15 @@ import org.eclipse.kapua.service.authentication.JwtCredentials;
 import org.eclipse.kapua.service.authentication.RefreshTokenCredentials;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 
+import javax.inject.Singleton;
+
 /**
  * {@link CredentialsFactory} factory implementation.
  *
  * @since 1.0
  *
  */
-@KapuaProvider
+@Singleton
 public class CredentialsFactoryImpl implements CredentialsFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/registration/RegistrationServiceImpl.java
@@ -13,13 +13,9 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.shiro.registration;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Optional;
-import java.util.ServiceLoader;
-
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.locator.KapuaProvider;
+import org.eclipse.kapua.plugin.sso.openid.JwtProcessor;
+import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDException;
 import org.eclipse.kapua.security.registration.RegistrationProcessor;
 import org.eclipse.kapua.security.registration.RegistrationProcessorProvider;
 import org.eclipse.kapua.service.authentication.JwtCredentials;
@@ -28,11 +24,16 @@ import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticatio
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authentication.shiro.utils.JwtProcessors;
 import org.eclipse.kapua.service.user.User;
-import org.eclipse.kapua.plugin.sso.openid.JwtProcessor;
-import org.eclipse.kapua.plugin.sso.openid.exception.OpenIDException;
 import org.jose4j.jwt.consumer.JwtContext;
 
-@KapuaProvider
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.ServiceLoader;
+
+import javax.inject.Singleton;
+
+@Singleton
 public class RegistrationServiceImpl implements RegistrationService, AutoCloseable {
 
     private final JwtProcessor jwtProcessor;

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.authentication.token.shiro;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.authentication.token.AccessTokenCreator;
@@ -22,6 +21,7 @@ import org.eclipse.kapua.service.authentication.token.AccessTokenListResult;
 import org.eclipse.kapua.service.authentication.token.AccessTokenQuery;
 import org.eclipse.kapua.service.authentication.token.LoginInfo;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -29,7 +29,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessTokenFactoryImpl implements AccessTokenFactory {
 
     @Override

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/token/shiro/AccessTokenServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -35,6 +34,7 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -42,7 +42,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class AccessTokenServiceImpl extends AbstractKapuaService implements AccessTokenService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(AccessTokenServiceImpl.class);

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
         <api>org.eclipse.kapua.service.authentication.UsernamePasswordTokenFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.authentication.AuthenticationService</api>
-        <api>org.eclipse.kapua.service.authentication.CredentialsFactory</api>
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3399, i.e. move Authentication bindings from the `locator.xml` file to local module.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding authentication services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations