### PR TITLE
Added return device management operation in REST API /packages

### DIFF
--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResource.java
@@ -18,6 +18,8 @@ import javax.ws.rs.core.Response.Status;
 
 import org.eclipse.kapua.model.KapuaEntity;
 
+import java.net.URI;
+
 /**
  *
  * @author alberto.codutti
@@ -52,19 +54,55 @@ public abstract class AbstractKapuaResource {
      * return javax.ws.rs.core.Response.ok().build();
      * </pre>
      *
-     * @return A build {@link Response#ok()}
+     * @return A built {@link Response#ok()}
      * @since 1.0.0
      */
     public Response returnOk() {
         return Response.ok().build();
     }
 
-    public Response returnNoContent() {
-        return Response.noContent().build();
+    /**
+     * Builds a 200 HTTP Response a content.
+     *
+     * <pre>
+     * return javax.ws.rs.core.Response.ok().entity(entity).build();
+     * </pre>
+     *
+     * @param entity The entity to return.
+     * @return A built {@link Response#ok()}
+     * @since 1.0.0
+     */
+    public Response returnOk(Object entity) {
+        return Response.ok().entity(entity).build();
     }
 
+    /**
+     * Builds a 201 HTTP Response a content.
+     *
+     * <pre>
+     * return javax.ws.rs.core.Response.status(Status.CREATED).entity(entity).build();
+     * </pre>
+     *
+     * @param entity The entity to return.
+     * @return A built {@link Response#created(URI)}
+     * @since 1.2.0
+     */
     public Response returnCreated(Object entity) {
         return Response.status(Status.CREATED).entity(entity).build();
+    }
+
+    /**
+     * Builds a 204 HTTP Response a content.
+     *
+     * <pre>
+     * return javax.ws.rs.core.Response.noContent().build();
+     * </pre>
+     *
+     * @return A built {@link Response#noContent()}
+     * @since 1.2.0
+     */
+    public Response returnNoContent() {
+        return Response.noContent().build();
     }
 
 }

--- a/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
+++ b/rest-api/core/src/main/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeys.java
@@ -15,22 +15,52 @@ package org.eclipse.kapua.app.api.core.settings;
 import org.eclipse.kapua.commons.setting.SettingKey;
 
 /**
- * Authorization setting key
+ * REST API {@link SettingKey}s
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public enum KapuaApiCoreSettingKeys implements SettingKey {
+
+    /**
+     * @since 1.0.0
+     */
     API_PATH_PARAM_SCOPEID_WILDCARD("api.path.param.scopeId.wildcard"),
+
+    /**
+     * @since 1.0.0
+     */
     API_EXCEPTION_STACKTRACE_SHOW("api.exception.stacktrace.show"),
+
+    /**
+     * Whether DeviceManagementPakages.download and DeviceManagementPakages.uninstall should return 200 with DeviceManagementOperation entity ({@code false}) or
+     * 204 without a content ({@code false})
+     *
+     * @since 2.0.0
+     */
+    API_DEVICE_MANAGEMENT_PACKAGE_RESPONSE_LEGACY_MODE("api.device.management.package.response.legacy.mode"),
+
+    /**
+     * @since 1.5.0
+     */
     API_CORS_REFRESH_INTERVAL("api.cors.refresh.interval"),
+    /**
+     * @since 1.5.0
+     */
     API_CORS_ORIGINS_ALLOWED("api.cors.origins.allowed");
 
     private final String key;
 
-    private KapuaApiCoreSettingKeys(String key) {
+    /**
+     * Constructor
+     *
+     * @param key The value for the setting.
+     * @since 1.0.0
+     */
+    KapuaApiCoreSettingKeys(String key) {
         this.key = key;
     }
 
+    @Override
     public String key() {
         return key;
     }

--- a/rest-api/core/src/main/resources/kapua-api-core-settings.properties
+++ b/rest-api/core/src/main/resources/kapua-api-core-settings.properties
@@ -11,7 +11,8 @@
 #     Eurotech - initial API and implementation
 #
 ###############################################################################
-api.path.param.scopeId.wildcard=_
-api.exception.stacktrace.show=false
 api.cors.refresh.interval=60
 api.cors.origins.allowed=
+api.device.management.package.response.legacy.mode=false
+api.exception.stacktrace.show=false
+api.path.param.scopeId.wildcard=_

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_download.yaml
@@ -60,6 +60,12 @@ paths:
                     installVerifyURI: https://download.eclipse.org/kura/releases/4.1.0/org.eclipse.kura.demo.heater_1.0.500.verifier.sh
         required: true
       responses:
+        200:
+          description: The corresponding Device Management Operation to track the progress of the Device Package Download Request
+          content:
+            application/json:
+              schema:
+                $ref: '../deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
         204:
           description: |
             The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install

--- a/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
+++ b/rest-api/resources/src/main/resources/openapi/devicePackage/devicePackage-scopeId-deviceId-_uninstall.yaml
@@ -44,6 +44,12 @@ paths:
               version: 1.0.500
         required: true
       responses:
+        200:
+          description: The corresponding Device Management Operation to track the progress of the Device Package Uninstall Request
+          content:
+            application/json:
+              schema:
+                $ref: '../deviceOperation/deviceOperation.yaml#/components/schemas/deviceOperation'
         204:
           description: |
             The Package Install request has been successfully received. However, this does NOT mean that the package has been successfully installed, since the Package Install


### PR DESCRIPTION
This PR adds the return of the `DeviceManagementOperation` associated with the `packages/_download` and `packages/_uninstall` operations.

Due to the fact that this is somewhat a breaking change, some options have been added to make the REST API resource return 204 as before.

**Related Issue**
_None_

**Description of the solution adopted**
Added the returning of the `DeviceManagementOperation`.

By setting REST API setting `api.device.management.package.response.legacy.mode` to `true` o adding the `legacy` queryparameter to the request the resources will answer 204.

**Screenshots**
_None_

**Any side note on the changes made**
Added a bit of javadoc