### PR TITLE
Bump version of jetty dependencies 9.2.x and 9.4.x to latest patch version 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -78,6 +78,7 @@
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.23.2</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
+        <jetty-activemq.version>9.2.30.v20200428</jetty-activemq.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.0</jose4j.version>
@@ -2008,6 +2009,37 @@
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>apache-jstl</artifactId>
                 <version>${jetty.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-security</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-rewrite</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jaas</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.aggregate</groupId>
+                <artifactId>jetty-all</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-server</artifactId>
+                <version>${jetty-activemq.version}</version>
             </dependency>
 
             <!-- Active MQ Artemis-->

--- a/pom.xml
+++ b/pom.xml
@@ -1982,22 +1982,22 @@
             <!-- Jetty-->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-server</artifactId>
+                <artifactId>jetty-annotations</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-webapp</artifactId>
-                <version>${jetty.version}</version>
+                <artifactId>jetty-continuation</artifactId>
+                <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-jaas</artifactId>
+                <version>${jetty-activemq.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jmx</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-annotations</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -2010,12 +2010,6 @@
                 <artifactId>apache-jstl</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
-
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-security</artifactId>
-                <version>${jetty-activemq.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-rewrite</artifactId>
@@ -2023,13 +2017,18 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-jaas</artifactId>
+                <artifactId>jetty-security</artifactId>
                 <version>${jetty-activemq.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-continuation</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <artifactId>jetty-server</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-webapp</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.aggregate</groupId>
@@ -2042,6 +2041,7 @@
                 <version>${jetty-activemq.version}</version>
             </dependency>
 
+            <!-- -->
             <!-- Active MQ Artemis-->
             <dependency>
                 <groupId>org.apache.activemq</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2108,7 +2108,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>websocket-server</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2003,7 +2003,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-continuation</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1982,13 +1982,38 @@
             <!-- Jetty-->
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>apache-jsp</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>apache-jstl</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-annotations</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-client</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-continuation</artifactId>
                 <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-http</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-io</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
@@ -2002,12 +2027,7 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
-                <artifactId>apache-jsp</artifactId>
-                <version>${jetty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>apache-jstl</artifactId>
+                <artifactId>jetty-plus</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -2027,7 +2047,32 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlet</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-servlets</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util-ajax</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-util</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-webapp</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-xml</artifactId>
                 <version>${jetty.version}</version>
             </dependency>
             <dependency>
@@ -2037,8 +2082,38 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>javax-websocket-client-impl</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>javax-websocket-server-impl</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-api</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-client</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-common</artifactId>
+                <version>${jetty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
                 <artifactId>websocket-server</artifactId>
                 <version>${jetty-activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.websocket</groupId>
+                <artifactId>websocket-servlet</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
 
             <!-- -->

--- a/pom.xml
+++ b/pom.xml
@@ -2038,7 +2038,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-security</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
         <javax-ws-rs-api.version>2.0.1</javax-ws-rs-api.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.23.2</jersey.version>
-        <jetty.version>9.4.39.v20210325</jetty.version>
+        <jetty.version>9.4.44.v20210927</jetty.version>
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.0</jose4j.version>


### PR DESCRIPTION
This PR updates the referenced versions of Jetty in the project.

- 9.2.x: In the pom.xml we had the property `jetty-activemq.version` which was referencing the latest version (9.2.30.v20200428) but some transient version were imported with an older version.
- 9.4.x: Updated the referenced version in the pom.xml and aligned each transient dependency usage to the same version 

Since these dependencies are from an Eclipse project and we are just updating the patch version, no IP review is required

**Related Issue**
_None_

**Description of the solution adopted**
Added dependencies in `dependencyManagement` section.

Diff between `mvn dependency:tree` run on `develop` and on this branch.

[jetty.diff.txt](https://github.com/eclipse/kapua/files/7931981/jetty.diff.txt)

Below the command and the report of the Eclipse Dash License tool on changed dependencies

```
echo "maven/mavencentral/org.eclipse.jetty/apache-jsp/9.4.44.v20210927                                                                                                                                             
maven/mavencentral/org.eclipse.jetty/apache-jstl/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-annotations/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-client/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-continuation/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-http/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-io/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-jmx/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-jndi/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-plus/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-security/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-server/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-servlet/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-servlets/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-util-ajax/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-util/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-webapp/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty/jetty-xml/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.aggregate/jetty-all/9.2.30.v20200428
maven/mavencentral/org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/websocket-api/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/websocket-client/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/websocket-common/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/websocket-server/9.4.44.v20210927
maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/9.4.44.v20210927
maven/mavencentral/org.mortbay.jasper/apache-el/8.5.70
maven/mavencentral/org.mortbay.jasper/apache-jsp/8.5.70
maven/mavencentral/org.ow2.asm/asm-analysis/9.2
maven/mavencentral/org.ow2.asm/asm-commons/9.2
maven/mavencentral/org.ow2.asm/asm-tree/9.2
maven/mavencentral/org.ow2.asm/asm/9.2" | java -jar -Dorg.slf4j.simpleLogger.defaultLogLevel=debug dash.license.tool.jar -
```

```
[main] INFO Querying Eclipse Foundation for license data for 32 items.
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/apache-jsp/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/apache-jstl/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-annotations/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-client/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-continuation/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-http/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-io/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-jmx/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-jndi/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-plus/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-security/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-server/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-servlet/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-servlets/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-util-ajax/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-util/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-webapp/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty/jetty-xml/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.aggregate/jetty-all/9.2.30.v20200428 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/javax-websocket-client-impl/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/javax-websocket-server-impl/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/websocket-api/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/websocket-client/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/websocket-common/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/websocket-server/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.eclipse.jetty.websocket/websocket-servlet/9.4.44.v20210927 score: 100 EPL-2.0 OR Apache-2.0 rt.jetty
[main] DEBUG EF approved: maven/mavencentral/org.mortbay.jasper/apache-jsp/8.5.70 score: 100  CQ19550
[main] DEBUG EF approved: maven/mavencentral/org.ow2.asm/asm/9.2 score: 100 BSD-3-Clause CQ23635
[main] INFO Found 28 items.
[main] INFO Querying ClearlyDefined for license data for 4 items.
[main] DEBUG Sending: maven/mavencentral/org.mortbay.jasper/apache-el/8.5.70
[main] DEBUG Sending: maven/mavencentral/org.ow2.asm/asm-analysis/9.2
[main] DEBUG Sending: maven/mavencentral/org.ow2.asm/asm-commons/9.2
[main] DEBUG Sending: maven/mavencentral/org.ow2.asm/asm-tree/9.2
[main] DEBUG ClearlyDefined maven/mavencentral/org.mortbay.jasper/apache-el/8.5.70 score: 75 Apache-2.0 approved
[main] DEBUG ClearlyDefined maven/mavencentral/org.ow2.asm/asm-analysis/9.2 score: 60 BSD-3-Clause approved
[main] DEBUG ClearlyDefined maven/mavencentral/org.ow2.asm/asm-commons/9.2 score: 60 BSD-3-Clause approved
[main] DEBUG ClearlyDefined maven/mavencentral/org.ow2.asm/asm-tree/9.2 score: 60 BSD-3-Clause approved
[main] INFO Found 4 items.
Vetted license information was found for all content. No further investigation is required.
```

**Screenshots**
_None_

**Any side note on the changes made**
_None_