### PR TITLE
Feature Authorization Service refactoring and improvement

### DIFF
--- a/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
+++ b/console/core/src/main/java/org/eclipse/kapua/app/console/core/server/GwtAuthorizationServiceImpl.java
@@ -118,12 +118,13 @@ public class GwtAuthorizationServiceImpl extends KapuaRemoteServiceServlet imple
             UsernamePasswordCredentials usernamePasswordCredentials = CREDENTIALS_FACTORY.newUsernamePasswordCredentials(gwtLoginCredentials.getUsername(), gwtLoginCredentials.getPassword());
             usernamePasswordCredentials.setAuthenticationCode(gwtLoginCredentials.getAuthenticationCode());
             usernamePasswordCredentials.setTrustKey(gwtLoginCredentials.getTrustKey());
+            usernamePasswordCredentials.setTrustMe(trustReq);
 
             // Cleanup any previous session
             cleanupSession();
 
             // Login
-            AUTHENTICATION_SERVICE.login(usernamePasswordCredentials, trustReq);
+            AUTHENTICATION_SERVICE.login(usernamePasswordCredentials);
 
             // Populate Session
             return establishSession();

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-mfa.yaml
@@ -17,6 +17,7 @@ paths:
       tags:
         - Authentication
       summary: MFA Login - User, Password and authenticationCode/trustKey
+      description: This resoruce is deprecated and will be removed in future releases. Please make use of /authentication/user and properties in UsernamePasswordCredentials.
       operationId: authenticationMfaUser
       parameters:
         - name: enableTrust
@@ -33,17 +34,13 @@ paths:
               type: object
               properties:
                 username:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/username'
+                  $ref: './authentication.yaml#/components/schemas/username'
                 password:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/password'
+                  $ref: './authentication.yaml#/components/schemas/password'
                 authenticationCode:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/authenticationCode'
+                  $ref: './authentication.yaml#/components/schemas/authenticationCode'
                 trustKey:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/trustKey'
+                  $ref: './authentication.yaml#/components/schemas/trustKey'
               required:
                 - username
                 - password
@@ -63,4 +60,4 @@ paths:
                 $ref: './authentication.yaml#/components/schemas/accessToken'
         500:
           $ref: '../openapi.yaml#/components/responses/kapuaError'
-      security: []
+      security: [ ]

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication-user.yaml
@@ -22,26 +22,24 @@ paths:
         content:
           application/json:
             schema:
-              type: object
-              properties:
-                username:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/username'
-                password:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/password'
-                trustKey:
-                  allOf:
-                    - $ref: './authentication.yaml#/components/schemas/trustKey'
-              required:
-                - username
-                - password
+              $ref: 'authentication.yaml#/components/schemas/usernamePasswordCredentials'
+            required: true
             examples:
-              kapua-sys:
-                description: Default kapua-sys login credentials
+              Admin:
                 value:
                   username: kapua-sys
                   password: kapua-password
+              MFA with AuthenticationCode:
+                value:
+                  username: kapua-sys
+                  password: kapua-password
+                  authenticationCode: 123456
+                  trustMe: true
+              MFA with TrustKey:
+                value:
+                  username: kapua-sys
+                  password: kapua-password
+                  trustKey: 4bba9938-aa8f-11ec-b909-0242ac120002
       responses:
         200:
           description: The new AccessToken

--- a/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
+++ b/rest-api/resources/src/main/resources/openapi/authentication/authentication.yaml
@@ -11,7 +11,7 @@ info:
     name: Eclipse Public License 2.0
     url: https://www.eclipse.org/legal/epl-2.0
 
-paths: {}
+paths: { }
 
 components:
   schemas:
@@ -21,11 +21,9 @@ components:
         - type: object
           properties:
             userId:
-              allOf:
-                - $ref: '../openapi.yaml#/components/schemas/kapuaId'
+              $ref: '../openapi.yaml#/components/schemas/kapuaId'
             tokenId:
-              allOf:
-                - $ref: '#/components/schemas/jwt'
+              $ref: '#/components/schemas/jwt'
             expiresOn:
               type: string
               format: 'date-time'
@@ -39,8 +37,9 @@ components:
               type: string
               format: 'date-time'
             trustKey:
-              allOf:
-                - $ref: '#/components/schemas/trustKey'
+              type: string
+              description: A long-lived key to be used within an authentication with MFA from a trusted machine
+              pattern: '^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$'
     loginInfo:
       type: object
       properties:
@@ -100,17 +99,36 @@ components:
               domain: user
               targetScopeId: AQ
               forwardable: false
+    usernamePasswordCredentials:
+      allOf:
+      - type: object
+        properties:
+          user:
+            $ref: '#/components/schemas/username'
+          password:
+            $ref: '#/components/schemas/password'
+          authenticationCode:
+            $ref: '#/components/schemas/authenticationCode'
+          trustKey:
+            $ref: '#/components/schemas/trustKey'
+          trustMe:
+            type: boolean
+            description: Whether to generate a TrustKey or not.
     username:
       type: string
+      description: the username of the user
       pattern: '^[a-zA-Z0-9\_\-]{3,}$'
     password:
       type: string
+      description: the password of the user
       pattern: '^.*(?=.{12,})(?=.*\d)(?=.*[a-z])(?=.*[A-Z])(?=.*[!\"\#$%&''()*+,\-./:;<=>?@\[\]\\^_`{|}~]).*$'
     authenticationCode:
       type: string
+      description: The MFA authentication code
       pattern: '^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$'
     trustKey:
       type: string
+      description: A long-lived key to be used within an authentication with MFA from a trusted machine
       pattern: '^[A-Za-z0-9-_=]+\.[A-Za-z0-9-_=]+\.?[A-Za-z0-9-_.+/=]*$'
     jwt:
       type: string

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/AuthenticationService.java
@@ -18,85 +18,125 @@ import org.eclipse.kapua.service.authentication.token.AccessToken;
 import org.eclipse.kapua.service.authentication.token.LoginInfo;
 
 /**
- * AuthenticationService exposes APIs to manage User object under an Account.<br>
- * It includes APIs to create, update, find, list and delete Users.<br>
- * Instances of the UserService can be acquired through the ServiceLocator.
+ * {@link AuthenticationService} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 public interface AuthenticationService extends KapuaService {
 
+    //
+    // Session
+
     /**
-     * Login the provided user login credentials on the system (if the credentials are valid)
+     * Logins the provided {@link LoginCredentials}.
+     * <p>
+     * Creates a new session that is represented by the {@link AccessToken}.
      *
-     * @param loginCredentials
-     * @return
-     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @param loginCredentials The {@link LoginCredentials} to validate.
+     * @return The {@link AccessToken} created by this login
+     * @throws KapuaException
+     * @since 1.0.0
      */
     AccessToken login(LoginCredentials loginCredentials) throws KapuaException;
 
     /**
-     * Login the provided user login credentials on the system (if the credentials are valid) and enable the trust key
+     * Logins the provided {@link LoginCredentials}.
      *
-     * @param loginCredentials
-     * @param enableTrust
-     * @return
-     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @param loginCredentials The {@link LoginCredentials} to validate.
+     * @param enableTrust      Whether to generate a trustkey.
+     * @return The {@link AccessToken} created by this login
+     * @throws KapuaException
+     * @since 1.0.0
+     * @deprecated Since 2.0.0. Please make use of {@link #login(LoginCredentials)}.
      */
+    @Deprecated
     AccessToken login(LoginCredentials loginCredentials, boolean enableTrust) throws KapuaException;
 
     /**
-     * FIXME: add javadoc
+     * Logins the provided {@link SessionCredentials}.
+     * <p>
+     * Restores a previously created session from a {@link #login(LoginCredentials)}.
      *
-     * @param sessionCredentials
-     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
+     * @param sessionCredentials The {@link SessionCredentials} to validate
+     * @throws KapuaException
+     * @since 1.0.0
      */
     void authenticate(SessionCredentials sessionCredentials) throws KapuaException;
 
     /**
-     * Logout the current logged user
+     * Verifies the given {@link LoginCredentials}.
+     * <p>
+     * This does not create a new session and does not create a new {@link AccessToken}.
+     *
+     * @param loginCredentials The {@link LoginCredentials} to validate.
+     * @throws KapuaException
+     * @since 1.0.0
+     */
+    void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException;
+
+    /**
+     * Checks if there is a session that is authenticated.
+     *
+     * @return {@code true} if session is authenticated, {@code false} otherwise.
+     * @throws KapuaException
+     * @since 2.0.0
+     */
+    boolean isAuthenticated() throws KapuaException;
+
+    /**
+     * Returns the {@link LoginInfo} related to the current session.
+     *
+     * @return The {@link LoginInfo} related to the current session.
+     * @throws KapuaException
+     * @since 1.1.0
+     */
+    LoginInfo getLoginInfo() throws KapuaException;
+
+    /**
+     * Logouts the current logged user.
+     * <p>
+     * Destroys the session represented by the {@link AccessToken}.
      *
      * @throws KapuaException
+     * @since 1.0.0
      */
     void logout() throws KapuaException;
 
+    //
+    // Access token
+
     /**
-     * Return the {@link AccessToken} identified by the provided token identifier. Expired {@link AccessToken}s are
-     * excluded.
+     * Gets the {@link AccessToken} identified by its {@link AccessToken#getTokenId()}.
+     * Expired {@link AccessToken}s are excluded.
      *
-     * @param tokenId           The ID of the {@link AccessToken}
-     * @return                  The desired {@link AccessToken} object
-     * @throws KapuaException if no {@link AccessToken} is found for that token identifier
+     * @param tokenId The {@link AccessToken#getTokenId()} to look for.
+     * @return The found {@link AccessToken} or {@code null} if not present.
+     * @throws KapuaException
+     * @since 1.0.0
      */
     AccessToken findAccessToken(String tokenId) throws KapuaException;
+
+    /**
+     * Refreshes the current {@link AccessToken} with a new one.
+     *
+     * @param tokenId The current {@link AccessToken#getTokenId()}
+     * @param refreshToken The current {@link AccessToken#getRefreshToken()}
+     * @return A new {@link AccessToken}.
+     * @throws KapuaException
+     * @since 1.0.0
+     */
+    AccessToken refreshAccessToken(String tokenId, String refreshToken) throws KapuaException;
 
     /**
      * Return a Refreshable {@link AccessToken} identified by the provided token identifier. A Refreshable token may be
      * already expired or not, but its Refresh Token is still valid
      *
-     * @param tokenId               The ID of the {@link AccessToken}
-     * @return                      The desired {@link AccessToken} object
+     * @param tokenId The ID of the {@link AccessToken}
+     * @return The desired {@link AccessToken} object
      * @throws KapuaException if no {@link AccessToken} is found for that token identifier
+     * @since 1.3.0
+     * @deprecated Since 2.0.0. This has been added to this API but is not necessary.
      */
+    @Deprecated
     AccessToken findRefreshableAccessToken(String tokenId) throws KapuaException;
-
-    AccessToken refreshAccessToken(String tokenId, String refreshToken) throws KapuaException;
-
-    /**
-     * Verifies the password of a user without logging him in, and thus create any kind of session
-     *
-     * @param loginCredentials
-     * @throws KapuaException an exception is thrown if the credentials are not found on the system, are expired or are disabled
-     */
-    void verifyCredentials(LoginCredentials loginCredentials) throws KapuaException;
-
-    /**
-     * Return the {@link LoginInfo} related to the current session
-     * @return the {@link LoginInfo} object containing all the permissions related to the current session and the current {@link AccessToken}
-     * @throws KapuaException
-     */
-    LoginInfo getLoginInfo() throws KapuaException;
-
-    boolean isAuthenticated() throws KapuaException;
-
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -20,66 +20,74 @@ import javax.xml.bind.annotation.XmlType;
 /**
  * Username and password {@link LoginCredentials} definition.
  *
- * @since 1.0
+ * @since 1.0.0
  */
 @XmlRootElement(name = "usernamePasswordCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = { "username", "password", "authenticationCode", "trustKey" }, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
+@XmlType(propOrder = {"username", "password", "authenticationCode", "trustKey"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
 public interface UsernamePasswordCredentials extends LoginCredentials {
 
     /**
-     * return the username
+     * Gets the username.
      *
-     * @return
+     * @return The username.
+     * @since 1.0.0
      */
     String getUsername();
 
     /**
-     * Set the username
+     * Sets the username.
      *
-     * @param username
+     * @param username The username.
+     * @since 1.0.0
      */
     void setUsername(String username);
 
     /**
-     * return the password
+     * Gets the password.
      *
-     * @return
+     * @return The password.
+     * @since 1.0.0
      */
     String getPassword();
 
     /**
-     * Set the password
+     * Sets the password.
      *
-     * @param password
+     * @param password The password.
+     * @since 1.0.0
      */
     void setPassword(String password);
 
     /**
-     * return the authenticationCode
+     * Gets the MFA authentication code.
      *
-     * @return
+     * @return The MFA authentication code.
+     * @since 1.3.0
      */
     String getAuthenticationCode();
 
     /**
-     * Set the authenticationCode
+     * Sets the MFA authentication code.
      *
-     * @param authenticationCode
+     * @param authenticationCode The MFA authentication code.
+     * @since 1.3.0
      */
     void setAuthenticationCode(String authenticationCode);
 
     /**
-     * return the trustKey
+     * Gets the trust key.
      *
-     * @return the trust key
+     * @return The trust key.
+     * @since 1.3.0
      */
     String getTrustKey();
 
     /**
-     * Set the trust key
+     * Sets the trust key.
      *
-     * @param trustKey
+     * @param trustKey The trust key.
+     * @since 1.3.0
      */
     void setTrustKey(String trustKey);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -24,7 +24,7 @@ import javax.xml.bind.annotation.XmlType;
  */
 @XmlRootElement(name = "usernamePasswordCredentials")
 @XmlAccessorType(XmlAccessType.PROPERTY)
-@XmlType(propOrder = {"username", "password", "authenticationCode", "trustKey"}, factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
+@XmlType(factoryClass = AuthenticationXmlRegistry.class, factoryMethod = "newUsernamePasswordCredentials")
 public interface UsernamePasswordCredentials extends LoginCredentials {
 
     /**

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/UsernamePasswordCredentials.java
@@ -90,4 +90,20 @@ public interface UsernamePasswordCredentials extends LoginCredentials {
      * @since 1.3.0
      */
     void setTrustKey(String trustKey);
+
+    /**
+     * Gets whether create a trust key or not.
+     *
+     * @return {@code true} if to be created, {@code false} otherwise
+     * @since 2.0.0
+     */
+    boolean getTrustMe();
+
+    /**
+     * Sets whether create a trust key or not.
+     *
+     * @param trustMe {@code true} if to be created, {@code false} if not.
+     * @since 2.0.0
+     */
+    void setTrustMe(boolean trustMe);
 }

--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionService.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/MfaOptionService.java
@@ -15,10 +15,14 @@ package org.eclipse.kapua.service.authentication.credential.mfa;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+import org.eclipse.kapua.service.user.User;
 
 /**
- * {@link MfaOption} service definition.
+ * {@link MfaOption} {@link KapuaService} definition.
+ *
+ * @since 1.3.0
  */
 public interface MfaOptionService extends KapuaEntityService<MfaOption, MfaOptionCreator>,
         KapuaUpdatableEntityService<MfaOption> {
@@ -26,10 +30,11 @@ public interface MfaOptionService extends KapuaEntityService<MfaOption, MfaOptio
     /**
      * Return the {@link MfaOption} result looking by user identifier (and also scope identifier)
      *
-     * @param scopeId
-     * @param userId
-     * @return
+     * @param scopeId The {@link User#getScopeId()}.
+     * @param userId  The {@link User#getId()}
+     * @return The {@link MfaOption} of the {@link User} if found.
      * @throws KapuaException
+     * @since 1.3.0
      */
     MfaOption findByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException;
 
@@ -38,23 +43,28 @@ public interface MfaOptionService extends KapuaEntityService<MfaOption, MfaOptio
      *
      * @param mfaOption the {@link MfaOption}
      * @return the value of the trust key in plain text
+     * @since 1.3.0
+     * @deprecated Since 2.0.0. Please make use of {@link #enableTrust(KapuaId, KapuaId)}
      */
+    @Deprecated
     String enableTrust(MfaOption mfaOption) throws KapuaException;
 
     /**
      * Enables the trust machine for the {@link KapuaId} of the {@link MfaOption}.
      *
-     * @param scopeId the scopeId
+     * @param scopeId     the scopeId
      * @param mfaOptionId the {@link KapuaId} of the {@link MfaOption}
      * @return the value of the trust key in plain text
+     * @since 1.3.0
      */
     String enableTrust(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;
 
     /**
      * Disable the trust machine for the given {@link MfaOption}.
      *
-     * @param scopeId the scopeid
+     * @param scopeId     the scopeid
      * @param mfaOptionId the {@link KapuaId} of the {@link MfaOption}
+     * @since 1.3.0
      */
     void disableTrust(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException;
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionServiceImpl.java
@@ -40,7 +40,6 @@ import org.eclipse.kapua.service.authentication.credential.mfa.KapuaExistingMfaO
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionAttributes;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
-import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
@@ -80,24 +79,35 @@ import java.util.UUID;
 
 /**
  * {@link MfaOptionService} implementation.
+ *
+ * @since 1.3.0
  */
 @Singleton
 public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOptionService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(MfaOptionServiceImpl.class);
+
     private static final MfaAuthenticatorServiceLocator MFA_AUTH_SERVICE_LOCATOR = MfaAuthenticatorServiceLocator.getInstance();
     private static final MfaAuthenticator MFA_AUTHENTICATOR = MFA_AUTH_SERVICE_LOCATOR.getMfaAuthenticator();
+
+    private static final KapuaAuthenticationSetting AUTHENTICATION_SETTING = KapuaAuthenticationSetting.getInstance();
+    private static final int TRUST_KEY_DURATION = AUTHENTICATION_SETTING.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_TRUST_KEY_DURATION);
     private static final int QR_CODE_SIZE = 134;  // TODO: make this configurable?
     private static final String IMAGE_FORMAT = "png";
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
+
     private final AccountService accountService = locator.getService(AccountService.class);
-    private final UserService userService = locator.getService(UserService.class);
     private final ScratchCodeService scratchCodeService = locator.getService(ScratchCodeService.class);
     private final ScratchCodeFactory scratchCodeFactory = locator.getFactory(ScratchCodeFactory.class);
 
-    private final KapuaAuthenticationSetting setting = KapuaAuthenticationSetting.getInstance();
-    private final int trustKeyDuration = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_MFA_TRUST_KEY_DURATION);
+    private final UserService userService = locator.getService(UserService.class);
 
+    /**
+     * Constructor.
+     *
+     * @since 1.3.0
+     */
     public MfaOptionServiceImpl() {
         super(AuthenticationEntityManagerFactory.getInstance());
     }
@@ -298,11 +308,8 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
         //
         // Query and return result
         MfaOptionListResult result = query(query);
-        if (!result.isEmpty()) {
-            return result.getFirstItem();
-        } else {
-            return null;
-        }
+
+        return result.getFirstItem();
     }
 
     @Override
@@ -311,31 +318,38 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
         // Argument Validation (fields validation is performed inside the 'update' method)
         ArgumentValidator.notNull(mfaOption, "mfaOption");
 
-        // Trust key generation always performed
-        // This allows the use only of a single trusted machine, until a solution with different trust keys is implemented
-        String trustKey = generateTrustKey();
-
-        Date expirationDate = new Date(System.currentTimeMillis());
-        expirationDate = DateUtils.addDays(expirationDate, trustKeyDuration);
-
-        mfaOption.setTrustKey(cryptTrustKey(trustKey));
-        mfaOption.setTrustExpirationDate(expirationDate);
-        update(mfaOption);
-
-        // post-persist magic
-        return trustKey;
+        return enableTrust(mfaOption.getScopeId(), mfaOption.getId());
     }
 
     @Override
     public String enableTrust(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException {
-
+        //
         // Argument Validation
-        ArgumentValidator.notNull(mfaOptionId, "mfaOptionId");
         ArgumentValidator.notNull(scopeId, "scopeId");
+        ArgumentValidator.notNull(mfaOptionId, "mfaOptionId");
 
-        // extracting the MfaOption
+        //
+        // Checking existence
         MfaOption mfaOption = find(scopeId, mfaOptionId);
-        return enableTrust(mfaOption);
+
+        if (mfaOption == null) {
+            throw new KapuaEntityNotFoundException(MfaOption.TYPE, mfaOptionId);
+        }
+
+        // Trust key generation always performed
+        // This allows the use only of a single trusted machine,
+        // until a solution with different trust keys is implemented!
+        String trustKey = generateTrustKey();
+        mfaOption.setTrustKey(cryptTrustKey(trustKey));
+
+        Date expirationDate = new Date(System.currentTimeMillis());
+        expirationDate = DateUtils.addDays(expirationDate, TRUST_KEY_DURATION);
+        mfaOption.setTrustExpirationDate(expirationDate);
+
+        // Update
+        update(mfaOption);
+
+        return trustKey;
     }
 
     @Override
@@ -359,36 +373,10 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
      * Generate the trust key string.
      *
      * @return String
+     * @since 1.3.0
      */
     private String generateTrustKey() {
         return UUID.randomUUID().toString();
-    }
-
-    private void deleteMfaOptionByUserId(KapuaId scopeId, KapuaId userId) throws KapuaException {
-        KapuaLocator locator = KapuaLocator.getInstance();
-        MfaOptionFactory mfaOptionFactory = locator.getFactory(MfaOptionFactory.class);
-
-        MfaOptionQuery query = mfaOptionFactory.newQuery(scopeId);
-        query.setPredicate(query.attributePredicate(MfaOptionAttributes.USER_ID, userId));
-
-        MfaOptionListResult mfaOptionsToDelete = query(query);
-
-        for (MfaOption c : mfaOptionsToDelete.getItems()) {
-            delete(c.getScopeId(), c.getId());
-        }
-    }
-
-    private void deleteMfaOptionByAccountId(KapuaId scopeId, KapuaId accountId) throws KapuaException {
-        KapuaLocator locator = KapuaLocator.getInstance();
-        MfaOptionFactory mfaOptionFactory = locator.getFactory(MfaOptionFactory.class);
-
-        MfaOptionQuery query = mfaOptionFactory.newQuery(accountId);
-
-        MfaOptionListResult mfaOptionsToDelete = query(query);
-
-        for (MfaOption c : mfaOptionsToDelete.getItems()) {
-            delete(c.getScopeId(), c.getId());
-        }
     }
 
     /**
@@ -400,6 +388,7 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
      * @param username         the username
      * @param key              the Mfa secret key in plain text
      * @return the QR code image in base64 format
+     * @since 1.3.0
      */
     private String generateQRCode(String organizationName, String accountName, String username, String key)
             throws IOException, WriterException, URISyntaxException {
@@ -422,6 +411,7 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
      *
      * @param img the {@link BufferedImage} to convert
      * @return the base64 string representation of the input image
+     * @since 1.3.0
      */
     private static String imgToBase64(BufferedImage img) throws IOException {
         final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
@@ -434,6 +424,7 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
      *
      * @param bitMatrix the {@link BitMatrix} to be converted into ad image
      * @return the {@link BufferedImage} obtained from the conversion
+     * @since 1.3.0
      */
     private static BufferedImage buildImage(BitMatrix bitMatrix) {
         BufferedImage qrCodeImage = MatrixToImageWriter.toBufferedImage(bitMatrix);
@@ -446,14 +437,14 @@ public class MfaOptionServiceImpl extends AbstractKapuaService implements MfaOpt
     }
 
     /**
-     * Encrypts the trust key
+     * Encrypts the trust key.
      *
      * @param plainTrustKey the trust key in plain text
      * @return the encrypted trust key
      * @throws KapuaException if the cryptCredential method throws a {@link KapuaException}
+     * @since 1.4.0
      */
     private static String cryptTrustKey(String plainTrustKey) throws KapuaException {
         return AuthenticationUtils.cryptCredential(CryptAlgorithm.BCRYPT, plainTrustKey);
     }
-
 }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -104,22 +104,25 @@ import java.util.UUID;
 import java.util.stream.Collectors;
 
 /**
- * Authentication service implementation.
- * <p>
- * since 1.0
+ * {@link AuthenticationService} implementation.
+ *
+ * @since 1.0.0
  */
 @Singleton
 public class AuthenticationServiceShiroImpl implements AuthenticationService {
 
     private static final Logger LOG = LoggerFactory.getLogger(AuthenticationServiceShiroImpl.class);
+
     private final KapuaLocator locator = KapuaLocator.getInstance();
-    private final UserService userService = locator.getService(UserService.class);
+
     private final CredentialService credentialService = locator.getService(CredentialService.class);
     private final MfaOptionService mfaOptionService = locator.getService(MfaOptionService.class);
+
     private final AccessTokenService accessTokenService = locator.getService(AccessTokenService.class);
     private final AccessTokenFactory accessTokenFactory = locator.getFactory(AccessTokenFactory.class);
     private final CertificateService certificateService = locator.getService(CertificateService.class);
     private final CertificateFactory certificateFactory = locator.getFactory(CertificateFactory.class);
+
     private final AccessInfoService accessInfoService = locator.getService(AccessInfoService.class);
     private final AccessRoleService accessRoleService = locator.getService(AccessRoleService.class);
     private final AccessRoleFactory accessRoleFactory = locator.getFactory(AccessRoleFactory.class);
@@ -127,6 +130,8 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
     private final RolePermissionFactory rolePermissionFactory = locator.getFactory(RolePermissionFactory.class);
     private final AccessPermissionService accessPermissionService = locator.getService(AccessPermissionService.class);
     private final AccessPermissionFactory accessPermissionFactory = locator.getFactory(AccessPermissionFactory.class);
+
+    private final UserService userService = locator.getService(UserService.class);
 
     @Override
     public AccessToken login(LoginCredentials loginCredentials) throws KapuaException {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/AuthenticationServiceShiroImpl.java
@@ -577,7 +577,7 @@ public class AuthenticationServiceShiroImpl implements AuthenticationService {
             if (usernamePasswordCredentials.getTrustMe()) {
                 String trustKey = KapuaSecurityUtils.doPrivileged(() -> {
                     MfaOption mfaOption = mfaOptionService.findByUserId(accessToken.getScopeId(), accessToken.getUserId());
-                    return mfaOptionService.enableTrust(mfaOption);
+                    return mfaOptionService.enableTrust(mfaOption.getScopeId(), mfaOption.getId());
                 });
 
                 accessToken.setTrustKey(trustKey);

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImpl.java
@@ -13,9 +13,9 @@
 package org.eclipse.kapua.service.authentication.shiro;
 
 import org.apache.shiro.authc.AuthenticationToken;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.eclipse.kapua.service.authentication.UsernamePasswordCredentials;
 
-import org.checkerframework.checker.nullness.qual.Nullable;
 import javax.validation.constraints.NotNull;
 
 /**
@@ -33,6 +33,7 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
     private String password;
     private String authenticationCode;
     private String trustKey;
+    private boolean trustMe;
 
     /**
      * Constructor.
@@ -46,7 +47,6 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
         setPassword(password);
     }
 
-
     /**
      * Clone constructor.
      *
@@ -58,6 +58,7 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
         setPassword(usernamePasswordCredentials.getPassword());
         setAuthenticationCode(usernamePasswordCredentials.getAuthenticationCode());
         setTrustKey(usernamePasswordCredentials.getTrustKey());
+        setTrustMe(usernamePasswordCredentials.getTrustMe());
     }
 
     @Override
@@ -110,11 +111,21 @@ public class UsernamePasswordCredentialsImpl implements UsernamePasswordCredenti
         this.trustKey = trustKey;
     }
 
+    @Override
+    public boolean getTrustMe() {
+        return trustMe;
+    }
+
+    @Override
+    public void setTrustMe(boolean trustMe) {
+        this.trustMe = trustMe;
+    }
+
     /**
      * Parses a {@link UsernamePasswordCredentials} into a {@link UsernamePasswordCredentialsImpl}.
      *
      * @param usernamePasswordCredentials The {@link UsernamePasswordCredentials} to parse.
-     * @return A instance of {@link UsernamePasswordCredentialsImpl}.
+     * @return An instance of {@link UsernamePasswordCredentialsImpl}.
      * @since 1.5.0
      */
     public static UsernamePasswordCredentialsImpl parse(@Nullable UsernamePasswordCredentials usernamePasswordCredentials) {

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/ApiKeyCredentialsMatcher.java
@@ -51,7 +51,7 @@ public class ApiKeyCredentialsMatcher implements CredentialsMatcher {
 
             int preLength = setting.getInt(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_LENGTH);
             String tokenPre = tokenApiFullKey.substring(0, preLength);
-            String tokenKey = tokenApiFullKey.substring(preLength, tokenApiFullKey.length());
+            String tokenKey = tokenApiFullKey.substring(preLength);
 
             String preSeparator = setting.getString(KapuaAuthenticationSettingKeys.AUTHENTICATION_CREDENTIAL_APIKEY_PRE_SEPARATOR);
             String infoPre = fullApiKey.split(preSeparator)[0];

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassAuthenticatingRealm.java
@@ -19,7 +19,6 @@ import org.apache.shiro.authc.AuthenticationInfo;
 import org.apache.shiro.authc.AuthenticationToken;
 import org.apache.shiro.authc.credential.CredentialsMatcher;
 import org.apache.shiro.realm.AuthenticatingRealm;
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.KapuaRuntimeException;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
@@ -36,7 +35,6 @@ import org.eclipse.kapua.service.user.UserService;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
@@ -150,50 +148,17 @@ public class UserPassAuthenticatingRealm extends KapuaAuthenticatingRealm {
     protected void assertCredentialsMatch(AuthenticationToken authcToken, AuthenticationInfo info)
             throws AuthenticationException {
         LoginAuthenticationInfo kapuaInfo = (LoginAuthenticationInfo) info;
-        CredentialService credentialService = LOCATOR.getService(CredentialService.class);
 
         try {
             super.assertCredentialsMatch(authcToken, info);
-        } catch (MfaRequiredException e) {
-            throw e;
-        } catch (AuthenticationException e) {
-            try {
-                Credential failedCredential = (Credential) kapuaInfo.getCredentials();
-                KapuaSecurityUtils.doPrivileged(() -> {
-                    Map<String, Object> credentialServiceConfig = kapuaInfo.getCredentialServiceConfig();
-                    boolean lockoutPolicyEnabled = (boolean) credentialServiceConfig.get("lockoutPolicy.enabled");
-                    if (lockoutPolicyEnabled) {
-                        Date now = new Date();
-                        int resetAfterSeconds = (int) credentialServiceConfig.get("lockoutPolicy.resetAfter");
+        } catch (MfaRequiredException mfaRequiredException) {
+            throw mfaRequiredException;
+        } catch (AuthenticationException authenticationException) {
+            //
+            // Increase count of failed attempts
+            increaseLockoutPolicyCount(kapuaInfo);
 
-                        Date firstLoginFailure;
-                        boolean resetAttempts = failedCredential.getFirstLoginFailure() == null ||
-                                now.after(failedCredential.getLoginFailuresReset());
-                        if (resetAttempts) {
-                            firstLoginFailure = now;
-                            failedCredential.setLoginFailures(1);
-                        } else {
-                            firstLoginFailure = failedCredential.getFirstLoginFailure();
-                            failedCredential.setLoginFailures(failedCredential.getLoginFailures() + 1);
-                        }
-
-                        Date loginFailureWindowExpiration = new Date(firstLoginFailure.getTime() + (resetAfterSeconds * 1000L));
-                        failedCredential.setFirstLoginFailure(firstLoginFailure);
-                        failedCredential.setLoginFailuresReset(loginFailureWindowExpiration);
-                        int maxLoginFailures = (int) credentialServiceConfig.get("lockoutPolicy.maxFailures");
-                        if (failedCredential.getLoginFailures() >= maxLoginFailures) {
-                            long lockoutDuration = (int) credentialServiceConfig.get("lockoutPolicy.lockDuration");
-                            Date resetDate = new Date(now.getTime() + (lockoutDuration * 1000));
-                            failedCredential.setLockoutReset(resetDate);
-                        }
-                    }
-
-                    credentialService.update(failedCredential);
-                });
-            } catch (KapuaException kex) {
-                throw new ShiroException("Unexpected error while updating the lockout policy", kex);
-            }
-            throw e;
+            throw authenticationException;
         }
 
         //

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/realm/UserPassCredentialsMatcher.java
@@ -43,11 +43,11 @@ import java.util.Date;
  */
 public class UserPassCredentialsMatcher implements CredentialsMatcher {
 
-    private KapuaLocator locator;
-    private MfaOptionService mfaOptionService;
-    private ScratchCodeService scratchCodeService;
-    private MfaAuthenticatorServiceLocator mfaAuthServiceLocator;
-    private MfaAuthenticator mfaAuthenticator;
+    private final KapuaLocator locator;
+    private final MfaOptionService mfaOptionService;
+    private final ScratchCodeService scratchCodeService;
+    private final MfaAuthenticatorServiceLocator mfaAuthServiceLocator;
+    private final MfaAuthenticator mfaAuthenticator;
 
     public UserPassCredentialsMatcher() {
         locator = KapuaLocator.getInstance();

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/UsernamePasswordCredentialsImplTest.java
@@ -166,8 +166,9 @@ class UsernamePasswordCredentialsAnother implements UsernamePasswordCredentials 
 
     private String username;
     private String password;
-    private String trustKey;
     private String authenticationCode;
+    private String trustKey;
+    private boolean trustMe;
 
     public UsernamePasswordCredentialsAnother(String username, String password) {
         this.username = username;
@@ -195,6 +196,16 @@ class UsernamePasswordCredentialsAnother implements UsernamePasswordCredentials 
     }
 
     @Override
+    public String getAuthenticationCode() {
+        return authenticationCode;
+    }
+
+    @Override
+    public void setAuthenticationCode(String authenticationCode) {
+        this.authenticationCode = authenticationCode;
+    }
+
+    @Override
     public String getTrustKey() {
         return trustKey;
     }
@@ -205,12 +216,12 @@ class UsernamePasswordCredentialsAnother implements UsernamePasswordCredentials 
     }
 
     @Override
-    public String getAuthenticationCode() {
-        return authenticationCode;
+    public boolean getTrustMe() {
+        return trustMe;
     }
 
     @Override
-    public void setAuthenticationCode(String authenticationCode) {
-        this.authenticationCode = authenticationCode;
+    public void setTrustMe(boolean trustMe) {
+        this.trustMe = trustMe;
     }
 }


### PR DESCRIPTION
This PR refactors a part of the AuthenticationService API and adds a bunch of missing javadoc.

**Related Issue**
_None_

**Description of the solution adopted**
Deprecated:

- `AuthenticationService` `AccessToken login(LoginCredentials loginCredentials, boolean enableTrust) throws KapuaException;` to promote the usage of the improved `AccessToken login(LoginCredentials loginCredentials) throws KapuaException;` with is far cleaner than having lots of overloads for the same method.
- `AuthenticationService` `AccessToken findRefreshableAccessToken(String tokenId) throws KapuaException;` it was not used at all.
- `MfaOptionService` `String enableTrust(MfaOption mfaOption) throws KapuaException` since it was used as a shortcut method for `String enableTrust(KapuaId scopeId, KapuaId mfaOptionId) throws KapuaException`. This makes the API cleaner and it makes all API calls clear and uniform

Refactored:
- `UsernamePasswordCredentials` new `trustMe` attribute to support deprecation of  `AuthenticationService` `AccessToken login(LoginCredentials loginCredentials, boolean enableTrust) throws KapuaException;`
- Moved logic that increases the login failed attempts to the base `KapuaAuthenticatingRealm` since was duplicated in two classes

**Screenshots**
_None_

**Any side note on the changes made**
Added a bunch of missing/incorrect javadoc.
All changes does not break compatibility