### PR TITLE
Added JobExecution indexes to improve query performances

### DIFF
--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/execution/internal/JobExecutionQueryImpl.java
@@ -14,6 +14,9 @@ package org.eclipse.kapua.service.job.execution.internal;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaQuery;
 import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaSortCriteria;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.job.execution.JobExecutionAttributes;
 import org.eclipse.kapua.service.job.execution.JobExecutionQuery;
 
 /**
@@ -31,5 +34,10 @@ public class JobExecutionQueryImpl extends AbstractKapuaQuery implements JobExec
      */
     public JobExecutionQueryImpl(KapuaId scopeId) {
         super(scopeId);
+    }
+
+    @Override
+    public KapuaSortCriteria getDefaultSortCriteria() {
+        return fieldSortCriteria(JobExecutionAttributes.STARTED_ON, SortOrder.DESCENDING);
     }
 }

--- a/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_execution-indexes.xml
+++ b/service/job/internal/src/main/resources/liquibase/1.6.0/job_job_execution-indexes.xml
@@ -18,8 +18,17 @@
                       http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd"
         logicalFilePath="KapuaDB/changelog-job-1.6.0.xml">
 
-    <include relativeToChangelogFile="true" file="job_job_step_properties-secret.xml"/>
-    <include relativeToChangelogFile="true" file="job_job_step_definition_properties-secret.xml"/>
-    <include relativeToChangelogFile="true" file="job_job_execution-indexes.xml"/>
+    <changeSet id="changelog-job_execution-1.6.0-indexes" author="eurotech">
+        <createIndex tableName="job_job_execution" indexName="idx_jobExecution_scopeId_jobId_startedOn">
+            <column name="scope_id"/>
+            <column name="job_id"/>
+            <column name="started_on"/>
+        </createIndex>
+        <createIndex tableName="job_job_execution" indexName="idx_jobExecution_scopeId_jobId_endedOn">
+            <column name="scope_id"/>
+            <column name="job_id"/>
+            <column name="ended_on"/>
+        </createIndex>
+    </changeSet>
 
 </databaseChangeLog>


### PR DESCRIPTION
This PR adds two indexes on the `job_job_execution` table to improve performance while performing common queries.

**Related Issue**
_None_

**Description of the solution adopted**
Added two indexes on:

`job_job_execution` on `scope_id`, `job_id`, `started_on`
`job_job_execution` on `scope_id`, `job_id`, `ended_on`

to support common display of JobExecution.

**Screenshots**
_None_

**Any side note on the changes made**
Set the default sorting for JobExecution to be on `startedOn` `DESCENDING`