### PR TITLE
Added authentication check to getMinimumPswLength

### DIFF
--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/server/GwtCredentialServiceImpl.java
@@ -16,7 +16,6 @@ import com.extjs.gxt.ui.client.data.BasePagingLoadResult;
 import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import org.apache.commons.lang3.StringUtils;
-
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.authc.AuthenticationException;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
@@ -285,6 +284,8 @@ public class GwtCredentialServiceImpl extends KapuaRemoteServiceServlet implemen
     @Override
     public Integer getMinPasswordLength(final String scopeId) throws GwtKapuaException {
         try {
+            AUTHENTICATION_SERVICE.isAuthenticated();
+
             // Do privileged because the request may come from a user with no permission who just wants to change his own password
             return KapuaSecurityUtils.doPrivileged(new Callable<Integer>() {
 

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -97,4 +97,6 @@ public interface AuthenticationService extends KapuaService {
      */
     LoginInfo getLoginInfo() throws KapuaException;
 
+    boolean isAuthenticated() throws KapuaException;
+
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -28,6 +28,7 @@ import org.apache.shiro.subject.Subject;
 import org.eclipse.kapua.KapuaEntityNotFoundException;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.KapuaUnauthenticatedException;
 import org.eclipse.kapua.commons.logging.LoggingMdcKeys;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
@@ -436,6 +437,18 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
         loginInfo.setAccessPermission(Sets.newHashSet(accessPermissions.getItems()));
 
         return loginInfo;
+    }
+
+    @Override
+    public boolean isAuthenticated()
+            throws KapuaException {
+        KapuaSession session = KapuaSecurityUtils.getSession();
+
+        if (session == null) {
+            throw new KapuaUnauthenticatedException();
+        }
+
+        return session.isTrustedMode() || SecurityUtils.getSubject().isAuthenticated();
     }
 
     //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authorization/shiro/AuthorizationServiceImpl.java
@@ -45,8 +45,7 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             boolean[] returnedPermissions = new boolean[permissions.size()];
             Arrays.fill(returnedPermissions, true);
             return returnedPermissions;
-        }
-        else {
+        } else {
             List<org.apache.shiro.authz.Permission> permissionsShiro = permissions.stream()
                     .map(permission -> (org.apache.shiro.authz.Permission) permission)
                     .collect(Collectors.toList());
@@ -63,7 +62,8 @@ public class AuthorizationServiceImpl implements AuthorizationService {
             throw new KapuaUnauthenticatedException();
         }
 
-        return session.isTrustedMode() ? true : SecurityUtils.getSubject().isPermitted((org.apache.shiro.authz.Permission) permission);
+        return session.isTrustedMode() ||
+                SecurityUtils.getSubject().isPermitted((org.apache.shiro.authz.Permission) permission);
     }
 
     @Override


### PR DESCRIPTION
**Brief description of the PR**
It is possible to discoverthe minimum password length for a given user by sending an unauthenticated POST request.
This PR fixes this problem, thus the security of the system is improved.