### PR TITLE
Endpoint - move bindings to local module

### DIFF
--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -20,9 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
-
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.fired.FiredTriggerService</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -19,9 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
-
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -39,9 +39,6 @@
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerFactory</api>
         <api>org.eclipse.kapua.service.scheduler.trigger.TriggerService</api>
 
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,9 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoFactory</api>
-        <api>org.eclipse.kapua.service.endpoint.EndpointInfoService</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoFactoryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.service.endpoint.internal;
 
 import org.eclipse.kapua.KapuaEntityCloneException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.endpoint.EndpointInfo;
 import org.eclipse.kapua.service.endpoint.EndpointInfoCreator;
@@ -22,12 +21,14 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointUsage;
 
+import javax.inject.Singleton;
+
 /**
  * {@link EndpointInfoFactory} implementation.
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class EndpointInfoFactoryImpl implements EndpointInfoFactory {
 
     @Override

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointInfoServiceImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
 import org.eclipse.kapua.commons.util.CommonsValidationRegex;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -42,6 +41,7 @@ import org.eclipse.kapua.service.endpoint.EndpointInfoListResult;
 import org.eclipse.kapua.service.endpoint.EndpointInfoQuery;
 import org.eclipse.kapua.service.endpoint.EndpointInfoService;
 
+import javax.inject.Singleton;
 import java.util.AbstractMap;
 import java.util.ArrayList;
 import java.util.List;
@@ -52,7 +52,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class EndpointInfoServiceImpl
         extends AbstractKapuaService
         implements EndpointInfoService {

--- a/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointModule.java
+++ b/service/endpoint/internal/src/main/java/org/eclipse/kapua/service/endpoint/internal/EndpointModule.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.endpoint.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.endpoint.EndpointInfoFactory;
+import org.eclipse.kapua.service.endpoint.EndpointInfoService;
+
+public class EndpointModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(EndpointInfoFactory.class).to(EndpointInfoFactoryImpl.class);
+        bind(EndpointInfoService.class).to(EndpointInfoServiceImpl.class);
+    }
+}


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3460, i.e. move Endpoint bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding endpoint services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations