### PR TITLE
Message - move bindings to local module

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -24,8 +24,6 @@
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,9 +25,6 @@
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -22,10 +22,6 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -22,9 +22,6 @@
 
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
 
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -24,9 +24,6 @@
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-        
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/KapuaMessageFactoryImpl.java
@@ -13,19 +13,20 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaChannel;
 import org.eclipse.kapua.message.KapuaMessage;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.KapuaPayload;
 import org.eclipse.kapua.message.KapuaPosition;
 
+import javax.inject.Singleton;
+
 /**
  * {@link KapuaMessageFactory} implementation
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaMessageFactoryImpl implements KapuaMessageFactory {
 
     @Override

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageModule.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/MessageModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.message.KapuaMessageFactory;
+
+public class MessageModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaMessageFactory.class).to(KapuaMessageFactoryImpl.class);
+    }
+}

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/KapuaDataMessageFactoryImpl.java
@@ -13,18 +13,19 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal.device.data;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.device.data.KapuaDataChannel;
 import org.eclipse.kapua.message.device.data.KapuaDataMessage;
 import org.eclipse.kapua.message.device.data.KapuaDataMessageFactory;
 import org.eclipse.kapua.message.device.data.KapuaDataPayload;
+
+import javax.inject.Singleton;
 
 /**
  * {@link KapuaDataMessageFactory} implementation
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaDataMessageFactoryImpl implements KapuaDataMessageFactory {
 
     @Override

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/MessageDataModule.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/data/MessageDataModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.data;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.message.device.data.KapuaDataMessageFactory;
+
+public class MessageDataModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaDataMessageFactory.class).to(KapuaDataMessageFactoryImpl.class);
+    }
+}

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaLifecycleMessageFactoryImpl.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/KapuaLifecycleMessageFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.message.internal.device.lifecycle;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.message.KapuaMessageFactory;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage;
@@ -28,12 +27,14 @@ import org.eclipse.kapua.message.device.lifecycle.KapuaMissingChannel;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingMessage;
 import org.eclipse.kapua.message.device.lifecycle.KapuaMissingPayload;
 
+import javax.inject.Singleton;
+
 /**
  * {@link KapuaMessageFactory} implementation.
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaLifecycleMessageFactoryImpl implements KapuaLifecycleMessageFactory {
     @Override
     public KapuaAppsMessage newKapuaAppsMessage() {

--- a/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/MessageLifecycleModule.java
+++ b/message/internal/src/main/java/org/eclipse/kapua/message/internal/device/lifecycle/MessageLifecycleModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.message.internal.device.lifecycle;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory;
+
+public class MessageLifecycleModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaLifecycleMessageFactory.class).to(KapuaLifecycleMessageFactoryImpl.class);
+    }
+}

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -14,10 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
-
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
     <packages>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -19,8 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.message.device.lifecycle.KapuaLifecycleMessageFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
@@ -28,10 +26,7 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-
+        
         <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -15,7 +15,6 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
     </provided>
 
     <packages>


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3465, i.e. move Message bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding message services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created a module, subclass of `AbstractKapuaModule`, in order to bind interfaces and implementations