### PR TITLE
Fixed Broker SERIALIZABLE_PACKAGES env definition

### DIFF
--- a/assembly/broker/docker/Dockerfile
+++ b/assembly/broker/docker/Dockerfile
@@ -42,7 +42,8 @@ ENV ACTIVEMQ_OPTS "-Dcommons.db.schema.update=true \
                    -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
                    -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
                    -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
-                   -Djob.engine.client.auth.mode=trusted"
+                   -Djob.engine.client.auth.mode=trusted \
+                   -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=\${AMQ_SERIALIZABLE_PACKAGES:-java.lang,java.math,java.util,org.apache.activemq,org.fusesource.hawtbuf,org.eclipse.kapua}"
 
 EXPOSE 1883 1893 5672 8883 61614 61615 8161
 


### PR DESCRIPTION
This PR fixes the SERIALIZABLE_PACKAGES env variable definition for the broker container.

Without this env set properly there will be errors while processing messages in the DLQ.

**Related Issue**
_None_

**Description of the solution adopted**
Added correct list of packages in the ENV.

**Screenshots**
_None_

**Any side note on the changes made**
_None_