### PR TITLE
Make KapuaDuplicateClientIdException more generic

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaBrokerErrorCodes.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaBrokerErrorCodes.java
@@ -19,6 +19,16 @@ public enum KapuaBrokerErrorCodes implements KapuaErrorCode {
     /**
      * Duplicated client id on connection (stealing link detected)
      */
-    DUPLICATED_CLIENT_ID
+    DUPLICATE_CLIENT_ID,
+
+    /**
+     * An illegal connection was detected
+     */
+    ILLEGAL_CONNECTION,
+
+    /**
+     * An unexpected device status was detected
+     */
+    UNEXPECTED_STATUS
 
 }

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaIllegalDeviceStateException.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaIllegalDeviceStateException.java
@@ -14,12 +14,12 @@ package org.eclipse.kapua.broker.core.plugin;
 
 import org.eclipse.kapua.KapuaException;
 
-public class KapuaDuplicateClientIdException extends KapuaException {
+public class KapuaIllegalDeviceStateException extends KapuaException {
 
     private static final long serialVersionUID = 1751650664486096457L;
 
-    public KapuaDuplicateClientIdException(String clientId) {
-        super(KapuaBrokerErrorCodes.DUPLICATED_CLIENT_ID, clientId);
+    public KapuaIllegalDeviceStateException(KapuaBrokerErrorCodes errorCode, String clientId) {
+        super(errorCode, clientId);
     }
 
 }

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -282,7 +282,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                 // Include Exception to notify the security broker filter
                 logger.info("New connection detected for {} on another broker.  Stopping the current connection...", kapuaSecurityContext.getFullClientId());
                 loginMetric.getRemoteStealingLinkDisconnect().inc();
-                conn.serviceExceptionAsync(new IOException(new KapuaDuplicateClientIdException(kapuaSecurityContext.getFullClientId())));
+                conn.serviceExceptionAsync(new IOException(new KapuaIllegalDeviceStateException(KapuaBrokerErrorCodes.DUPLICATE_CLIENT_ID, kapuaSecurityContext.getFullClientId())));
                 // assume only one connection since this broker should have already handled any duplicates
                 return;
             }

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AdminAuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AdminAuthenticationLogic.java
@@ -44,7 +44,7 @@ public class AdminAuthenticationLogic extends AuthenticationLogic {
 
     @Override
     public boolean disconnect(KapuaSecurityContext kapuaSecurityContext, Throwable error) {
-        boolean stealingLinkDetected = isStealingLink(kapuaSecurityContext, error);
+        boolean stealingLinkDetected = isIllegalState(kapuaSecurityContext, error);
         logger.debug("Old connection id: {} - new connection id: {} - error: {} - error cause: {}", kapuaSecurityContext.getOldConnectionId(), kapuaSecurityContext.getConnectionId(), error, (error!=null ? error.getCause() : "null"), error);
         if (stealingLinkDetected) {
             loginMetric.getAdminStealingLinkDisconnect().inc();

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/UserAuthenticationLogic.java
@@ -103,6 +103,12 @@ public class UserAuthenticationLogic extends AuthenticationLogic {
                     kapuaSecurityContext.getClientId(),
                     kapuaSecurityContext.getConnectionId());
         }
+        else if (isIllegalState(kapuaSecurityContext, error)) {
+            loginMetric.getIllegalStateDisconnect().inc();
+            logger.debug("Skip device connection status update from illegal device status disconnection. Client id: {} - Connection id: {}",
+                    kapuaSecurityContext.getClientId(),
+                    kapuaSecurityContext.getConnectionId());
+        }
         else {
             // update device connection (if the disconnection wasn't caused by a stealing link)
             DeviceConnection deviceConnection;

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/LoginMetric.java
@@ -34,6 +34,7 @@ public class LoginMetric {
     private Counter adminStealingLinkDisconnect;
     private Counter remoteStealingLinkDisconnect;
     private Counter internalConnectorDisconnected;
+    private Counter illegalStateDisconnect;
     private Timer addConnectionTime;
     private Timer normalUserTime;
     private Timer shiroLoginTime;
@@ -64,6 +65,7 @@ public class LoginMetric {
         stealingLinkDisconnect = metricsService.getCounter(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_STEALING_LINK, SecurityMetrics.METRIC_DISCONNECT, SecurityMetrics.METRIC_COUNT);
         adminStealingLinkDisconnect = metricsService.getCounter(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_ADMIN_STEALING_LINK, SecurityMetrics.METRIC_DISCONNECT, SecurityMetrics.METRIC_COUNT);
         remoteStealingLinkDisconnect = metricsService.getCounter(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_REMOTE_STEALING_LINK, SecurityMetrics.METRIC_DISCONNECT, SecurityMetrics.METRIC_COUNT);
+        illegalStateDisconnect = metricsService.getCounter(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_ILLEGAL_STATE, SecurityMetrics.METRIC_DISCONNECT, SecurityMetrics.METRIC_COUNT);
         // login time
         addConnectionTime = metricsService.getTimer(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_ADD_CONNECTION, SecurityMetrics.METRIC_TIME, SecurityMetrics.METRIC_S);
         normalUserTime = metricsService.getTimer(SecurityMetrics.METRIC_MODULE_NAME, SecurityMetrics.METRIC_COMPONENT_LOGIN, SecurityMetrics.METRIC_USER, SecurityMetrics.METRIC_TIME, SecurityMetrics.METRIC_S);
@@ -118,6 +120,10 @@ public class LoginMetric {
 
     public Counter getAdminStealingLinkDisconnect() {
         return adminStealingLinkDisconnect;
+    }
+
+    public Counter getIllegalStateDisconnect() {
+        return illegalStateDisconnect;
     }
 
     public Counter getInternalConnectorConnected() {

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SecurityMetrics.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/metric/SecurityMetrics.java
@@ -37,6 +37,7 @@ public class SecurityMetrics {
     public static final String METRIC_STEALING_LINK = "stealing_link";
     public static final String METRIC_ADMIN_STEALING_LINK = "admin_" + METRIC_STEALING_LINK;
     public static final String METRIC_REMOTE_STEALING_LINK = "remote_" + METRIC_STEALING_LINK;
+    public static final String METRIC_ILLEGAL_STATE = "illegal_state";
     public static final String METRIC_ADD_CONNECTION = "add_connection";
     public static final String METRIC_USER = "user";
     public static final String METRIC_SHIRO = "shiro";


### PR DESCRIPTION
This updates `KapuaDuplicateClientIdException` to make it more generic by renaming it to `KapuaIllegalDeviceStateException`, and adding additional error codes. This will allow it to be used in other scenarios, while maintaining the same disconnect logic.

**Related Issue**
This fixes #3445.

**Description of the solution adopted**
N/A

**Screenshots**
N/A

**Any side note on the changes made**
I also added an additional metric to track disconnects from other uses of this exception.
