### PR TITLE
Set JAXB dependencies to fixed version

### DIFF
--- a/message/internal/pom.xml
+++ b/message/internal/pom.xml
@@ -22,11 +22,7 @@
     </parent>
 
     <artifactId>kapua-message-internal</artifactId>
-    <name>${project.artifactId}</name>
 
-    <properties>
-        <jaxb.version>2.2.5</jaxb.version>
-    </properties>
     <dependencies>
         <!-- Internal dependencies -->
         <dependency>
@@ -35,11 +31,6 @@
         </dependency>
 
         <!-- External dependencies -->
-        <dependency>
-            <groupId>com.sun.xml.bind</groupId>
-            <artifactId>jaxb-impl</artifactId>
-            <version>${jaxb.version}</version>
-        </dependency>
         <dependency>
             <groupId>commons-configuration</groupId>
             <artifactId>commons-configuration</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -75,6 +75,9 @@
         <javax-servlet-api.version>3.1.0</javax-servlet-api.version>
         <javax-validation-api.version>2.0.1.Final</javax-validation-api.version>
         <javax-ws-rs-api.version>2.0.1</javax-ws-rs-api.version>
+        <jaxb-api.version>2.3.1</jaxb-api.version>
+        <jaxb-core.version>2.3.0.1</jaxb-core.version>
+        <jaxb-impl.version>2.3.6</jaxb-impl.version>
         <jbatch.version>1.0.2</jbatch.version>
         <jersey.version>2.23.2</jersey.version>
         <jetty.version>9.4.44.v20210927</jetty.version>
@@ -1310,6 +1313,23 @@
                 <artifactId>h2</artifactId>
                 <version>${h2.version}</version>
             </dependency>
+
+            <dependency>
+                <groupId>javax.xml.bind</groupId>
+                <artifactId>jaxb-api</artifactId>
+                <version>${jaxb-api.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-core</artifactId>
+                <version>${jaxb-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.sun.xml.bind</groupId>
+                <artifactId>jaxb-impl</artifactId>
+                <version>${jaxb-impl.version}</version>
+            </dependency>
+
             <dependency>
                 <!-- TOTP dependencies -->
                 <groupId>com.warrenstrange</groupId>


### PR DESCRIPTION
This PR sets a fixed version of JAXB dependencies to avoid version mismatch within same components.

New versions are 

- javax.xml.bind:jaxb-api.version:2.3.1
- com.sun.xml.bind.jaxb-core:2.3.0.1
- com.sun.xml.bind:jaxb-impl:2.3.6

`develop` dependency tree

[jaxb.pre.txt](https://github.com/eclipse/kapua/files/8361219/jaxb.pre.txt)

`fix-setCommonJaxbVersions` dependency tree

[jaxb.post.txt](https://github.com/eclipse/kapua/files/8361221/jaxb.post.txt)

Dependencies version diff

```
- com.sun.xml.bind:jaxb-impl:jar:2.2.5
- com.sun.xml.bind:jaxb-core:jar:2.3.0

+ com.sun.activation:jakarta.activation:jar:1.2.2
+ com.sun.xml.bind:jaxb-impl:jar:2.3.6
+ com.sun.xml.bind:jaxb-core:jar:2.3.0.1
```

Dash License Tool report
 
```
echo "maven/mavencentral/com.sun.xml.bind/jaxb-impl/2.3.6                                                                                                             
maven/mavencentral/com.sun.xml.bind/jaxb-core/2.3.0.1
maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1" | java -jar -Dorg.slf4j.simpleLogger.defaultLogLevel=debug dash.license.tool.jar -
[main] INFO Querying Eclipse Foundation for license data for 3 items.
[main] DEBUG EF approved: maven/mavencentral/com.sun.xml.bind/jaxb-impl/2.3.6 (prerequisite) score: 100 BSD-3-Clause #230
[main] DEBUG EF approved: maven/mavencentral/com.sun.xml.bind/jaxb-core/2.3.0.1 (prerequisite) score: 100 CDDL-1.0 OR GPL-2.0 WITH Classpath-exception-2.0 #229
[main] DEBUG EF approved: maven/mavencentral/javax.xml.bind/jaxb-api/2.3.1 (prerequisite) score: 100 CDDL-1.1 OR GPL-2.0 CQ16911
[main] INFO Found 3 items.
Vetted license information was found for all content. No further investigation is required.

```

**Related Issue**
_None_

**Description of the solution adopted**
Declared jaxb dependencies into `dependencyManagement` section.

**Screenshots**
_None_

**Any side note on the changes made**
_None_