### PR TITLE
Fix unit test build

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/authentication/AuthenticationLogic.java
@@ -263,14 +263,14 @@ public abstract class AuthenticationLogic {
     }
 
     protected boolean isStealingLink(KapuaSecurityContext kapuaSecurityContext, Throwable error) {
-        if(!isIllegalState(kapuaSecurityContext, error) || error == null) {
-            return false;
+        if(isIllegalState(kapuaSecurityContext, error)) {
+            return true;
         }
 
         KapuaIllegalDeviceStateException illegalStateException = null;
         if(error instanceof KapuaIllegalDeviceStateException) {
             illegalStateException = (KapuaIllegalDeviceStateException) error;
-        } else if (error.getCause() != null && error.getCause() instanceof KapuaIllegalDeviceStateException) {
+        } else if (error != null && error.getCause() != null && error.getCause() instanceof KapuaIllegalDeviceStateException) {
             illegalStateException = (KapuaIllegalDeviceStateException) error.getCause();
         }
 

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -198,9 +198,21 @@
             <groupId>org.elasticsearch.plugin</groupId>
             <artifactId>percolator-client</artifactId>
         </dependency>
+
+        <!-- Test -->
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
This PR fixes the `unit-test` workflow build step, which broke after merging #3446 

**Related Issue**
This PR fixes test issue introduced in #3446

**Description of the solution adopted**
Added handling of `null` error while checking stealink event.

**Screenshots**
_None_

**Any side note on the changes made**
Fixed test dependency configuration for `kapua-rest-api-web` module