### PR TITLE
Fixed failing RunEndpointServiceI9nTest

### DIFF
--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/service/endpoint/RunEndpointServiceI9nTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/service/endpoint/RunEndpointServiceI9nTest.java
@@ -22,6 +22,7 @@ import org.junit.runner.RunWith;
         features = { "classpath:features/endpoint/EndpointServiceI9n.feature" },
         glue = {
                 "org.eclipse.kapua.service.user.steps",
+                "org.eclipse.kapua.qa.integration.steps",
                 "org.eclipse.kapua.service.endpoint.steps",
                 "org.eclipse.kapua.qa.common",
                 "org.eclipse.kapua.service.account.steps",

--- a/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/endpoint/EndpointServiceI9n.feature
@@ -17,9 +17,10 @@ Feature: Endpoint Info Service Integration Tests
   Integration test scenarios for Endpoint Info service
 
 @setup
-Scenario: Init Security Context for all scenarios
-  Given Init Jaxb Context
-  And Init Security Context
+  Scenario: Start full docker environment
+    Given Init Jaxb Context
+    And Init Security Context
+    And Start full docker environment
 
   Scenario: Creating Valid Endpoint
   Login as kapua-sys
@@ -892,5 +893,5 @@ Scenario: Init Security Context for all scenarios
     And I logout
 
 @teardown
-Scenario: Reset Security Context for all scenarios
-    Given Reset Security Context
+  Scenario: Stop full docker environment
+    Given Stop full docker environment


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3418, i.e. fixes the failing tests in the RunEndpointServiceI9nTest test class.


**Description of the solution adopted**
Run correctly the docker environment before the tests