### PR TITLE
Fixed message-broker container name when launched in debug mode

### DIFF
--- a/deployment/docker/compose/extras/docker-compose.broker-debug.yml
+++ b/deployment/docker/compose/extras/docker-compose.broker-debug.yml
@@ -1,7 +1,7 @@
 version: '3.1'
 
 services:
-  broker:
+  message-broker:
     ports:
       - ${KAPUA_BROKER_DEBUG_PORT}:5005
     environment:


### PR DESCRIPTION
This PR fixes the container name for the `message-broker` in debug mode.

**Related Issue**
This PR fixes the bud that was introduced with #3449 

**Description of the solution adopted**
Fixed the name

**Screenshots**
_None_

**Any side note on the changes made**
_None_