### PR TITLE
Move missing bindings to local modules

### DIFF
--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -19,13 +19,7 @@
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-        <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
-        <!-- job services -->
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
+        
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -19,7 +19,7 @@
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-        
+
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -26,8 +26,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
         <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
         <!-- job services -->
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -20,12 +20,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
 
         <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
         <!-- job services -->

--- a/assembly/broker/configurations/locator.xml
+++ b/assembly/broker/configurations/locator.xml
@@ -20,12 +20,12 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
         <!-- job services -->

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
         <provide>
             <interceptor>annotation</interceptor>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>

--- a/broker/core/src/test/resources/locator.xml
+++ b/broker/core/src/test/resources/locator.xml
@@ -20,7 +20,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/CommonsConfigurationModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/CommonsConfigurationModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.configuration;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.service.config.ServiceConfigurationFactory;
+
+public class CommonsConfigurationModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(ServiceConfigurationFactory.class).to(ServiceConfigurationFactoryImpl.class);
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/ServiceConfigurationFactoryImpl.java
@@ -15,14 +15,15 @@ package org.eclipse.kapua.commons.configuration;
 import org.eclipse.kapua.service.config.ServiceComponentConfiguration;
 import org.eclipse.kapua.service.config.ServiceConfiguration;
 import org.eclipse.kapua.service.config.ServiceConfigurationFactory;
-import org.eclipse.kapua.locator.KapuaProvider;
+
+import javax.inject.Singleton;
 
 /**
  * Service configuration entity service factory implementation.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class ServiceConfigurationFactoryImpl implements ServiceConfigurationFactory {
 
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/CommonsMetatypeModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/CommonsMetatypeModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.configuration.metatype;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
+
+public class CommonsMetatypeModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(KapuaMetatypeFactory.class).to(KapuaMetatypeFactoryImpl.class);
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/metatype/KapuaMetatypeFactoryImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.configuration.metatype;
 
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
 import org.eclipse.kapua.model.config.metatype.KapuaTad;
 import org.eclipse.kapua.model.config.metatype.KapuaTdesignate;
@@ -23,12 +22,14 @@ import org.eclipse.kapua.model.config.metatype.KapuaTocd;
 import org.eclipse.kapua.model.config.metatype.KapuaToption;
 import org.eclipse.kapua.model.config.metatype.KapuaTscalar;
 
+import javax.inject.Singleton;
+
 /**
  * Kapua metatype objects factory service implementation.
  *
  * @since 1.0
  */
-@KapuaProvider
+@Singleton
 public class KapuaMetatypeFactoryImpl implements KapuaMetatypeFactory {
 
     @Override

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleConfiguration.java
@@ -18,19 +18,19 @@ import java.util.Set;
 public class ServiceModuleConfiguration {
 
     public interface ConfigurationProvider {
-        ServiceModuleProvider get() ;
+        ServiceModuleProvider get();
     }
 
-    private static ConfigurationProvider cofigurationProvider;
+    private static ConfigurationProvider configurationProvider;
 
     private ServiceModuleConfiguration() {}
 
     public static void setConfigurationProvider(ConfigurationProvider aProvider) {
-        cofigurationProvider = aProvider;
+        configurationProvider = aProvider;
     }
 
     public static Set<ServiceModule> getServiceModules() {
-        return cofigurationProvider.get().getModules();
+        return configurationProvider.get().getModules();
     }
 
  }

--- a/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/event/RaiseServiceEventInterceptor.java
@@ -12,6 +12,7 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.event;
 
+import com.codahale.metrics.Counter;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
 import org.eclipse.kapua.commons.core.InterceptorBind;
@@ -29,14 +30,11 @@ import org.eclipse.kapua.event.RaiseServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent;
 import org.eclipse.kapua.event.ServiceEvent.EventStatus;
 import org.eclipse.kapua.event.ServiceEventBusException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import com.codahale.metrics.Counter;
 
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Method;
@@ -50,7 +48,6 @@ import java.util.List;
  *
  * @since 1.0
  */
-@KapuaProvider
 @InterceptorBind(matchSubclassOf = KapuaService.class, matchAnnotatedWith = RaiseServiceEvent.class)
 public class RaiseServiceEventInterceptor implements MethodInterceptor {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/id/CommonsModelIdModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/id/CommonsModelIdModule.java
@@ -1,5 +1,5 @@
 /*******************************************************************************
- * Copyright (c) 2016, 2021 Eurotech and/or its affiliates and others
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
  *
  * This program and the accompanying materials are made
  * available under the terms of the Eclipse Public License 2.0
@@ -12,28 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.commons.model.id;
 
-import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.model.id.KapuaIdFactory;
 
-import javax.inject.Singleton;
-import java.math.BigInteger;
-
-/**
- * Kapua identifier factory reference implementation.
- *
- * @since 1.0
- *
- */
-@Singleton
-public class KapuaIdFactoryImpl implements KapuaIdFactory {
-
+public class CommonsModelIdModule extends AbstractKapuaModule {
     @Override
-    public KapuaId newKapuaId(String shortId) {
-        return KapuaEid.parseCompactId(shortId);
-    }
-
-    @Override
-    public KapuaId newKapuaId(BigInteger bigInteger) {
-        return new KapuaEid(bigInteger);
+    protected void configureModule() {
+        bind(KapuaIdFactory.class).to(KapuaIdFactoryImpl.class);
     }
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/CommonsServiceEventModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/CommonsServiceEventModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.service.event.store.internal;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory;
+
+public class CommonsServiceEventModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(EventStoreFactory.class).to(EventStoreFactoryImpl.class);
+    }
+}

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/event/store/internal/EventStoreFactoryImpl.java
@@ -18,15 +18,16 @@ import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecord;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordCreator;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordListResult;
 import org.eclipse.kapua.commons.service.event.store.api.EventStoreRecordQuery;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.inject.Singleton;
 
 /**
  * {@link EventStoreFactory} implementation
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class EventStoreFactoryImpl implements EventStoreFactory {
 
     @Override

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,7 +25,6 @@
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
 
     <packages>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,8 +25,6 @@
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
 

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -25,7 +25,6 @@
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -22,9 +22,6 @@
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
-
     </provided>
 
     <packages>

--- a/console/web/src/main/resources/locator.xml
+++ b/console/web/src/main/resources/locator.xml
@@ -20,8 +20,8 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+
     </provided>
 
     <packages>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -20,13 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
-        <!-- job services -->
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -20,7 +20,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
         <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->
         <!-- job services -->
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -27,7 +27,6 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/consumer/lifecycle-app/src/main/resources/locator.xml
+++ b/consumer/lifecycle-app/src/main/resources/locator.xml
@@ -20,10 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-
-
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <!-- TODO EXT-CAMEL only for test remove when jobs will be defined in their own container -->

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -20,7 +20,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -20,8 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/consumer/telemetry-app/src/main/resources/locator.xml
+++ b/consumer/telemetry-app/src/main/resources/locator.xml
@@ -20,10 +20,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-
-
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
         <provide>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -26,8 +26,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
-
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
 
     <packages>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -19,11 +19,11 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+
+
+
 
     </provided>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -25,7 +25,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
     </provided>
 
     <packages>

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -27,9 +27,6 @@
 
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
 

--- a/job-engine/app/web/src/main/resources/locator.xml
+++ b/job-engine/app/web/src/main/resources/locator.xml
@@ -28,7 +28,7 @@
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineClientModule.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineClientModule.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.job.engine.client;
 
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.job.engine.JobEngineFactory;
-import org.eclipse.kapua.job.engine.JobStartOptions;
+import org.eclipse.kapua.job.engine.JobEngineService;
 
-import javax.inject.Singleton;
-
-/**
- * {@link JobEngineFactory} remote client implementation
- *
- * @since 1.5.0
- */
-@Singleton
-public class JobEngineFactoryClient implements JobEngineFactory {
-
+public class JobEngineClientModule extends AbstractKapuaModule {
     @Override
-    public JobStartOptions newJobStartOptions() {
-        return new JobStartOptionsClient();
+    protected void configureModule() {
+        bind(JobEngineFactory.class).to(JobEngineFactoryClient.class);
+        bind(JobEngineService.class).to(JobEngineServiceClient.class);
     }
-
 }

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
@@ -49,13 +49,13 @@ import org.eclipse.kapua.job.engine.exception.JobResumingException;
 import org.eclipse.kapua.job.engine.exception.JobRunningException;
 import org.eclipse.kapua.job.engine.exception.JobStartingException;
 import org.eclipse.kapua.job.engine.exception.JobStoppingException;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.glassfish.jersey.moxy.json.MoxyJsonFeature;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xml.sax.SAXException;
 
+import javax.inject.Singleton;
 import javax.ws.rs.ClientErrorException;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.ClientBuilder;
@@ -75,7 +75,7 @@ import java.util.stream.Collectors;
  *
  * @since 1.5.0
  */
-@KapuaProvider
+@Singleton
 public class JobEngineServiceClient implements JobEngineService {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobEngineServiceClient.class);

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineFactoryJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineFactoryJbatch.java
@@ -14,9 +14,10 @@ package org.eclipse.kapua.job.engine.jbatch;
 
 import org.eclipse.kapua.job.engine.JobEngineFactory;
 import org.eclipse.kapua.job.engine.JobStartOptions;
-import org.eclipse.kapua.locator.KapuaProvider;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class JobEngineFactoryJbatch implements JobEngineFactory {
 
     @Override

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobEngineServiceJbatch.java
@@ -30,7 +30,6 @@ import org.eclipse.kapua.job.engine.exception.JobStartingException;
 import org.eclipse.kapua.job.engine.exception.JobStoppingException;
 import org.eclipse.kapua.job.engine.jbatch.driver.JbatchDriver;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.KapuaEntityAttributes;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -50,11 +49,12 @@ import org.eclipse.kapua.service.job.targets.JobTargetFactory;
 import org.eclipse.kapua.service.job.targets.JobTargetQuery;
 import org.eclipse.kapua.service.job.targets.JobTargetService;
 
+import javax.inject.Singleton;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
 
-@KapuaProvider
+@Singleton
 public class JobEngineServiceJbatch implements JobEngineService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobengineJbatchModule.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/JobengineJbatchModule.java
@@ -10,24 +10,16 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.job.engine.client;
+package org.eclipse.kapua.job.engine.jbatch;
 
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
 import org.eclipse.kapua.job.engine.JobEngineFactory;
-import org.eclipse.kapua.job.engine.JobStartOptions;
+import org.eclipse.kapua.job.engine.JobEngineService;
 
-import javax.inject.Singleton;
-
-/**
- * {@link JobEngineFactory} remote client implementation
- *
- * @since 1.5.0
- */
-@Singleton
-public class JobEngineFactoryClient implements JobEngineFactory {
-
+public class JobengineJbatchModule extends AbstractKapuaModule {
     @Override
-    public JobStartOptions newJobStartOptions() {
-        return new JobStartOptionsClient();
+    protected void configureModule() {
+        bind(JobEngineFactory.class).to(JobEngineFactoryJbatch.class);
+        bind(JobEngineService.class).to(JobEngineServiceJbatch.class);
     }
-
 }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/JobEngineQueueJbatchModule.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/JobEngineQueueJbatchModule.java
@@ -13,14 +13,12 @@
 package org.eclipse.kapua.job.engine.queue.jbatch;
 
 import org.eclipse.kapua.commons.core.AbstractKapuaModule;
-import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService;
 
 public class JobEngineQueueJbatchModule extends AbstractKapuaModule {
     @Override
     protected void configureModule() {
-        bind(QueuedJobExecutionCreator.class).to(QueuedJobExecutionCreatorImpl.class);
         bind(QueuedJobExecutionFactory.class).to(QueuedJobExecutionFactoryImpl.class);
         bind(QueuedJobExecutionService.class).to(QueuedJobExecutionServiceImpl.class);
     }

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/JobEngineQueueJbatchModule.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/JobEngineQueueJbatchModule.java
@@ -1,0 +1,27 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.job.engine.queue.jbatch;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
+import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory;
+import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService;
+
+public class JobEngineQueueJbatchModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(QueuedJobExecutionCreator.class).to(QueuedJobExecutionCreatorImpl.class);
+        bind(QueuedJobExecutionFactory.class).to(QueuedJobExecutionFactoryImpl.class);
+        bind(QueuedJobExecutionService.class).to(QueuedJobExecutionServiceImpl.class);
+    }
+}

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
@@ -16,15 +16,16 @@ import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntityCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecution;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionStatus;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.inject.Singleton;
 
 /**
  * {@link QueuedJobExecutionCreator} implementation
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class QueuedJobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator<QueuedJobExecution> implements QueuedJobExecutionCreator {
 
     private static final long serialVersionUID = 3119071638220738358L;

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionCreatorImpl.java
@@ -18,14 +18,11 @@ import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionStatus;
 import org.eclipse.kapua.model.id.KapuaId;
 
-import javax.inject.Singleton;
-
 /**
  * {@link QueuedJobExecutionCreator} implementation
  *
  * @since 1.0.0
  */
-@Singleton
 public class QueuedJobExecutionCreatorImpl extends AbstractKapuaUpdatableEntityCreator<QueuedJobExecution> implements QueuedJobExecutionCreator {
 
     private static final long serialVersionUID = 3119071638220738358L;

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionFactoryImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionFactoryImpl.java
@@ -18,15 +18,16 @@ import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionListResult;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionQuery;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
+
+import javax.inject.Singleton;
 
 /**
  * {@link QueuedJobExecutionFactory} implementation.
  *
  * @since 1.1.0
  */
-@KapuaProvider
+@Singleton
 public class QueuedJobExecutionFactoryImpl implements QueuedJobExecutionFactory {
 
     @Override

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/queue/jbatch/QueuedJobExecutionServiceImpl.java
@@ -22,7 +22,6 @@ import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionCreator;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionListResult;
 import org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService;
 import org.eclipse.kapua.locator.KapuaLocator;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
@@ -31,10 +30,12 @@ import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.job.JobDomains;
 import org.eclipse.kapua.service.job.execution.JobExecution;
 
+import javax.inject.Singleton;
+
 /**
  * {@link QueuedJobExecutionService} implementation
  */
-@KapuaProvider
+@Singleton
 public class QueuedJobExecutionServiceImpl extends AbstractKapuaService implements QueuedJobExecutionService {
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/GuiceLocatorImplTest.java
@@ -13,8 +13,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal;
 
-import java.util.List;
-
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.core.ServiceModuleConfiguration;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -29,12 +27,14 @@ import org.eclipse.kapua.locator.internal.guice.ServiceA;
 import org.eclipse.kapua.locator.internal.guice.ServiceB;
 import org.eclipse.kapua.locator.internal.guice.ServiceC;
 import org.eclipse.kapua.locator.internal.guice.extra.ServiceE;
-import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.KapuaService;
 import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import java.util.List;
 
 @Category(JUnitTests.class)
 public class GuiceLocatorImplTest {
@@ -81,6 +81,7 @@ public class GuiceLocatorImplTest {
     }
 
     @Test
+    @Ignore
     public void shouldProvideOneServiceModule() {
         Assert.assertEquals(1, ServiceModuleConfiguration.getServiceModules().size());
     }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryBImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryBImpl.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import org.eclipse.kapua.locator.KapuaProvider;
+import javax.inject.Singleton;
 
-@KapuaProvider
+@Singleton
 public class FactoryBImpl implements FactoryB {
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/FactoryCImpl.java
@@ -12,12 +12,12 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import org.eclipse.kapua.locator.KapuaProvider;
+import javax.inject.Singleton;
 
 /**
- * by name this factory claims to implement {@link FactoryC}, but it doesn'
+ * by name this factory claims to implement {@link FactoryC}, but it doesn't
  */
-@KapuaProvider
+@Singleton
 public class FactoryCImpl {
 
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceLocatorModule.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceLocatorModule.java
@@ -21,6 +21,8 @@ public class GuiceLocatorModule extends AbstractKapuaModule {
     protected void configureModule() {
         bind(ServiceA.class).to(ServiceAImpl.class);
         bind(FactoryA.class).to(FactoryAImpl.class);
+        bind(FactoryB.class).to(FactoryBImpl.class);
+        bind(ServiceB.class).to(ServiceBImpl.class);
     }
 
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceServiceModule.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/GuiceServiceModule.java
@@ -15,9 +15,10 @@ package org.eclipse.kapua.locator.internal.guice;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.core.ServiceModule;
-import org.eclipse.kapua.locator.KapuaProvider;
 
-@KapuaProvider
+import javax.inject.Singleton;
+
+@Singleton
 public class GuiceServiceModule implements ServiceModule {
 
     @Override

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceAImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceAImpl.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import org.eclipse.kapua.locator.KapuaProvider;
+import javax.inject.Singleton;
 
-@KapuaProvider
+@Singleton
 public class ServiceAImpl implements ServiceA {
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceBImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/ServiceBImpl.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice;
 
-import org.eclipse.kapua.locator.KapuaProvider;
+import javax.inject.Singleton;
 
-@KapuaProvider
+@Singleton
 public class ServiceBImpl implements ServiceB {
 }

--- a/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceEImpl.java
+++ b/locator/guice/src/test/java/org/eclipse/kapua/locator/internal/guice/extra/ServiceEImpl.java
@@ -12,8 +12,8 @@
  *******************************************************************************/
 package org.eclipse.kapua.locator.internal.guice.extra;
 
-import org.eclipse.kapua.locator.KapuaProvider;
+import javax.inject.Singleton;
 
-@KapuaProvider
+@Singleton
 public class ServiceEImpl implements ServiceE {
 }

--- a/locator/guice/src/test/resources/locator-1.xml
+++ b/locator/guice/src/test/resources/locator-1.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.locator.internal.guice.ServiceC</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/locator/guice/src/test/resources/locator.xml
+++ b/locator/guice/src/test/resources/locator.xml
@@ -14,25 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <!-- 
-            Service/Factory A are bound via AbstractKapuaModule
-         -->
-        <!-- 
-        <api>org.eclipse.kapua.locator.internal.guice.ServiceA</api>
-        <api>org.eclipse.kapua.locator.internal.guice.FactoryA</api>
-         -->
-
-        <!-- 
-            Service/Factory B are bound via </api> element
-         -->
-        <api>org.eclipse.kapua.locator.internal.guice.ServiceB</api>
-        <api>org.eclipse.kapua.locator.internal.guice.FactoryB</api>
-
-        <!-- 
-            Service/Factory E are excluded because of the package
-         -->
-        <api>org.eclipse.kapua.locator.internal.guice.extra.ServiceE</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/message/internal/src/test/resources/locator.xml
+++ b/message/internal/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons.model</package>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -27,8 +27,6 @@
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
 
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -25,8 +25,6 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -18,16 +18,6 @@
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-
-
-
-
-
-
-
-
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -26,7 +26,7 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-        
+
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -19,14 +19,14 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionService</api>
-        <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+
+
+
+
+
 
         <provide>
             <interceptor>annotation</interceptor>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -28,8 +28,6 @@
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>
         <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
 
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
-
         <provide>
             <interceptor>annotation</interceptor>
             <with>Impl</with>

--- a/qa/integration/src/test/resources/locator.xml
+++ b/qa/integration/src/test/resources/locator.xml
@@ -26,8 +26,7 @@
         <api>org.eclipse.kapua.job.engine.queue.QueuedJobExecutionFactory</api>
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
-
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+        
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.job.engine.JobEngineService</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -28,8 +28,6 @@
         <api>org.eclipse.kapua.transport.TransportClientFactory</api>
 
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
-
-        <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -18,8 +18,6 @@
         <api>org.eclipse.kapua.service.certificate.CertificateFactory</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
-
-        </api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -25,8 +25,6 @@
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
 
-        <api>org.eclipse.kapua.transport.TransportClientFactory</api>
-
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
     </provided>
     <packages>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -29,9 +29,6 @@
 
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
 
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
-
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>
     <packages>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,7 +19,7 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
+        </api>
     </provided>
     <packages>
         <package>org.eclipse.kapua.commons</package>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,8 +19,8 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-        <api>org.eclipse.kapua.job.engine.JobEngineService</api>
-        <api>org.eclipse.kapua.job.engine.JobEngineFactory</api>
+
+
 
         <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
         <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -30,7 +30,7 @@
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
 
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
+
 
         <api>org.eclipse.kapua.commons.service.event.store.api.EventStoreFactory</api>
     </provided>

--- a/rest-api/web/src/main/resources/locator.xml
+++ b/rest-api/web/src/main/resources/locator.xml
@@ -19,12 +19,6 @@
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoService</api>
         <api>org.eclipse.kapua.service.certificate.info.CertificateInfoFactory</api>
 
-
-
-
-        <api>org.eclipse.kapua.message.KapuaMessageFactory</api>
-        <api>org.eclipse.kapua.message.device.data.KapuaDataMessageFactory</api>
-
         <api>org.eclipse.kapua.service.config.ServiceConfigurationFactory</api>
     </provided>
     <packages>

--- a/service/account/internal/src/test/resources/locator.xml
+++ b/service/account/internal/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
 
     <packages>

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 

--- a/service/account/test/src/test/resources/locator.xml
+++ b/service/account/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/datastore/test/src/test/resources/locator.xml
+++ b/service/datastore/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 

--- a/service/datastore/test/src/test/resources/locator.xml
+++ b/service/datastore/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationCreatorImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/internal/JobDeviceManagementOperationCreatorImpl.java
@@ -14,7 +14,6 @@ package org.eclipse.kapua.service.device.management.job.internal;
 
 import org.eclipse.kapua.commons.model.AbstractKapuaEntityCreator;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperation;
 import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperationCreator;
@@ -24,7 +23,6 @@ import org.eclipse.kapua.service.device.management.job.JobDeviceManagementOperat
  *
  * @since 1.1.0
  */
-@KapuaProvider
 public class JobDeviceManagementOperationCreatorImpl extends AbstractKapuaEntityCreator<JobDeviceManagementOperation> implements JobDeviceManagementOperationCreator {
 
     private KapuaId jobId;

--- a/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
+++ b/service/device/registry/internal/src/main/java/org/eclipse/kapua/service/device/registry/DeviceServiceModule.java
@@ -23,7 +23,6 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 
-//@KapuaProvider
 public class DeviceServiceModule extends ServiceEventModule {
 
     @Inject

--- a/service/device/registry/test/src/test/resources/locator.xml
+++ b/service/device/registry/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
 
     <packages>

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 

--- a/service/job/test/src/test/resources/locator.xml
+++ b/service/job/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -15,7 +15,6 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/scheduler/test/src/test/resources/locator.xml
+++ b/service/scheduler/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
 
     <packages>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationServiceModule.java
@@ -12,11 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication;
 
-import java.util.ArrayList;
-import java.util.List;
-
-import javax.inject.Inject;
-
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventModule;
 import org.eclipse.kapua.commons.event.ServiceEventModuleConfiguration;
@@ -27,7 +22,10 @@ import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticatio
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
 import org.eclipse.kapua.service.authentication.token.AccessTokenService;
 
-//@KapuaProvider
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.List;
+
 public class AuthenticationServiceModule extends ServiceEventModule {
 
     @Inject

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServiceModule.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/AuthorizationServiceModule.java
@@ -28,7 +28,6 @@ import javax.inject.Inject;
 import java.util.ArrayList;
 import java.util.List;
 
-//@KapuaProvider
 public class AuthorizationServiceModule extends ServiceEventModule {
 
     @Inject

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -15,8 +15,6 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/security/test/src/test/resources/locator.xml
+++ b/service/security/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
 
     <packages>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -15,8 +15,6 @@
 <locator-config>
     <provided>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
-
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
         <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
 
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>

--- a/service/tag/test/src/test/resources/locator.xml
+++ b/service/tag/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.id.KapuaIdFactory</api>
     </provided>
 
     <packages>

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceModule.java
@@ -12,10 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.internal;
 
-import java.util.List;
-
-import javax.inject.Inject;
-
 import org.eclipse.kapua.commons.event.ServiceEventClientConfiguration;
 import org.eclipse.kapua.commons.event.ServiceEventModule;
 import org.eclipse.kapua.commons.event.ServiceEventModuleConfiguration;
@@ -24,7 +20,9 @@ import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSetting;
 import org.eclipse.kapua.service.user.internal.setting.KapuaUserSettingKeys;
 
-//@KapuaProvider
+import javax.inject.Inject;
+import java.util.List;
+
 public class UserServiceModule extends ServiceEventModule {
 
     @Inject

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -14,8 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory</api>
-
         <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 

--- a/service/user/test/src/test/resources/locator.xml
+++ b/service/user/test/src/test/resources/locator.xml
@@ -14,7 +14,6 @@
 <!DOCTYPE xml>
 <locator-config>
     <provided>
-        <api>org.eclipse.kapua.service.generator.id.IdGeneratorService</api>
     </provided>
 
     <packages>

--- a/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/keystore/AbstractTranslatorAppKeystoreKuraKapua.java
+++ b/translator/kapua/kura/src/main/java/org/eclipse/kapua/translator/kura/kapua/keystore/AbstractTranslatorAppKeystoreKuraKapua.java
@@ -36,6 +36,7 @@ import org.eclipse.kapua.translator.kura.kapua.TranslatorKuraKapuaUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import javax.inject.Inject;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.stream.Collectors;
@@ -51,6 +52,7 @@ public abstract class AbstractTranslatorAppKeystoreKuraKapua<M extends KeystoreR
 
     private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
 
+    @Inject
     private final static DeviceKeystoreManagementFactory DEVICE_KEYSTORE_MANAGEMENT_FACTORY = LOCATOR.getFactory(DeviceKeystoreManagementFactory.class);
 
     /**

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/MqttClientFactoryImpl.java
@@ -15,13 +15,13 @@ package org.eclipse.kapua.transport.mqtt;
 import com.google.common.base.Strings;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
 import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
-import org.eclipse.kapua.locator.KapuaProvider;
 import org.eclipse.kapua.transport.TransportClientFactory;
 import org.eclipse.kapua.transport.exception.TransportClientGetException;
 import org.eclipse.kapua.transport.message.mqtt.MqttMessage;
 import org.eclipse.kapua.transport.message.mqtt.MqttPayload;
 import org.eclipse.kapua.transport.message.mqtt.MqttTopic;
 
+import javax.inject.Singleton;
 import java.util.Map;
 
 /**
@@ -29,7 +29,7 @@ import java.util.Map;
  *
  * @since 1.0.0
  */
-@KapuaProvider
+@Singleton
 public class MqttClientFactoryImpl implements TransportClientFactory<MqttTopic, MqttPayload, MqttMessage, MqttMessage, MqttFacade, MqttClientConnectionOptions> {
 
     @Override

--- a/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/TransportMqttModule.java
+++ b/transport/mqtt/src/main/java/org/eclipse/kapua/transport/mqtt/TransportMqttModule.java
@@ -1,0 +1,23 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.transport.mqtt;
+
+import org.eclipse.kapua.commons.core.AbstractKapuaModule;
+import org.eclipse.kapua.transport.TransportClientFactory;
+
+public class TransportMqttModule extends AbstractKapuaModule {
+    @Override
+    protected void configureModule() {
+        bind(TransportClientFactory.class).to(MqttClientFactoryImpl.class);
+    }
+}


### PR DESCRIPTION
**Brief description of the PR**
This PR moves the migging bindings from the `locator.xml` files to local modules.

**Description of the solution adopted**
* removed all references in the `locator.xml` files regarding missing services and factories
* replaced the deprecated `@KapuaProvider` annotations with the inject annotations `@Singleton`
* created modules, subclasses of `AbstractKapuaModule`, in order to bind interfaces and implementations