### PR TITLE
Add missing DeviceConnection attributes

### DIFF
--- a/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
+++ b/service/device/registry/api/src/main/java/org/eclipse/kapua/service/device/registry/connection/DeviceConnectionAttributes.java
@@ -52,9 +52,19 @@ public class DeviceConnectionAttributes extends KapuaUpdatableEntityAttributes {
     public static final String USER_COUPLING_MODE = "userCouplingMode";
 
     /**
+     * Allow user change
+     */
+    public static final String ALLOW_USER_CHANGE = "allowUserChange";
+
+    /**
      * Client IP
      */
     public static final String CLIENT_IP = "clientIp";
+
+    /**
+     * Server IP
+     */
+    public static final String SERVER_IP = "serverIp";
 
     /**
      * Protocol


### PR DESCRIPTION
This adds the missing `serverIp` and `allowUserChange` attributes to DeviceConnectionAttributes, which is used for building DeviceConnection queries.

**Related Issue**
This fixes #3444.

**Description of the solution adopted**
This adds a couple constant strings for the missing attributes.

**Screenshots**
N/A

**Any side note on the changes made**
N/A
