### PR TITLE
FIxed original cause eaten in process on connect.

### DIFF
--- a/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
+++ b/service/device/management/job/internal/src/main/java/org/eclipse/kapua/service/device/management/job/scheduler/internal/JobDeviceManagementTriggerManagerServiceImpl.java
@@ -152,7 +152,7 @@ public class JobDeviceManagementTriggerManagerServiceImpl implements JobDeviceMa
             }
 
         } catch (Exception e) {
-            throw new ProcessOnConnectException(scopeId, deviceId);
+            throw new ProcessOnConnectException(e, scopeId, deviceId);
         }
     }
 }


### PR DESCRIPTION
This PR fixes the fact that the original cause was eaten when thrown an error while running process on connect feature.

**Related Issue**
_None_

**Description of the solution adopted**
Added the original cause to the thrown `ProcessOnConnectException`

**Screenshots**
_None_

**Any side note on the changes made**
_None_