### PR TITLE
Fixed refresh of Deployment Packages subtab

### DIFF
--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabDeploymentPackages.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/client/device/inventory/DeviceTabInventoryTabDeploymentPackages.java
@@ -191,6 +191,12 @@ public class DeviceTabInventoryTabDeploymentPackages extends TabItem {
         }
     }
 
+    @Override
+    protected void onShow() {
+        super.onShow();
+        refresh();
+    }
+
     public TreeGrid<ModelData> getTreeGrid() {
         return treeGrid;
     }


### PR DESCRIPTION
**Brief description of the PR**
When you navigate in the Deployment Packages sub-tab within the Inventory tab of the Device view, the refresh is not triggered automatically. In fact, if the device do have a package it doesn't show by simply selecting the tab. By clicking on the refresh button the package appears.
This PR adds the refresh when the subtab is selected.