### PR TITLE
Fixed fields validation bypass

### DIFF
--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -90,6 +90,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         ArgumentValidator.notNull(accountCreator, "accountCreator");
         ArgumentValidator.notNull(accountCreator.getScopeId(), "accountCreator.scopeId");
         ArgumentValidator.notEmptyOrNull(accountCreator.getName(), "accountCreator.name");
+        ArgumentValidator.match(accountCreator.getName(), CommonsValidationRegex.NAME_REGEXP, "accountCreator.name");
         ArgumentValidator.notEmptyOrNull(accountCreator.getOrganizationName(), "accountCreator.organizationName");
         ArgumentValidator.notEmptyOrNull(accountCreator.getOrganizationEmail(), "accountCreator.organizationEmail");
         ArgumentValidator.match(accountCreator.getOrganizationEmail(), CommonsValidationRegex.EMAIL_REGEXP, "accountCreator.organizationEmail");
@@ -154,6 +155,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(account.getId(), "account.id");
         ArgumentValidator.notEmptyOrNull(account.getName(), "account.name");
+        ArgumentValidator.match(account.getName(), CommonsValidationRegex.NAME_REGEXP, "account.name");
         ArgumentValidator.notNull(account.getOrganization(), "account.organization");
         ArgumentValidator.match(account.getOrganization().getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "account.organization.email");
 

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -219,6 +219,22 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
         ArgumentValidator.notNull(credential.getCredentialType(), "credential.credentialType");
         ArgumentValidator.notEmptyOrNull(credential.getCredentialKey(), "credential.credentialKey");
 
+        if (CredentialType.PASSWORD == credential.getCredentialType()) {
+            // Validate Password length
+            int minPasswordLength = getMinimumPasswordLength(credential.getScopeId());
+            if (credential.getCredentialKey().length() < minPasswordLength) {
+                throw new KapuaPasswordTooShortException(minPasswordLength);
+            }
+            if (credential.getCredentialKey().length() > SYSTEM_MAXIMUM_PASSWORD_LENGTH) {
+                throw new KapuaPasswordTooLongException(SYSTEM_MAXIMUM_PASSWORD_LENGTH);
+            }
+
+            //
+            // Validate Password regex
+            ArgumentValidator.match(credential.getCredentialKey(),
+                    CommonsValidationRegex.PASSWORD_REGEXP, "credentialCreator.credentialKey");
+        }
+
         //
         // Check access
         KapuaLocator locator = KapuaLocator.getInstance();


### PR DESCRIPTION
**Brief description of the PR**
While editing an existing user account or creating a new children account, it is possible to bypass the length and composition policies enforced by the application frontend to, respectively, the `password` and `account name` fields.
This PR fixes this problems adding the validation of the fields even in the service backend.