### PR TITLE
Fixed external consumers Shiro initialization

### DIFF
--- a/assembly/broker/configurations/shiro.ini
+++ b/assembly/broker/configurations/shiro.ini
@@ -16,7 +16,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 securityManager.realms = $kapuaUserPassAuthenticatingRealm
 
 # Authorizer
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 

--- a/assembly/consumer/lifecycle/docker/Dockerfile
+++ b/assembly/consumer/lifecycle/docker/Dockerfile
@@ -26,14 +26,16 @@ ENV SQL_DB_PORT 3306
 ENV SERVICE_BROKER_ADDR failover:(amqp://events-broker:5672)?jms.sendTimeout=1000
 ENV JOB_ENGINE_BASE_ADDR http://job-engine:8080/v1
 
-ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
+ENV JAVA_OPTS -Dcommons.db.schema.update=true \
               -Dconsumer.jaxb_context_class_name=org.eclipse.kapua.consumer.lifecycle.LifecycleJAXBContextProvider \
               -Dcommons.db.connection.host=${SQL_DB_ADDR} \
               -Dcommons.db.connection.port=${SQL_DB_PORT} \
               -Dbroker.host=${BROKER_ADDR} \
               -Dbroker.port=${BROKER_PORT} \
               -Dcommons.eventbus.url=${SERVICE_BROKER_ADDR} \
-              -Djob.engine.base.url=${JOB_ENGINE_BASE_ADDR} "
+              -Djob.engine.base.url=${JOB_ENGINE_BASE_ADDR} \
+              -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
+              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem
 
 EXPOSE 8080
 

--- a/assembly/consumer/telemetry/docker/Dockerfile
+++ b/assembly/consumer/telemetry/docker/Dockerfile
@@ -38,7 +38,9 @@ ENV JAVA_OPTS -Dcommons.db.schema.update=true \
               -Ddatastore.client.class=${DATASTORE_CLIENT} \
               -Dbroker.host=${BROKER_ADDR} \
               -Dbroker.port=${BROKER_PORT} \
-              -Dcommons.eventbus.url="${SERVICE_BROKER_ADDR}"
+              -Dcommons.eventbus.url="${SERVICE_BROKER_ADDR}" \
+              -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
+              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem
 
 EXPOSE 8080
 

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/KapuaBrokerSecurityPlugin.java
@@ -13,17 +13,10 @@
  *******************************************************************************/
 package org.eclipse.kapua.broker.core;
 
-import java.io.InputStream;
-import java.net.URL;
-
 import org.eclipse.kapua.broker.core.plugin.KapuaSecurityBrokerFilter;
-
+import org.eclipse.kapua.service.security.SecurityUtil;
 import org.apache.activemq.broker.Broker;
 import org.apache.activemq.broker.BrokerPlugin;
-import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.config.Ini;
-import org.apache.shiro.config.IniSecurityManagerFactory;
-import org.apache.shiro.mgt.SecurityManager;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,18 +42,8 @@ public class KapuaBrokerSecurityPlugin implements BrokerPlugin {
     @Override
     public Broker installPlugin(final Broker broker) throws Exception {
         logger.info("Installing Kapua broker plugin...");
-
         try {
-            // initialize shiro context for broker plugin from shiro ini file
-            final URL shiroIniUrl = getClass().getResource("/shiro.ini");
-            Ini shiroIni = new Ini();
-            try (final InputStream input = shiroIniUrl.openStream()) {
-                shiroIni.load(input);
-            }
-
-            SecurityManager securityManager = new IniSecurityManagerFactory(shiroIni).getInstance();
-            SecurityUtils.setSecurityManager(securityManager);
-
+            SecurityUtil.initSecurityManager();
             // install the filters
             return new KapuaSecurityBrokerFilter(broker);
         } catch (Exception e) {

--- a/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleApplication.java
+++ b/consumer/lifecycle-app/src/main/java/org/eclipse/kapua/consumer/lifecycle/LifecycleApplication.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.consumer.lifecycle;
 
 import org.eclipse.kapua.consumer.commons.setting.ConsumerSettingKey;
+import org.eclipse.kapua.service.security.SecurityUtil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ImportResource;
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.PropertySource;
 public class LifecycleApplication {
 
     public LifecycleApplication() {
+        SecurityUtil.initSecurityManager();
     }
 
     public void doNothing() {

--- a/consumer/lifecycle-app/src/main/resources/shiro.ini
+++ b/consumer/lifecycle-app/src/main/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryApplication.java
+++ b/consumer/telemetry-app/src/main/java/org/eclipse/kapua/consumer/telemetry/TelemetryApplication.java
@@ -13,6 +13,7 @@
 package org.eclipse.kapua.consumer.telemetry;
 
 import org.eclipse.kapua.consumer.commons.setting.ConsumerSettingKey;
+import org.eclipse.kapua.service.security.SecurityUtil;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.ImportResource;
@@ -28,6 +29,7 @@ import org.springframework.context.annotation.PropertySource;
 public class TelemetryApplication {
 
     public TelemetryApplication() {
+        SecurityUtil.initSecurityManager();
     }
 
     public void doNothing() {

--- a/consumer/telemetry-app/src/main/resources/shiro.ini
+++ b/consumer/telemetry-app/src/main/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/utils/InitShiro.java
@@ -13,14 +13,11 @@
 package org.eclipse.kapua.qa.common.utils;
 
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.UnavailableSecurityManagerException;
-import org.apache.shiro.config.Ini;
-import org.apache.shiro.config.IniSecurityManagerFactory;
 import org.apache.shiro.mgt.SecurityManager;
+import org.eclipse.kapua.service.security.SecurityUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,13 +38,7 @@ public class InitShiro {
         }
         catch (UnavailableSecurityManagerException e) {
             logger.info("Init shiro security manager...");
-            final URL shiroIniUrl = getClass().getResource("/shiro.ini");
-            Ini shiroIni = new Ini();
-            try (final InputStream input = shiroIniUrl.openStream()) {
-                shiroIni.load(input);
-            }
-            SecurityManager securityManager = new IniSecurityManagerFactory(shiroIni).getInstance();
-            SecurityUtils.setSecurityManager(securityManager);
+            SecurityUtil.initSecurityManager();
         }
         logger.info("Init shiro security manager... DONE");
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
@@ -13,13 +13,12 @@
 package org.eclipse.kapua.integration.misc;
 
 import org.apache.shiro.SecurityUtils;
-import org.apache.shiro.config.Ini;
-import org.apache.shiro.config.IniSecurityManagerFactory;
 import org.apache.shiro.mgt.SecurityManager;
 import org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.security.SecurityUtil;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -31,16 +30,11 @@ import javax.servlet.FilterChain;
 import javax.servlet.ServletResponse;
 import javax.servlet.ServletRequest;
 import java.io.IOException;
-import java.io.InputStream;
-import java.net.URL;
 
 @Category(JUnitTests.class)
 public class KapuaSessionCleanupFilterTest extends Assert {
 
     KapuaSessionCleanupFilter kapuaSessionCleanupFilter;
-    URL shiroIniUrl;
-    Ini shiroIni;
-    InputStream input;
     SecurityManager securityManager;
     ServletRequest request;
     ServletResponse response;
@@ -50,11 +44,8 @@ public class KapuaSessionCleanupFilterTest extends Assert {
     @Before
     public void initialize() throws IOException {
         kapuaSessionCleanupFilter = new KapuaSessionCleanupFilter();
-        shiroIniUrl = getClass().getResource("/shiro.ini");
-        shiroIni = new Ini();
-        input = shiroIniUrl.openStream();
-        shiroIni.load(input);
-        securityManager = new IniSecurityManagerFactory(shiroIni).getInstance();
+        SecurityUtil.initSecurityManager();
+        securityManager = SecurityUtils.getSecurityManager();
 
         request = Mockito.mock(ServletRequest.class);
         response = Mockito.mock(ServletResponse.class);

--- a/qa/integration/src/test/resources/shiro.ini
+++ b/qa/integration/src/test/resources/shiro.ini
@@ -24,7 +24,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
 # Authorizer
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 

--- a/service/account/test/src/test/resources/shiro.ini
+++ b/service/account/test/src/test/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/service/device/registry/test/src/test/resources/shiro.ini
+++ b/service/device/registry/test/src/test/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/service/job/test/src/test/resources/shiro.ini
+++ b/service/job/test/src/test/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/service/scheduler/test/src/test/resources/shiro.ini
+++ b/service/scheduler/test/src/test/resources/shiro.ini
@@ -24,7 +24,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
 # Authorizer
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/security/EnhModularRealmAuthorizer.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/security/EnhModularRealmAuthorizer.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.broker.core.security;
+package org.eclipse.kapua.service.security;
 
 import java.util.Arrays;
 import java.util.Collection;
@@ -32,6 +32,7 @@ import org.slf4j.LoggerFactory;
  * Without these changes this Authorizer will not have any realm configured. (see shiro.ini for explanation)
  * This authorizer takes the first valid configured realm and return the isPermitted evaluation skipping any aggregation strategy if more than one valid aggregator is defined.
  *
+ * NOTE this class is replicated also in broker-core module
  */
 public class EnhModularRealmAuthorizer extends ModularRealmAuthorizer {
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/security/SecurityUtil.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/security/SecurityUtil.java
@@ -1,0 +1,44 @@
+/*******************************************************************************
+ * Copyright (c) 2021 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.service.security;
+
+import org.apache.shiro.SecurityUtils;
+import org.apache.shiro.env.BasicIniEnvironment;
+import org.apache.shiro.env.Environment;
+import org.apache.shiro.mgt.SecurityManager;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Utility class to setup Security stuff like the Shiro Security Manager
+ *
+ */
+public class SecurityUtil {
+
+    private static final Logger logger = LoggerFactory.getLogger(SecurityUtil.class);
+
+    private SecurityUtil() {
+    }
+
+    public static void initSecurityManager() {
+        try {
+            Environment env = new BasicIniEnvironment("classpath:shiro.ini");
+            SecurityManager securityManager = env.getSecurityManager();
+            SecurityUtils.setSecurityManager(securityManager);
+        } catch (Exception e) {
+            logger.error("Error loading Shiro configuration.", e);
+            throw new SecurityException(e);
+        }
+    }
+
+}

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/security/EnhModularRealmAuthorizerTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/security/EnhModularRealmAuthorizerTest.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.broker.core.security;
+package org.eclipse.kapua.service.security;
 
 import org.apache.shiro.authz.Permission;
 import org.apache.shiro.authz.permission.PermissionResolver;
@@ -19,7 +19,6 @@ import org.apache.shiro.realm.Realm;
 import org.apache.shiro.subject.PrincipalCollection;
 import org.apache.shiro.subject.SimplePrincipalCollection;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
@@ -134,7 +133,7 @@ public class EnhModularRealmAuthorizerTest {
         realms.add(realm3);
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 0, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -144,7 +143,7 @@ public class EnhModularRealmAuthorizerTest {
         permissions.add(permission1);
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 1, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -156,7 +155,7 @@ public class EnhModularRealmAuthorizerTest {
         permissions.add(permission1);
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 1, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -168,7 +167,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         Mockito.when(authorizingRealm1.isPermitted(principals, permissions)).thenReturn(booleanArray1);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 3, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -184,7 +183,7 @@ public class EnhModularRealmAuthorizerTest {
         Mockito.when(authorizingRealm2.isPermitted(principals, permissions)).thenReturn(booleanArray1);
         Mockito.when(authorizingRealm3.isPermitted(principals, permissions)).thenReturn(booleanArray1);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 1, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -200,7 +199,7 @@ public class EnhModularRealmAuthorizerTest {
         Mockito.when(authorizingRealm1.isPermitted(principals, permissions)).thenReturn(booleanArray1);
         Mockito.when(authorizingRealm2.isPermitted(principals, permissions)).thenReturn(booleanArray2);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 2, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -222,7 +221,7 @@ public class EnhModularRealmAuthorizerTest {
         Mockito.when(authorizingRealm2.isPermitted(principals, permissions)).thenReturn(booleanArray1);
         Mockito.when(authorizingRealm3.isPermitted(principals, permissions)).thenReturn(booleanArray1);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 3, enhModularRealmAuthorizer2.isPermitted(principals, permissions).length);
     }
 
@@ -245,7 +244,7 @@ public class EnhModularRealmAuthorizerTest {
         realms.add(realm3);
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, permissions), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, permissions) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 0, enhModularRealmAuthorizer2.isPermitted(null, permissions).length);
     }
 
@@ -267,7 +266,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         enhModularRealmAuthorizer2.setPermissionResolver(permissionResolver);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 3, enhModularRealmAuthorizer2.isPermitted(principals, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3).length);
     }
 
@@ -277,7 +276,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         enhModularRealmAuthorizer2.setPermissionResolver(permissionResolver);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 3, enhModularRealmAuthorizer2.isPermitted(null, stringPermissionResolver1, stringPermissionResolver2, stringPermissionResolver3).length);
     }
 
@@ -287,7 +286,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         enhModularRealmAuthorizer2.setPermissionResolver(permissionResolver);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, null, stringPermissionResolver1), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, null, stringPermissionResolver1) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 2, enhModularRealmAuthorizer2.isPermitted(principals, null, stringPermissionResolver1).length);
     }
 
@@ -297,7 +296,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         enhModularRealmAuthorizer2.setPermissionResolver(permissionResolver);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, null, null), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(principals, null, null) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 2, enhModularRealmAuthorizer2.isPermitted(principals, null, null).length);
     }
 
@@ -307,7 +306,7 @@ public class EnhModularRealmAuthorizerTest {
         enhModularRealmAuthorizer2 = new EnhModularRealmAuthorizer(realms);
         enhModularRealmAuthorizer2.setPermissionResolver(permissionResolver);
 
-        Assert.assertThat("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, null, null), IsInstanceOf.instanceOf(boolean[].class));
+        Assert.assertTrue("Instance of boolean[] expected.", enhModularRealmAuthorizer2.isPermitted(null, null, null) instanceof boolean[]);
         Assert.assertEquals("Expected and actual values should be the same.", 2, enhModularRealmAuthorizer2.isPermitted(null, null, null).length);
     }
 }

--- a/service/tag/test/src/test/resources/shiro.ini
+++ b/service/tag/test/src/test/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/service/user/test/src/test/resources/shiro.ini
+++ b/service/user/test/src/test/resources/shiro.ini
@@ -35,7 +35,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 #removed from realms the authorizing realm (kapuaAuthorizingRealm) since it will be defined into the new Authorizer component
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 #realms must be set again otherwise the authorizer will not have any.
 #The security manager (AuthorizingSecurityManager) is built in this way:
 #    AuthorizingSecurityManager()         //constructor

--- a/translator/test/src/test/resources/shiro.ini
+++ b/translator/test/src/test/resources/shiro.ini
@@ -24,7 +24,7 @@ kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAutho
 securityManager.realms = $kapuaAccessTokenAuthenticatingRealm, $kapuaUserPassAuthenticatingRealm
 
 # Authorizer
-authorizer = org.eclipse.kapua.broker.core.security.EnhModularRealmAuthorizer
+authorizer = org.eclipse.kapua.service.security.EnhModularRealmAuthorizer
 authorizer.realms = $kapuaAuthorizingRealm
 securityManager.authorizer = $authorizer
 


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>

Brief description of the PR.
added programmatically Shiro security managaer initialization in each external consumer.

**Related Issue**
fix #3474 

**Description of the solution adopted**
added programmatically Shiro security managaer initialization in each external consumer.

**Screenshots**
none

**Any side note on the changes made**
shiro.ini was modified since one realm was moved to another position
