### PR TITLE
Fix timeout and random failures on QAs

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -24,13 +24,7 @@ jobs:
             ${{ runner.os }}-maven-
       - run: mvn -v
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
-      - uses: satackey/action-docker-layer-caching@v0.0.11  # docker images cache
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}  # cache is valid only for current run on the current repository
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
-      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
+      - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
   test-brokerAcl:
     needs: build-kapua
@@ -46,19 +40,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@brokerAcl" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-tag:
@@ -79,7 +67,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@tag" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-broker:
@@ -96,19 +84,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@broker" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-device:
@@ -125,17 +107,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
+      - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@device" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-device-management:
@@ -152,19 +130,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@deviceManagement" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-connection:
@@ -181,19 +153,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@connection" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-datastore:
@@ -210,19 +176,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@datastore" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-user:
@@ -243,7 +203,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@user" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-userIntegrationBase:
@@ -260,19 +220,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-userIntegration:
@@ -289,19 +243,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@userIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-security:
@@ -322,7 +270,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@security" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobs:
@@ -343,7 +291,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobs" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobsIntegrationBase:
@@ -360,19 +308,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobsIntegration:
@@ -389,19 +331,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobsIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerService:
@@ -418,19 +354,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerService" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerServiceIntegrationBase:
@@ -447,19 +377,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegrationBase" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-triggerServiceIntegration:
@@ -476,19 +400,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@triggerServiceIntegration" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-account:
@@ -509,7 +427,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@account" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStepDefinitions:
@@ -526,19 +444,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStepDefinitions" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStartOfflineDevice:
@@ -555,19 +467,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOfflineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineStartOnlineDevice:
@@ -584,19 +490,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineStartOnlineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOfflineDevice:
@@ -613,19 +513,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOfflineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOnlineDevice:
@@ -642,19 +536,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDevice" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineRestartOnlineDeviceSecondPart:
@@ -671,19 +559,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineRestartOnlineDeviceSecondPart" verify
       - run: bash <(curl -s https://codecov.io/bash)
   test-jobEngineServiceStop:
@@ -700,19 +582,13 @@ jobs:
           key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
           restore-keys: |
             ${{ runner.os }}-maven-
-      - uses: satackey/action-docker-layer-caching@v0.0.11
-        continue-on-error: true
-        with:
-          key: ${{ github.run_id }}-${{ github.run_number }}-docker-cache-{hash}
-          restore-keys: |
-            ${{ github.run_id }}-${{ github.run_number }}-docker-cache-
       - run: echo "127.0.0.1       message-broker" | sudo tee -a /etc/hosts
-      - run: docker images -a
+      - run: mvn -B ${BUILD_OPTS} -Pdocker -DskipTests clean install
       - uses: nick-invision/retry@v2.4.0
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='!org.eclipse.kapua.qa.markers.junit.JUnitTests' -Dcucumber.filter.tags="@jobEngineServiceStop" verify
       - run: bash <(curl -s https://codecov.io/bash)
   junit-tests:
@@ -733,7 +609,7 @@ jobs:
         with:
           timeout_minutes: 45
           retry_on: error
-          max_attempts: 3
+          max_attempts: 1
           command: ./ci-output.sh mvn -B ${BUILD_OPTS} ${CONFIG_OVERRIDES} -Dgroups='org.eclipse.kapua.qa.markers.junit.JUnitTests' verify
       - run: bash <(curl -s https://codecov.io/bash)
   build-javadoc:

--- a/pom.xml
+++ b/pom.xml
@@ -1952,6 +1952,12 @@
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-junit</artifactId>
                 <version>${artemis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.slf4j</groupId>
+                        <artifactId>slf4j-simple</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -306,11 +306,6 @@
         </dependency>
 
         <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>io.cucumber</groupId>
             <artifactId>cucumber-core</artifactId>
             <scope>test</scope>
@@ -385,6 +380,16 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+            <scope>test</scope>
         </dependency>
 
         <!-- needed by Elasticsearch -->

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -49,8 +49,7 @@ Feature: Device Registry Integration
     And A birth message from device "device_1"
     When I search for the device "device_1" in account "AccountA"
     Then I find 1 device
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 1 device event
+    When I search for events from device "device_1" in account "AccountA" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -81,8 +80,7 @@ Feature: Device Registry Integration
       | clientId | displayName | modelId         | serialNumber |
       | device_1 | testGateway | ReliaGate 10-20 | 12341234ABC  |
     And A birth message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 1 device event
+    When I search for events from device "device_1" in account "AccountA" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -111,8 +109,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     And A birth message from device "device_1"
     And A birth message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -170,8 +167,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And A disconnect message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     And I logout
 
@@ -202,8 +198,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And A missing message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "MISSING"
     And I logout
 
@@ -234,8 +229,7 @@ Feature: Device Registry Integration
       | integer | maxNumberChildEntities | 10    |
     Given A birth message from device "device_1"
     And An application message from device "device_1"
-    When I search for events from device "device_1" in account "AccountA"
-    Then I find 2 device events
+    When I search for events from device "device_1" in account "AccountA" I find 2 events within 30 seconds
     And The type of the last event is "APPLICATION"
     And I logout
 

--- a/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobExecutionServiceI9n.feature
@@ -134,5 +134,5 @@ Scenario: Job execution factory sanity checks
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobServiceI9n.feature
@@ -229,5 +229,5 @@ Feature: Job service CRUD tests
 
   @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/job/JobTargetsServiceI9n.feature
@@ -15,47 +15,47 @@
 @env_docker_base
 
 Feature: Job Target service CRUD tests
-    The Job service is responsible for maintaining a list of job targets.
+  The Job service is responsible for maintaining a list of job targets.
 
-@setup
-Scenario: Init Security Context for all scenarios
-  Given Init Jaxb Context
-  And Init Security Context
-  And Start base docker environment
+  @setup
+  Scenario: Init Security Context for all scenarios
+    Given Init Jaxb Context
+    And Init Security Context
+    And Start base docker environment
 
-Scenario: Regular target creation
+  Scenario: Regular target creation
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     Then No exception was thrown
     And The job target matches the creator
     Then I logout
 
-Scenario: Target with a null scope ID
+  Scenario: Target with a null scope ID
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given A null scope
     Given I expect the exception "KapuaIllegalNullArgumentException" with the text "scopeId"
     When I create a job with the name "TestJob"
     Then An exception was thrown
     Then I logout
 
-Scenario: Delete a job target
+  Scenario: Delete a job target
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     When I delete the last job target in the database
@@ -63,13 +63,13 @@ Scenario: Delete a job target
     Then There is no such job target item in the database
     Then I logout
 
-Scenario: Delete a job target twice
+  Scenario: Delete a job target twice
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     When I delete the last job target in the database
@@ -78,13 +78,13 @@ Scenario: Delete a job target twice
     Then An exception was thrown
     Then I logout
 
-Scenario: Create and count multiple job targets
+  Scenario: Create and count multiple job targets
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob"
     And A regular job target item
     And A regular job target item
@@ -94,13 +94,13 @@ Scenario: Create and count multiple job targets
     Then I count 4
     Then I logout
 
-Scenario: Query for the targets of a specific job
+  Scenario: Query for the targets of a specific job
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob1"
     And A regular job target item
     And A regular job target item
@@ -121,26 +121,26 @@ Scenario: Query for the targets of a specific job
     Then I count 4
     Then I logout
 
-Scenario: Update a job target step index
+  Scenario: Update a job target step index
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob1"
     And A regular job target item
     When I update the job target step number to 3
     Then The target step index is indeed 3
     Then I logout
 
-Scenario: Update a job target status
+  Scenario: Update a job target status
 
     Given I login as user with name "kapua-sys" and password "kapua-password"
     And I configure the job service
-        | type    | name                       | value |
-        | boolean | infiniteChildEntities      | true  |
-        | integer | maxNumberChildEntities     | 5     |
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 5     |
     Given I create a job with the name "TestJob1"
     And A regular job target item
     When I update the job target step status to "PROCESS_OK"
@@ -149,18 +149,11 @@ Scenario: Update a job target status
     Then The target step status is indeed "PROCESS_AWAITING"
     Then I logout
 
-#Scenario: Update a job target step exception
-#
-#    Given I create a job with the name "TestJob1"
-#    And A regular job target item
-#    When I update the job target step exception message to "RandomExceptionText"
-#    Then The target step exception message is indeed "RandomExceptionText"
-
-Scenario: Job target factory sanity checks
+  Scenario: Job target factory sanity checks
 
     When I test the sanity of the job target factory
 
-@teardown
+  @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceKeystoreStepDefinitionsI9n.feature
@@ -16,7 +16,7 @@
 
 Feature: Job Engine Service - Keystore Step Definitions
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -35,28 +35,23 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
     And Search for step definition with the name "Keystore Certificate Create"
-    And A regular step creator with the name "Keystore Certificate Create" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Certificate Create" and the following properties
       | name        | type             | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
       | keystoreId  | java.lang.String | SSLKeystore                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
       | alias       | java.lang.String | qaCertificate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
       | certificate | java.lang.String | -----BEGIN CERTIFICATE-----\nMIIFVzCCBD+gAwIBAgISA38CzQctm3+HkSyZPnDL8TFsMA0GCSqGSIb3DQEBCwUA\nMEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD\nExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xOTA3MTkxMDIxMTdaFw0x\nOTEwMTcxMDIxMTdaMBsxGTAXBgNVBAMTEG1xdHQuZWNsaXBzZS5vcmcwggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDQnt6ZBEZ/vDG0JLqVB45lO6xlLazt\nYpEqZlGBket6PtjUGLdE2XivTpjtUkERS1cvPBqT1DH/yEZ1CU7iT/gfZtZotR0c\nqEMogSGkmrN1sAV6Eb+xGT3sPm1WFeKZqKdzAScdULoweUgwbNXa9kAB1uaSYBTe\ncq2ynfxBKWL/7bVtoeXUOyyaiIxVPTYz5XgpjSUB+9ML/v/+084XhIKA/avGPOSi\nRHOB+BsqTGyGhDgAHF+CDrRt8U1preS9AKXUvZ0aQL+djV8Y5nXPQPR8c2wplMwL\n5W/YMrM/dBm64vclKQLVPyEPqMOLMqcf+LkfQi6WOH+JByJfywAlme6jAgMBAAGj\nggJkMIICYDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG\nAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFHc+PmokFlx8Fh/0Lob125ef\nfLNyMB8GA1UdIwQYMBaAFKhKamMEfd265tE5t6ZFZe/zqOyhMG8GCCsGAQUFBwEB\nBGMwYTAuBggrBgEFBQcwAYYiaHR0cDovL29jc3AuaW50LXgzLmxldHNlbmNyeXB0\nLm9yZzAvBggrBgEFBQcwAoYjaHR0cDovL2NlcnQuaW50LXgzLmxldHNlbmNyeXB0\nLm9yZy8wGwYDVR0RBBQwEoIQbXF0dC5lY2xpcHNlLm9yZzBMBgNVHSAERTBDMAgG\nBmeBDAECATA3BgsrBgEEAYLfEwEBATAoMCYGCCsGAQUFBwIBFhpodHRwOi8vY3Bz\nLmxldHNlbmNyeXB0Lm9yZzCCAQMGCisGAQQB1nkCBAIEgfQEgfEA7wB2AHR+2oMx\nrTMQkSGcziVPQnDCv/1eQiAIxjc1eeYQe8xWAAABbAn2/p8AAAQDAEcwRQIhAIBl\nIZC2ZCMDs7bkBQN79xNO84VFpe7bQcMeaqHsQH9jAiAYV5kdZBgl17M5RB44NQ+y\nY/WOF1PWOrNrP3XdeEo7HAB1ACk8UZZUyDlluqpQ/FgH1Ldvv1h6KXLcpMMM9OVF\nR/R4AAABbAn2/o4AAAQDAEYwRAIgNYxfY0bjRfjhXjjAgyPRSLKq4O5tWTd2W4mn\nCpE3aCYCIGeKPyuuo9tvHbyVKF4bsoN76FmnOkdsYE0MCKeKkUOkMA0GCSqGSIb3\nDQEBCwUAA4IBAQCB0ykl1N2U2BMhzFo6dwrECBSFO+ePV2UYGrb+nFunWE4MMKBb\ndyu7dj3cYRAFCM9A3y0H967IcY+h0u9FgZibmNs+y/959wcbr8F1kvgpVKDb1FGs\ncuEArADQd3X+4TMM+IeIlqbGVXv3mYPrsP78LmUXkS7ufhMXsD5GSbSc2Zp4/v0o\n3bsJz6qwzixhqg30tf6siOs9yrpHpPnDnbRrahbwnYTpm6JP0lK53GeFec4ckNi3\nzT5+hEVOZ4JYPb3xVXkzIjSWmnDVbwC9MFtRaER9MhugKmiAp8SRLbylD0GKOhSB\n2BDf6JrzhIddKxQ75KgMZE6FQaC3Bz1DFyrj\n-----END CERTIFICATE----- |
       | timeout     | java.lang.Long   | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -69,13 +64,12 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
     And Search for step definition with the name "Keystore Keypair Create"
-    And A regular step creator with the name "Keystore Keypair Create" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Keypair Create" and the following properties
       | name               | type              | value                                              |
       | keystoreId         | java.lang.String  | SSLKeystore                                        |
       | alias              | java.lang.String  | qaKeypair                                          |
@@ -84,16 +78,12 @@ Feature: Job Engine Service - Keystore Step Definitions
       | signatureAlgorithm | java.lang.String  | SHA256withRSA                                      |
       | attributes         | java.lang.String  | CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US |
       | timeout            | java.lang.Long    | 10000                                              |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -108,22 +98,21 @@ Feature: Job Engine Service - Keystore Step Definitions
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob - Keystore Steps"
     And I create a new job target item
     And Search for step definition with the name "Keystore Certificate Create"
-    And A regular step creator with the name "Keystore Certificate Create" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Certificate Create" and the following properties
       | name        | type             | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
       | keystoreId  | java.lang.String | SSLKeystore                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                          |
       | alias       | java.lang.String | qaCertificate                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        |
       | certificate | java.lang.String | -----BEGIN CERTIFICATE-----\nMIIFVzCCBD+gAwIBAgISA38CzQctm3+HkSyZPnDL8TFsMA0GCSqGSIb3DQEBCwUA\nMEoxCzAJBgNVBAYTAlVTMRYwFAYDVQQKEw1MZXQncyBFbmNyeXB0MSMwIQYDVQQD\nExpMZXQncyBFbmNyeXB0IEF1dGhvcml0eSBYMzAeFw0xOTA3MTkxMDIxMTdaFw0x\nOTEwMTcxMDIxMTdaMBsxGTAXBgNVBAMTEG1xdHQuZWNsaXBzZS5vcmcwggEiMA0G\nCSqGSIb3DQEBAQUAA4IBDwAwggEKAoIBAQDQnt6ZBEZ/vDG0JLqVB45lO6xlLazt\nYpEqZlGBket6PtjUGLdE2XivTpjtUkERS1cvPBqT1DH/yEZ1CU7iT/gfZtZotR0c\nqEMogSGkmrN1sAV6Eb+xGT3sPm1WFeKZqKdzAScdULoweUgwbNXa9kAB1uaSYBTe\ncq2ynfxBKWL/7bVtoeXUOyyaiIxVPTYz5XgpjSUB+9ML/v/+084XhIKA/avGPOSi\nRHOB+BsqTGyGhDgAHF+CDrRt8U1preS9AKXUvZ0aQL+djV8Y5nXPQPR8c2wplMwL\n5W/YMrM/dBm64vclKQLVPyEPqMOLMqcf+LkfQi6WOH+JByJfywAlme6jAgMBAAGj\nggJkMIICYDAOBgNVHQ8BAf8EBAMCBaAwHQYDVR0lBBYwFAYIKwYBBQUHAwEGCCsG\nAQUFBwMCMAwGA1UdEwEB/wQCMAAwHQYDVR0OBBYEFHc+PmokFlx8Fh/0Lob125ef\nfLNyMB8GA1UdIwQYMBaAFKhKamMEfd265tE5t6ZFZe/zqOyhMG8GCCsGAQUFBwEB\nBGMwYTAuBggrBgEFBQcwAYYiaHR0cDovL29jc3AuaW50LXgzLmxldHNlbmNyeXB0\nLm9yZzAvBggrBgEFBQcwAoYjaHR0cDovL2NlcnQuaW50LXgzLmxldHNlbmNyeXB0\nLm9yZy8wGwYDVR0RBBQwEoIQbXF0dC5lY2xpcHNlLm9yZzBMBgNVHSAERTBDMAgG\nBmeBDAECATA3BgsrBgEEAYLfEwEBATAoMCYGCCsGAQUFBwIBFhpodHRwOi8vY3Bz\nLmxldHNlbmNyeXB0Lm9yZzCCAQMGCisGAQQB1nkCBAIEgfQEgfEA7wB2AHR+2oMx\nrTMQkSGcziVPQnDCv/1eQiAIxjc1eeYQe8xWAAABbAn2/p8AAAQDAEcwRQIhAIBl\nIZC2ZCMDs7bkBQN79xNO84VFpe7bQcMeaqHsQH9jAiAYV5kdZBgl17M5RB44NQ+y\nY/WOF1PWOrNrP3XdeEo7HAB1ACk8UZZUyDlluqpQ/FgH1Ldvv1h6KXLcpMMM9OVF\nR/R4AAABbAn2/o4AAAQDAEYwRAIgNYxfY0bjRfjhXjjAgyPRSLKq4O5tWTd2W4mn\nCpE3aCYCIGeKPyuuo9tvHbyVKF4bsoN76FmnOkdsYE0MCKeKkUOkMA0GCSqGSIb3\nDQEBCwUAA4IBAQCB0ykl1N2U2BMhzFo6dwrECBSFO+ePV2UYGrb+nFunWE4MMKBb\ndyu7dj3cYRAFCM9A3y0H967IcY+h0u9FgZibmNs+y/959wcbr8F1kvgpVKDb1FGs\ncuEArADQd3X+4TMM+IeIlqbGVXv3mYPrsP78LmUXkS7ufhMXsD5GSbSc2Zp4/v0o\n3bsJz6qwzixhqg30tf6siOs9yrpHpPnDnbRrahbwnYTpm6JP0lK53GeFec4ckNi3\nzT5+hEVOZ4JYPb3xVXkzIjSWmnDVbwC9MFtRaER9MhugKmiAp8SRLbylD0GKOhSB\n2BDf6JrzhIddKxQ75KgMZE6FQaC3Bz1DFyrj\n-----END CERTIFICATE----- |
       | timeout     | java.lang.Long   | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And Search for step definition with the name "Keystore Keypair Create"
-    And A regular step creator with the name "Keystore Keypair Create" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Keypair Create" and the following properties
       | name               | type              | value                                              |
       | keystoreId         | java.lang.String  | SSLKeystore                                        |
       | alias              | java.lang.String  | qaKeypair                                          |
@@ -132,35 +121,31 @@ Feature: Job Engine Service - Keystore Step Definitions
       | signatureAlgorithm | java.lang.String  | SHA256withRSA                                      |
       | attributes         | java.lang.String  | CN=Let's Encrypt Authority X3,O=Let's Encrypt,C=US |
       | timeout            | java.lang.Long    | 10000                                              |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And Search for step definition with the name "Keystore Item Delete"
-    And A regular step creator with the name "Keystore Keypair Delete Keypair" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Keypair Delete Keypair" and the following properties
       | name       | type             | value       |
       | keystoreId | java.lang.String | SSLKeystore |
       | alias      | java.lang.String | qaKeypair   |
       | timeout    | java.lang.Long   | 10000       |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And Search for step definition with the name "Keystore Item Delete"
-    And A regular step creator with the name "Keystore Keypair Delete Certificate" and the following properties
+    And I prepare a JobStepCreator with the name "Keystore Keypair Delete Certificate" and the following properties
       | name       | type             | value         |
       | keystoreId | java.lang.String | SSLKeystore   |
       | alias      | java.lang.String | qaCertificate |
       | timeout    | java.lang.Long   | 10000         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 3 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob - Keystore Steps" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    And I confirm job target has step index 3 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob - Keystore Steps" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
-@teardown
+  @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOfflineDeviceI9n.feature
@@ -15,7 +15,7 @@
 
 Feature: JobEngineService tests for restarting job with offline device
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -44,17 +44,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -78,17 +75,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -112,17 +106,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -146,17 +137,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -180,17 +168,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -214,17 +199,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -248,17 +230,14 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                         |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.ble.tisensortag</name><version>1.0.0</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -286,24 +265,21 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -327,24 +303,21 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -368,23 +341,20 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -408,23 +378,20 @@ Feature: JobEngineService tests for restarting job with offline device
     And I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                         |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.ble.tisensortag</name><version>1.0.0</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     When I restart a job
-    And I wait 10 seconds
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     Then I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -448,23 +415,20 @@ Feature: JobEngineService tests for restarting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -488,23 +452,20 @@ Feature: JobEngineService tests for restarting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -528,23 +489,20 @@ Feature: JobEngineService tests for restarting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -574,17 +532,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -610,17 +565,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -646,17 +598,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -682,17 +631,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                         |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>heater</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>30000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -718,17 +664,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -754,17 +697,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -790,17 +730,14 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -830,24 +767,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -873,24 +807,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -916,24 +847,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -959,24 +887,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                         |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>heater</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>30000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1002,24 +927,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1045,24 +967,21 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1088,28 +1007,25 @@ Feature: JobEngineService tests for restarting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
-@teardown
+  @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceI9n.feature
@@ -15,7 +15,7 @@
 
 Feature: JobEngineService restart job tests with online device
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -38,31 +38,23 @@ Feature: JobEngineService restart job tests with online device
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then KuraMock is disconnected
     And I logout
 
@@ -81,32 +73,24 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And KuraMock is disconnected
@@ -127,32 +111,24 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And KuraMock is disconnected
@@ -172,31 +148,23 @@ Feature: JobEngineService restart job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     Then Packages are requested and 1 package is received
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 or more events within 30 seconds
     Then Packages are requested and 0 packages are received
     And KuraMock is disconnected
     And I logout
@@ -220,36 +188,28 @@ Feature: JobEngineService restart job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definition with the name
       | Command Execution          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then KuraMock is disconnected
     And I logout
 
@@ -269,39 +229,31 @@ Feature: JobEngineService restart job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 or more events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -331,23 +283,17 @@ Feature: JobEngineService restart job tests with online device
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then KuraMock is disconnected
     And I logout
@@ -372,24 +318,18 @@ Feature: JobEngineService restart job tests with online device
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -416,24 +356,18 @@ Feature: JobEngineService restart job tests with online device
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -459,23 +393,17 @@ Feature: JobEngineService restart job tests with online device
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 2 or more events are found
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
@@ -507,26 +435,20 @@ Feature: JobEngineService restart job tests with online device
     And I search for step definition with the name
       | Command Execution          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
     Then KuraMock is disconnected
@@ -553,31 +475,25 @@ Feature: JobEngineService restart job tests with online device
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 4 or more events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -585,6 +501,6 @@ Feature: JobEngineService restart job tests with online device
     And KuraMock is disconnected
     And I logout
 
-    @teardown
-      Scenario: Stop full docker environment
-        Given Stop full docker environment
+  @teardown
+  Scenario: Stop full docker environment
+    Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceRestartOnlineDeviceSecondPartI9n.feature
@@ -15,7 +15,7 @@
 
 Feature: JobEngineService restart job tests with online device - second part
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -40,31 +40,23 @@ Feature: JobEngineService restart job tests with online device - second part
     And I get the KuraMock device after 5 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    Then I create a new step entity from the existing creator
+    Then I create a new JobStep from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     And KuraMock is disconnected
@@ -84,31 +76,23 @@ Feature: JobEngineService restart job tests with online device - second part
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     When I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
     And I logout
@@ -128,31 +112,23 @@ Feature: JobEngineService restart job tests with online device - second part
     And I get the KuraMock device after 5 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "ASSET"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                     |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     Then KuraMock is disconnected
@@ -178,35 +154,28 @@ Feature: JobEngineService restart job tests with online device - second part
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Command "pwd" is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "COMMAND"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definitions with the name
       | Configuration Put |
       | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item or more and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     When KuraMock is disconnected
@@ -228,36 +197,28 @@ Feature: JobEngineService restart job tests with online device - second part
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definitions with the name
       | Package Uninstall |
       | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                     |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                    |
       | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 14 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
@@ -287,23 +248,17 @@ Feature: JobEngineService restart job tests with online device - second part
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -327,23 +282,17 @@ Feature: JobEngineService restart job tests with online device - second part
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Then I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Then I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
@@ -369,23 +318,17 @@ Feature: JobEngineService restart job tests with online device - second part
     Given I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                     |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -420,25 +363,20 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search for step definitions with the name
       | Configuration Put |
       | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     Then I restart a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2
-    And I confirm the executed job is finished
-    And I confirm job target has step index 1 and status "PROCESS_OK"
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -468,26 +406,20 @@ Feature: JobEngineService restart job tests with online device - second part
     And I search for step definitions with the name
       | Package Uninstall |
       | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                     |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                    |
       | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I restart a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     Then I restart a job
-    And I wait 14 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 2 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events is found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -495,6 +427,6 @@ Feature: JobEngineService restart job tests with online device - second part
     Then KuraMock is disconnected
     And I logout
 
-    @teardown
-      Scenario: Stop full docker environment
-        Given Stop full docker environment
+  @teardown
+  Scenario: Stop full docker environment
+    Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOfflineDeviceI9n.feature
@@ -15,7 +15,7 @@
 
 Feature: JobEngineService tests for starting job with offline device
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -44,17 +44,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -78,17 +75,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -114,17 +108,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -158,17 +149,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -199,17 +187,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -234,17 +219,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -276,17 +258,14 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -322,23 +301,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -371,23 +347,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                                   |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -420,23 +393,21 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 95    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -471,23 +442,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -521,23 +489,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -571,23 +536,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -623,23 +585,20 @@ Feature: JobEngineService tests for starting job with offline device
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     When I start the Kura Mock
@@ -673,18 +632,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 136   |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -710,18 +665,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 136   |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -748,18 +699,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I add 2 devices to Kura Mock
@@ -790,18 +737,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 30000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -827,18 +770,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 50000                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -864,18 +803,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 50000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -901,18 +836,14 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 50000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -942,25 +873,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 136   |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -987,25 +914,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 136   |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1032,25 +955,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                           |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.demo.heater_1.0.300.dp</uri><name>heater</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                           |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I add 2 devices to Kura Mock
@@ -1081,25 +1000,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 30000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1125,25 +1040,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                                   |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>assetName</name><channels><channel><valueType>binary</valueType><value>EGVzdCBzdHJpbmcgdmFsdWU=</value><name>binaryTest</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 50000                                                                                                                                                                                                                                                   |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1169,25 +1080,21 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.demo.heater.Heater</id><properties><property name="temperature.increment" array="false" encrypted="false" type="Float"><value>0.25</value></property><property name="publish.rate" array="false" encrypted="false" type="Integer"><value>60</value></property><property name="program.stopTime" array="false" encrypted="false" type="String"><value>22:00</value></property><property name="publish.retain" array="false" encrypted="false" type="Boolean"><value>false</value></property><property name="service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="kura.service.pid" array="false" encrypted="false" type="String"><value>org.eclipse.kura.demo.heater.Heater</value></property><property name="program.startTime" array="false" encrypted="false" type="String"><value>06:00</value></property><property name="mode" array="false" encrypted="false" type="String"><value>Program</value></property><property name="publish.semanticTopic" array="false" encrypted="false" type="String"><value>data/210</value></property><property name="manual.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property><property name="publish.qos" array="false" encrypted="false" type="Integer"><value>2</value></property><property name="temperature.initial" array="false" encrypted="false" type="Float"><value>13.0</value></property><property name="program.setPoint" array="false" encrypted="false" type="Float"><value>30.0</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 50000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
@@ -1213,29 +1120,25 @@ Feature: JobEngineService tests for starting job with offline device
     When I count the targets in the current scope
     Then I count 2
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 50000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 36    |
       | timeout  | java.lang.Long   | 50000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_FAILED"
     And I logout
 
-    @teardown
-      Scenario: Stop full docker environment
-        Given Stop full docker environment
+  @teardown
+  Scenario: Stop full docker environment
+    Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStartOnlineDeviceI9n.feature
@@ -15,7 +15,7 @@
 
 Feature: JobEngineService start job tests with online device
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -38,26 +38,21 @@ Feature: JobEngineService start job tests with online device
     Then Device status is "CONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 1 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     Given I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    And I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    And I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And KuraMock is disconnected
     And I logout
 
@@ -76,26 +71,21 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
     And A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     When KuraMock is disconnected
@@ -116,26 +106,21 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And KuraMock is disconnected
@@ -156,25 +141,20 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     When Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    Then I create a new step entity from the existing creator
+    Then I create a new JobStep from the existing creator
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "CONFIGURATION"
     And Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -195,26 +175,21 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
     And KuraMock is disconnected
     And I logout
@@ -234,26 +209,21 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "ASSET"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                     |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And KuraMock is disconnected
@@ -273,26 +243,21 @@ Feature: JobEngineService start job tests with online device
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
     And I logout
@@ -316,30 +281,25 @@ Feature: JobEngineService start job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     Then The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definition with the name
       | Command Execution          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    And I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     And Packages are requested and 2 packages are received
     When KuraMock is disconnected
     And I logout
@@ -360,32 +320,27 @@ Feature: JobEngineService start job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "BUNDLE"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -408,29 +363,25 @@ Feature: JobEngineService start job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Command "pwd" is executed
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definitions with the name
       | Configuration Put |
       | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     When KuraMock is disconnected
@@ -452,29 +403,25 @@ Feature: JobEngineService start job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I create a new job target item
     And I search for step definitions with the name
       | Package Uninstall |
       | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                     |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                    |
       | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 or more device events
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 or more events within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 0 packages are received
@@ -504,18 +451,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    Then I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     When KuraMock is disconnected
     And I logout
@@ -540,18 +484,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -578,18 +519,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | #34   |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_FAILED"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_FAILED" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 2 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
@@ -616,18 +554,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
@@ -652,17 +587,14 @@ Feature: JobEngineService start job tests with online device
     And I add targets to job
     When I count the targets in the current scope and I count 2
     And Search for step definition with the name "Configuration Put"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -689,18 +621,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Asset Write"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name    | type                                                           | value                                                                                                                                                                                                                                     |
       | assets  | org.eclipse.kapua.service.device.management.asset.DeviceAssets | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout | java.lang.Long                                                 | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items and I confirm the executed jobs is finished within 20 seconds
     And I search events from devices in account "kapua-sys" and 3 events are found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -725,18 +654,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Package Uninstall"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 0 packages are received
     And KuraMock is disconnected
@@ -760,18 +686,15 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Package Download / Install"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 30000                                                                                                                                                                                                                                                            |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 0 and status "PROCESS_OK"
-    And  I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 0 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     And I search events from devices in account "kapua-sys" and 3 or more events are found
     When Packages are requested and 2 packages are received
     And KuraMock is disconnected
@@ -803,20 +726,17 @@ Feature: JobEngineService start job tests with online device
     And I search for step definition with the name
       | Command Execution          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    And I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Packages are requested and 2 packages are received
     When KuraMock is disconnected
@@ -843,24 +763,21 @@ Feature: JobEngineService start job tests with online device
     And I create a job with the name "TestJob"
     And I add targets to job
     And Search for step definition with the name "Bundle Start"
-    And A regular step creator with the name "TestStep1" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep1" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 34    |
       | timeout  | java.lang.Long   | 10000 |
-    And I create a new step entity from the existing creator
+    And I create a new JobStep from the existing creator
     Then Search for step definition with the name "Bundle Stop"
-    And A regular step creator with the name "TestStep2" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep2" and the following properties
       | name     | type             | value |
       | bundleId | java.lang.String | 77    |
       | timeout  | java.lang.Long   | 10000 |
-    When I create a new step entity from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create a new JobStep from the existing creator
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    Given I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    Given I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 4 events are found
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
@@ -891,19 +808,17 @@ Feature: JobEngineService start job tests with online device
     And I search for step definitions with the name
       | Configuration Put |
       | Command Execution |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name          | type                                                                          | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | commandInput  | org.eclipse.kapua.service.device.management.command.DeviceCommandInput        | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                            |
       | timeout       | java.lang.Long                                                                | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     Then I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     When I search events from devices in account "kapua-sys" and 5 events are found
     Then Configuration is requested
     And A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
@@ -933,20 +848,17 @@ Feature: JobEngineService start job tests with online device
     And I search for step definitions with the name
       | Package Uninstall |
       | Asset Write       |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                     |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                    |
       | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                     |
-    When I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
-    Then No exception was thrown
+    When I create multiple new JobSteps from the existing creators
+    And No exception was thrown
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    And I query for the job with the name "TestJob" and I find it
-    When I query for the execution items for the current job and I count 1 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    And I query for the job with the name "TestJob" and I count 1 execution items or more and I confirm the executed jobs are finished within 45 seconds
     When I search events from devices in account "kapua-sys" and 3 or more events are found
     And Device assets are requested
     And Asset with name "asset1" and channel with name "channel1" and value 1233 are received
@@ -954,6 +866,6 @@ Feature: JobEngineService start job tests with online device
     When KuraMock is disconnected
     And I logout
 
-    @teardown
-      Scenario: Stop full docker environment
-        Given Stop full docker environment
+  @teardown
+  Scenario: Stop full docker environment
+    Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobEngine/JobEngineServiceStopOnlineDeviceI9n.feature
@@ -17,7 +17,7 @@ Feature: JobEngineService stop job tests with online device
   Job Engine Service test scenarios for stopping job. This feature file contains scenarios for stopping job with one target and one step,
   one target and multiple steps, multiple targets and one step and multiple targets and multiple steps.
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -44,8 +44,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -55,25 +54,23 @@ Feature: JobEngineService stop job tests with online device
       | Bundle Start               |
       | Package Download / Install |
       | Package Uninstall          |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
       | bundleId                | java.lang.String                                                                                   | 34                                                                                                                                                                                                                                                               |
       | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 3
+    And I count the JobSteps and I find 3 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And Packages are requested and 2 packages are received
@@ -97,8 +94,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -108,25 +104,23 @@ Feature: JobEngineService stop job tests with online device
       | Bundle Stop                |
       | Package Uninstall          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
       | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                                                                               |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
       | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 3
+    And I count the JobSteps and I find 3 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And Packages are requested and 2 packages are received
@@ -149,8 +143,7 @@ Feature: JobEngineService stop job tests with online device
     And I get the KuraMock device after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -160,25 +153,23 @@ Feature: JobEngineService stop job tests with online device
       | Command Execution          |
       | Package Download / Install |
       | Package Uninstall          |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
       | commandInput            | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                             | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 3
+    And I count the JobSteps and I find 3 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     And Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -200,8 +191,7 @@ Feature: JobEngineService stop job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Packages are requested and 1 packages is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -211,25 +201,23 @@ Feature: JobEngineService stop job tests with online device
       | Configuration Put          |
       | Package Uninstall          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
       | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                         |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 3
+    And I count the JobSteps and I find 3 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     Then Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -251,8 +239,7 @@ Feature: JobEngineService stop job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add target to job
@@ -262,25 +249,23 @@ Feature: JobEngineService stop job tests with online device
       | Asset Write                |
       | Package Download / Install |
       | Package Uninstall          |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                            |
       | assets                  | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                     | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
       | packageDownloadRequest  | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest   | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                           |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 3
+    And I count the JobSteps and I find 3 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 2 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 2 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 2 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 2 packages are received
@@ -308,8 +293,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "RESOLVED"
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -318,22 +302,20 @@ Feature: JobEngineService stop job tests with online device
     And I search for step definition with the name
       | Bundle Start               |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | bundleId               | java.lang.String                                                                                 | 34                                                                                                                                                                                                                                                               |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
-    And I create a new step entities from the existing creator
-    And I search the database for created job steps and I find 2
+    And I create multiple new JobSteps from the existing creators
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     Then A bundle named "slf4j.api" with id 34 and version "1.7.21" is present and "ACTIVE"
     And Packages are requested and 2 packages are received
@@ -357,8 +339,7 @@ Feature: JobEngineService stop job tests with online device
     And Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "ACTIVE"
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -367,24 +348,22 @@ Feature: JobEngineService stop job tests with online device
     And I search for step definition with the name
       | Bundle Stop       |
       | Package Uninstall |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                  |
       | bundleId                | java.lang.String                                                                                   | 77                                                                                                                                                                                                     |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest> |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                  |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Bundles are requested
     And A bundle named "org.eclipse.kura.linux.bluetooth" with id 77 and version "1.0.300" is present and "RESOLVED"
     And Packages are requested and 0 packages are received
@@ -407,8 +386,7 @@ Feature: JobEngineService stop job tests with online device
     And I get the KuraMock devices after 5 seconds
     And Command "pwd" is executed
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -417,24 +395,22 @@ Feature: JobEngineService stop job tests with online device
     And I search for step definition with the name
       | Command Execution          |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | commandInput           | org.eclipse.kapua.service.device.management.command.DeviceCommandInput                           | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput>                                                                                                                    |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
@@ -456,8 +432,7 @@ Feature: JobEngineService stop job tests with online device
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "5"
     And Packages are requested and 1 packages is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -466,24 +441,22 @@ Feature: JobEngineService stop job tests with online device
     And I search for step definition with the name
       | Configuration Put |
       | Package Uninstall |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                    | type                                                                                               | value                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
       | configuration           | org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration                      | <?xml version="1.0" encoding="UTF-8"?><configurations xmlns:ns0="http://www.osgi.org/xmlns/metatype/v1.2.0"><configuration><id>org.eclipse.kura.clock.ClockService></id><properties><property name="clock.ntp.host" array="false" encrypted="false" type="String"><value>0.pool.ntp.org</value></property><property name="clock.provider" array="false" encrypted="false" type="String"><value>java-ntp</value></property><property name="clock.ntp.port" array="false" encrypted="false" type="Integer"><value>123</value></property><property name="clock.ntp.max-retry" array="false" encrypted="false" type="Integer"><value>0</value></property><property name="clock.ntp.refresh-interval" array="false" encrypted="false" type="Integer"><value>3600</value></property><property name="clock.set.hwclock" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="enabled" array="false" encrypted="false" type="Boolean"><value>true</value></property><property name="clock.ntp.timeout" array="false" encrypted="false" type="Integer"><value>10000</value></property><property name="clock.ntp.retry.interval" array="false" encrypted="false" type="Integer"><value>10</value></property></properties></configuration></configurations> |
       | packageUninstallRequest | org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest | <?xml version="1.0" encoding="UTF-8"?><uninstallRequest><name>org.eclipse.kura.example.beacon</name><version>1.0.300</version><reboot>true</reboot><rebootDelay>10000</rebootDelay></uninstallRequest>                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   |
       | timeout                 | java.lang.Long                                                                                     | 10000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                    |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     And Configuration is requested
     Then A Configuration named "org.eclipse.kura.clock.ClockService" has property "clock.ntp.retry.interval" with value "10"
     And Packages are requested and 0 packages are received
@@ -507,8 +480,7 @@ Feature: JobEngineService stop job tests with online device
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 123 are received
     And Packages are requested and 1 package is received
-    When I search for events from device "device0" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "device0" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "DEPLOY"
     And I create a job with the name "TestJob"
     And I add targets to job
@@ -517,30 +489,28 @@ Feature: JobEngineService stop job tests with online device
     And I search for step definition with the name
       | Asset Write                |
       | Package Download / Install |
-    And I create a regular step creator with the name "TestStep1" and properties
+    And I prepare a JobStepCreator with the name "TestStep1" and properties
       | name                   | type                                                                                             | value                                                                                                                                                                                                                                                            |
       | assets                 | org.eclipse.kapua.service.device.management.asset.DeviceAssets                                   | <?xml version="1.0" encoding="UTF-8"?><deviceAssets><deviceAsset><name>asset1</name><channels><channel><valueType>java.lang.Integer</valueType><value>1233</value><name>channel1</name></channel></channels></deviceAsset></deviceAssets>                        |
       | packageDownloadRequest | org.eclipse.kapua.service.device.management.packages.model.download.DevicePackageDownloadRequest | <?xml version="1.0" encoding="UTF-8"?><downloadRequest><uri>http://download.eclipse.org/kura/releases/3.2.0/org.eclipse.kura.example.publisher_1.0.300.dp</uri><name>Example Publisher</name><version>1.0.300</version><install>true</install></downloadRequest> |
       | timeout                | java.lang.Long                                                                                   | 10000                                                                                                                                                                                                                                                            |
-    And I create a new step entities from the existing creator
+    And I create multiple new JobSteps from the existing creators
     Then No exception was thrown
-    And I search the database for created job steps and I find 2
+    And I count the JobSteps and I find 2 JobStep within 30 seconds
     And I start a job
     And I wait for 10 milliseconds for processes to settle down
     And I stop the job
     And I search for the last job target in the database
     And I confirm the step index is different than 1 and status is "PROCESS_AWAITING"
     And I start a job
-    And I wait 10 seconds
-    And I confirm job target has step index 1 and status "PROCESS_OK"
-    When I query for the execution items for the current job and I count 2 or more
-    And I confirm the executed job is finished
+    And I confirm job target has step index 1 and status "PROCESS_OK" within 180 seconds
+    When I query for the execution items for the current job and I count 2 or more finished within 30 seconds
     When Device assets are requested
     Then Asset with name "asset1" and channel with name "channel1" and value 1233 are received
     And Packages are requested and 2 packages are received
     Then KuraMock is disconnected
     And I logout
 
-@teardown
+  @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/ExecuteOnDeviceConnectI9n.feature
@@ -16,7 +16,7 @@
 
 Feature: JobEngineService execute job on device connect
 
-@setup
+  @setup
   Scenario: Start full docker environment
     Given Init Jaxb Context
     And Init Security Context
@@ -42,17 +42,16 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "TestSchedule1" is created
@@ -61,15 +60,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I logout
 
@@ -92,17 +86,16 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "TestSchedule2" is created
@@ -111,14 +104,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -141,17 +130,16 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "TestSchedule3" is created
@@ -161,15 +149,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     And I logout
 
@@ -192,17 +175,16 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "TestSchedule4" is created
@@ -213,13 +195,10 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     And I wait 3 seconds
     When Device is connected
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -243,17 +222,16 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
     And Search for step definition with the name "Command Execution"
-    And A regular step creator with the name "TestStep" and the following properties
+    And I prepare a JobStepCreator with the name "TestStep" and the following properties
       | name         | type                                                                   | value                                                                                                                                         |
       | commandInput | org.eclipse.kapua.service.device.management.command.DeviceCommandInput | <?xml version="1.0" encoding="UTF-8"?><commandInput><command>pwd</command><timeout>30000</timeout><runAsynch>false</runAsynch></commandInput> |
       | timeout      | java.lang.Long                                                         | 10000                                                                                                                                         |
-    When I create a new step entity from the existing creator
+    When I create a new JobStep from the existing creator
     Then No exception was thrown
     And I find scheduler properties with name "Device Connect"
     And A regular trigger creator with the name "TestSchedule1" is created
@@ -262,22 +240,16 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     When Device is connected
     And I wait 14 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 4 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 4 events within 30 seconds
     And The type of the last event is "COMMAND"
     Then KuraMock is disconnected
     And I wait 3 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 1
-    And I confirm the executed job is finished
+    And I query for the job with the name "TestJob" and I count 1 execution item and I confirm the executed job is finished within 20 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_OK"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 6 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 6 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
@@ -300,8 +272,7 @@ Feature: JobEngineService execute job on device connect
     Then Device status is "DISCONNECTED"
     And I select account "kapua-sys"
     And I get the KuraMock device after 5 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 2 device event
+    When I search for events from device "rpione3" in account "kapua-sys" I find 2 events within 30 seconds
     And The type of the last event is "DEATH"
     Given I create a job with the name "TestJob"
     And A new job target item
@@ -312,24 +283,19 @@ Feature: JobEngineService execute job on device connect
     And I restart the Kura Mock
     When Device is connected
     And I wait 3 seconds
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 3 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 3 events within 30 seconds
     And The type of the last event is "BIRTH"
     Then KuraMock is disconnected
     And I wait 3 seconds
     When I restart the Kura Mock
     Then Device is connected
-    And I wait 10 seconds
-    Given I query for the job with the name "TestJob"
-    When I query for the execution items for the current job
-    Then I count 0
+    And I query for the job with the name "TestJob" and I count 0 execution item after 10 seconds
     And I search for the last job target in the database
     And I confirm the step index is 0 and status is "PROCESS_AWAITING"
-    When I search for events from device "rpione3" in account "kapua-sys"
-    Then I find 5 device events
+    When I search for events from device "rpione3" in account "kapua-sys" I find 5 events within 30 seconds
     And The type of the last event is "BIRTH"
     And I logout
 
-@teardown
+  @teardown
   Scenario: Stop full docker environment
     Given Stop full docker environment

--- a/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/jobScheduling/TriggerServiceI9n.feature
@@ -787,5 +787,5 @@ Scenario: Init Security Context for all scenarios
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserRoleServiceI9n.feature
@@ -192,8 +192,7 @@ Scenario: Initialize test environment
       | 1       | delete     |
     And I logout
     Given I login as user with name "user1" and password "User@10031995"
-    When I search for events from device "device_1" in account "kapua-sys"
-    Then I find 1 device events
+    When I search for events from device "device_1" in account "kapua-sys" I find 1 event within 30 seconds
     And The type of the last event is "BIRTH"
     And No exception was thrown
     And I logout
@@ -1643,5 +1642,5 @@ Scenario: Initialize test environment
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/user/UserServiceI9n.feature
@@ -214,5 +214,5 @@ Scenario: Initialize test environment
 
 @teardown
   Scenario: Stop test environment
-    Given Stop base docker environment
+    Given Stop full docker environment
     And Reset Security Context

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -51,5 +51,15 @@
             <artifactId>kapua-scheduler-quartz</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <!-- Log -->
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
     </dependencies>
 </project>


### PR DESCRIPTION
**Brief description of the PR.**
see description (replacing #3401 since the branch is changed)

**Related Issue**
fix #3393

**Description of the solution adopted**
Removed docker cache to make available containers to test steps since this causes random failures (429 error)
Job steps widely used wait steps with fixed amount of time. The major part of them are no more present and replaced with a while loop with a timeout. In this way the stability of the tests is improved.

**Screenshots**
none

**Any side note on the changes made**
none
