### PR TITLE
Stream - move bindings to local module

### DIFF
--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -94,8 +94,6 @@
                                         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 -->
 
-        <!--        <api>org.eclipse.kapua.service.stream.StreamService</api>-->
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -89,8 +89,6 @@
         <api>org.eclipse.kapua.service.job.targets.JobTargetService</api>
         <api>org.eclipse.kapua.service.job.targets.JobTargetFactory</api>
 
-        <api>org.eclipse.kapua.service.stream.StreamService</api>
-
         <api>org.eclipse.kapua.service.job.JobFactory</api>
         <api>org.eclipse.kapua.service.job.JobService</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -95,8 +95,6 @@
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.stream.StreamService</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamModule.java
+++ b/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.stream.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.stream.StreamService;
+
+public class StreamModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(StreamService.class).to(StreamServiceImpl.class);
+    }
+}

--- a/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
+++ b/service/stream/internal/src/main/java/org/eclipse/kapua/service/stream/internal/StreamServiceImpl.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaIllegalArgumentException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.Message;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.model.domain.Actions;
@@ -46,6 +45,7 @@ import org.eclipse.kapua.transport.TransportFacade;
 import org.eclipse.kapua.transport.exception.TransportClientGetException;
 import org.eclipse.kapua.transport.message.TransportMessage;
 
+import javax.inject.Singleton;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -55,7 +55,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class StreamServiceImpl implements StreamService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3415, i.e. move Stream bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding stream services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations