### PR TITLE
Device Registry - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -21,24 +21,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
 
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
@@ -54,14 +36,10 @@
         <!-- job services -->
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
+
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
+
         <api>org.eclipse.kapua.service.job.JobService</api>
         <api>org.eclipse.kapua.service.job.JobFactory</api>
         <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,19 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -30,46 +30,6 @@
         <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
-        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -20,34 +20,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
-        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
@@ -61,18 +34,10 @@
         <!-- job services -->
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
+
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
+
         <api>org.eclipse.kapua.service.job.JobService</api>
         <api>org.eclipse.kapua.service.job.JobFactory</api>
         <api>org.eclipse.kapua.service.job.execution.JobExecutionService</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -33,16 +33,7 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -19,53 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
-        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService</api>
-
-        <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
-
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
-
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -31,8 +31,6 @@
 
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandInput</api>
-
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -29,53 +29,9 @@
         <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
         <api>org.eclipse.kapua.service.device.management.command.DeviceCommandInput</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
-        <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService</api>
-        <api>org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationFactory</api>
-        <api>org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService</api>
-        <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
 
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,53 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
-        <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
-        <!-- <api>org.eclipse.kapua.service.device.management.channel.DeviceChannelFactory</api> -->
-
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.command.DeviceCommandFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService</api>
-        <api>org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
-        <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
-
-        <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
-
         <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
         <api>org.eclipse.kapua.service.datastore.ClientInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraCallModule.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraCallModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,25 +8,19 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Eurotech - initial API and implementation
+ *     Eurotech - initial API and implementation
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura;
 
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.device.call.DeviceCallFactory;
+import org.eclipse.kapua.service.device.call.DeviceMessageFactory;
 
-import javax.inject.Singleton;
-
-/**
- * {@link DeviceCallFactory} {@link Kura} implementation.
- *
- * @since 1.0.0
- */
-@Singleton
-public class KuraDeviceCallFactoryImpl implements DeviceCallFactory {
+public class KuraCallModule extends AbstractKapuaModule {
 
     @Override
-    public KuraDeviceCallImpl newDeviceCall() {
-        return new KuraDeviceCallImpl();
+    protected void configureModule() {
+        bind(DeviceCallFactory.class).to(KuraDeviceCallFactoryImpl.class);
+        bind(DeviceMessageFactory.class).to(KuraMessageFactoryImpl.class);
     }
-
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.call.DeviceMessageFactory;
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
@@ -25,12 +24,14 @@ import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraReques
 import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestMessage;
 import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestPayload;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceMessageFactory} {@link Kura} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KuraMessageFactoryImpl implements DeviceMessageFactory {
 
     @Override

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceCommonsModule.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceCommonsModule.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaRequestMessageFactoryImpl;
+import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory;
+
+public class DeviceCommonsModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaRequestMessageFactory.class).to(KapuaRequestMessageFactoryImpl.class);
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons.message;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.commons.KapuaAppPropertiesImpl;
 import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestMessageImpl;
@@ -24,12 +23,14 @@ import org.eclipse.kapua.service.device.management.message.request.KapuaRequestM
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestPayload;
 
+import javax.inject.Singleton;
+
 /**
  * {@link KapuaRequestMessageFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaRequestMessageFactoryImpl implements KapuaRequestMessageFactory {
 
     @Override

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetFactoryImpl.java
@@ -12,18 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.asset.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.asset.DeviceAsset;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetChannel;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory;
 import org.eclipse.kapua.service.device.management.asset.DeviceAssets;
+
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceAssetFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceAssetFactoryImpl implements DeviceAssetFactory {
 
     @Override

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetManagementServiceImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.device.management.asset.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -29,6 +28,7 @@ import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecut
 import org.eclipse.kapua.service.device.management.exception.DeviceManagementRequestContentException;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -36,7 +36,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceAssetManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceAssetManagementService {
 
     private static final String SCOPE_ID = "scopeId";

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetModule.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetModule.java
@@ -21,6 +21,5 @@ public class DeviceAssetModule extends AbstractKapuaModule {
     protected void configureModule() {
         bind(DeviceAssetFactory.class).to(DeviceAssetFactoryImpl.class);
         bind(DeviceAssetManagementService.class).to(DeviceAssetManagementServiceImpl.class);
-        //bind(DeviceAssetChannel.class).to(DeviceAssetChannelImpl.class);
     }
 }

--- a/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetModule.java
+++ b/service/device/management/asset/internal/src/main/java/org/eclipse/kapua/service/device/management/asset/internal/DeviceAssetModule.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.asset.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory;
+import org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService;
+
+public class DeviceAssetModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceAssetFactory.class).to(DeviceAssetFactoryImpl.class);
+        bind(DeviceAssetManagementService.class).to(DeviceAssetManagementServiceImpl.class);
+        //bind(DeviceAssetChannel.class).to(DeviceAssetChannelImpl.class);
+    }
+}

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleManagementServiceImpl.java
@@ -15,7 +15,6 @@ package org.eclipse.kapua.service.device.management.bundle.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -29,6 +28,7 @@ import org.eclipse.kapua.service.device.management.commons.AbstractDeviceManagem
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -36,7 +36,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceBundleManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceBundleManagementService {
 
     private static final String SCOPE_ID = "scopeId";

--- a/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleModule.java
+++ b/service/device/management/bundle/internal/src/main/java/org/eclipse/kapua/service/device/management/bundle/internal/DeviceBundleModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,29 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.bundle.internal;
 
-import org.eclipse.kapua.service.device.management.bundle.DeviceBundle;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.device.management.bundle.DeviceBundleFactory;
-import org.eclipse.kapua.service.device.management.bundle.DeviceBundles;
+import org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService;
 
-import javax.inject.Singleton;
-
-/**
- * Device bundle entity service factory implementation.
- *
- * @since 1.0
- *
- */
-@Singleton
-public class DeviceBundleFactoryImpl implements DeviceBundleFactory {
-
+public class DeviceBundleModule extends AbstractKapuaModule {
     @Override
-    public DeviceBundles newBundleListResult() {
-        return new DeviceBundlesImpl();
+    protected void configureModule() {
+        bind(DeviceBundleManagementService.class).to(DeviceBundleManagementServiceImpl.class);
+        bind(DeviceBundleFactory.class).to(DeviceBundleFactoryImpl.class);
     }
-
-    @Override
-    public DeviceBundle newDeviceBundle() {
-        return new DeviceBundleImpl();
-    }
-
 }

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandFactoryImpl.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandFactory;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandInput;
 import org.eclipse.kapua.service.device.management.command.DeviceCommandOutput;
+
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceCommandFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceCommandFactoryImpl implements DeviceCommandFactory {
 
     @Override

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandManagementServiceImpl.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -8,13 +8,12 @@
  * SPDX-License-Identifier: EPL-2.0
  *
  * Contributors:
- *      Eurotech - initial API and implementation
+ *     Eurotech - initial API and implementation
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.command.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -30,6 +29,7 @@ import org.eclipse.kapua.service.device.management.commons.AbstractDeviceManagem
 import org.eclipse.kapua.service.device.management.commons.call.DeviceCallExecutor;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -37,7 +37,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceCommandManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceCommandManagementService {
 
     @Override

--- a/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandModule.java
+++ b/service/device/management/command/internal/src/main/java/org/eclipse/kapua/service/device/management/command/internal/DeviceCommandModule.java
@@ -1,0 +1,26 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.command.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.command.DeviceCommandFactory;
+import org.eclipse.kapua.service.device.management.command.DeviceCommandManagementService;
+
+public class DeviceCommandModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceCommandManagementService.class).to(DeviceCommandManagementServiceImpl.class);
+        bind(DeviceCommandFactory.class).to(DeviceCommandFactoryImpl.class);
+        //bind(DeviceCommandInput.class).to(DeviceCommandInputImpl.class);
+    }
+}

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/DeviceConfigurationModule.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/DeviceConfigurationModule.java
@@ -1,0 +1,34 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory;
+import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationManagementService;
+import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationFactoryImpl;
+import org.eclipse.kapua.service.device.management.configuration.internal.DeviceConfigurationManagementServiceImpl;
+import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory;
+import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotManagementService;
+import org.eclipse.kapua.service.device.management.snapshot.internal.DeviceSnapshotFactoryImpl;
+import org.eclipse.kapua.service.device.management.snapshot.internal.DeviceSnapshotManagementServiceImpl;
+
+public class DeviceConfigurationModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceConfigurationManagementService.class).to(DeviceConfigurationManagementServiceImpl.class);
+        bind(DeviceConfigurationFactory.class).to(DeviceConfigurationFactoryImpl.class);
+
+        bind(DeviceSnapshotManagementService.class).to(DeviceSnapshotManagementServiceImpl.class);
+        bind(DeviceSnapshotFactory.class).to(DeviceSnapshotFactoryImpl.class);
+    }
+}

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationFactoryImpl.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.configuration.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.configuration.DeviceComponentConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfiguration;
 import org.eclipse.kapua.service.device.management.configuration.DeviceConfigurationFactory;
+
+import javax.inject.Singleton;
 
 /**
  * Device configuration entity service factory implementation.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConfigurationFactoryImpl implements DeviceConfigurationFactory {
 
     @Override

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/configuration/internal/DeviceConfigurationManagementServiceImpl.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.xml.XmlUtil;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -36,6 +35,7 @@ import org.eclipse.kapua.service.device.management.exception.DeviceManagementReq
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 import org.xml.sax.SAXException;
 
+import javax.inject.Singleton;
 import javax.xml.bind.JAXBException;
 import java.util.Date;
 
@@ -44,7 +44,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConfigurationManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceConfigurationManagementService {
 
     private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotFactoryImpl.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.snapshot.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshot;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshotFactory;
 import org.eclipse.kapua.service.device.management.snapshot.DeviceSnapshots;
+
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceSnapshotFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceSnapshotFactoryImpl implements DeviceSnapshotFactory {
 
     @Override

--- a/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
+++ b/service/device/management/configuration/internal/src/main/java/org/eclipse/kapua/service/device/management/snapshot/internal/DeviceSnapshotManagementServiceImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.device.management.snapshot.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -29,6 +28,7 @@ import org.eclipse.kapua.service.device.management.snapshot.message.internal.Sna
 import org.eclipse.kapua.service.device.management.snapshot.message.internal.SnapshotRequestPayload;
 import org.eclipse.kapua.service.device.management.snapshot.message.internal.SnapshotResponseMessage;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -36,7 +36,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceSnapshotManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceSnapshotManagementService {
 
     @Override

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryModule.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/DeviceInventoryModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.inventory;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.inventory.internal.DeviceInventoryManagementFactoryImpl;
+import org.eclipse.kapua.service.device.management.inventory.internal.DeviceInventoryManagementServiceImpl;
+
+public class DeviceInventoryModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceInventoryManagementService.class).to(DeviceInventoryManagementServiceImpl.class);
+        bind(DeviceInventoryManagementFactory.class).to(DeviceInventoryManagementFactoryImpl.class);
+    }
+}

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementFactoryImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.inventory.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.inventory.DeviceInventoryManagementFactory;
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundle;
 import org.eclipse.kapua.service.device.management.inventory.model.bundle.DeviceInventoryBundles;
@@ -31,12 +30,14 @@ import org.eclipse.kapua.service.device.management.inventory.model.system.Device
 import org.eclipse.kapua.service.device.management.inventory.model.system.internal.DeviceInventorySystemPackageImpl;
 import org.eclipse.kapua.service.device.management.inventory.model.system.internal.DeviceInventorySystemPackagesImpl;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceInventoryManagementFactory} implementation.
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceInventoryManagementFactoryImpl implements DeviceInventoryManagementFactory {
 
     @Override

--- a/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
+++ b/service/device/management/inventory/internal/src/main/java/org/eclipse/kapua/service/device/management/inventory/internal/DeviceInventoryManagementServiceImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.device.management.inventory.internal;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -39,6 +38,7 @@ import org.eclipse.kapua.service.device.management.inventory.model.packages.Devi
 import org.eclipse.kapua.service.device.management.inventory.model.system.DeviceInventorySystemPackages;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -46,7 +46,7 @@ import java.util.Date;
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceInventoryManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceInventoryManagementService {
 
     private static final String SCOPE_ID = "scopeId";

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementModule.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/JobDeviceManagementModule.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.job;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.job.internal.JobDeviceManagementOperationFactoryImpl;
+import org.eclipse.kapua.service.device.management.job.internal.JobDeviceManagementOperationServiceImpl;
+import org.eclipse.kapua.service.device.management.job.manager.JobDeviceManagementOperationManagerService;
+import org.eclipse.kapua.service.device.management.job.manager.internal.JobDeviceManagementOperationManagerServiceImpl;
+import org.eclipse.kapua.service.device.management.job.scheduler.internal.JobDeviceManagementTriggerManagerServiceImpl;
+import org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService;
+
+public class JobDeviceManagementModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(JobDeviceManagementTriggerManagerService.class).to(JobDeviceManagementTriggerManagerServiceImpl.class);
+
+        bind(JobDeviceManagementOperationManagerService.class).to(JobDeviceManagementOperationManagerServiceImpl.class);
+        bind(JobDeviceManagementOperationService.class).to(JobDeviceManagementOperationServiceImpl.class);
+        bind(JobDeviceManagementOperationFactory.class).to(JobDeviceManagementOperationFactoryImpl.class);
+    }
+}

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationFactoryImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.management.job.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperation;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperat
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationListResult;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link JobDeviceManagementOperationFactory} implementation.
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class JobDeviceManagementOperationFactoryImpl implements JobDeviceManagementOperationFactory {
 
     @Override

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.model.query.predicate.AttributePredicateImpl;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -34,6 +33,7 @@ import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperat
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationService;
 import org.eclipse.kapua.service.job.JobDomains;
 
+import javax.inject.Singleton;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -44,7 +44,7 @@ import java.util.Map;
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class JobDeviceManagementOperationServiceImpl extends AbstractKapuaService
         implements JobDeviceManagementOperationService {
 

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/manager/internal/JobDeviceManagementOperationManagerServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.job.engine.JobEngineFactory;
 import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperation;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationAttributes;
@@ -43,6 +42,7 @@ import org.eclipse.kapua.service.job.targets.JobTargetStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -50,7 +50,7 @@ import java.util.Date;
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class JobDeviceManagementOperationManagerServiceImpl implements JobDeviceManagementOperationManagerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobDeviceManagementOperationManagerService.class);

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.job.engine.JobEngineFactory;
 import org.eclipse.kapua.job.engine.JobEngineService;
 import org.eclipse.kapua.job.engine.JobStartOptions;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.predicate.AttributePredicate;
 import org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService;
@@ -45,6 +44,7 @@ import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionS
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -52,7 +52,7 @@ import java.util.Date;
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class JobDeviceManagementTriggerManagerServiceImpl implements JobDeviceManagementTriggerManagerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobDeviceManagementTriggerManagerServiceImpl.class);

--- a/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/DeviceKeystoreModule.java
+++ b/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/DeviceKeystoreModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.keystore;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.keystore.internal.DeviceKeystoreManagementFactoryImpl;
+import org.eclipse.kapua.service.device.management.keystore.internal.DeviceKeystoreManagementServiceImpl;
+
+public class DeviceKeystoreModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceKeystoreManagementService.class).to(DeviceKeystoreManagementServiceImpl.class);
+        bind(DeviceKeystoreManagementFactory.class).to(DeviceKeystoreManagementFactoryImpl.class);
+    }
+}

--- a/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementFactoryImpl.java
+++ b/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.keystore.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.keystore.DeviceKeystoreManagementFactory;
 import org.eclipse.kapua.service.device.management.keystore.model.DeviceKeystore;
 import org.eclipse.kapua.service.device.management.keystore.model.DeviceKeystoreCSR;
@@ -35,12 +34,14 @@ import org.eclipse.kapua.service.device.management.keystore.model.internal.Devic
 import org.eclipse.kapua.service.device.management.keystore.model.internal.DeviceKeystoreSubjectANImpl;
 import org.eclipse.kapua.service.device.management.keystore.model.internal.DeviceKeystoresImpl;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceKeystoreManagementFactory} implementation.
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceKeystoreManagementFactoryImpl implements DeviceKeystoreManagementFactory {
 
     @Override

--- a/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementServiceImpl.java
+++ b/service/device/management/keystore/internal/src/main/java/org/eclipse/kapua/service/device/management/keystore/internal/DeviceKeystoreManagementServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.certificate.info.CertificateInfo;
@@ -55,6 +54,7 @@ import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -62,7 +62,7 @@ import java.util.Date;
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceKeystoreManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceKeystoreManagementService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceKeystoreManagementServiceImpl.class);

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.packages.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.packages.DevicePackageFactory;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackage;
 import org.eclipse.kapua.service.device.management.packages.model.DevicePackageBundleInfo;
@@ -43,12 +42,14 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.inte
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallOptionsImpl;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.internal.DevicePackageUninstallRequestImpl;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DevicePackageFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DevicePackageFactoryImpl implements DevicePackageFactory {
 
     @Override

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageManagementServiceImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.IdGenerator;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -50,6 +49,7 @@ import org.eclipse.kapua.service.device.management.packages.model.uninstall.Devi
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallOptions;
 import org.eclipse.kapua.service.device.management.packages.model.uninstall.DevicePackageUninstallRequest;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -57,7 +57,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DevicePackageManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DevicePackageManagementService {
 
     private static final String CHAR_ENCODING = DeviceManagementSetting.getInstance().getString(DeviceManagementSettingKey.CHAR_ENCODING);

--- a/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageModule.java
+++ b/service/device/management/packages/internal/src/main/java/org/eclipse/kapua/service/device/management/packages/internal/DevicePackageModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.packages.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.packages.DevicePackageFactory;
+import org.eclipse.kapua.service.device.management.packages.DevicePackageManagementService;
+
+ public class DevicePackageModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DevicePackageFactory.class).to(DevicePackageFactoryImpl.class);
+        bind(DevicePackageManagementService.class).to(DevicePackageManagementServiceImpl.class);
+    }
+}

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceManagementRegistryManagerServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceManagementRegistryManagerServiceImpl.java
@@ -12,9 +12,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.registry.manager.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class DeviceManagementRegistryManagerServiceImpl implements DeviceManagementRegistryManagerService {
 }

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceRegistryModule.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/manager/internal/DeviceRegistryModule.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.registry.manager.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory;
+import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService;
+import org.eclipse.kapua.service.device.management.registry.operation.internal.DeviceManagementOperationFactoryImpl;
+import org.eclipse.kapua.service.device.management.registry.operation.internal.DeviceManagementOperationRegistryServiceImpl;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.internal.ManagementOperationNotificationFactoryImpl;
+import org.eclipse.kapua.service.device.management.registry.operation.notification.internal.ManagementOperationNotificationServiceImpl;
+
+public class DeviceRegistryModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceManagementRegistryManagerService.class).to(DeviceManagementRegistryManagerServiceImpl.class);
+
+        bind(DeviceManagementOperationRegistryService.class).to(DeviceManagementOperationRegistryServiceImpl.class);
+        bind(DeviceManagementOperationFactory.class).to(DeviceManagementOperationFactoryImpl.class);
+
+        bind(ManagementOperationNotificationService.class).to(ManagementOperationNotificationServiceImpl.class);
+        bind(ManagementOperationNotificationFactory.class).to(ManagementOperationNotificationFactoryImpl.class);
+    }
+}

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationFactoryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.management.registry.operation.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperation;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.device.management.registry.operation.DeviceMana
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationProperty;
 import org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceManagementOperationFactory} implementation
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceManagementOperationFactoryImpl implements DeviceManagementOperationFactory {
 
     @Override

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/internal/DeviceManagementOperationRegistryServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -34,7 +33,9 @@ import org.eclipse.kapua.service.device.management.registry.operation.DeviceMana
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class DeviceManagementOperationRegistryServiceImpl extends AbstractKapuaService implements DeviceManagementOperationRegistryService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationFactoryImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.registry.operation.notification.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotification;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationCreator;
@@ -20,12 +19,14 @@ import org.eclipse.kapua.service.device.management.registry.operation.notificati
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationListResult;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link ManagementOperationNotificationFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class ManagementOperationNotificationFactoryImpl implements ManagementOperationNotificationFactory {
 
     @Override

--- a/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationServiceImpl.java
+++ b/service/device/management/registry/internal/src/main/java/org/eclipse/kapua/service/device/management/registry/operation/notification/internal/ManagementOperationNotificationServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -33,7 +32,9 @@ import org.eclipse.kapua.service.device.management.registry.operation.notificati
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationListResult;
 import org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class ManagementOperationNotificationServiceImpl extends AbstractKapuaService implements ManagementOperationNotificationService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestManagementServiceImpl.java
@@ -16,7 +16,6 @@ package org.eclipse.kapua.service.device.management.request.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.DeviceManagementDomains;
@@ -30,6 +29,7 @@ import org.eclipse.kapua.service.device.management.request.message.request.Gener
 import org.eclipse.kapua.service.device.management.request.message.request.GenericRequestPayload;
 import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -37,7 +37,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceRequestManagementServiceImpl extends AbstractDeviceManagementServiceImpl implements DeviceRequestManagementService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestModule.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/DeviceRequestModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.request.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService;
+import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
+
+public class DeviceRequestModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(GenericRequestFactory.class).to(GenericRequestFactoryImpl.class);
+        bind(DeviceRequestManagementService.class).to(DeviceRequestManagementServiceImpl.class);
+    }
+}

--- a/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
+++ b/service/device/management/request/internal/src/main/java/org/eclipse/kapua/service/device/management/request/internal/GenericRequestFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.request.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.request.GenericRequestFactory;
 import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestChannelImpl;
 import org.eclipse.kapua.service.device.management.request.internal.message.request.GenericRequestMessageImpl;
@@ -27,7 +26,9 @@ import org.eclipse.kapua.service.device.management.request.message.response.Gene
 import org.eclipse.kapua.service.device.management.request.message.response.GenericResponseMessage;
 import org.eclipse.kapua.service.device.management.request.message.response.GenericResponsePayload;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class GenericRequestFactoryImpl implements GenericRequestFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionFactoryImpl;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceImpl;
+import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory;
+import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService;
+import org.eclipse.kapua.service.device.registry.connection.option.internal.DeviceConnectionOptionFactoryImpl;
+import org.eclipse.kapua.service.device.registry.connection.option.internal.DeviceConnectionOptionServiceImpl;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventFactoryImpl;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventServiceImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceFactoryImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryServiceImpl;
+import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
+import org.eclipse.kapua.service.device.registry.lifecycle.internal.DeviceLifeCycleServiceImpl;
+
+public class DeviceRegistryModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceRegistryService.class).to(DeviceRegistryServiceImpl.class);
+        bind(DeviceFactory.class).to(DeviceFactoryImpl.class);
+
+        bind(DeviceConnectionFactory.class).to(DeviceConnectionFactoryImpl.class);
+        bind(DeviceConnectionService.class).to(DeviceConnectionServiceImpl.class);
+
+        bind(DeviceConnectionOptionFactory.class).to(DeviceConnectionOptionFactoryImpl.class);
+        bind(DeviceConnectionOptionService.class).to(DeviceConnectionOptionServiceImpl.class);
+
+        bind(DeviceEventFactory.class).to(DeviceEventFactoryImpl.class);
+        bind(DeviceEventService.class).to(DeviceEventServiceImpl.class);
+
+        bind(DeviceLifeCycleService.class).to(DeviceLifeCycleServiceImpl.class);
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.connection.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFact
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceConnectionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionFactoryImpl implements DeviceConnectionFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -41,13 +40,15 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryCacheFac
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableService implements DeviceConnectionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnectionServiceImpl.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.connection.option.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOption;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnect
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionListResult;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceConnectionOptionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionOptionFactoryImpl implements DeviceConnectionOptionFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -39,13 +38,15 @@ import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnect
 import org.eclipse.kapua.service.device.registry.connection.option.UserAlreadyReservedException;
 import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionOptionServiceImpl extends AbstractKapuaService implements DeviceConnectionOptionService {
 
     public DeviceConnectionOptionServiceImpl() {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
@@ -21,6 +20,7 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceEventFactoryImpl implements DeviceEventFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.KapuaOptimisticLockingException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -36,13 +35,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceEventService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceEventServiceImpl extends AbstractKapuaService implements DeviceEventService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceEventServiceImpl.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceFactoryImpl implements DeviceFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResource
 import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.device.registry.Device;
@@ -36,12 +35,14 @@ import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceRegistryService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Device, DeviceCreator, DeviceRegistryService, DeviceListResult, DeviceQuery, DeviceFactory>
         implements DeviceRegistryService {
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -15,12 +15,12 @@ package org.eclipse.kapua.service.device.registry.lifecycle.internal;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaOptimisticLockingException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
@@ -49,7 +49,7 @@ import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleServic
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +61,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceLifeCycleServiceImpl.class);

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -14,11 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
     </provided>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3408, i.e. move Device Registry bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* Create appropriate classes derived from `AbstractKapuaModule`
* Move service/factory bindings in the previously created subclasses of `AbstractKapuaModule`
* Remove `@KapuaProvider` annotation from service/factory implementation classes
* Remove Service/Factory from `locator.xml` for each `locator.xml` file in the project