### PR TITLE
Fixed failing Scheduler tests

### DIFF
--- a/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
+++ b/service/scheduler/test/src/test/java/org/eclipse/kapua/service/scheduler/test/SchedulerLocatorConfiguration.java
@@ -21,8 +21,10 @@ import io.cucumber.java.Before;
 
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.configuration.metatype.KapuaMetatypeFactoryImpl;
+import org.eclipse.kapua.commons.model.query.QueryFactoryImpl;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.config.metatype.KapuaMetatypeFactory;
+import org.eclipse.kapua.model.query.QueryFactory;
 import org.eclipse.kapua.qa.common.MockedLocator;
 import org.eclipse.kapua.service.account.AccountFactory;
 import org.eclipse.kapua.service.account.AccountService;
@@ -85,6 +87,9 @@ public class SchedulerLocatorConfiguration {
                 bind(TriggerFactory.class).toInstance(new TriggerFactoryImpl());
                 bind(TriggerDefinitionService.class).toInstance(new TriggerDefinitionServiceImpl());
                 bind(TriggerDefinitionFactory.class).toInstance(new TriggerDefinitionFactoryImpl());
+
+                // bind Query related services
+                bind(QueryFactory.class).toInstance(new QueryFactoryImpl());
             }
         };
 


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes the fail of the tests in the `SchedulerService.feature` caused by a `NullPointerException` due to the missing binding of the `QueryFactory`interface.