### PR TITLE
Removed log line leftover from #3440

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
@@ -92,7 +92,6 @@ public class KapuaWebFilter extends ShiroFilter {
      * @since 1.6.0
      */
     protected void checkAndRefreshAccessTokenIfExpired(AccessToken accessToken) throws KapuaException {
-        LoggerFactory.getLogger(KapuaWebFilter.class).info("Access Token is: {}", accessToken);
         if (accessToken == null) {
             return;
         }


### PR DESCRIPTION
This PR removes a log line leftover from https://github.com/eclipse/kapua/pull/3440 which now clutters the log of the console.

**Related Issue**
This PR is an addition to https://github.com/eclipse/kapua/pull/3440

**Description of the solution adopted**
Removed the log line.

**Screenshots**
_None_

**Any side note on the changes made**
_None_