### PR TITLE
Fix parent account path format - errata corrige

### DIFF
--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -133,7 +133,7 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
         try {
             AccountCreator accountCreator = ACCOUNT_FACTORY.newCreator(parentAccountId);
 
-            accountCreator.setName(accountCreator.getName());
+            accountCreator.setName(gwtAccountCreator.getAccountName());
             accountCreator.setOrganizationName(gwtAccountCreator.getOrganizationName());
             accountCreator.setOrganizationPersonName(gwtAccountCreator.getOrganizationPersonName());
             accountCreator.setOrganizationEmail(gwtAccountCreator.getOrganizationEmail());


### PR DESCRIPTION
This PR fixes an issue introduced in #3414 which is now preventing any account to be created.

**Related Issue**
This PR fixes an issue introduced in #3414.

**Description of the solution adopted**
Used the correct parameter to set the `AccountCreator.name`

**Screenshots**
_None_

**Any side note on the changes made**
_None_