### PR TITLE
Bump version of Slf4j from 1.7.30 to 1.7.33

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -100,7 +100,7 @@
         <reflections.version>0.9.12</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.5.3</shiro.version>
-        <slf4j.version>1.7.30</slf4j.version>
+        <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>


### PR DESCRIPTION
This PR bumps the version of `Slf4j` from 1.7.30 to 1.7.33

This PR updates a patch version of the dependency so no CQ in required

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version.

**Screenshots**
_None_

**Any side note on the changes made**
_None_