### PR TITLE
Added session AccessToken refreshing on the Console Web Filter

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
@@ -12,40 +12,106 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.console.core.filter;
 
-import java.io.IOException;
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.authc.AuthenticationException;
+import org.apache.shiro.subject.Subject;
+import org.apache.shiro.web.servlet.ShiroFilter;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.security.KapuaSession;
+import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.service.authentication.AuthenticationService;
+import org.eclipse.kapua.service.authentication.CredentialsFactory;
+import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.ServletRequest;
 import javax.servlet.ServletResponse;
-
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.subject.Subject;
-import org.apache.shiro.web.servlet.ShiroFilter;
-import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
-import org.eclipse.kapua.commons.security.KapuaSession;
+import java.io.IOException;
+import java.util.Date;
 
 /**
- * {@link ShiroFilter} override. Used to intercept the http request execute and plug into thread context the Kapua session
+ * {@link ShiroFilter} override.
+ * <p>
+ * Used to intercept the HTTP request execute and plug into thread context the {@link KapuaSession}.
  *
+ * @since 1.0.0
  */
 public class KapuaWebFilter extends ShiroFilter {
 
+    private static final Logger LOG = LoggerFactory.getLogger(KapuaWebFilter.class);
+
+    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
+
+    private static final AuthenticationService AUTHENTICATION_SERVICE = LOCATOR.getService(AuthenticationService.class);
+    private static final CredentialsFactory CREDENTIALS_FACTORY = LOCATOR.getFactory(CredentialsFactory.class);
+
+    @Override
     protected void executeChain(ServletRequest request, ServletResponse response, FilterChain origChain)
             throws IOException, ServletException {
-        // bind kapua session
 
-        // TODO workaround to fix the null kapua session on webconsole requests. to be removed and substitute with getToken or another solution?
-        Subject shiroSubject = SecurityUtils.getSubject();
-        KapuaSession kapuaSession = (KapuaSession) shiroSubject.getSession().getAttribute(KapuaSession.KAPUA_SESSION_KEY);
         try {
-            KapuaSecurityUtils.setSession(kapuaSession);
+            KapuaSession kapuaSession = getSession();
+
+            if (kapuaSession != null) {
+                checkAndRefreshAccessTokenIfExpired(kapuaSession.getAccessToken());
+            }
+
+            KapuaSecurityUtils.setSession(getSession());
 
             super.executeChain(request, response, origChain);
+        } catch (KapuaException e) {
+            LOG.error("Error while plugging KapuaSession into the ServletRequest", e);
+
+            throw new ServletException(e);
         } finally {
             // unbind kapua session
             KapuaSecurityUtils.clearSession();
         }
     }
 
+    /**
+     * Gets the {@link KapuaSession} from the {@link Subject}
+     *
+     * @return The {@link KapuaSession} from the {@link Subject}
+     * @since 1.6.0
+     */
+    protected KapuaSession getSession() {
+        Subject shiroSubject = SecurityUtils.getSubject();
+        return (KapuaSession) shiroSubject.getSession().getAttribute(KapuaSession.KAPUA_SESSION_KEY);
+    }
+
+    /**
+     * Check the {@link AccessToken#getExpiresOn()} and refreshes it on behalf of the user.
+     *
+     * @param accessToken The {@link AccessToken} to check and refresh if needed.
+     * @throws KapuaException If one of the checks fails or refreshing the token fails.
+     * @since 1.6.0
+     */
+    protected void checkAndRefreshAccessTokenIfExpired(AccessToken accessToken) throws KapuaException {
+        LoggerFactory.getLogger(KapuaWebFilter.class).info("Access Token is: {}", accessToken);
+        if (accessToken == null) {
+            return;
+        }
+
+        Date now = new Date();
+
+        if (now.after(accessToken.getExpiresOn()) && now.before(accessToken.getRefreshExpiresOn())) {
+            LOG.info("Refreshing AccessToken for user {} of scope {} expired on {} - token: {}", accessToken.getUserId(), accessToken.getScopeId(), accessToken.getExpiresOn(), accessToken.getTokenId());
+
+            // Remove logout the user to perform a new login with the refreshed token.
+            SecurityUtils.getSubject().logout();
+
+            // Get a new AccessToken from the current AccessToken.refreshToken
+            AccessToken refreshAccessToken = AUTHENTICATION_SERVICE.refreshAccessToken(accessToken.getTokenId(), accessToken.getRefreshToken());
+
+            // Authenticate with the refreshed AccessToken
+            AUTHENTICATION_SERVICE.authenticate(CREDENTIALS_FACTORY.newAccessTokenCredentials(refreshAccessToken.getTokenId()));
+        } else if (now.after(accessToken.getRefreshExpiresOn())) {
+            throw new AuthenticationException("AccessToken.refreshToken is expired!");
+        }
+    }
 }

--- a/console/web/src/main/resources/shiro.ini
+++ b/console/web/src/main/resources/shiro.ini
@@ -9,11 +9,13 @@ authenticator = org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticato
 securityManager.authenticator = $authenticator
 
 # Realms
-kapuaAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
-kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
-jwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
+kapuaUserPassAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.UserPassAuthenticatingRealm
+kapuaAccessTokenAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.AccessTokenAuthenticatingRealm
+kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.realm.JwtAuthenticatingRealm
 
-securityManager.realms = $kapuaAuthorizingRealm, $kapuaAuthenticatingRealm, $jwtAuthenticatingRealm
+kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
+
+securityManager.realms = $kapuaAuthorizingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
 
 # Request Filtering
 filterChainResolver = org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver


### PR DESCRIPTION
This PR adds the automatic refresh of the AccessToken of the session in Console.

**Related Issue**
_None_

**Description of the solution adopted**
Added a check on the KapuaWebFilter that checks for the `AccessToken.expiresOn` and `AccessToken.refreshExpiresOn` fields and if needed refreshes silently the `AccessToken` for the given session.

**Screenshots**
_None_

**Any side note on the changes made**
_None_