### PR TITLE
Changed the displayed messaged for `No Item Selected...` in tabs

### DIFF
--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -55,7 +55,7 @@ browserWindowTooSmall=Browser Window is too small for accurate UI display.
  specifyEndDate=Please specify end date.
  
  gridNoResultFound=No {0}s found
- tabDescriptionNoItemSelected=None of the {0}s selected
+ tabDescriptionNoItemSelected=No {0}s selected
  specificPagingToolbarShowingPost={0}s
  specificPagingToolbarNoResult=No {0}s to show
  


### PR DESCRIPTION
This PR changes the displayed message when there is no selected entity and the tab cannot show any information for a entity.

**Related Issue**
_None_

**Description of the solution adopted**
Just replaced the message

**Screenshots**
![Screenshot 2021-10-20 at 10 03 04](https://user-images.githubusercontent.com/3942036/138052882-0af49d11-7d99-4f15-a945-81f4da55c0b9.png)

**Any side note on the changes made**
_None_