### PR TITLE
Device Registry - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -30,16 +30,6 @@
         <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
         <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -23,16 +23,6 @@
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
         <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -30,16 +30,6 @@
         <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
-
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
         <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -34,15 +34,6 @@
         <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationService</api>
         <api>org.eclipse.kapua.service.device.management.registry.operation.notification.ManagementOperationNotificationFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
         <api>org.eclipse.kapua.service.device.management.packages.DevicePackageFactory</api>
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -41,9 +41,6 @@
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
         <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -19,12 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -29,15 +29,6 @@
         <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-        <api>org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService</api>
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,15 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventFactory</api>
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceRegistryModule.java
@@ -1,0 +1,50 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.registry;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFactory;
+import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionService;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionFactoryImpl;
+import org.eclipse.kapua.service.device.registry.connection.internal.DeviceConnectionServiceImpl;
+import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionFactory;
+import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionService;
+import org.eclipse.kapua.service.device.registry.connection.option.internal.DeviceConnectionOptionFactoryImpl;
+import org.eclipse.kapua.service.device.registry.connection.option.internal.DeviceConnectionOptionServiceImpl;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
+import org.eclipse.kapua.service.device.registry.event.DeviceEventService;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventFactoryImpl;
+import org.eclipse.kapua.service.device.registry.event.internal.DeviceEventServiceImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceFactoryImpl;
+import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryServiceImpl;
+import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleService;
+import org.eclipse.kapua.service.device.registry.lifecycle.internal.DeviceLifeCycleServiceImpl;
+
+public class DeviceRegistryModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceRegistryService.class).to(DeviceRegistryServiceImpl.class);
+        bind(DeviceFactory.class).to(DeviceFactoryImpl.class);
+
+        bind(DeviceConnectionFactory.class).to(DeviceConnectionFactoryImpl.class);
+        bind(DeviceConnectionService.class).to(DeviceConnectionServiceImpl.class);
+
+        bind(DeviceConnectionOptionFactory.class).to(DeviceConnectionOptionFactoryImpl.class);
+        bind(DeviceConnectionOptionService.class).to(DeviceConnectionOptionServiceImpl.class);
+
+        bind(DeviceEventFactory.class).to(DeviceEventFactoryImpl.class);
+        bind(DeviceEventService.class).to(DeviceEventServiceImpl.class);
+
+        bind(DeviceLifeCycleService.class).to(DeviceLifeCycleServiceImpl.class);
+    }
+}

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.connection.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnection;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionFact
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionListResult;
 import org.eclipse.kapua.service.device.registry.connection.DeviceConnectionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceConnectionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionFactoryImpl implements DeviceConnectionFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/internal/DeviceConnectionServiceImpl.java
@@ -20,7 +20,6 @@ import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -41,13 +40,15 @@ import org.eclipse.kapua.service.device.registry.internal.DeviceRegistryCacheFac
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionServiceImpl extends AbstractKapuaConfigurableService implements DeviceConnectionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(DeviceConnectionServiceImpl.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.connection.option.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOption;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnect
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionListResult;
 import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnectionOptionQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceConnectionOptionFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionOptionFactoryImpl implements DeviceConnectionOptionFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/connection/option/internal/DeviceConnectionOptionServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -39,13 +38,15 @@ import org.eclipse.kapua.service.device.registry.connection.option.DeviceConnect
 import org.eclipse.kapua.service.device.registry.connection.option.UserAlreadyReservedException;
 import org.eclipse.kapua.service.device.registry.internal.DeviceEntityManagerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * DeviceConnectionService exposes APIs to retrieve Device connections under a scope.
  * It includes APIs to find, list, and update devices connections associated with a scope.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceConnectionOptionServiceImpl extends AbstractKapuaService implements DeviceConnectionOptionService {
 
     public DeviceConnectionOptionServiceImpl() {

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.registry.event.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.message.KapuaMethod;
 import org.eclipse.kapua.service.device.registry.event.DeviceEvent;
@@ -21,6 +20,7 @@ import org.eclipse.kapua.service.device.registry.event.DeviceEventFactory;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventListResult;
 import org.eclipse.kapua.service.device.registry.event.DeviceEventQuery;
 
+import javax.inject.Singleton;
 import java.util.Date;
 
 /**
@@ -28,7 +28,7 @@ import java.util.Date;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceEventFactoryImpl implements DeviceEventFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/event/internal/DeviceEventServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.KapuaOptimisticLockingException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -36,13 +35,14 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceEventService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceEventServiceImpl extends AbstractKapuaService implements DeviceEventService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceEventServiceImpl.class);

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.device.registry.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.registry.Device;
 import org.eclipse.kapua.service.device.registry.DeviceCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.device.registry.DeviceFactory;
 import org.eclipse.kapua.service.device.registry.DeviceListResult;
 import org.eclipse.kapua.service.device.registry.DeviceQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceFactoryImpl implements DeviceFactory {
 
     @Override

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/internal/DeviceRegistryServiceImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.kapua.commons.configuration.AbstractKapuaConfigurableResource
 import org.eclipse.kapua.commons.jpa.EntityManagerContainer;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.device.registry.Device;
@@ -36,12 +35,14 @@ import org.eclipse.kapua.service.device.registry.common.DeviceValidation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceRegistryService} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceRegistryServiceImpl extends AbstractKapuaConfigurableResourceLimitedService<Device, DeviceCreator, DeviceRegistryService, DeviceListResult, DeviceQuery, DeviceFactory>
         implements DeviceRegistryService {
 

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/lifecycle/internal/DeviceLifeCycleServiceImpl.java
@@ -15,12 +15,12 @@ package org.eclipse.kapua.service.device.registry.lifecycle.internal;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.base.Strings;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaOptimisticLockingException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaPosition;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaBirthChannel;
@@ -49,7 +49,7 @@ import org.eclipse.kapua.service.device.registry.lifecycle.DeviceLifeCycleServic
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
+import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -61,7 +61,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DeviceLifeCycleServiceImpl implements DeviceLifeCycleService {
 
     private static final Logger LOG = LoggerFactory.getLogger(DeviceLifeCycleServiceImpl.class);

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -14,11 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.device.registry.DeviceRegistryService</api>
-        <api>org.eclipse.kapua.service.device.registry.DeviceFactory</api>
-
-        <api>org.eclipse.kapua.service.device.registry.event.DeviceEventService</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
     </provided>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3408, i.e. move Device Registry bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding device registry services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations