### PR TITLE
Excluded c3p0 dependencies from Quartz scheduler

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1531,9 +1531,19 @@
                 <version>${quartz-scheduler.version}</version>
                 <exclusions>
                     <exclusion>
-                        <!-- This is not required. We are using EclipseLink connection pooling. -->
+                        <!-- This is not required. We are using directly HikariCP connection pooling. -->
                         <groupId>com.zaxxer</groupId>
                         <artifactId>HikariCP-java7</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- This is not required. We are using HikariCP connection pooling. -->
+                        <groupId>com.mchange</groupId>
+                        <artifactId>c3p0</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- This is not required. We are using HikariCP connection pooling. -->
+                        <groupId>com.mchange</groupId>
+                        <artifactId>mchange-commons-java</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>


### PR DESCRIPTION
This PR excludes some of transitive dependencies of Quartz scheduler since they are no longer required (we now use HikariCP).

**Related Issue**
_None_

**Description of the solution adopted**
Run `mvn dependency:tree` and check referenced artefacts.

**Screenshots**
_None_

**Any side note on the changes made**
_None_