### PR TITLE
Bump version of jetty dependencies from 9.2.x to 9.4.44

### DIFF
--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -249,6 +249,10 @@
                     <groupId>org.apache.hadoop</groupId>
                     <artifactId>hadoop-core</artifactId>
                 </exclusion>
+                <exclusion>
+                    <groupId>org.eclipse.jetty.aggregate</groupId>
+                    <artifactId>jetty-all</artifactId>
+                </exclusion>
             </exclusions>
         </dependency>
 
@@ -272,6 +276,11 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-annotations</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.jetty.aggregate</groupId>
+            <artifactId>jetty-all</artifactId>
+            <classifier>uber</classifier>
         </dependency>
         <dependency>
             <groupId>org.eclipse.persistence</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2078,7 +2078,13 @@
             <dependency>
                 <groupId>org.eclipse.jetty.aggregate</groupId>
                 <artifactId>jetty-all</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
+                <classifier>uber</classifier>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.jetty.aggregate</groupId>
+                <artifactId>jetty-all</artifactId>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty.websocket</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2033,7 +2033,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-rewrite</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2018,7 +2018,7 @@
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>
                 <artifactId>jetty-jaas</artifactId>
-                <version>${jetty-activemq.version}</version>
+                <version>${jetty.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.eclipse.jetty</groupId>


### PR DESCRIPTION
This PR integrates more upgrades of Jetty dependency from 9.2.30 to 9.4.44

**Related Issue**
This PR relates to 3495

**Description of the solution adopted**
Bumped the version and fixes definition for `jetty-all` dependency

**Screenshots**
_None_

**Any side note on the changes made**
_None_