### PR TITLE
Disabled webconsole for H2 container - CVE-2018-10054

### DIFF
--- a/assembly/sql/entrypoint/run-h2
+++ b/assembly/sql/entrypoint/run-h2
@@ -24,4 +24,4 @@ eval java $JAVA_OPTS -cp /opt/h2/h2.jar org.h2.tools.RunScript -url jdbc:h2:/var
 rm /tmp/backup.sql
 
 # exec server
-exec /usr/bin/java $JAVA_OPTS $H2_OPTS -cp /opt/h2/h2.jar org.h2.tools.Server -web -webAllowOthers -webPort 8181 -tcp -tcpAllowOthers -tcpPort 3306 -baseDir /var/opt/h2/data
+exec /usr/bin/java $JAVA_OPTS $H2_OPTS -cp /opt/h2/h2.jar org.h2.tools.Server -tcp -tcpAllowOthers -tcpPort 3306 -baseDir /var/opt/h2/data

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -5,7 +5,6 @@ services:
     container_name: db
     image: kapua/kapua-sql:${IMAGE_VERSION}
     ports:
-      - 8181:8181
       - 3306:3306
   es:
     container_name: es


### PR DESCRIPTION
Disabled web console for H2 sql container. 

This solves CVE-2018-10054

**Related Issue**
_None_

**Description of the solution adopted**
Removed options that allowed the web console to be enabled thus exposing the vulnerability.

**Screenshots**
_None_

**Any side note on the changes made**
Web console will be enabled with a dedicated option in a subsequent PR 