### PR TITLE
Set log4j version from 2.14.0 to 2.17.0 - CVE-2021-45046 CVE-2021-45105

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <jose4j.version>0.7.0</jose4j.version>
         <junit.version>4.12</junit.version>
         <liquibase.version>3.6.3</liquibase.version>
-        <log4j-api.version>2.14.0</log4j-api.version>
+        <log4j-api.version>2.17.0</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.3</logback.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
This PR bumps the version of `log4j` from 2.14.0 to 2.17.0 fixing:

- CVE-2021-45046
- CVE-2021-45105

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version

**Screenshots**
_None_

**Any side note on the changes made**
_None_