### PR TITLE
Fix connectionId format to remove extra commas

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -108,7 +108,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
     protected static final String VT_CONSUMER_PREFIX = "Consumer";
 
     // full client id, with account prepended
-    protected static final String MULTI_ACCOUNT_CLIENT_ID = "{0}:{1}";
+    protected static final String MULTI_ACCOUNT_CLIENT_ID = "%s:%s";
 
     private static final String CONNECT_MESSAGE_TOPIC_PATTERN = "VirtualTopic.%s.%s.%s.MQTT.CONNECT";
     private static final String DISCONNECT_MESSAGE_TOPIC_PATTERN = "VirtualTopic.%s.%s.%s.MQTT.DISCONNECT";

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityContext.java
@@ -15,7 +15,6 @@ package org.eclipse.kapua.broker.core.plugin;
 import java.math.BigInteger;
 import java.security.Principal;
 import java.security.cert.Certificate;
-import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -177,11 +176,11 @@ public class KapuaSecurityContext extends SecurityContext {
     }
 
     private void updateFullClientId() {
-        fullClientId = MessageFormat.format(KapuaSecurityBrokerFilter.MULTI_ACCOUNT_CLIENT_ID, scopeId.getId().longValue(), clientId);
+        fullClientId = String.format(KapuaSecurityBrokerFilter.MULTI_ACCOUNT_CLIENT_ID, scopeId.getId().longValue(), clientId);
     }
 
     private void updateFullClientId(Long scopeId) {
-        fullClientId = MessageFormat.format(KapuaSecurityBrokerFilter.MULTI_ACCOUNT_CLIENT_ID, scopeId, clientId);
+        fullClientId = String.format(KapuaSecurityBrokerFilter.MULTI_ACCOUNT_CLIENT_ID, scopeId, clientId);
     }
 
     public String getFullClientId() {


### PR DESCRIPTION
Brief description of the PR.
This fixes the connectionId used in the broker, which is in the format `<accountId>:<clientId>` to remove the commas that were being included as part of the accountId portion.

**Related Issue**
This fixes #3443.

**Description of the solution adopted**
Instead of using `MessageFormat.format()` which was adding commas for `long` values, I changed it to use the simpler `String.format()` instead.

**Screenshots**
N/A

**Any side note on the changes made**
N/A
