### PR TITLE
Set console 'job.engine.client.auth.mode' to 'access_token'

### DIFF
--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -40,7 +40,7 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
                -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
                -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
-               -Djob.engine.client.auth.mode=trusted"
+               -Djob.engine.client.auth.mode=access_token"
 USER 0
 
 RUN chown -R 1000:0 /opt/jetty /var/opt/jetty && \


### PR DESCRIPTION
This PR changes the console `job.engine.client.auth.mode` from `trusted` to `access_token`

**Related Issue**
_None_

**Description of the solution adopted**
Just changed the setting

**Screenshots**
_None_

**Any side note on the changes made**
_None_