### PR TITLE
Added 'forced' paramer to DELETE /jobs/{jobId}

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/Jobs.java
@@ -12,19 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DELETE;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.PUT;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
@@ -43,7 +31,18 @@ import org.eclipse.kapua.service.job.JobListResult;
 import org.eclipse.kapua.service.job.JobQuery;
 import org.eclipse.kapua.service.job.JobService;
 
-import com.google.common.base.Strings;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DELETE;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.PUT;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.Response;
 
 @Path("{scopeId}/jobs")
 public class Jobs extends AbstractKapuaResource {
@@ -141,7 +140,7 @@ public class Jobs extends AbstractKapuaResource {
      * Returns the Job specified by the "jobId" path parameter.
      *
      * @param scopeId The {@link ScopeId} of the requested {@link Job}.
-     * @param jobId The id of the requested Job.
+     * @param jobId   The id of the requested Job.
      * @return The requested Job object.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.0.0
@@ -165,13 +164,12 @@ public class Jobs extends AbstractKapuaResource {
      * Creates a new {@link Job} based on the information provided in {@link JobCreator}
      * parameter.
      *
-     * @param scopeId           The {@link ScopeId} in which to create the {@link Job}
-     * @param jobCreator        Provides the information for the new {@link Job} to be created.
-     * @return                  The newly created {@link Job} object.
-     * @throws                  KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @param scopeId    The {@link ScopeId} in which to create the {@link Job}
+     * @param jobCreator Provides the information for the new {@link Job} to be created.
+     * @return The newly created {@link Job} object.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.5.0
      */
-
     @POST
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -186,14 +184,13 @@ public class Jobs extends AbstractKapuaResource {
     /**
      * Updates the Job based on the information provided in the Job parameter.
      *
-     * @param scopeId        The ScopeId of the requested {@link Job}.
-     * @param jobId          The id of the requested {@link Job}
-     * @param job            The modified Job whose attributed need to be updated.
-     * @return               The updated job.
-     * @throws               KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @param scopeId The ScopeId of the requested {@link Job}.
+     * @param jobId   The id of the requested {@link Job}
+     * @param job     The modified Job whose attributed need to be updated.
+     * @return The updated job.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.5.0
      */
-
     @PUT
     @Path("{jobId}")
     @Consumes({MediaType.APPLICATION_XML, MediaType.APPLICATION_JSON})
@@ -211,19 +208,25 @@ public class Jobs extends AbstractKapuaResource {
     /**
      * Deletes the Job specified by the "jobId" path parameter.
      *
-     * @param scopeId        The ScopeId of the requested {@link Job}.
-     * @param jobId          The id of the Job to be deleted.
-     * @return               HTTP 201 if operation has completed successfully.
-     * @throws               KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
+     * @param scopeId The ScopeId of the requested {@link Job}.
+     * @param jobId   The id of the Job to be deleted.
+     * @return HTTP 201 if operation has completed successfully.
+     * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.5.0
      */
-
     @DELETE
     @Path("{jobId}")
     public Response deleteJob(
             @PathParam("scopeId") ScopeId scopeId,
-            @PathParam("jobId") EntityId jobId) throws KapuaException {
-        jobService.delete(scopeId, jobId);
+            @PathParam("jobId") EntityId jobId,
+            @QueryParam("forced") @DefaultValue("false") Boolean forced)
+            throws KapuaException {
+
+        if (forced) {
+            jobService.deleteForced(scopeId, jobId);
+        } else {
+            jobService.delete(scopeId, jobId);
+        }
 
         return returnNoContent();
     }

--- a/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/job/job-scopeId-jobId.yaml
@@ -77,6 +77,12 @@ paths:
       parameters:
         - $ref: '../openapi.yaml#/components/parameters/scopeId'
         - $ref: './job.yaml#/components/parameters/jobId'
+        - name: forced
+          in: query
+          description: Delete the Job forcibly. It can only be used by the system administrator.
+          schema:
+            type: boolean
+            default: false
       responses:
         204:
           description: The Job has been deleted


### PR DESCRIPTION
Added mapping for `forced` DELETE of a job.

**Related Issue**
_None_

**Description of the solution adopted**
Added `forced` parameter to `DELETE v1/{scopeId}/jobs/{jobId}` resource

**Screenshots**
_None_

**Any side note on the changes made**
_None_