### PR TITLE
Add Permission targetScopeId informations to grid and dialogs

### DIFF
--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/role/dialog/RolePermissionAddDialog.java
@@ -19,6 +19,7 @@ import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.widget.form.LabelField;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboValue;
 import com.google.gwt.core.client.GWT;
@@ -176,9 +177,11 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
         actionsCombo.setTriggerAction(TriggerAction.ALL);
         actionsCombo.setEmptyText(MSGS.permissionAddDialogLoading());
         actionsCombo.setToolTip(MSGS.dialogAddFieldPermissionsActionTooltip());
+        permissionFormPanel.add(actionsCombo);
 
         actionsCombo.addSelectionChangedListener(new SelectionChangedListener<SimpleComboValue<GwtAction>>() {
 
+            @Override
             public void selectionChanged(SelectionChangedEvent<SimpleComboValue<GwtAction>> se) {
                 domainsCombo.clearInvalid();
                 actionsCombo.clearInvalid();
@@ -186,8 +189,16 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
             }
         });
 
-        permissionFormPanel.add(actionsCombo);
+        //
+        // Target Scope Id
+        LabelField labelField = new LabelField();
+        labelField.setFieldLabel("Target Scope");
+        labelField.setLabelSeparator(":");
+        labelField.setToolTip("The scope on which the permission is given.");
+        labelField.setValue(currentSession.getSelectedAccountName());
+        permissionFormPanel.add(labelField);
 
+        //
         // Groups
         groupsCombo = new ComboBox<GwtGroup>();
         groupsCombo.setStore(new ListStore<GwtGroup>());
@@ -298,7 +309,7 @@ public class RolePermissionAddDialog extends EntityAddEditDialog {
                 }
                 domainsCombo.markInvalid(exitMessage);
                 actionsCombo.markInvalid(exitMessage);
-                if (groupsCombo.isEnabled()){
+                if (groupsCombo.isEnabled()) {
                     groupsCombo.markInvalid(exitMessage);
                 }
                 ConsoleInfo.display(CMSGS.error(), exitMessage);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/PermissionAddDialog.java
@@ -19,6 +19,7 @@ import com.extjs.gxt.ui.client.widget.form.CheckBox;
 import com.extjs.gxt.ui.client.widget.form.CheckBoxGroup;
 import com.extjs.gxt.ui.client.widget.form.ComboBox;
 import com.extjs.gxt.ui.client.widget.form.ComboBox.TriggerAction;
+import com.extjs.gxt.ui.client.widget.form.LabelField;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboBox;
 import com.extjs.gxt.ui.client.widget.form.SimpleComboValue;
 import com.google.gwt.core.client.GWT;
@@ -99,7 +100,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
             }
         });
 
-        DialogUtils.resizeDialog(this, 500, 220);
+        DialogUtils.resizeDialog(this, 500, 240);
     }
 
     @Override
@@ -202,6 +203,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
 
         actionsCombo.addSelectionChangedListener(new SelectionChangedListener<SimpleComboValue<GwtAction>>() {
 
+            @Override
             public void selectionChanged(SelectionChangedEvent<SimpleComboValue<GwtAction>> se) {
                 domainsCombo.clearInvalid();
                 actionsCombo.clearInvalid();
@@ -210,6 +212,15 @@ public class PermissionAddDialog extends EntityAddEditDialog {
         });
 
         permissionFormPanel.add(actionsCombo);
+
+        //
+        // Target Scope Id
+        LabelField labelField = new LabelField();
+        labelField.setFieldLabel("Target Scope");
+        labelField.setLabelSeparator(":");
+        labelField.setToolTip("The scope on which the permission is given.");
+        labelField.setValue(currentSession.getSelectedAccountName());
+        permissionFormPanel.add(labelField);
 
         // Groups
         groupsCombo = new ComboBox<GwtGroup>();
@@ -321,7 +332,7 @@ public class PermissionAddDialog extends EntityAddEditDialog {
                 }
                 domainsCombo.markInvalid(exitMessage);
                 actionsCombo.markInvalid(exitMessage);
-                if (groupsCombo.isEnabled()){
+                if (groupsCombo.isEnabled()) {
                     groupsCombo.markInvalid(exitMessage);
                 }
                 ConsoleInfo.display(CMSGS.error(), exitMessage);

--- a/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
+++ b/console/module/authorization/src/main/java/org/eclipse/kapua/app/console/module/authorization/client/tabs/permission/UserTabPermissionGrid.java
@@ -99,6 +99,10 @@ public class UserTabPermissionGrid extends EntityGrid<GwtAccessPermission> {
         columnConfig.setSortable(false);
         columnConfigs.add(columnConfig);
 
+        columnConfig = new ColumnConfig("permissionTargetScopeIdByName", PERMISSION_MSGS.gridRolePermissionColumnHeaderTargetScopeId(), 200);
+        columnConfig.setSortable(false);
+        columnConfigs.add(columnConfig);
+
         if (currentSession.hasPermission(GroupSessionPermission.read())) {
             columnConfig = new ColumnConfig("groupName", PERMISSION_MSGS.gridAccessRoleColumnHeaderGroupName(), 200);
             columnConfig.setSortable(false);


### PR DESCRIPTION
Thsi PR adds showing for `Permission.targetScopeId` value in User Permission grid and User/Role add Permission dialogs to make more clear to which scope the permission is given

**Related Issue**
_None_

**Description of the solution adopted**
Added a new "Target Scope Id" column to the User Permission grid.

Added "Target Scope" label field of User and Role add Permission dialog.

**Screenshots**
_None_

**Any side note on the changes made**
_None_