### PR TITLE
Removed duplicate dependency declarations from `kapua-job-test` module

### DIFF
--- a/service/job/test/pom.xml
+++ b/service/job/test/pom.xml
@@ -11,7 +11,6 @@
     Contributors:
         Eurotech - initial API and implementation
  -->
-
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
@@ -46,23 +45,8 @@
             <artifactId>kapua-job-test-steps</artifactId>
             <scope>test</scope>
         </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-job-test-steps</artifactId>
-            <scope>test</scope>
-        </dependency>
 
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-core</artifactId>
-            <scope>test</scope>
-        </dependency>
-
+        <!-- -->
         <!-- Log -->
         <dependency>
             <groupId>ch.qos.logback</groupId>


### PR DESCRIPTION
This PR removes duplicate dependency declaration in `kapua-job-test` module.

**Related Issue**
Thse unwanted duplications were introduced with https://github.com/eclipse/kapua/pull/3403

**Description of the solution adopted**
Removed the duplicated declarations

**Screenshots**
_None_

**Any side note on the changes made**
_None_