### PR TITLE
Device Commons - move bindings to local module

### DIFF
--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -21,7 +21,6 @@
 
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -34,8 +34,6 @@
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
         <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
 
         <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -21,7 +21,6 @@
 
         <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
 
-        <api>org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory</api>
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceCommonsModule.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/DeviceCommonsModule.java
@@ -1,0 +1,24 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.management.commons;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.management.commons.message.KapuaRequestMessageFactoryImpl;
+import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory;
+
+public class DeviceCommonsModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaRequestMessageFactory.class).to(KapuaRequestMessageFactoryImpl.class);
+    }
+}

--- a/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
+++ b/service/device/commons/src/main/java/org/eclipse/kapua/service/device/management/commons/message/KapuaRequestMessageFactoryImpl.java
@@ -13,7 +13,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.management.commons.message;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.management.commons.KapuaAppPropertiesImpl;
 import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestChannelImpl;
 import org.eclipse.kapua.service.device.management.commons.message.request.KapuaRequestMessageImpl;
@@ -24,12 +23,14 @@ import org.eclipse.kapua.service.device.management.message.request.KapuaRequestM
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestMessageFactory;
 import org.eclipse.kapua.service.device.management.message.request.KapuaRequestPayload;
 
+import javax.inject.Singleton;
+
 /**
  * {@link KapuaRequestMessageFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaRequestMessageFactoryImpl implements KapuaRequestMessageFactory {
 
     @Override


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3422, i.e. move Device Commons bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding device commons services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations