### PR TITLE
Bump Commons Io version from 2.4 to 2.11.0 - CVE-2021-29425

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -45,7 +45,7 @@
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-fileupload.versison>1.4</commons-fileupload.versison>
-        <commons-io.version>2.4</commons-io.version>
+        <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
         <commons-logging.version>1.2</commons-logging.version>
         <commons-pool.version>2.3</commons-pool.version>


### PR DESCRIPTION
This PR bumps the version of `Commons Io` from 2.4 to 2.11.0 fixing:

- CVE-2021-29425

CQ for this version has been already submitted by another project https://dev.eclipse.org/ipzilla/show_bug.cgi?id=23745

**Related Issue**
_None_

**Description of the solution adopted**
Bumped the version

**Screenshots**
_None_

**Any side note on the changes made**
_None_