### PR TITLE
Fixed docker logs command

### DIFF
--- a/deployment/docker/unix/docker-logs.sh
+++ b/deployment/docker/unix/docker-logs.sh
@@ -28,7 +28,7 @@ docker_logs() {
       COMPOSE_FILES+=(-f "${SCRIPT_DIR}/../compose/sso/docker-compose.keycloak.yml")
     fi
 
-    docker-compose -f "${SCRIPT_DIR}"/../compose/docker-compose.yml logs -f
+    docker-compose -f "${SCRIPT_DIR}"/../compose/docker-compose.yml "${COMPOSE_FILES[@]}" logs -f
 }
 
 docker_common


### PR DESCRIPTION
This PR fixes the command run by `docker-logs.sh` which was missing the optional compose list file.

**Related Issue**
This is a small addition to #3504 

**Description of the solution adopted**
Added missing variable to command arguments

**Screenshots**
_None_

**Any side note on the changes made**
_None_