### PR TITLE
Bump shiro dependencies version from 1.5.3 to 1.8.0 - CVE-2020-13933 CVE-2021-41303

### DIFF
--- a/console/web/src/main/resources/shiro.ini
+++ b/console/web/src/main/resources/shiro.ini
@@ -16,6 +16,3 @@ kapuaJwtAuthenticatingRealm = org.eclipse.kapua.service.authentication.shiro.rea
 kapuaAuthorizingRealm = org.eclipse.kapua.service.authorization.shiro.KapuaAuthorizingRealm
 
 securityManager.realms = $kapuaAuthorizingRealm, $kapuaUserPassAuthenticatingRealm, $kapuaAccessTokenAuthenticatingRealm, $kapuaJwtAuthenticatingRealm
-
-# Request Filtering
-filterChainResolver = org.apache.shiro.web.filter.mgt.PathMatchingFilterChainResolver

--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.9.12</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.5.3</shiro.version>
+        <shiro.version>1.8.0</shiro.version>
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>


### PR DESCRIPTION
This PR bumps the version of `Apache Shiro` from 1.5.3 to 1.8.0 fixing:

- CVE-2020-13933 
- CVE-2021-41303

CQ for this version and transitive dependencies are yet to be checked

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version

**Screenshots**
_None_

**Any side note on the changes made**
_None_