### PR TITLE
Added check for duplicate JobTarget and few more checks

### DIFF
--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobTargets.java
@@ -217,6 +217,7 @@ public class JobTargets extends AbstractKapuaResource {
             JobTargetCreator jobTargetCreator) throws KapuaException {
         jobTargetCreator.setScopeId(scopeId);
         jobTargetCreator.setJobId(jobId);
+
         return returnCreated(jobTargetService.create(jobTargetCreator));
     }
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/targets/internal/JobTargetServiceImpl.java
@@ -13,103 +13,95 @@
 package org.eclipse.kapua.service.job.targets.internal;
 
 import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaEntityUniquenessException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
 import org.eclipse.kapua.commons.util.ArgumentValidator;
-import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.domain.Actions;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authorization.AuthorizationService;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
+import org.eclipse.kapua.service.job.Job;
 import org.eclipse.kapua.service.job.JobDomains;
+import org.eclipse.kapua.service.job.JobService;
 import org.eclipse.kapua.service.job.internal.JobEntityManagerFactory;
 import org.eclipse.kapua.service.job.targets.JobTarget;
+import org.eclipse.kapua.service.job.targets.JobTargetAttributes;
 import org.eclipse.kapua.service.job.targets.JobTargetCreator;
 import org.eclipse.kapua.service.job.targets.JobTargetListResult;
+import org.eclipse.kapua.service.job.targets.JobTargetQuery;
 import org.eclipse.kapua.service.job.targets.JobTargetService;
 
 import javax.inject.Inject;
 import javax.inject.Singleton;
+import java.util.AbstractMap;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
 
 /**
- * {@link JobTargetService} implementation
+ * {@link JobTargetService} implementation.
  *
  * @since 1.0.0
  */
 @Singleton
 public class JobTargetServiceImpl extends AbstractKapuaService implements JobTargetService {
 
-    private static final KapuaLocator LOCATOR = KapuaLocator.getInstance();
-
     @Inject
     private AuthorizationService authorizationService;
     @Inject
     private PermissionFactory permissionFactory;
+
+    @Inject
+    JobService jobService;
 
     public JobTargetServiceImpl() {
         super(JobEntityManagerFactory.getInstance(), null);
     }
 
     @Override
-    public JobTarget create(JobTargetCreator creator) throws KapuaException {
+    public JobTarget create(JobTargetCreator jobTargetCreator) throws KapuaException {
         //
         // Argument validation
-        ArgumentValidator.notNull(creator, "jobTargetCreator");
-        ArgumentValidator.notNull(creator.getScopeId(), "jobTargetCreator.scopeId");
+        ArgumentValidator.notNull(jobTargetCreator, "jobTargetCreator");
+        ArgumentValidator.notNull(jobTargetCreator.getScopeId(), "jobTargetCreator.scopeId");
+        ArgumentValidator.notNull(jobTargetCreator.getJobId(), "jobTargetCreator.jobId");
+        ArgumentValidator.notNull(jobTargetCreator.getJobTargetId(), "jobTargetCreator.jobTargetId");
 
         //
         // Check access
-        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.write, creator.getScopeId()));
+        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.write, jobTargetCreator.getScopeId()));
+
+        //
+        // Check Job Existing
+        Job job = jobService.find(jobTargetCreator.getScopeId(), jobTargetCreator.getJobId());
+        if (job == null) {
+            throw new KapuaEntityNotFoundException(Job.TYPE, jobTargetCreator.getJobId());
+        }
+
+        //
+        // Check duplicate
+        JobTargetQuery jobTargetQuery = new JobTargetQueryImpl(jobTargetCreator.getScopeId());
+        jobTargetQuery.setPredicate(
+                jobTargetQuery.andPredicate(
+                        jobTargetQuery.attributePredicate(JobTargetAttributes.JOB_ID, jobTargetCreator.getJobId()),
+                        jobTargetQuery.attributePredicate(JobTargetAttributes.JOB_TARGET_ID, jobTargetCreator.getJobTargetId())
+                )
+        );
+
+        if (count(jobTargetQuery) > 0) {
+            List<Map.Entry<String, Object>> uniquesFieldValues = new ArrayList<>();
+            uniquesFieldValues.add(new AbstractMap.SimpleEntry<>(JobTargetAttributes.SCOPE_ID, jobTargetCreator.getScopeId()));
+            uniquesFieldValues.add(new AbstractMap.SimpleEntry<>(JobTargetAttributes.JOB_ID, jobTargetCreator.getJobId()));
+            uniquesFieldValues.add(new AbstractMap.SimpleEntry<>(JobTargetAttributes.ENTITY_ID, jobTargetCreator.getJobTargetId()));
+
+            throw new KapuaEntityUniquenessException(JobTarget.TYPE, uniquesFieldValues);
+        }
 
         //
         // Do create
-        return entityManagerSession.doTransactedAction(em -> JobTargetDAO.create(em, creator));
-    }
-
-    @Override
-    public JobTarget update(JobTarget jobTarget) throws KapuaException {
-        //
-        // Argument Validation
-        ArgumentValidator.notNull(jobTarget, "jobTarget");
-        ArgumentValidator.notNull(jobTarget.getScopeId(), "jobTarget.scopeId");
-        ArgumentValidator.notNull(jobTarget.getId(), "jobTarget.id");
-
-        //
-        // Check access
-        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.write, jobTarget.getScopeId()));
-
-        //
-        // Check existence
-        if (find(jobTarget.getScopeId(), jobTarget.getId()) == null) {
-            throw new KapuaEntityNotFoundException(jobTarget.getType(), jobTarget.getId());
-        }
-
-        //
-        // Do update
-        return entityManagerSession.doTransactedAction(em -> JobTargetDAO.update(em, jobTarget));
-    }
-
-    @Override
-    public void delete(KapuaId scopeId, KapuaId jobTargetId) throws KapuaException {
-        //
-        // Argument validation
-        ArgumentValidator.notNull(scopeId, "scopeId");
-        ArgumentValidator.notNull(jobTargetId, "jobTargetId");
-
-        //
-        // Check Access
-        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.delete, scopeId));
-
-        //
-        // Check existence
-        if (find(scopeId, jobTargetId) == null) {
-            throw new KapuaEntityNotFoundException(JobTarget.TYPE, jobTargetId);
-        }
-
-        //
-        // Do delete
-        entityManagerSession.doTransactedAction(em -> JobTargetDAO.delete(em, scopeId, jobTargetId));
+        return entityManagerSession.doTransactedAction(em -> JobTargetDAO.create(em, jobTargetCreator));
     }
 
     @Override
@@ -156,5 +148,52 @@ public class JobTargetServiceImpl extends AbstractKapuaService implements JobTar
         //
         // Do query
         return entityManagerSession.doAction(em -> JobTargetDAO.count(em, query));
+    }
+
+    @Override
+    public JobTarget update(JobTarget jobTarget) throws KapuaException {
+        //
+        // Argument Validation
+        ArgumentValidator.notNull(jobTarget, "jobTarget");
+        ArgumentValidator.notNull(jobTarget.getScopeId(), "jobTarget.scopeId");
+        ArgumentValidator.notNull(jobTarget.getId(), "jobTarget.id");
+        ArgumentValidator.notNull(jobTarget.getStepIndex(), "jobTarget.stepIndex");
+        ArgumentValidator.notNull(jobTarget.getStatus(), "jobTarget.status");
+
+        //
+        // Check access
+        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.write, jobTarget.getScopeId()));
+
+        //
+        // Check existence
+        if (find(jobTarget.getScopeId(), jobTarget.getId()) == null) {
+            throw new KapuaEntityNotFoundException(jobTarget.getType(), jobTarget.getId());
+        }
+
+        //
+        // Do update
+        return entityManagerSession.doTransactedAction(em -> JobTargetDAO.update(em, jobTarget));
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId jobTargetId) throws KapuaException {
+        //
+        // Argument validation
+        ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(jobTargetId, "jobTargetId");
+
+        //
+        // Check Access
+        authorizationService.checkPermission(permissionFactory.newPermission(JobDomains.JOB_DOMAIN, Actions.delete, scopeId));
+
+        //
+        // Check existence
+        if (find(scopeId, jobTargetId) == null) {
+            throw new KapuaEntityNotFoundException(JobTarget.TYPE, jobTargetId);
+        }
+
+        //
+        // Do delete
+        entityManagerSession.doTransactedAction(em -> JobTargetDAO.delete(em, scopeId, jobTargetId));
     }
 }


### PR DESCRIPTION
This PR adds a check when adding a `JobTarget` that check that no duplicates `JobTartget.jobTargetId` are created for the same `Job`.

**Related Issue**
_None_

**Description of the solution adopted**
Added a check before persisting into the DB

**Screenshots**
_None_

**Any side note on the changes made**
Added also more checks when validating input data and Job existence