### PR TITLE
Datastore - move bindings to local module

### DIFF
--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -20,16 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ClientInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
-
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetManagementService</api>
         <api>org.eclipse.kapua.service.device.management.asset.DeviceAssetFactory</api>
         <api>org.eclipse.kapua.service.device.management.bundle.DeviceBundleManagementService</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -20,16 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ClientInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -19,16 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ClientInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
-
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
         <api>org.eclipse.kapua.service.device.management.job.scheduler.manager.JobDeviceManagementTriggerManagerService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -54,17 +54,6 @@
 
         <api>org.eclipse.kapua.service.device.management.request.DeviceRequestManagementService</api>
 
-        <api>org.eclipse.kapua.service.datastore.ClientInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ClientInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.ChannelInfoFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreService</api>
-        <api>org.eclipse.kapua.service.datastore.MessageStoreFactory</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoRegistryService</api>
-        <api>org.eclipse.kapua.service.datastore.MetricInfoFactory</api>
-
-        <api>org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory</api>
-
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
         <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
 

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.ChannelInfoFactory;
 import org.eclipse.kapua.service.datastore.internal.model.ChannelInfoImpl;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.datastore.model.ChannelInfo;
 import org.eclipse.kapua.service.datastore.model.ChannelInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ChannelInfoQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link ChannelInfoFactory} implementation.
  *
  * @since 1.3.0
  */
-@KapuaProvider
+@Singleton
 public class ChannelInfoFactoryImpl implements ChannelInfoFactory {
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ChannelInfoRegistryServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -50,6 +49,7 @@ import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -59,7 +59,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class ChannelInfoRegistryServiceImpl extends AbstractKapuaService implements ChannelInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ChannelInfoRegistryServiceImpl.class);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.ClientInfoFactory;
 import org.eclipse.kapua.service.datastore.internal.model.ClientInfoImpl;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.datastore.model.ClientInfo;
 import org.eclipse.kapua.service.datastore.model.ClientInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.ClientInfoQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link ClientInfoFactory} implementation.
  *
  * @since 1.3.0
  */
-@KapuaProvider
+@Singleton
 public class ClientInfoFactoryImpl implements ClientInfoFactory {
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/ClientInfoRegistryServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -52,6 +51,7 @@ import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -61,7 +61,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class ClientInfoRegistryServiceImpl extends AbstractKapuaService implements ClientInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(ClientInfoRegistryServiceImpl.class);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreModule.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/DatastoreModule.java
@@ -1,0 +1,37 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.datastore.ChannelInfoFactory;
+import org.eclipse.kapua.service.datastore.ChannelInfoRegistryService;
+import org.eclipse.kapua.service.datastore.ClientInfoFactory;
+import org.eclipse.kapua.service.datastore.ClientInfoRegistryService;
+import org.eclipse.kapua.service.datastore.MessageStoreFactory;
+import org.eclipse.kapua.service.datastore.MessageStoreService;
+import org.eclipse.kapua.service.datastore.MetricInfoFactory;
+import org.eclipse.kapua.service.datastore.MetricInfoRegistryService;
+
+public class DatastoreModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(ChannelInfoFactory.class).to(ChannelInfoFactoryImpl.class);
+        bind(ChannelInfoRegistryService.class).to(ChannelInfoRegistryServiceImpl.class);
+        bind(ClientInfoFactory.class).to(ClientInfoFactoryImpl.class);
+        bind(ClientInfoRegistryService.class).to(ClientInfoRegistryServiceImpl.class);
+        bind(MessageStoreFactory.class).to(MessageStoreFactoryImpl.class);
+        bind(MessageStoreService.class).to(MessageStoreServiceImpl.class);
+        bind(MetricInfoFactory.class).to(MetricInfoFactoryImpl.class);
+        bind(MetricInfoRegistryService.class).to(MetricInfoRegistryServiceImpl.class);
+    }
+}

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.MessageStoreFactory;
 import org.eclipse.kapua.service.datastore.MetricInfoFactory;
@@ -23,12 +22,14 @@ import org.eclipse.kapua.service.datastore.model.DatastoreMessage;
 import org.eclipse.kapua.service.datastore.model.MessageListResult;
 import org.eclipse.kapua.service.datastore.model.query.MessageQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link MetricInfoFactory} implementation.
  *
  * @since 1.3.0
  */
-@KapuaProvider
+@Singleton
 public class MessageStoreFactoryImpl implements MessageStoreFactory {
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -23,7 +23,6 @@ import org.eclipse.kapua.commons.metric.MetricServiceFactory;
 import org.eclipse.kapua.commons.metric.MetricsService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -46,6 +45,7 @@ import org.eclipse.kapua.service.elasticsearch.client.exception.ClientCommunicat
 import org.eclipse.kapua.service.storable.model.id.StorableId;
 import org.eclipse.kapua.service.storable.model.query.StorableFetchStyle;
 
+import javax.inject.Singleton;
 import java.util.UUID;
 
 /**
@@ -53,7 +53,7 @@ import java.util.UUID;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService implements MessageStoreService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.datastore.MetricInfoFactory;
 import org.eclipse.kapua.service.datastore.internal.model.MetricInfoImpl;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.datastore.model.MetricInfo;
 import org.eclipse.kapua.service.datastore.model.MetricInfoListResult;
 import org.eclipse.kapua.service.datastore.model.query.MetricInfoQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link MetricInfoFactory} implementation.
  *
  * @since 1.3.0
  */
-@KapuaProvider
+@Singleton
 public class MetricInfoFactoryImpl implements MetricInfoFactory {
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MetricInfoRegistryServiceImpl.java
@@ -18,7 +18,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.service.internal.KapuaServiceDisabledException;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.account.AccountService;
@@ -53,6 +52,7 @@ import org.eclipse.kapua.service.storable.model.query.predicate.TermPredicate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Singleton;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
@@ -62,7 +62,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class MetricInfoRegistryServiceImpl extends AbstractKapuaService implements MetricInfoRegistryService {
 
     private static final Logger LOG = LoggerFactory.getLogger(MetricInfoRegistryServiceImpl.class);

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/DatastorePredicateFactoryImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/DatastorePredicateFactoryImpl.java
@@ -12,19 +12,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.datastore.internal.model.query.predicate;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.datastore.model.query.predicate.ChannelMatchPredicate;
 import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
 import org.eclipse.kapua.service.datastore.model.query.predicate.MetricExistsPredicate;
 import org.eclipse.kapua.service.datastore.model.query.predicate.MetricPredicate;
 import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactoryImpl;
 
+import javax.inject.Singleton;
+
 /**
  * {@link DatastorePredicateFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class DatastorePredicateFactoryImpl extends StorablePredicateFactoryImpl implements DatastorePredicateFactory {
 
     @Override

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/DatastoreQueryPredicateModule.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/model/query/predicate/DatastoreQueryPredicateModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.datastore.internal.model.query.predicate;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.datastore.model.query.predicate.DatastorePredicateFactory;
+
+public class DatastoreQueryPredicateModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(DatastorePredicateFactory.class).to(DatastorePredicateFactoryImpl.class);
+    }
+}


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3439, i.e. move Datastore bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding datastore services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created modules, subclasses of `AbstractKapuaModule`, in order to bind interfaces and implementations