### PR TITLE
Set module version to 2.0.0-SNAPSHOT

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ The team maintains some docker images in a Docker Hub repository at [Kapua Repos
 **Note:** the Docker Hub repository mentioned above is not the official project repository from Eclipse Foundation.
 ***
 
-Suppose the target is the current snapshot 1.6.0-SNAPSHOT.
+Suppose the target is the current snapshot 2.0.0-SNAPSHOT.
 
 * Clone Eclipse Kapua&trade; into a local directory
 * Open an OS shell and move to Kapua project root directory

--- a/assembly/api/pom.xml
+++ b/assembly/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-assembly</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/broker/pom.xml
+++ b/assembly/broker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/console/pom.xml
+++ b/assembly/console/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
+++ b/assembly/consumer/lifecycle/entrypoint/run-consumer-lifecycle
@@ -11,4 +11,4 @@
 #        Eurotech
 ################################################################################
 
-java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-lifecycle-1.6.0-SNAPSHOT-app.jar
+java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-lifecycle-2.0.0-SNAPSHOT-app.jar

--- a/assembly/consumer/lifecycle/pom.xml
+++ b/assembly/consumer/lifecycle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-assembly-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/assembly/consumer/pom.xml
+++ b/assembly/consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
+++ b/assembly/consumer/telemetry/entrypoint/run-consumer-telemetry
@@ -11,4 +11,4 @@
 #        Eurotech
 ################################################################################
 
-java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-telemetry-1.6.0-SNAPSHOT-app.jar
+java ${JAVA_OPTS} ${DEBUG_OPTIONS} -jar kapua-consumer-telemetry-2.0.0-SNAPSHOT-app.jar

--- a/assembly/consumer/telemetry/pom.xml
+++ b/assembly/consumer/telemetry/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-assembly-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/jetty-base/pom.xml
+++ b/assembly/jetty-base/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/job-engine/pom.xml
+++ b/assembly/job-engine/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-assembly</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/assembly/pom.xml
+++ b/assembly/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/assembly/sql/pom.xml
+++ b/assembly/sql/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-assembly</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/broker/api/pom.xml
+++ b/broker/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-broker</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/broker/client/pom.xml
+++ b/broker/client/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-broker</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-broker-client</artifactId>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-broker</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-broker-core</artifactId>

--- a/broker/pom.xml
+++ b/broker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/build-tools/pom.xml
+++ b/build-tools/pom.xml
@@ -24,7 +24,7 @@
 
     <groupId>org.eclipse.kapua.build</groupId>
     <artifactId>kapua-build-tools</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
     
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>

--- a/client/gateway/api/pom.xml
+++ b/client/gateway/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/features/karaf/pom.xml
+++ b/client/gateway/features/karaf/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-features</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/features/pom.xml
+++ b/client/gateway/features/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client-gateway-features</artifactId>

--- a/client/gateway/pom.xml
+++ b/client/gateway/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client-gateway</artifactId>

--- a/client/gateway/profile/kura/pom.xml
+++ b/client/gateway/profile/kura/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>../..</relativePath>
     </parent>
 

--- a/client/gateway/provider/fuse/pom.xml
+++ b/client/gateway/provider/fuse/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/mqtt/pom.xml
+++ b/client/gateway/provider/mqtt/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/paho/pom.xml
+++ b/client/gateway/provider/paho/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway-provider</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/provider/pom.xml
+++ b/client/gateway/provider/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/gateway/spi/pom.xml
+++ b/client/gateway/spi/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-client-gateway</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/client/pom.xml
+++ b/client/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-client</artifactId>

--- a/commons/pom.xml
+++ b/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-commons</artifactId>

--- a/commons/src/main/java/org/eclipse/kapua/commons/CommonsModule.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/CommonsModule.java
@@ -19,7 +19,7 @@ import org.eclipse.kapua.model.query.QueryFactory;
 /**
  * {@code kapua-commons} {@link AbstractKapuaModule}.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class CommonsModule extends AbstractKapuaModule {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ClassProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ClassProvider.java
@@ -17,7 +17,7 @@ import java.util.List;
 /**
  * Just a container to pass a bunch of classes around
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public interface ClassProvider {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleJaxbClassConfig.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleJaxbClassConfig.java
@@ -18,7 +18,7 @@ import java.util.List;
  * Utility class used by the {@link org.eclipse.kapua.locator.KapuaLocator} implementation to export configuration 
  * regarding JAXB serializable classes defined within Kapua modules.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class ServiceModuleJaxbClassConfig {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleJaxbClassProvider.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/core/ServiceModuleJaxbClassProvider.java
@@ -21,7 +21,7 @@ import org.eclipse.kapua.locator.KapuaLocator;
  * implementation. KapuaLocator is initialized in the constructor in order let the
  * implementation export the required list of classes.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class ServiceModuleJaxbClassProvider implements ClassProvider {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/jpa/AbstractEntityManagerFactory.java
@@ -60,7 +60,7 @@ public abstract class AbstractEntityManagerFactory implements org.eclipse.kapua.
      * Constructor.
      *
      * @param persistenceUnitName The {@link PersistenceUnit} name.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected AbstractEntityManagerFactory(String persistenceUnitName) {
         this(persistenceUnitName, DEFAULT_DATASOURCE_NAME);
@@ -71,7 +71,7 @@ public abstract class AbstractEntityManagerFactory implements org.eclipse.kapua.
      *
      * @param persistenceUnitName The {@link PersistenceUnit} name.
      * @param datasourceName      The {@link DataSource} name.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected AbstractEntityManagerFactory(String persistenceUnitName, String datasourceName) {
         //
@@ -121,7 +121,7 @@ public abstract class AbstractEntityManagerFactory implements org.eclipse.kapua.
      * @param persistenceUnitName The {@link PersistenceUnit#name()}.
      * @param datasourceName      The datasource name.
      * @param configOverrides     The configuration overrides for the {@link EntityManager}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private void printEntityManagerConfiguration(String persistenceUnitName, String datasourceName, Map<String, Object> configOverrides) {
         ConfigurationPrinter configurationPrinter =

--- a/commons/src/main/java/org/eclipse/kapua/commons/logging/LoggingMdcKeys.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/logging/LoggingMdcKeys.java
@@ -20,14 +20,14 @@ import org.slf4j.MDC;
  * Logging {@link MDC} keys.
  *
  * @see MDC
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class LoggingMdcKeys {
 
     /**
      * Constructor.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private LoggingMdcKeys() {
     }
@@ -56,7 +56,7 @@ public class LoggingMdcKeys {
     /**
      * The {@link User#getName()}.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static final String USER_NAME = "userName";
 }

--- a/commons/src/main/java/org/eclipse/kapua/commons/model/query/QueryFactoryImpl.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/model/query/QueryFactoryImpl.java
@@ -20,7 +20,7 @@ import javax.inject.Singleton;
 /**
  * {@link QueryFactory} implementation.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 @Singleton
 public class QueryFactoryImpl implements QueryFactory {

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/KapuaNamedEntityServiceUtils.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/KapuaNamedEntityServiceUtils.java
@@ -34,7 +34,7 @@ import java.util.List;
 /**
  * Util class that offers checks on the {@link KapuaNamedEntity#getName()} uniqueness in different flavors.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class KapuaNamedEntityServiceUtils {
 
@@ -44,7 +44,7 @@ public class KapuaNamedEntityServiceUtils {
     /**
      * Constructor.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private KapuaNamedEntityServiceUtils() {
     }
@@ -58,7 +58,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <C>                     The {@link KapuaNamedEntityCreator} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntityCreator#getName()} is duplicated within the {@link KapuaNamedEntityCreator#getScopeId()}.
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity, C extends KapuaNamedEntityCreator<E>> void checkEntityNameUniqueness(@NotNull KapuaEntityService<E, C> kapuaNamedEntityService, @NotNull C creator) throws KapuaException {
         checkEntityNameUniqueness(kapuaNamedEntityService, creator, Collections.emptyList());
@@ -74,7 +74,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <C>                     The {@link KapuaNamedEntityCreator} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntityCreator#getName()} is duplicated within the {@link KapuaNamedEntityCreator#getScopeId()}.
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity, C extends KapuaNamedEntityCreator<E>> void checkEntityNameUniqueness(@NotNull KapuaEntityService<E, C> kapuaNamedEntityService, @NotNull C creator, @NotNull List<QueryPredicate> additionalPredicates) throws KapuaException {
         KapuaQuery query = QUERY_FACTORY.newQuery();
@@ -102,7 +102,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <E>                     The {@link KapuaNamedEntity} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntity#getName()} is duplicated within the {@link KapuaNamedEntity#getScopeId()}.
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity> void checkEntityNameUniqueness(@NotNull KapuaEntityService<E, ?> kapuaNamedEntityService, @NotNull E entity) throws KapuaException {
         checkEntityNameUniqueness(kapuaNamedEntityService, entity, Collections.emptyList());
@@ -117,7 +117,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <E>                     The {@link KapuaNamedEntity} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntity#getName()} is duplicated within the {@link KapuaNamedEntity#getScopeId()}.
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity> void checkEntityNameUniqueness(@NotNull KapuaEntityService<E, ?> kapuaNamedEntityService, @NotNull E entity, @NotNull List<QueryPredicate> additionalPredicates) throws KapuaException {
         KapuaQuery query = QUERY_FACTORY.newQuery();
@@ -147,7 +147,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <C>                     The {@link KapuaNamedEntityCreator} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntityCreator#getName()} is duplicated within all the scopes
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity, C extends KapuaNamedEntityCreator<E>> void checkEntityNameUniquenessInAllScopes(@NotNull KapuaEntityService<E, C> kapuaNamedEntityService, @NotNull C creator) throws KapuaException {
         KapuaQuery query = QUERY_FACTORY.newQuery();
@@ -166,7 +166,7 @@ public class KapuaNamedEntityServiceUtils {
      * @param <E>                     The {@link KapuaNamedEntity} type.
      * @throws KapuaDuplicateNameException if the {@link KapuaNamedEntity#getName()} is duplicated within all the scopes
      * @throws KapuaException              if any other error occurs.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <E extends KapuaNamedEntity> void checkEntityNameUniquenessInAllScopes(@NotNull KapuaEntityService<E, ?> kapuaNamedEntityService, @NotNull E entity) throws KapuaException {
         KapuaQuery query = QUERY_FACTORY.newQuery();

--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/ServiceDAO.java
@@ -291,7 +291,7 @@ public class ServiceDAO {
      * @param value The value of the {@link KapuaNamedEntity#getName()} to search.
      * @return The {@link KapuaNamedEntity} found, or {@code null} if not found.
      * @throws NonUniqueResultException When more than one result is returned
-     * @since 1.6.0
+     * @since 2.0.0
      */
     @Nullable
     public static <E extends KapuaNamedEntity> E findByName(@NonNull EntityManager em,

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/log/ConfigurationPrinter.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/log/ConfigurationPrinter.java
@@ -483,7 +483,7 @@ public class ConfigurationPrinter {
      * <p>
      * Used to create the list of parameters (value) to print.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private static class SimpleConfigurationParameter extends ConfigurationHeader {
 

--- a/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/util/xml/XmlUtil.java
@@ -84,7 +84,7 @@ public class XmlUtil {
      *
      * @return The configured {@link JAXBContextProvider}.
      * @throws KapuaIllegalStateException if {@link JAXBContextProvider} is not configured.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static JAXBContextProvider getContextProvider() {
         if (jaxbContextProvider == null) {
@@ -375,7 +375,7 @@ public class XmlUtil {
      * @return The unmarshalled {@link Object}.
      * @throws JAXBException See {@link #getContext()}.
      * @throws SAXException  See {@link XMLReaderFactory#createXMLReader()}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static <T> T unmarshalJson(@NotNull Reader reader, @NotNull Class<T> type)
             throws JAXBException, SAXException {

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTestJAXBContextProvider.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTestJAXBContextProvider.java
@@ -22,7 +22,7 @@ import java.util.Map;
 /**
  * {@link JAXBContextProvider} implementation to be used in {@link XmlUtilTest}.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class XmlUtilTestJAXBContextProvider implements JAXBContextProvider {
 

--- a/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTestObject.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/util/xml/XmlUtilTestObject.java
@@ -24,7 +24,7 @@ import java.util.List;
 /**
  * Test {@link Object} to be used in {@link XmlUtilTest}.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.FIELD)

--- a/console/core/pom.xml
+++ b/console/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-core</artifactId>

--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/filter/KapuaWebFilter.java
@@ -77,7 +77,7 @@ public class KapuaWebFilter extends ShiroFilter {
      * Gets the {@link KapuaSession} from the {@link Subject}
      *
      * @return The {@link KapuaSession} from the {@link Subject}
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected KapuaSession getSession() {
         Subject shiroSubject = SecurityUtils.getSubject();
@@ -89,7 +89,7 @@ public class KapuaWebFilter extends ShiroFilter {
      *
      * @param accessToken The {@link AccessToken} to check and refresh if needed.
      * @throws KapuaException If one of the checks fails or refreshing the token fails.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void checkAndRefreshAccessTokenIfExpired(AccessToken accessToken) throws KapuaException {
         if (accessToken == null) {

--- a/console/module/about/pom.xml
+++ b/console/module/about/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-about</artifactId>

--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-account</artifactId>

--- a/console/module/api/pom.xml
+++ b/console/module/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-api</artifactId>

--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-authentication</artifactId>

--- a/console/module/authorization/pom.xml
+++ b/console/module/authorization/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-authorization</artifactId>

--- a/console/module/certificate/pom.xml
+++ b/console/module/certificate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-certificate</artifactId>

--- a/console/module/data/pom.xml
+++ b/console/module/data/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-data</artifactId>

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-device</artifactId>

--- a/console/module/endpoint/pom.xml
+++ b/console/module/endpoint/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-endpoint</artifactId>

--- a/console/module/job/pom.xml
+++ b/console/module/job/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-job</artifactId>

--- a/console/module/pom.xml
+++ b/console/module/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-console</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module</artifactId>

--- a/console/module/tag/pom.xml
+++ b/console/module/tag/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-tag</artifactId>

--- a/console/module/user/pom.xml
+++ b/console/module/user/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-user</artifactId>

--- a/console/module/welcome/pom.xml
+++ b/console/module/welcome/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-console-module</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-module-welcome</artifactId>

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console</artifactId>

--- a/console/web/pom.xml
+++ b/console/web/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-console</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-console-web</artifactId>

--- a/consumer/commons/pom.xml
+++ b/consumer/commons/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-consumer</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-consumer-commons</artifactId>

--- a/consumer/lifecycle-app/pom.xml
+++ b/consumer/lifecycle-app/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-consumer-lifecycle-app</artifactId>

--- a/consumer/lifecycle/pom.xml
+++ b/consumer/lifecycle/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-consumer</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-consumer-lifecycle</artifactId>

--- a/consumer/pom.xml
+++ b/consumer/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/consumer/telemetry-app/pom.xml
+++ b/consumer/telemetry-app/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-consumer</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/consumer/telemetry/pom.xml
+++ b/consumer/telemetry/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-consumer</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-consumer-telemetry</artifactId>

--- a/deployment/commons/pom.xml
+++ b/deployment/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-deployment-commons</artifactId>

--- a/deployment/docker/pom.xml
+++ b/deployment/docker/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-docker</artifactId>

--- a/deployment/minishift/pom.xml
+++ b/deployment/minishift/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-minishift</artifactId>

--- a/deployment/openshift/pom.xml
+++ b/deployment/openshift/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-deployment</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/deployment/pom.xml
+++ b/deployment/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-deployment</artifactId>

--- a/dev-tools/cucumber-reports/pom.xml
+++ b/dev-tools/cucumber-reports/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-dev-tools</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-cucumber-reports</artifactId>

--- a/dev-tools/pom.xml
+++ b/dev-tools/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-dev-tools</artifactId>

--- a/docs/developer-guide/en/running.md
+++ b/docs/developer-guide/en/running.md
@@ -167,7 +167,7 @@ default, Kapua comes with the NodePort service that routes all traffic from port
 connect your MQTT clients directly to this service. For the simulator example similar to the above, that would look
 something like
 
-    java -jar target/kapua-simulator-kura-1.6.0-SNAPSHOT-app.jar --broker tcp://kapua-broker:kapua-password@192.168.64.2:31883
+    java -jar target/kapua-simulator-kura-2.0.0-SNAPSHOT-app.jar --broker tcp://kapua-broker:kapua-password@192.168.64.2:31883
 
 This is suitable only for the local deployments. In the cloud or production environments, you should deploy a proper
 LoadBalancer Openshift service to enable external traffic flow to the broker.

--- a/extras/es-migrator/pom.xml
+++ b/extras/es-migrator/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-extras</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <artifactId>kapua-es-migrator</artifactId>

--- a/extras/foreignkeys/pom.xml
+++ b/extras/foreignkeys/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-extras</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-foreignkeys</artifactId>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-extras</artifactId>

--- a/job-engine/api/pom.xml
+++ b/job-engine/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-api</artifactId>

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/exception/JobResumingException.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/exception/JobResumingException.java
@@ -62,7 +62,7 @@ public class JobResumingException extends JobScopedEngineException {
      * Gets the {@link JobExecution#getId()} which was not able to resume.
      *
      * @return The {@link JobExecution#getId()} which was not able to resume.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public KapuaId getJobExecutionId() {
         return jobExecutionId;

--- a/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/exception/JobStoppingException.java
+++ b/job-engine/api/src/main/java/org/eclipse/kapua/job/engine/exception/JobStoppingException.java
@@ -76,7 +76,7 @@ public class JobStoppingException extends JobScopedEngineException {
      * Gets the {@link JobExecution#getId()} that cannot be stopped.
      *
      * @return The {@link JobExecution#getId()} that cannot be stopped.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public KapuaId getJobExecutionId() {
         return jobExecutionId;

--- a/job-engine/app/core/pom.xml
+++ b/job-engine/app/core/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-job-engine-app</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-app-core</artifactId>

--- a/job-engine/app/pom.xml
+++ b/job-engine/app/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-app</artifactId>

--- a/job-engine/app/resources/pom.xml
+++ b/job-engine/app/resources/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-job-engine-app</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-app-resources</artifactId>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-job-engine-app</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-app-web</artifactId>

--- a/job-engine/client/pom.xml
+++ b/job-engine/client/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <artifactId>kapua-job-engine</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-client</artifactId>

--- a/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
+++ b/job-engine/client/src/main/java/org/eclipse/kapua/job/engine/client/JobEngineServiceClient.java
@@ -234,7 +234,7 @@ public class JobEngineServiceClient implements JobEngineService {
      *
      * @param path The path of the request.
      * @return The {@link Invocation.Builder}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private Invocation.Builder getPreparedRequest(String path) {
         return jobEngineTarget.path(path)
@@ -250,7 +250,7 @@ public class JobEngineServiceClient implements JobEngineService {
      * @param response The {@link Response} to check.
      * @return The body of the request in {@link String} format.
      * @throws KapuaException The proper {@link KapuaException} if needed.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private String checkResponse(String method, String path, Response response) throws KapuaException {
         String responseText = response.readEntity(String.class);

--- a/job-engine/commons/pom.xml
+++ b/job-engine/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-commons</artifactId>

--- a/job-engine/jbatch/pom.xml
+++ b/job-engine/jbatch/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job-engine</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine-jbatch</artifactId>

--- a/job-engine/pom.xml
+++ b/job-engine/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-engine</artifactId>

--- a/locator/guice/pom.xml
+++ b/locator/guice/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-locator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-locator-guice</artifactId>

--- a/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
+++ b/locator/guice/src/main/java/org/eclipse/kapua/locator/guice/GuiceLocatorImpl.java
@@ -188,7 +188,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      * @param className        The {@link Class#getName()} to check.
      * @param excludedPackages The {@link Collection} of excluded {@link Class#getPackage()}.
      * @return {@code true} if matched, {@code false otherwise}
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private boolean isExcluded(@NotNull String className, @NotNull Collection<String> excludedPackages) {
         for (String pkg : excludedPackages) {
@@ -205,7 +205,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      * @param resourceNameURL The {@link KapuaLocator} configuration resource name.
      * @param locatorConfig   The loaded {@link LocatorConfig}.
      * @param kapuaModules    The laaded {@link KapuaModule}s
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private void printLoadedKapuaModuleConfiguration(@NotNull URL resourceNameURL, @NotNull LocatorConfig locatorConfig, @NotNull List<AbstractKapuaModule> kapuaModules, @NotNull List<Class<? extends AbstractKapuaModule>> excludedKapuaModules) {
         ConfigurationPrinter configurationPrinter =
@@ -251,7 +251,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      * @param resourceNameURL       The {@link KapuaLocator} configuration resource name.
      * @param locatorConfig         The loaded {@link LocatorConfig}.
      * @param loadedXmlSerializable The laaded {@link KapuaModule}s
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private void printLoadedXmlSerializableConfiguration(@NotNull URL resourceNameURL, @NotNull LocatorConfig locatorConfig, @NotNull List<Class<?>> loadedXmlSerializable, @NotNull List<Class<?>> excludedXmlSerializable) {
         ConfigurationPrinter configurationPrinter =
@@ -306,7 +306,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      *
      * @param configurationPrinter The {@link ConfigurationPrinter} to add the configuration to.
      * @param locatorConfig        The {@link LocatorConfig}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private void addIncludedExcludedPackageConfig(@NotNull ConfigurationPrinter configurationPrinter, @NotNull LocatorConfig locatorConfig) {
         // Inclusions
@@ -338,7 +338,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      * @param strings The {@link Collection} to sort.
      * @param <C>     The type of {@link Comparable}.
      * @return The sorted {@link Collection}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private <C extends Comparable<?>> Collection<C> sortedComparable(Collection<C> strings) {
         return strings.stream().sorted().collect(Collectors.toList());
@@ -350,7 +350,7 @@ public class GuiceLocatorImpl extends KapuaLocator {
      * @param classes The {@link Collection} to sort.
      * @param <T>     The type of {@link Class}.
      * @return The sorted {@link Collection}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private <T extends Class<?>> Collection<T> sortedClass(Collection<T> classes) {
         return classes.stream().sorted(Comparator.comparing(Class::getName)).collect(Collectors.toList());

--- a/locator/pom.xml
+++ b/locator/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-locator</artifactId>

--- a/message/api/pom.xml
+++ b/message/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-message</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-message-api</artifactId>

--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-message</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-message-internal</artifactId>

--- a/message/pom.xml
+++ b/message/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/plug-ins/pom.xml
+++ b/plug-ins/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/plug-ins/sso/openid-connect/api/pom.xml
+++ b/plug-ins/sso/openid-connect/api/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-openid-connect</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-openid-api</artifactId>

--- a/plug-ins/sso/openid-connect/pom.xml
+++ b/plug-ins/sso/openid-connect/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-sso</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/plug-ins/sso/openid-connect/provider-generic/pom.xml
+++ b/plug-ins/sso/openid-connect/provider-generic/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-openid-connect</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-openid-provider-generic</artifactId>

--- a/plug-ins/sso/openid-connect/provider-keycloak/pom.xml
+++ b/plug-ins/sso/openid-connect/provider-keycloak/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-openid-connect</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-openid-provider-keycloak</artifactId>

--- a/plug-ins/sso/openid-connect/provider/pom.xml
+++ b/plug-ins/sso/openid-connect/provider/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-openid-connect</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-openid-provider</artifactId>

--- a/plug-ins/sso/pom.xml
+++ b/plug-ins/sso/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-plug-ins</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/pom.xml
+++ b/pom.xml
@@ -17,7 +17,7 @@
 
     <groupId>org.eclipse.kapua</groupId>
     <artifactId>kapua</artifactId>
-    <version>1.6.0-SNAPSHOT</version>
+    <version>2.0.0-SNAPSHOT</version>
 
     <name>kapua</name>
     <packaging>pom</packaging>

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-common</artifactId>

--- a/qa/integration-steps/pom.xml
+++ b/qa/integration-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-integration-steps</artifactId>

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -68,7 +68,7 @@ public class DockerSteps {
     private static final Logger logger = LoggerFactory.getLogger(DockerSteps.class);
 
     private static final String NETWORK_PREFIX = "kapua-net";
-    private static final String KAPUA_VERSION = "1.6.0-SNAPSHOT";
+    private static final String KAPUA_VERSION = "2.0.0-SNAPSHOT";
     private static final String ES_IMAGE = "elasticsearch:7.8.1";
     private static final List<String> DEFAULT_DEPLOYMENT_CONTAINERS_NAME;
     private static final List<String> DEFAULT_BASE_DEPLOYMENT_CONTAINERS_NAME;

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-integration</artifactId>

--- a/qa/integration/src/test/resources/features/docker/broker.feature
+++ b/qa/integration/src/test/resources/features/docker/broker.feature
@@ -18,8 +18,8 @@ Feature: Testing docker steps
   Scenario: Execute possible docker steps to show its usage
     For now it only lists docker images
 
-    Given List images by name "kapua/kapua-broker:1.6.0-SNAPSHOT"
-    #And Pull image "kapua/kapua-sql:1.6.0-SNAPSHOT"
+    Given List images by name "kapua/kapua-broker:2.0.0-SNAPSHOT"
+    #And Pull image "kapua/kapua-sql:2.0.0-SNAPSHOT"
     And Pull image "elasticsearch:7.8.1"
     Then Create network
     And Start DB container with name "db"
@@ -28,10 +28,10 @@ Feature: Testing docker steps
     Then I wait 15 seconds
     And Start Message Broker container
       | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
-      | broker-1 | broker1         | 0.0.0.0  | test-cluster | 1883     | 1883         | 8883      | 8883          | 8161    | 8161        | 9999      | 9999          | 9991                   | kapua/kapua-broker:1.6.0-SNAPSHOT |
+      | broker-1 | broker1         | 0.0.0.0  | test-cluster | 1883     | 1883         | 8883      | 8883          | 8161    | 8161        | 9999      | 9999          | 9991                   | kapua/kapua-broker:2.0.0-SNAPSHOT |
     And Start Message Broker container
       | name     | brokerAddress  | brokerIp | clusterName  | mqttPort | mqttHostPort | mqttsPort | mqttsHostPort | webPort | webHostPort | debugPort | debugHostPort | brokerInternalDebugPort| dockerImage |
-      | broker-2 | broker2        | 0.0.0.0  | test-cluster | 1883     | 1884         | 8883      | 8884          | 8161    | 8162        | 9999      | 9998          | 9991                   | kapua/kapua-broker:1.6.0-SNAPSHOT |
+      | broker-2 | broker2        | 0.0.0.0  | test-cluster | 1883     | 1884         | 8883      | 8884          | 8161    | 8162        | 9999      | 9998          | 9991                   | kapua/kapua-broker:2.0.0-SNAPSHOT |
     Then I wait 30 seconds
     And Create mqtt "client-1" client for broker "0.0.0.0" on port 1883 with user "kapua-sys" and pass "kapua-password"
     And Connect to mqtt client "client-1"

--- a/qa/markers/pom.xml
+++ b/qa/markers/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-qa</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-qa-markers</artifactId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>
@@ -81,7 +81,7 @@
                             <images>
                                 <image>
                                     <alias>db</alias>
-                                    <name>kapua/kapua-sql:1.6.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-sql:2.0.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8181:8181</port>
@@ -116,7 +116,7 @@
                                 </image>
                                 <image>
                                     <alias>events-broker</alias>
-                                    <name>kapua/kapua-events-broker:1.6.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-events-broker:2.0.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>5672:5672</port>
@@ -129,7 +129,7 @@
                                 </image>
                                 <image>
                                     <alias>broker</alias>
-                                    <name>kapua/kapua-broker:1.6.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-broker:2.0.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>1883:1883</port>
@@ -154,7 +154,7 @@
                                 </image>
                                 <image>
                                     <alias>kapua-console</alias>
-                                    <name>kapua/kapua-console:1.6.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-console:2.0.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8080:8080</port>
@@ -180,7 +180,7 @@
                                 </image>
                                 <image>
                                     <alias>kapua-api</alias>
-                                    <name>kapua/kapua-api:1.6.0-SNAPSHOT</name>
+                                    <name>kapua/kapua-api:2.0.0-SNAPSHOT</name>
                                     <run>
                                         <ports>
                                             <port>8081:8080</port>

--- a/rest-api/core/pom.xml
+++ b/rest-api/core/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-core</artifactId>

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityUniquenessExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/EntityUniquenessExceptionInfo.java
@@ -70,7 +70,7 @@ public class EntityUniquenessExceptionInfo extends ExceptionInfo {
      * Gets the {@link KapuaEntityUniquenessException#getUniquesFieldValues()}.
      *
      * @return The {@link KapuaEntityUniquenessException#getUniquesFieldValues()}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public List<Map.Entry<String, Object>> getUniquesFieldValues() {
         return uniquesFieldValues;

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/exception/model/ExceptionInfo.java
@@ -43,7 +43,7 @@ public class ExceptionInfo extends ThrowableInfo {
      *
      * @param httpStatus The {@link Status} of the {@link Response}
      * @param exception  The cause of the error.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public ExceptionInfo(Status httpStatus, KapuaException exception) {
         super(httpStatus, exception);

--- a/rest-api/pom.xml
+++ b/rest-api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api</artifactId>

--- a/rest-api/resources/pom.xml
+++ b/rest-api/resources/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-resources</artifactId>

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-rest-api</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-rest-api-web</artifactId>

--- a/service/account/api/pom.xml
+++ b/service/account/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-api</artifactId>

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/xml/AccountParentPathXmlAdapter.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/xml/AccountParentPathXmlAdapter.java
@@ -27,7 +27,7 @@ import java.util.stream.Collectors;
 /**
  * {@link Account#getParentAccountPath()} {@link XmlAdapter}.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class AccountParentPathXmlAdapter extends XmlAdapter<String, String> {
 

--- a/service/account/internal/pom.xml
+++ b/service/account/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-internal</artifactId>

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountModule.java
@@ -20,7 +20,7 @@ import org.eclipse.kapua.service.account.AccountService;
 /**
  * {@code kapua-account-internal} {@link Module} implementation.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class AccountModule extends AbstractKapuaModule implements Module {
 

--- a/service/account/pom.xml
+++ b/service/account/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/account/test-steps/pom.xml
+++ b/service/account/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-test-steps</artifactId>

--- a/service/account/test/pom.xml
+++ b/service/account/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-account</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-account-test</artifactId>

--- a/service/api/pom.xml
+++ b/service/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-api</artifactId>

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/KapuaListResult.java
@@ -81,7 +81,7 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
      *
      * @param filter The filter to apply to select results.
      * @return The filtered {@link KapuaEntity}s that matched the {@link KapuaQuery#getPredicate()}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     List<E> getItems(@NotNull Predicate<E> filter);
 
@@ -94,7 +94,7 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
      * @param keyMapper The {@link Function} which defines the {@link Map.Entry#getKey()} for each {@link Map.Entry}
      * @param <K>       The type of the {@link Map.Entry#getKey()}
      * @return The {@link Map} generated according to the mapping {@link Map.Entry#getKey()} {@link Function}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     <K> Map<K, E> getItemsAsMap(@NotNull Function<E, K> keyMapper);
 
@@ -107,7 +107,7 @@ public interface KapuaListResult<E extends KapuaEntity> extends KapuaSerializabl
      * @param <K>         The type of the {@link Map.Entry#getKey()}
      * @param <V>         The type of the {@link Map.Entry#getValue()}
      * @return The {@link Map} generated according to the mapping {@link Function}s.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     <K, V> Map<K, V> getItemsAsMap(@NotNull Function<E, K> keyMapper, @NotNull Function<E, V> valueMapper);
 

--- a/service/api/src/main/java/org/eclipse/kapua/model/query/QueryFactory.java
+++ b/service/api/src/main/java/org/eclipse/kapua/model/query/QueryFactory.java
@@ -17,7 +17,7 @@ import org.eclipse.kapua.model.KapuaObjectFactory;
 /**
  * {@link KapuaQuery} {@link KapuaObjectFactory} definition.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public interface QueryFactory extends KapuaObjectFactory {
 
@@ -25,7 +25,7 @@ public interface QueryFactory extends KapuaObjectFactory {
      * Instantiates a new {@link KapuaQuery}.
      *
      * @return The newly instantiated {@link KapuaQuery}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     KapuaQuery newQuery();
 }

--- a/service/commons/elasticsearch/client-api/pom.xml
+++ b/service/commons/elasticsearch/client-api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service-elasticsearch</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-elasticsearch-client-api</artifactId>

--- a/service/commons/elasticsearch/client-rest/pom.xml
+++ b/service/commons/elasticsearch/client-rest/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service-elasticsearch</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-elasticsearch-client-rest</artifactId>

--- a/service/commons/elasticsearch/pom.xml
+++ b/service/commons/elasticsearch/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service-commons</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-elasticsearch</artifactId>

--- a/service/commons/elasticsearch/server-embedded/pom.xml
+++ b/service/commons/elasticsearch/server-embedded/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service-elasticsearch</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-elasticsearch-server-embedded</artifactId>

--- a/service/commons/pom.xml
+++ b/service/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-commons</artifactId>

--- a/service/commons/storable/api/pom.xml
+++ b/service/commons/storable/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service-storable</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-storable-api</artifactId>

--- a/service/commons/storable/internal/pom.xml
+++ b/service/commons/storable/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service-storable</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-storable-internal</artifactId>

--- a/service/commons/storable/pom.xml
+++ b/service/commons/storable/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service-commons</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service-storable</artifactId>

--- a/service/datastore/api/pom.xml
+++ b/service/datastore/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-api</artifactId>

--- a/service/datastore/internal/pom.xml
+++ b/service/datastore/internal/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-internal</artifactId>

--- a/service/datastore/pom.xml
+++ b/service/datastore/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore</artifactId>

--- a/service/datastore/test-steps/pom.xml
+++ b/service/datastore/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-test-steps</artifactId>

--- a/service/datastore/test/pom.xml
+++ b/service/datastore/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-datastore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-datastore-test</artifactId>

--- a/service/device/api/pom.xml
+++ b/service/device/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-api</artifactId>

--- a/service/device/call/api/pom.xml
+++ b/service/device/call/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-call</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-call-api</artifactId>

--- a/service/device/call/kura/pom.xml
+++ b/service/device/call/kura/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-call</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-call-kura</artifactId>

--- a/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/bundles/KuraInventoryBundle.java
+++ b/service/device/call/kura/src/main/java/org/eclipse/kapua/service/device/call/kura/model/inventory/bundles/KuraInventoryBundle.java
@@ -122,7 +122,7 @@ public class KuraInventoryBundle {
      * Whether the bundle is signed.
      *
      * @return {@code true} if is signed, {@code false} if not or {@code null} if the information is not known.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public Boolean getSigned() {
         return signed;
@@ -132,7 +132,7 @@ public class KuraInventoryBundle {
      * Sets whether the bundle is signed.
      *
      * @param signed {@code true} if is signed, {@code false} if not or {@code null} if the information is not known.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public void setSigned(Boolean signed) {
         this.signed = signed;

--- a/service/device/call/pom.xml
+++ b/service/device/call/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/commons/pom.xml
+++ b/service/device/commons/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-commons</artifactId>

--- a/service/device/management/all/api/pom.xml
+++ b/service/device/management/all/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-api</artifactId>

--- a/service/device/management/all/internal/pom.xml
+++ b/service/device/management/all/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-internal</artifactId>

--- a/service/device/management/all/job/pom.xml
+++ b/service/device/management/all/job/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-all</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-all-job</artifactId>

--- a/service/device/management/all/pom.xml
+++ b/service/device/management/all/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/api/pom.xml
+++ b/service/device/management/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-api</artifactId>

--- a/service/device/management/asset/api/pom.xml
+++ b/service/device/management/asset/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-api</artifactId>

--- a/service/device/management/asset/internal/pom.xml
+++ b/service/device/management/asset/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-internal</artifactId>

--- a/service/device/management/asset/job/pom.xml
+++ b/service/device/management/asset/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-asset</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-asset-job</artifactId>

--- a/service/device/management/asset/pom.xml
+++ b/service/device/management/asset/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/bundle/api/pom.xml
+++ b/service/device/management/bundle/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-api</artifactId>

--- a/service/device/management/bundle/internal/pom.xml
+++ b/service/device/management/bundle/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-internal</artifactId>

--- a/service/device/management/bundle/job/pom.xml
+++ b/service/device/management/bundle/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-bundle</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-bundle-job</artifactId>

--- a/service/device/management/bundle/pom.xml
+++ b/service/device/management/bundle/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/command/api/pom.xml
+++ b/service/device/management/command/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-api</artifactId>

--- a/service/device/management/command/internal/pom.xml
+++ b/service/device/management/command/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-internal</artifactId>

--- a/service/device/management/command/job/pom.xml
+++ b/service/device/management/command/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-command</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-command-job</artifactId>

--- a/service/device/management/command/pom.xml
+++ b/service/device/management/command/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/management/configuration/api/pom.xml
+++ b/service/device/management/configuration/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-api</artifactId>

--- a/service/device/management/configuration/internal/pom.xml
+++ b/service/device/management/configuration/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-internal</artifactId>

--- a/service/device/management/configuration/job/pom.xml
+++ b/service/device/management/configuration/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-configuration</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-configuration-job</artifactId>

--- a/service/device/management/configuration/pom.xml
+++ b/service/device/management/configuration/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/inventory/api/pom.xml
+++ b/service/device/management/inventory/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-inventory</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-inventory-api</artifactId>

--- a/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/bundle/DeviceInventoryBundle.java
+++ b/service/device/management/inventory/api/src/main/java/org/eclipse/kapua/service/device/management/inventory/model/bundle/DeviceInventoryBundle.java
@@ -102,7 +102,7 @@ public interface DeviceInventoryBundle {
      * Whether the bundle is signed.
      *
      * @return {@code true} if is signed, {@code false} if not or {@code null} if the information is not known.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     Boolean getSigned();
 
@@ -110,7 +110,7 @@ public interface DeviceInventoryBundle {
      * Sets whether the bundle is signed.
      *
      * @param signed {@code true} if is signed, {@code false} if not or {@code null} if the information is not known.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     void setSigned(Boolean signed);
 }

--- a/service/device/management/inventory/internal/pom.xml
+++ b/service/device/management/inventory/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-inventory</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-inventory-internal</artifactId>

--- a/service/device/management/inventory/pom.xml
+++ b/service/device/management/inventory/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-inventory</artifactId>

--- a/service/device/management/job/api/pom.xml
+++ b/service/device/management/job/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-job-api</artifactId>

--- a/service/device/management/job/internal/pom.xml
+++ b/service/device/management/job/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-job</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-job-internal</artifactId>

--- a/service/device/management/job/pom.xml
+++ b/service/device/management/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/keystore/api/pom.xml
+++ b/service/device/management/keystore/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-keystore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-keystore-api</artifactId>

--- a/service/device/management/keystore/internal/pom.xml
+++ b/service/device/management/keystore/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-keystore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-keystore-internal</artifactId>

--- a/service/device/management/keystore/job/pom.xml
+++ b/service/device/management/keystore/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-keystore</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-keystore-job</artifactId>

--- a/service/device/management/keystore/pom.xml
+++ b/service/device/management/keystore/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-keystore</artifactId>

--- a/service/device/management/packages/api/pom.xml
+++ b/service/device/management/packages/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-api</artifactId>

--- a/service/device/management/packages/internal/pom.xml
+++ b/service/device/management/packages/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-internal</artifactId>

--- a/service/device/management/packages/job/pom.xml
+++ b/service/device/management/packages/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management-packages</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-packages-job</artifactId>

--- a/service/device/management/packages/pom.xml
+++ b/service/device/management/packages/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-management</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/pom.xml
+++ b/service/device/management/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management</artifactId>

--- a/service/device/management/registry/api/pom.xml
+++ b/service/device/management/registry/api/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-registry</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-registry-api</artifactId>

--- a/service/device/management/registry/internal/pom.xml
+++ b/service/device/management/registry/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-registry</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-registry-internal</artifactId>

--- a/service/device/management/registry/pom.xml
+++ b/service/device/management/registry/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/management/request/api/pom.xml
+++ b/service/device/management/request/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management-request</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-request-api</artifactId>

--- a/service/device/management/request/internal/pom.xml
+++ b/service/device/management/request/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-device-management-request</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-management-request-internal</artifactId>

--- a/service/device/management/request/pom.xml
+++ b/service/device/management/request/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-device-management</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/device/pom.xml
+++ b/service/device/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/registry/api/pom.xml
+++ b/service/device/registry/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-api</artifactId>

--- a/service/device/registry/internal/pom.xml
+++ b/service/device/registry/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-internal</artifactId>

--- a/service/device/registry/pom.xml
+++ b/service/device/registry/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/device/registry/test-steps/pom.xml
+++ b/service/device/registry/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-test-steps</artifactId>

--- a/service/device/registry/test/pom.xml
+++ b/service/device/registry/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-device-registry</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-device-registry-test</artifactId>

--- a/service/endpoint/api/pom.xml
+++ b/service/endpoint/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <artifactId>kapua-endpoint</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/endpoint/internal/pom.xml
+++ b/service/endpoint/internal/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-endpoint</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-endpoint-internal</artifactId>

--- a/service/endpoint/pom.xml
+++ b/service/endpoint/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/endpoint/test-steps/pom.xml
+++ b/service/endpoint/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-endpoint</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-endpoint-test-steps</artifactId>

--- a/service/job/api/pom.xml
+++ b/service/job/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-api</artifactId>

--- a/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
+++ b/service/job/api/src/main/java/org/eclipse/kapua/service/job/step/definition/JobStepProperty.java
@@ -97,7 +97,7 @@ public interface JobStepProperty {
      * Gets whether this {@link #getPropertyValue()} is a secret that shouldn't be shown (i.e. passwords).
      *
      * @return {@code true} if {@link #getPropertyValue()} is a secret that shouldn't be shown, {@code false} otherwise.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     Boolean getSecret();
 
@@ -105,7 +105,7 @@ public interface JobStepProperty {
      * Whether t{@link #getPropertyValue()} is a secret that shouldn't be shown (i.e. passwords).
      *
      * @param se {@code true} if {@link #getPropertyValue()} is a secret that shouldn't be shown, {@code false} otherwise.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     void setSecret(Boolean se);
 

--- a/service/job/internal/pom.xml
+++ b/service/job/internal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-internal</artifactId>

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -372,7 +372,7 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
      * @param selectorQuery The selector {@link JobStepQuery}.
      * @param increment     The increment o apply to the matched {@link JobStep}s
      * @throws KapuaException
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private void shiftJobStepPosition(EntityManager em, JobStepQuery selectorQuery, int increment) throws KapuaException {
         selectorQuery.setSortCriteria(selectorQuery.fieldSortCriteria(JobStepAttributes.STEP_INDEX, SortOrder.ASCENDING));

--- a/service/job/pom.xml
+++ b/service/job/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/job/test-steps/pom.xml
+++ b/service/job/test-steps/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-test-steps</artifactId>

--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-job</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-job-test</artifactId>

--- a/service/pom.xml
+++ b/service/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-service</artifactId>

--- a/service/scheduler/api/pom.xml
+++ b/service/scheduler/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-api</artifactId>

--- a/service/scheduler/pom.xml
+++ b/service/scheduler/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/scheduler/quartz/pom.xml
+++ b/service/scheduler/quartz/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-quartz</artifactId>

--- a/service/scheduler/test-steps/pom.xml
+++ b/service/scheduler/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-test-steps</artifactId>

--- a/service/scheduler/test/pom.xml
+++ b/service/scheduler/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-scheduler</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-scheduler-test</artifactId>

--- a/service/security/authentication/api/pom.xml
+++ b/service/security/authentication/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authentication</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-authentication-api</artifactId>

--- a/service/security/authentication/pom.xml
+++ b/service/security/authentication/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/security/authorization/api/pom.xml
+++ b/service/security/authorization/api/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-authorization</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-authorization-api</artifactId>

--- a/service/security/authorization/pom.xml
+++ b/service/security/authorization/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/security/certificate/api/pom.xml
+++ b/service/security/certificate/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/certificate/internal/pom.xml
+++ b/service/security/certificate/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-security-certificate</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/certificate/pom.xml
+++ b/service/security/certificate/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-security</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/security/pom.xml
+++ b/service/security/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <packaging>pom</packaging>

--- a/service/security/registration/api/pom.xml
+++ b/service/security/registration/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-registration</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration-api</artifactId>

--- a/service/security/registration/pom.xml
+++ b/service/security/registration/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration</artifactId>

--- a/service/security/registration/simple/pom.xml
+++ b/service/security/registration/simple/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security-registration</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-registration-simple</artifactId>

--- a/service/security/shiro/pom.xml
+++ b/service/security/shiro/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-shiro</artifactId>

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/KapuaAuthenticatingRealm.java
@@ -43,7 +43,7 @@ import java.util.Map;
 /**
  * Base {@code abstract} {@link AuthenticatingRealm} extension.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
 
@@ -57,7 +57,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      *
      * @param subject                 The {@link Subject} of the login.
      * @param loginAuthenticationInfo The {@link LoginAuthenticationInfo} source of the data
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void populateSession(@NotNull Subject subject, @NotNull LoginAuthenticationInfo loginAuthenticationInfo) {
         Session session = subject.getSession();
@@ -82,7 +82,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      *
      * @param accountId The {@link Account#getId()} to check.
      * @return The found {@link Account}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected Account checkAccount(KapuaId accountId) {
         AccountService accountService = LOCATOR.getService(AccountService.class);
@@ -127,7 +127,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      * @throws UnknownAccountException     if {@link Credential} is {@code null}
      * @throws DisabledAccountException    if {@link Credential#getStatus()} is {@link CredentialStatus#DISABLED}.
      * @throws ExpiredCredentialsException if {@link Credential#getExpirationDate()} is passed.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void checkCredential(Credential credential) throws UnknownAccountException, DisabledAccountException, ExpiredCredentialsException {
         if (credential == null) {
@@ -151,7 +151,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      * @param credential              The {@link Credential} to check.
      * @param credentialServiceConfig The {@link CredentialService#getConfigValues(KapuaId)}
      * @throws TemporaryLockedAccountException if the {@link Credential} is temporary locked.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void checkCredentialLockout(Credential credential, Map<String, Object> credentialServiceConfig) throws TemporaryLockedAccountException {
 
@@ -170,7 +170,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      *
      * @param scopeId The scope {@link KapuaId}.
      * @return The {@link Map} of configuration values of the {@link CredentialService}.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected Map<String, Object> getCredentialServiceConfig(KapuaId scopeId) {
         try {
@@ -186,7 +186,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      * To be used after a succeessful login.
      *
      * @param credential The {@link Credential} to reset.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void resetCredentialLockout(Credential credential) {
         CredentialService credentialService = LOCATOR.getService(CredentialService.class);
@@ -219,7 +219,7 @@ public abstract class KapuaAuthenticatingRealm extends AuthenticatingRealm {
      * @throws UnknownAccountException     if {@link User} is {@code null}
      * @throws DisabledAccountException    if {@link User#getStatus()} is {@link UserStatus#DISABLED}.
      * @throws ExpiredCredentialsException if {@link User#getExpirationDate()} is passed.
-     * @since 1.6.0
+     * @since 2.0.0
      */
     protected void checkUser(User user) {
         if (user == null) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/session/ShiroSessionKeys.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/session/ShiroSessionKeys.java
@@ -19,14 +19,14 @@ import org.eclipse.kapua.service.user.User;
 /**
  * {@link Session#getAttribute(Object)} keys.
  *
- * @since 1.6.0
+ * @since 2.0.0
  */
 public class ShiroSessionKeys {
 
     /**
      * Constructor.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     private ShiroSessionKeys() {
     }
@@ -41,7 +41,7 @@ public class ShiroSessionKeys {
     /**
      * The {@link Account#getName()}.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static final String ACCOUNT_NAME = "scopeName";
 
@@ -55,7 +55,7 @@ public class ShiroSessionKeys {
     /**
      * The {@link User#getName()}.
      *
-     * @since 1.6.0
+     * @since 2.0.0
      */
     public static final String USER_NAME = "userName";
 }

--- a/service/security/test-steps/pom.xml
+++ b/service/security/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-test-steps</artifactId>

--- a/service/security/test/pom.xml
+++ b/service/security/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-security</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-security-test</artifactId>

--- a/service/stream/api/pom.xml
+++ b/service/stream/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-stream</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-stream-api</artifactId>

--- a/service/stream/internal/pom.xml
+++ b/service/stream/internal/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <artifactId>kapua-stream</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-stream-internal</artifactId>

--- a/service/stream/pom.xml
+++ b/service/stream/pom.xml
@@ -15,7 +15,7 @@
     <parent>
         <artifactId>kapua-service</artifactId>
         <groupId>org.eclipse.kapua</groupId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
 

--- a/service/tag/api/pom.xml
+++ b/service/tag/api/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-api</artifactId>

--- a/service/tag/internal/pom.xml
+++ b/service/tag/internal/pom.xml
@@ -16,7 +16,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-internal</artifactId>

--- a/service/tag/pom.xml
+++ b/service/tag/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/tag/test-steps/pom.xml
+++ b/service/tag/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-test-steps</artifactId>

--- a/service/tag/test/pom.xml
+++ b/service/tag/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-tag</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-tag-test</artifactId>

--- a/service/user/api/pom.xml
+++ b/service/user/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-api</artifactId>

--- a/service/user/internal/pom.xml
+++ b/service/user/internal/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-internal</artifactId>

--- a/service/user/pom.xml
+++ b/service/user/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-service</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 

--- a/service/user/test-steps/pom.xml
+++ b/service/user/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-test-steps</artifactId>

--- a/service/user/test/pom.xml
+++ b/service/user/test/pom.xml
@@ -20,7 +20,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-user</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-user-test</artifactId>

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
         <relativePath>..</relativePath>
     </parent>
 

--- a/translator/api/pom.xml
+++ b/translator/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-api</artifactId>

--- a/translator/kapua/kura/pom.xml
+++ b/translator/kapua/kura/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator-kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kapua-kura</artifactId>

--- a/translator/kapua/pom.xml
+++ b/translator/kapua/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kapua</artifactId>

--- a/translator/kura/jms/pom.xml
+++ b/translator/kura/jms/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator-kura</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kura-jms</artifactId>

--- a/translator/kura/mqtt/pom.xml
+++ b/translator/kura/mqtt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator-kura</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kura-mqtt</artifactId>

--- a/translator/kura/pom.xml
+++ b/translator/kura/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-kura</artifactId>

--- a/translator/pom.xml
+++ b/translator/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator</artifactId>

--- a/translator/test-steps/pom.xml
+++ b/translator/test-steps/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-test-steps</artifactId>

--- a/translator/test/pom.xml
+++ b/translator/test/pom.xml
@@ -17,7 +17,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-translator</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-translator-test</artifactId>

--- a/transport/api/pom.xml
+++ b/transport/api/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-api</artifactId>

--- a/transport/jms/pom.xml
+++ b/transport/jms/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-jms</artifactId>

--- a/transport/mqtt/pom.xml
+++ b/transport/mqtt/pom.xml
@@ -19,7 +19,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua-transport</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>kapua-transport-mqtt</artifactId>

--- a/transport/pom.xml
+++ b/transport/pom.xml
@@ -18,7 +18,7 @@
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
-        <version>1.6.0-SNAPSHOT</version>
+        <version>2.0.0-SNAPSHOT</version>
     </parent>
     <packaging>pom</packaging>
 


### PR DESCRIPTION
This PR sets version of all modules to 2.0.0-SNAPSHOT.

**Related Issue**
_None_

**Description of the solution adopted**
Changed version and replaces existing `@since 1.6.0` with correct `@since 2.0.0`

**Screenshots**
_None_

**Any side note on the changes made**
_None_