### PR TITLE
Certificate - move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -15,11 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -15,12 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -15,13 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-
-
     </provided>
 
     <packages>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -15,11 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -15,11 +15,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -14,17 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-
-
-
-
-
-
     </provided>
 
     <packages>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -14,15 +14,10 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>
         </provide>
-
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -14,10 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.certificate.CertificateService</api>
-        <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
-        <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/CertificateModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/CertificateModule.java
@@ -1,0 +1,32 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.certificate;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
+import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
+import org.eclipse.kapua.service.certificate.info.internal.CertificateInfoFactoryImpl;
+import org.eclipse.kapua.service.certificate.info.internal.CertificateInfoServiceImpl;
+import org.eclipse.kapua.service.certificate.internal.CertificateFactoryImpl;
+import org.eclipse.kapua.service.certificate.internal.CertificateServiceImpl;
+
+public class CertificateModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(CertificateInfoFactory.class).to(CertificateInfoFactoryImpl.class);
+        bind(CertificateInfoService.class).to(CertificateInfoServiceImpl.class);
+
+        bind(CertificateFactory.class).to(CertificateFactoryImpl.class);
+        bind(CertificateService.class).to(CertificateServiceImpl.class);
+    }
+}

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoFactoryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.certificate.info.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.certificate.info.CertificateInfo;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoCreator;
@@ -21,7 +20,9 @@ import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoListResult;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class CertificateInfoFactoryImpl implements CertificateInfoFactory {
 
     @Override

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoModule.java
@@ -10,23 +10,16 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.certificate;
+package org.eclipse.kapua.service.certificate.info.internal;
 
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoFactory;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
-import org.eclipse.kapua.service.certificate.info.internal.CertificateInfoFactoryImpl;
-import org.eclipse.kapua.service.certificate.info.internal.CertificateInfoServiceImpl;
-import org.eclipse.kapua.service.certificate.internal.CertificateFactoryImpl;
-import org.eclipse.kapua.service.certificate.internal.CertificateServiceImpl;
 
-public class CertificateModule extends AbstractKapuaModule {
+public class CertificateInfoModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
         bind(CertificateInfoFactory.class).to(CertificateInfoFactoryImpl.class);
         bind(CertificateInfoService.class).to(CertificateInfoServiceImpl.class);
-
-        bind(CertificateFactory.class).to(CertificateFactoryImpl.class);
-        bind(CertificateService.class).to(CertificateServiceImpl.class);
     }
 }

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/info/internal/CertificateInfoServiceImpl.java
@@ -15,7 +15,6 @@ package org.eclipse.kapua.service.certificate.info.internal;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.certificate.CertificateQuery;
@@ -28,9 +27,10 @@ import org.eclipse.kapua.service.certificate.info.CertificateInfoQuery;
 import org.eclipse.kapua.service.certificate.info.CertificateInfoService;
 import org.eclipse.kapua.service.certificate.internal.CertificateQueryImpl;
 
+import javax.inject.Singleton;
 import java.util.List;
 
-@KapuaProvider
+@Singleton
 public class CertificateInfoServiceImpl implements CertificateInfoService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateFactoryImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateFactoryImpl.java
@@ -13,24 +13,25 @@
 package org.eclipse.kapua.service.certificate.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
-import org.eclipse.kapua.service.certificate.CertificateGenerator;
-import org.eclipse.kapua.service.certificate.CertificateUsage;
-import org.eclipse.kapua.service.certificate.KeyUsage;
-import org.eclipse.kapua.service.certificate.KeyUsageSetting;
 import org.eclipse.kapua.service.certificate.Certificate;
 import org.eclipse.kapua.service.certificate.CertificateCreator;
 import org.eclipse.kapua.service.certificate.CertificateFactory;
+import org.eclipse.kapua.service.certificate.CertificateGenerator;
 import org.eclipse.kapua.service.certificate.CertificateListResult;
 import org.eclipse.kapua.service.certificate.CertificateQuery;
+import org.eclipse.kapua.service.certificate.CertificateUsage;
+import org.eclipse.kapua.service.certificate.KeyUsage;
+import org.eclipse.kapua.service.certificate.KeyUsageSetting;
+
+import javax.inject.Singleton;
 
 /**
  * {@link CertificateFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class CertificateFactoryImpl implements CertificateFactory {
 
     @Override

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateModule.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.certificate.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.certificate.CertificateFactory;
+import org.eclipse.kapua.service.certificate.CertificateService;
+
+public class CertificateModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(CertificateFactory.class).to(CertificateFactoryImpl.class);
+        bind(CertificateService.class).to(CertificateServiceImpl.class);
+    }
+}

--- a/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
+++ b/service/security/certificate/internal/src/main/java/org/eclipse/kapua/service/certificate/internal/CertificateServiceImpl.java
@@ -20,23 +20,22 @@ import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.KapuaFileUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.certificate.Certificate;
+import org.eclipse.kapua.service.certificate.CertificateCreator;
 import org.eclipse.kapua.service.certificate.CertificateDomains;
+import org.eclipse.kapua.service.certificate.CertificateFactory;
 import org.eclipse.kapua.service.certificate.CertificateGenerator;
+import org.eclipse.kapua.service.certificate.CertificateListResult;
+import org.eclipse.kapua.service.certificate.CertificateService;
 import org.eclipse.kapua.service.certificate.CertificateUsage;
 import org.eclipse.kapua.service.certificate.KeyUsage;
 import org.eclipse.kapua.service.certificate.KeyUsageSetting;
-import org.eclipse.kapua.service.certificate.Certificate;
-import org.eclipse.kapua.service.certificate.CertificateCreator;
-import org.eclipse.kapua.service.certificate.CertificateFactory;
-import org.eclipse.kapua.service.certificate.CertificateListResult;
-import org.eclipse.kapua.service.certificate.CertificateService;
 import org.eclipse.kapua.service.certificate.exception.KapuaCertificateErrorCodes;
 import org.eclipse.kapua.service.certificate.exception.KapuaCertificateException;
 import org.eclipse.kapua.service.certificate.internal.setting.KapuaCertificateSetting;
@@ -45,12 +44,13 @@ import org.eclipse.kapua.service.certificate.util.CertificateUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
-@KapuaProvider
+@Singleton
 public class CertificateServiceImpl implements CertificateService {
 
     private static final Logger LOG = LoggerFactory.getLogger(CertificateServiceImpl.class);

--- a/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authentication/steps/AuthenticationServiceSteps.java
+++ b/service/security/test-steps/src/main/java/org/eclipse/kapua/service/authentication/steps/AuthenticationServiceSteps.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.steps;
 
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
-import javax.inject.Inject;
-
+import com.google.inject.Singleton;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.When;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -34,16 +34,12 @@ import org.eclipse.kapua.service.user.User;
 import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserService;
-
 import org.junit.Assert;
 
-import com.google.inject.Singleton;
-
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.Scenario;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.When;
+import javax.inject.Inject;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 // Implementation of Gherkin steps used to test miscellaneous Shiro
 // authorization functionality.
@@ -80,7 +76,7 @@ public class AuthenticationServiceSteps extends TestBase {
     }
 
     @When("I create default test-user")
-    public void createDefualtUser() throws KapuaException {
+    public void createDefaultUser() throws KapuaException {
         UserCreator userCreator = userFactory.newCreator(KapuaId.ONE, "test-user");
         User user = userService.create(userCreator);
         stepData.put("User", user);


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3430, i.e. move Certificate bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding certificate services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations