### PR TITLE
Fixed translator tests syntax

### DIFF
--- a/translator/test-steps/src/main/java/org/eclipse/kapua/translator/test/steps/TranslatorSteps.java
+++ b/translator/test-steps/src/main/java/org/eclipse/kapua/translator/test/steps/TranslatorSteps.java
@@ -172,7 +172,7 @@ public class TranslatorSteps extends TestBase {
 
     }
 
-    @Then("I get mqtt message with channel with scope {string}, client id {string} and (empty body/non empty body)")
+    @Then("I get mqtt message with channel with scope {string}, client id {string} and (empty body|non empty body)")
     public void mqttMessageWithChanneScopeClienIDandBody(String scope, String clientId) {
         MqttMessage mqttMessage = (MqttMessage) stepData.get("MqttMessage");
         String requestTopic = scope.concat("/" + clientId);
@@ -260,7 +260,7 @@ public class TranslatorSteps extends TestBase {
         Assert.assertEquals(null, kuraDataMessage.getPayload().getBody());
     }
 
-    @Given("I create jms message with (valid/invalid/empty) payload {string} and (valid/invalid) topic {string}")
+    @Given("I create jms message with (valid|invalid|empty) payload {string} and (valid|invalid) topic {string}")
     public void iCreateJmsMessageWithInvalidPayloadAndInvalidTopic(String payload, String topic) throws Exception {
         try {
             Date date = new Date();
@@ -311,7 +311,7 @@ public class TranslatorSteps extends TestBase {
         }
     }
 
-    @Then("I got jms message with topic {string} and (?:empty body|non empty body)")
+    @Then("I got jms message with topic {string} and (empty body|non empty body)")
     public void iGotJmsMessageWithTopicAndEmptyPayload(String topic) {
         JmsMessage jmsMessage = (JmsMessage) stepData.get("JmsMessage");
         Assert.assertEquals(new JmsTopic(topic).getTopic(), jmsMessage.getTopic().getTopic());

--- a/translator/test-steps/src/main/java/org/eclipse/kapua/translator/test/steps/TranslatorSteps.java
+++ b/translator/test-steps/src/main/java/org/eclipse/kapua/translator/test/steps/TranslatorSteps.java
@@ -173,7 +173,7 @@ public class TranslatorSteps extends TestBase {
     }
 
     @Then("I get mqtt message with channel with scope {string}, client id {string} and (empty body|non empty body)")
-    public void mqttMessageWithChanneScopeClienIDandBody(String scope, String clientId) {
+    public void mqttMessageWithChannelScopeClientIDAndBody(String scope, String clientId) {
         MqttMessage mqttMessage = (MqttMessage) stepData.get("MqttMessage");
         String requestTopic = scope.concat("/" + clientId);
         Assert.assertEquals(requestTopic, mqttMessage.getRequestTopic().getTopic());


### PR DESCRIPTION
Brief description of the PR.
The `TranslatorSteps` file had a wrong syntax in the gherkin statement that consequence in the fail of the test.