### PR TITLE
Scheduler - move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -39,11 +39,7 @@
 
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
+        
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
         <provide>
             <interceptor>annotation</interceptor>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -20,13 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -38,10 +38,6 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
         <provide>
             <interceptor>annotation</interceptor>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -24,13 +24,7 @@
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
-
+        
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -21,12 +21,6 @@
 
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 
@@ -35,9 +29,6 @@
 
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -22,13 +22,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
-
         <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
         <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
 

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/SchedulerTriggerDefinitionModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/SchedulerTriggerDefinitionModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory;
+import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService;
+
+public class SchedulerTriggerDefinitionModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(TriggerDefinitionFactory.class).to(TriggerDefinitionFactoryImpl.class);
+        bind(TriggerDefinitionService.class).to(TriggerDefinitionServiceImpl.class);
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionFactoryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.scheduler.trigger.definition.quartz;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinition;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionL
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionQuery;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
 
+import javax.inject.Singleton;
+
 /**
  * {@link TriggerDefinitionFactory} implementation.
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class TriggerDefinitionFactoryImpl implements TriggerDefinitionFactory {
 
     @Override

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/definition/quartz/TriggerDefinitionServiceImpl.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -31,13 +30,14 @@ import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionL
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link TriggerDefinitionService} implementation.
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class TriggerDefinitionServiceImpl extends AbstractKapuaService implements TriggerDefinitionService {
 
     @Inject

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/FiredTriggerFactoryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/FiredTriggerFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.scheduler.trigger.fired.quartz;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTrigger;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerCreator;
@@ -21,12 +20,14 @@ import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerFactory;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerListResult;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerQuery;
 
+import javax.inject.Singleton;
+
 /**
  * {@link FiredTriggerFactory} implementation.
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class FiredTriggerFactoryImpl implements FiredTriggerFactory {
 
     @Override

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/FiredTriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/FiredTriggerServiceImpl.java
@@ -16,7 +16,6 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -33,13 +32,14 @@ import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerListResult;
 import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 
 /**
  * {@link FiredTriggerService} implementation.
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class FiredTriggerServiceImpl extends AbstractKapuaService implements FiredTriggerService {
 
     @Inject

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/SchedulerTriggerFiredModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/fired/quartz/SchedulerTriggerFiredModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.fired.quartz;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerFactory;
+import org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService;
+
+public class SchedulerTriggerFiredModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(FiredTriggerFactory.class).to(FiredTriggerFactoryImpl.class);
+        bind(FiredTriggerService.class).to(FiredTriggerServiceImpl.class);
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerQuartzModule.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/SchedulerQuartzModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.scheduler.trigger.quartz;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerFactory;
+import org.eclipse.kapua.service.scheduler.trigger.TriggerService;
+
+public class SchedulerQuartzModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(TriggerFactory.class).to(TriggerFactoryImpl.class);
+        bind(TriggerService.class).to(TriggerServiceImpl.class);
+    }
+}

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerFactoryImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.scheduler.trigger.quartz;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.scheduler.trigger.Trigger;
 import org.eclipse.kapua.service.scheduler.trigger.TriggerCreator;
@@ -23,12 +22,14 @@ import org.eclipse.kapua.service.scheduler.trigger.TriggerQuery;
 import org.eclipse.kapua.service.scheduler.trigger.definition.TriggerProperty;
 import org.eclipse.kapua.service.scheduler.trigger.definition.quartz.TriggerPropertyImpl;
 
+import javax.inject.Singleton;
+
 /**
  * {@link TriggerFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class TriggerFactoryImpl implements TriggerFactory {
 
     @Override

--- a/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
+++ b/service/scheduler/quartz/src/main/java/org/eclipse/kapua/service/scheduler/trigger/quartz/TriggerServiceImpl.java
@@ -17,7 +17,6 @@ import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -44,6 +43,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.inject.Inject;
+import javax.inject.Singleton;
 import javax.validation.constraints.NotNull;
 import java.util.ArrayList;
 import java.util.Date;
@@ -54,7 +54,7 @@ import java.util.List;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class TriggerServiceImpl extends AbstractKapuaService implements TriggerService {
 
     private static final Logger LOG = LoggerFactory.getLogger(TriggerServiceImpl.class);

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -14,11 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionService</api>
-        <api>org.eclipse.kapua.service.scheduler.trigger.definition.TriggerDefinitionFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3437, i.e. move scheduler bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding scheduler services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations