### PR TITLE
Device Call - Move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -21,8 +21,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>
         <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,9 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -30,9 +30,6 @@
         <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
         <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -25,9 +25,6 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>
         <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationRegistryService</api>
         <api>org.eclipse.kapua.service.device.management.registry.operation.DeviceManagementOperationFactory</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -38,9 +38,6 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -19,8 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -31,9 +31,6 @@
 
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-        <api>org.eclipse.kapua.service.device.call.DeviceMessageFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>
 
         <api>org.eclipse.kapua.service.device.management.registry.manager.DeviceManagementRegistryManagerService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,8 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.device.call.DeviceCallFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.request.GenericRequestFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallModule.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/DeviceCallModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.device.call;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.device.call.kura.KuraDeviceCallFactoryImpl;
+import org.eclipse.kapua.service.device.call.kura.KuraMessageFactoryImpl;
+
+public class DeviceCallModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DeviceCallFactory.class).to(KuraDeviceCallFactoryImpl.class);
+        bind(DeviceMessageFactory.class).to(KuraMessageFactoryImpl.class);
+    }
+}

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/DeviceCallKuraModule.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/DeviceCallKuraModule.java
@@ -10,13 +10,13 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.device.call;
+package org.eclipse.kapua.service.device.call.kura;
 
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
-import org.eclipse.kapua.service.device.call.kura.KuraDeviceCallFactoryImpl;
-import org.eclipse.kapua.service.device.call.kura.KuraMessageFactoryImpl;
+import org.eclipse.kapua.service.device.call.DeviceCallFactory;
+import org.eclipse.kapua.service.device.call.DeviceMessageFactory;
 
-public class DeviceCallModule extends AbstractKapuaModule {
+public class DeviceCallKuraModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
         bind(DeviceCallFactory.class).to(KuraDeviceCallFactoryImpl.class);

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallFactoryImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraDeviceCallFactoryImpl.java
@@ -12,20 +12,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.call.DeviceCallFactory;
+
+import javax.inject.Singleton;
 
 /**
  * {@link DeviceCallFactory} {@link Kura} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KuraDeviceCallFactoryImpl implements DeviceCallFactory {
-
     @Override
     public KuraDeviceCallImpl newDeviceCall() {
         return new KuraDeviceCallImpl();
     }
-
 }

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/KuraMessageFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.device.call.kura;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.device.call.DeviceMessageFactory;
 import org.eclipse.kapua.service.device.call.message.DeviceMessage;
 import org.eclipse.kapua.service.device.call.message.DevicePayload;
@@ -25,12 +24,14 @@ import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraReques
 import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestMessage;
 import org.eclipse.kapua.service.device.call.message.kura.app.request.KuraRequestPayload;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DeviceMessageFactory} {@link Kura} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KuraMessageFactoryImpl implements DeviceMessageFactory {
 
     @Override


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3424, i.e. move Device Call bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding device call services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations