### PR TITLE
Storable - move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -22,9 +22,6 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,9 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -20,9 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -20,9 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -21,9 +21,6 @@
 
         <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -22,9 +22,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
-        <api>org.eclipse.kapua.service.storable.model.id.StorableIdFactory</api>
-        <api>org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicateFactory</api>
-
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/id/StorableIdModule.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/id/StorableIdModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,18 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.storable.model.id;
 
-import javax.inject.Singleton;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 
-/**
- * {@link StorableIdFactory} implementation.
- *
- * @since 1.0.0
- */
-@Singleton
-public class StorableIdFactoryImpl implements StorableIdFactory {
-
+public class StorableIdModule extends AbstractKapuaModule {
     @Override
-    public StorableId newStorableId(String stringId) {
-        return new StorableIdImpl(stringId);
+    protected void configureModule() {
+        bind(StorableIdFactory.class).to(StorableIdFactoryImpl.class);
     }
 }

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/StorablePredicateFactoryImpl.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/StorablePredicateFactoryImpl.java
@@ -12,10 +12,11 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.storable.model.query.predicate;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.service.storable.model.query.StorableField;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class StorablePredicateFactoryImpl implements StorablePredicateFactory {
 
     @Override

--- a/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/StorableQueryPredicateModule.java
+++ b/service/commons/storable/internal/src/main/java/org/eclipse/kapua/service/storable/model/query/predicate/StorableQueryPredicateModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -10,20 +10,13 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.service.storable.model.id;
+package org.eclipse.kapua.service.storable.model.query.predicate;
 
-import javax.inject.Singleton;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 
-/**
- * {@link StorableIdFactory} implementation.
- *
- * @since 1.0.0
- */
-@Singleton
-public class StorableIdFactoryImpl implements StorableIdFactory {
-
+public class StorableQueryPredicateModule extends AbstractKapuaModule {
     @Override
-    public StorableId newStorableId(String stringId) {
-        return new StorableIdImpl(stringId);
+    protected void configureModule() {
+        bind(StorablePredicateFactory.class).to(StorablePredicateFactoryImpl.class);
     }
 }


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3463, i.e. move Storable bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding storable services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations