### PR TITLE
Entity Attribute encryption migrator tool

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -3,7 +3,7 @@ on: [ push, pull_request ] # Triggers the workflow on push or pull request event
 
 env:
   BUILD_OPTS: ""
-  CONFIG_OVERRIDES: "-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dbroker.host=localhost"
+  CONFIG_OVERRIDES: "-Dcommons.db.schema=kapuadb -Dcommons.settings.hotswap=true -Dbroker.host=localhost -Dcrypto.secret.key=kapuaTestsKey!!!"
   MAVEN_OPTS: "-Xmx4096m"
 
 jobs:

--- a/commons/src/main/java/org/eclipse/kapua/commons/crypto/CryptoUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/crypto/CryptoUtil.java
@@ -61,12 +61,12 @@ public class CryptoUtil {
     static {
         String defaultSecretKey = SECRET_KEY_LEGACY;
 
-        if (Strings.isNullOrEmpty(defaultSecretKey)) {
+        if (!Strings.isNullOrEmpty(SECRET_KEY)) {
             defaultSecretKey = SECRET_KEY;
         }
 
         if (("changeMePlease!!".equals(defaultSecretKey) ||
-                "Y3h14xr2!fEDp_@1".equals(defaultSecretKey)) &&
+                "rv;ipse329183!@#".equals(defaultSecretKey)) &&
                 SECRET_KEY_ENFORCE) {
             throw new DefaultSecretKeyDetectedRuntimeException(defaultSecretKey);
         }

--- a/commons/src/main/java/org/eclipse/kapua/commons/crypto/setting/CryptoSettingKeys.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/crypto/setting/CryptoSettingKeys.java
@@ -18,7 +18,7 @@ import org.eclipse.kapua.commons.setting.SettingKey;
 /**
  * {@link SettingKey}s for {@link CryptoSettings}.
  *
- * @since 2.0.0
+ * @since 2.0.0 "crypto.secret.key=kapuaTestsKey!!!",
  */
 public enum CryptoSettingKeys implements SettingKey {
 

--- a/commons/src/main/resources/crypto-error-messages.properties
+++ b/commons/src/main/resources/crypto-error-messages.properties
@@ -14,5 +14,5 @@
 AES_DECODE_ERROR=Error while decoding a value. For security reasons value is not shown.
 AES_ENCODE_ERROR=Error while encoding a value. For security reasons value is not shown.
 ALGORITHM_NOT_AVAILABLE=The {0} algorithm is not available or supported.
-DEFAULT_SECRET_KEY_DETECTED=The default encryption key '{0}' has been detected. Please change it for security reasons. If you want really to continue with the default one please set 'crypto.secret.enforce.change' to false
+DEFAULT_SECRET_KEY_DETECTED=The default encryption key "{0}" has been detected. Please change it for security reasons. If you want really to continue with the default one please set 'crypto.secret.enforce.change' to false
 INVALID_SECRET_KEY=The provided algorithm {0} and secret key {1} are an invalid.

--- a/extras/encryption-migrator/README.md
+++ b/extras/encryption-migrator/README.md
@@ -42,7 +42,7 @@ The following settings are available as system properties when running the migra
 |-----------------------------|---------------------------------------------------------------------------|------------------|
 | migrator.encryption.dryRun  | Run the tool without affecting data                                       | false            |
 | migrator.encryption.key.old | The old secret key for symmetric encryption                               | changeMePlease!! |
-| migrator.encryption.key.mfs | The old secret key for symmetric encryption of the MfaOption.mfaSecretKey | rv;ipse329183!@# |
+| migrator.encryption.key.mfa | The old secret key for symmetric encryption of the MfaOption.mfaSecretKey | rv;ipse329183!@# |
 | migrator.encryption.key.new | The new secret key for symmetric encryption                               | changedMeThanks! |
 
 Other useful properties from Kapua

--- a/extras/encryption-migrator/README.md
+++ b/extras/encryption-migrator/README.md
@@ -38,11 +38,12 @@ The encryption migration tool has been implemented with two goals:
 
 The following settings are available as system properties when running the migration tool:
 
-| Name                                         | Description                                                                                                                                                              | Default Value                                         |
-|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
-| migrator.encryption.key.old                  | The old secret key for simmetric encryption                                                                                                                              | changeMePlease!!                                      |
-| migrator.encryption.key.mfs                  | The old secret key for simmetric encryption of the MfaOption.mfaSecretKey                                                                                                | rv;ipse329183!@#                                      |
-| migrator.encryption.key.new                  | The new secret key for simmetric encryption                                                                                                                              | changedMeThanks!                                      |
+| Name                        | Description                                                               | Default Value    |
+|-----------------------------|---------------------------------------------------------------------------|------------------|
+| migrator.encryption.dryRun  | Run the tool without affecting data                                       | false            |
+| migrator.encryption.key.old | The old secret key for symmetric encryption                               | changeMePlease!! |
+| migrator.encryption.key.mfs | The old secret key for symmetric encryption of the MfaOption.mfaSecretKey | rv;ipse329183!@# |
+| migrator.encryption.key.new | The new secret key for symmetric encryption                               | changedMeThanks! |
 
 Other useful properties from Kapua
 
@@ -50,7 +51,7 @@ Other useful properties from Kapua
 |----------------------------|------------------------------|----------------|
 | commons.db.name            | The target database name     | kapuadb        |
 | commons.db.username        | The target database username | kapua          | 
-| commons.db.password        | The target database passowrd | kapua          | 
+| commons.db.password        | The target database password | kapua          | 
 | commons.db.connection.host | The target database host     | 192.168.33.10  |
 | commons.db.connection.port | The target database port     | 3306           | 
 

--- a/extras/encryption-migrator/README.md
+++ b/extras/encryption-migrator/README.md
@@ -1,0 +1,61 @@
+Kapua Encryption Migrator
+==========
+
+## Introduction
+
+This module contains a Java Application that leverages the Kapua APIs to update the encryption key used to perform symmetric encryption of entity attributes on DB persistence and any other usage of CryptoUtil class.
+
+## Background
+
+To improve security against unauthorized access to DB some fields that contain sensible data needs to be encrypted. This encryption makes difficult for an attacker to easily read data from the database that may contain sensible data.
+
+Kapua had already in place one-way encryption for Credentials and other resources while fields that required symmetric encryption didn't have a uniform and simple way to manage the encryption of the fields.
+
+## Changes in Kapua 2.0
+
+With Kapua 2.0.0 entity attributes can be symmetric encrypted by simply adding an annotation to the rest of the JPA mappings for an entity attribute which instructs JPA to crypt and decrypt fields values.
+
+Before Kapua 2.0.0 fields that were symmetric-encrypted are:
+
+- MfaOption.mfaSecretKey: which had its own mechanisms with its own key.
+
+After Kapua 2.0.0 fields that are symmetric-encrypted are:
+
+- MfaOption.mfaSecretKey
+- JobStepProperty.propertyValue
+
+Every field share the same key and lets the developer abstract from the specific task of encrypting fields which gets delegated to JPA. While this can affect performances (we lose the on-demand encryption/decryption), we gain the ease of using this security feature.
+
+## The ES indices Migration tool
+
+The encryption migration tool has been implemented with two goals:
+
+- Do the first migration: to allow every field listed before to be unified under a single encryption key and mechanism.
+- Update the encryption secret key: it might happen that a secret key needs to be replaced (e.g.: the secret key disclosure)
+  and this tools migrate every attribute from a given old encryption secret key to the newly given.
+
+### Settings
+
+The following settings are available as system properties when running the migration tool:
+
+| Name                                         | Description                                                                                                                                                              | Default Value                                         |
+|----------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-------------------------------------------------------|
+| migrator.encryption.key.old                  | The old secret key for simmetric encryption                                                                                                                              | changeMePlease!!                                      |
+| migrator.encryption.key.mfs                  | The old secret key for simmetric encryption of the MfaOption.mfaSecretKey                                                                                                | rv;ipse329183!@#                                      |
+| migrator.encryption.key.new                  | The new secret key for simmetric encryption                                                                                                                              | changedMeThanks!                                      |
+
+Other useful properties from Kapua
+
+| Name                       | Description                  | Default Value  |
+|----------------------------|------------------------------|----------------|
+| commons.db.name            | The target database name     | kapuadb        |
+| commons.db.username        | The target database username | kapua          | 
+| commons.db.password        | The target database passowrd | kapua          | 
+| commons.db.connection.host | The target database host     | 192.168.33.10  |
+| commons.db.connection.port | The target database port     | 3306           | 
+
+#### Example usage
+
+```bash
+java -Dcommons.db.connection.host=somehost -Dmigrator.encryption.key.old=changeMePlease\!\! -Dmigrator.encryption.key.new=changedMeThanks\! -jar kapua-encryption-migrator-2.0.0-SNAPSHOT-app.jar
+```

--- a/extras/encryption-migrator/pom.xml
+++ b/extras/encryption-migrator/pom.xml
@@ -1,0 +1,126 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>kapua-extras</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-encryption-migrator</artifactId>
+
+    <dependencies>
+        <!-- -->
+        <!-- Kapua -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-job-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-locator-guice</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-security-shiro</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-service-api</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- External-->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/DEPENDENCIES</exclude>
+                                <exclude>bundle.properties</exclude>
+                                <exclude>about.*</exclude>
+                                <exclude>OSGI-OPT/**</exclude>
+                                <exclude>LICENSE</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.eclipse.kapua.extras.migrator.encryption.Application</mainClass>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                            <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                    </transformers>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>app</shadedClassifierName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/Application.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/Application.java
@@ -1,0 +1,61 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption;
+
+import com.google.common.base.MoreObjects;
+import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Application {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.class.getName());
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
+
+    private Application() {
+    }
+
+    public static void main(String[] args) {
+        LOG.info("Entity Secret Attribute Migration Tool... STARTING");
+        try {
+            LOG.info("Running Liquibase...");
+            {
+                String dbUsername = SYSTEM_SETTING.getString(SystemSettingKey.DB_USERNAME);
+                String dbPassword = SYSTEM_SETTING.getString(SystemSettingKey.DB_PASSWORD);
+                String schema = MoreObjects.firstNonNull(
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA_ENV),
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA)
+                );
+
+                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).update();
+            }
+            LOG.info("Running Liquibase... DONE!");
+            LOG.info("Running Entity Attribute Migrator...");
+            {
+                KapuaSecurityUtils.doPrivileged(() -> new EntityAttributeMigrator().migrate());
+            }
+            LOG.info("Running Entity Attribute Migrator... DONE!");
+
+        } catch (Exception e) {
+            LOG.info("Entity Secret Attribute Migration Tool... ERROR!", e);
+            return;
+        }
+
+        LOG.info("Entity Secret Attribute Migration Tool... DONE!");
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/EntityAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/EntityAttributeMigrator.java
@@ -1,0 +1,67 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.api.EntitySecretAttributeMigrator;
+import org.eclipse.kapua.extras.migrator.encryption.authentication.MfaOptionAttributeMigrator;
+import org.eclipse.kapua.extras.migrator.encryption.job.JobStepAttributeMigrator;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Arrays;
+import java.util.List;
+
+public class EntityAttributeMigrator {
+
+    private static final Logger LOG = LoggerFactory.getLogger(EntityAttributeMigrator.class);
+
+    private static final int PAGE_SIZE = 50;
+
+    protected EntityAttributeMigrator() {
+    }
+
+    public void migrate() throws KapuaException {
+        List<EntitySecretAttributeMigrator<?>> entitySecretAttributeMigrators = getEntityMigrators();
+
+        LOG.info("Found {} entity migrators:", entitySecretAttributeMigrators.size());
+        for (EntitySecretAttributeMigrator<?> entityAttributeMigrator : entitySecretAttributeMigrators) {
+            LOG.info("    + {} for entity {}", entityAttributeMigrator.getClass(), entityAttributeMigrator.getEntityName());
+        }
+        LOG.info("");
+
+        for (EntitySecretAttributeMigrator<?> entityAttributeMigrator : entitySecretAttributeMigrators) {
+            LOG.info("Migrating: {}...", entityAttributeMigrator.getEntityName());
+
+            long totalEntitiesToMigrate = entityAttributeMigrator.getTotalCount();
+
+            LOG.info("    Entities to migrate: {}", totalEntitiesToMigrate);
+            for (int i = 0; i < totalEntitiesToMigrate; i = i + PAGE_SIZE) {
+                LOG.info("        Migrating entities from {} to {} - total {}", i, i + PAGE_SIZE, totalEntitiesToMigrate);
+                List entitiesToMigrate = entityAttributeMigrator.getChunk(i, PAGE_SIZE);
+
+                entityAttributeMigrator.migrate(entitiesToMigrate);
+            }
+            LOG.info("    Entities migrated: {}", totalEntitiesToMigrate);
+            LOG.info("Migrating: {}... DONE!", entityAttributeMigrator.getEntityName());
+            LOG.info("");
+        }
+    }
+
+    public List<EntitySecretAttributeMigrator<?>> getEntityMigrators() {
+        return Arrays.asList(
+                new JobStepAttributeMigrator(),
+                new MfaOptionAttributeMigrator()
+        );
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/MigratorEntityManagerFactory.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/MigratorEntityManagerFactory.java
@@ -1,0 +1,48 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption;
+
+import org.eclipse.kapua.commons.jpa.AbstractEntityManagerFactory;
+import org.eclipse.kapua.commons.jpa.EntityManagerFactory;
+import org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigratorServiceImpl;
+
+/**
+ * {@link JobStepMigratorServiceImpl} {@link EntityManagerFactory} implementation.
+ *
+ * @since 2.0.0
+ */
+public class MigratorEntityManagerFactory extends AbstractEntityManagerFactory implements EntityManagerFactory {
+
+    private static final String PERSISTENCE_UNIT_NAME = "kapua-encryption-migrator";
+
+    private static final MigratorEntityManagerFactory INSTANCE = new MigratorEntityManagerFactory();
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    private MigratorEntityManagerFactory() {
+        super(PERSISTENCE_UNIT_NAME);
+    }
+
+    /**
+     * Returns the {@link EntityManagerFactory} instance.
+     *
+     * @return The {@link EntityManagerFactory} instance.
+     * @since 2.0.0
+     */
+    public static MigratorEntityManagerFactory getInstance() {
+        return INSTANCE;
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/AbstractEntityAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/AbstractEntityAttributeMigrator.java
@@ -1,0 +1,75 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.api;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettingKeys;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettings;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.KapuaUpdatableEntity;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.KapuaEntityService;
+import org.eclipse.kapua.service.KapuaUpdatableEntityService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.List;
+
+public abstract class AbstractEntityAttributeMigrator<E extends KapuaUpdatableEntity> implements EntitySecretAttributeMigrator<E> {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AbstractEntityAttributeMigrator.class);
+
+    private static final Boolean DRY_RUN = EncryptionMigrationSettings.getInstance().getBoolean(EncryptionMigrationSettingKeys.DRY_RUN);
+
+    protected final KapuaEntityService<E, ?> entityService;
+    protected final KapuaUpdatableEntityService<E> entityUpdatableService;
+
+    public AbstractEntityAttributeMigrator(KapuaUpdatableEntityService<E> entityService) {
+        this.entityService = (KapuaEntityService) entityService;
+        this.entityUpdatableService = entityService;
+    }
+
+    @Override
+    public void migrate(List<E> entitiesToMigrate) throws KapuaException {
+        for (E entityToMigrate : entitiesToMigrate) {
+            if (DRY_RUN) {
+                LOG.info("            [DRY RUN] Found {} to migrate with scopeId {} and Id {}", getEntityName(), entityToMigrate.getScopeId(), entityToMigrate.getId());
+            } else {
+                LOG.info("            Migrating {} with scopeId {} and Id {}", getEntityName(), entityToMigrate.getScopeId(), entityToMigrate.getId());
+                entityUpdatableService.update(entityToMigrate);
+            }
+        }
+    }
+
+    @Override
+    public List<E> getChunk(int offset, int limit) throws KapuaException {
+        KapuaQuery query = newEntityQuery();
+
+        // This is the most stable sorting even if it is not always indexed
+        query.setSortCriteria(query.fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return entityService.query(query).getItems();
+    }
+
+    @Override
+    public long getTotalCount() throws KapuaException {
+        KapuaQuery query = newEntityQuery();
+        return entityService.count(query);
+    }
+
+    protected abstract KapuaQuery newEntityQuery();
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/EntitySecretAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/api/EntitySecretAttributeMigrator.java
@@ -1,0 +1,29 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.api;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.model.KapuaEntity;
+
+import java.util.List;
+
+public interface EntitySecretAttributeMigrator<E extends KapuaEntity> {
+
+    String getEntityName();
+
+    List<E> getChunk(int offset, int limit) throws KapuaException;
+
+    long getTotalCount() throws KapuaException;
+
+    void migrate(List<E> entitiesToMigrate) throws KapuaException;
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionAttributeMigrator.java
@@ -1,0 +1,58 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.api.EntitySecretAttributeMigrator;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+
+import java.util.List;
+
+public class MfaOptionAttributeMigrator implements EntitySecretAttributeMigrator<MfaOption> {
+
+    private static final MfaOptionMigratorServiceImpl MFA_OPTION_MIGRATOR_SERVICE = new MfaOptionMigratorServiceImpl();
+
+    @Override
+    public String getEntityName() {
+        return MfaOption.TYPE;
+    }
+
+    @Override
+    public void migrate(List<MfaOption> entitiesToMigrate) throws KapuaException {
+        for (MfaOption mfaOption : entitiesToMigrate) {
+            MFA_OPTION_MIGRATOR_SERVICE.update(mfaOption);
+        }
+    }
+
+    @Override
+    public List<MfaOption> getChunk(int offset, int limit) throws KapuaException {
+        MfaOptionMigratorQueryImpl query = new MfaOptionMigratorQueryImpl(null);
+
+        // This is the most stable sorting even if it is not always indexed
+        query.setSortCriteria(query.fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return MFA_OPTION_MIGRATOR_SERVICE.query(query).getItems();
+    }
+
+    @Override
+    public long getTotalCount() throws KapuaException {
+        MfaOptionMigratorQueryImpl query = new MfaOptionMigratorQueryImpl(null);
+
+        return MFA_OPTION_MIGRATOR_SERVICE.count(query);
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionAttributeMigrator.java
@@ -12,17 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.extras.migrator.encryption.authentication;
 
-import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.api.AbstractEntityAttributeMigrator;
 import org.eclipse.kapua.extras.migrator.encryption.api.EntitySecretAttributeMigrator;
-import org.eclipse.kapua.model.KapuaEntityAttributes;
-import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 
-import java.util.List;
-
-public class MfaOptionAttributeMigrator implements EntitySecretAttributeMigrator<MfaOption> {
+public class MfaOptionAttributeMigrator extends AbstractEntityAttributeMigrator<MfaOption> implements EntitySecretAttributeMigrator<MfaOption> {
 
     private static final MfaOptionMigratorServiceImpl MFA_OPTION_MIGRATOR_SERVICE = new MfaOptionMigratorServiceImpl();
+
+    public MfaOptionAttributeMigrator() {
+        super(MFA_OPTION_MIGRATOR_SERVICE);
+    }
 
     @Override
     public String getEntityName() {
@@ -30,29 +31,7 @@ public class MfaOptionAttributeMigrator implements EntitySecretAttributeMigrator
     }
 
     @Override
-    public void migrate(List<MfaOption> entitiesToMigrate) throws KapuaException {
-        for (MfaOption mfaOption : entitiesToMigrate) {
-            MFA_OPTION_MIGRATOR_SERVICE.update(mfaOption);
-        }
-    }
-
-    @Override
-    public List<MfaOption> getChunk(int offset, int limit) throws KapuaException {
-        MfaOptionMigratorQueryImpl query = new MfaOptionMigratorQueryImpl(null);
-
-        // This is the most stable sorting even if it is not always indexed
-        query.setSortCriteria(query.fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
-
-        query.setOffset(offset);
-        query.setLimit(limit);
-
-        return MFA_OPTION_MIGRATOR_SERVICE.query(query).getItems();
-    }
-
-    @Override
-    public long getTotalCount() throws KapuaException {
-        MfaOptionMigratorQueryImpl query = new MfaOptionMigratorQueryImpl(null);
-
-        return MFA_OPTION_MIGRATOR_SERVICE.count(query);
+    protected KapuaQuery newEntityQuery() {
+        return new MfaOptionMigratorQueryImpl();
     }
 }

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigrator.java
@@ -1,0 +1,159 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.KapuaRuntimeException;
+import org.eclipse.kapua.commons.crypto.setting.CryptoSettingKeys;
+import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettingKeys;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettings;
+import org.eclipse.kapua.extras.migrator.encryption.utils.SecretAttributeMigratorModelUtils;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.ScratchCode;
+import org.eclipse.kapua.service.job.step.JobStep;
+
+import javax.crypto.Cipher;
+import javax.crypto.spec.SecretKeySpec;
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.Table;
+import java.security.Key;
+import java.util.Date;
+import java.util.List;
+
+/**
+ * {@link JobStep} implementation.
+ *
+ * @since 2.0.0
+ */
+@Entity(name = "MfaOption")
+@Table(name = "atht_mfa_option")
+public class MfaOptionMigrator extends AbstractKapuaUpdatableEntity implements MfaOption {
+
+    private static final String OLD_MFA_ENCRYPTION_KEY = EncryptionMigrationSettings.getInstance().getString(EncryptionMigrationSettingKeys.MFA_OLD_ENCRYPTION_KEY);
+
+    @Basic
+    @Column(name = "mfa_secret_key", nullable = false)
+    private String mfaSecretKey;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    public MfaOptionMigrator() {
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param mfaOption The {@link MfaOption} to clone.
+     * @since 2.0.0
+     */
+    public MfaOptionMigrator(MfaOption mfaOption) {
+        super(mfaOption);
+
+        setMfaSecretKey(mfaOption.getMfaSecretKey());
+    }
+
+    /**
+     * Before reading the value for the migration when changing the {@link CryptoSettingKeys#CRYPTO_SECRET_KEY} we need
+     * decrypt the value with the original encryption key and way to encrypt information.
+     *
+     * @return The decrypted MFA secret key.
+     * @since 2.0.0
+     */
+    @Override
+    public String getMfaSecretKey() {
+        if (mfaSecretKey != null && !mfaSecretKey.startsWith("$aes$")) {
+            try {
+                byte[] oldMfaEncryptionKey = OLD_MFA_ENCRYPTION_KEY.getBytes();
+
+                Key key = new SecretKeySpec(oldMfaEncryptionKey, "AES");
+
+                Cipher decryptCipher = Cipher.getInstance("AES");
+                decryptCipher.init(Cipher.DECRYPT_MODE, key);
+
+                byte[] decryptedValueBase64 = java.util.Base64.getUrlDecoder().decode(mfaSecretKey);
+                byte[] decryptedValueBytes = decryptCipher.doFinal(decryptedValueBase64);
+
+                mfaSecretKey = new String(decryptedValueBytes);
+            } catch (Exception e) {
+                throw KapuaRuntimeException.internalError(e, "Cannot decrypt MfaOption.secretKey value with original MFA encryption key");
+            }
+        }
+
+        return SecretAttributeMigratorModelUtils.read(mfaSecretKey);
+    }
+
+    @Override
+    public void setMfaSecretKey(String mfaSecretKey) {
+        this.mfaSecretKey = SecretAttributeMigratorModelUtils.write(mfaSecretKey);
+    }
+
+    //
+    // Attributes below do not require migration
+    //
+
+    @Override
+    public KapuaId getUserId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setUserId(KapuaId userId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getTrustKey() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTrustKey(String trustKey) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Date getTrustExpirationDate() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setTrustExpirationDate(Date trustExpirationDate) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getQRCodeImage() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setQRCodeImage(String qrCodeImage) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public List<ScratchCode> getScratchCodes() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setScratchCodes(List<ScratchCode> scratchCodes) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorDAO.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorDAO.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.ServiceDAO;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
+
+/**
+ * MfaOption DAO
+ *
+ * @since 2.0.0
+ */
+public class MfaOptionMigratorDAO {
+
+    private MfaOptionMigratorDAO() {
+    }
+
+    public static MfaOption update(EntityManager em, MfaOption mfaOption) throws KapuaException {
+        MfaOptionMigrator mfaOptionImpl = (MfaOptionMigrator) mfaOption;
+
+        mfaOptionImpl.setMfaSecretKey(mfaOptionImpl.getMfaSecretKey());
+
+        return ServiceDAO.update(em, MfaOptionMigrator.class, mfaOptionImpl);
+    }
+
+    public static MfaOptionListResult query(EntityManager em, KapuaQuery mfaOptionQuery) throws KapuaException {
+        return ServiceDAO.query(em, MfaOption.class, MfaOptionMigrator.class, new MfaOptionMigratorListResultImpl(), mfaOptionQuery);
+    }
+
+    public static long count(EntityManager em, KapuaQuery mfaOptionQuery) throws KapuaException {
+        return ServiceDAO.count(em, MfaOption.class, MfaOptionMigrator.class, mfaOptionQuery);
+    }
+
+    //
+    // Unsupported methods
+    //
+
+    public static MfaOption create(EntityManager em, MfaOptionCreator mfaOptionCreator) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static MfaOption find(EntityManager em, KapuaId scopeId, KapuaId mfaOptionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static MfaOption findByName(EntityManager em, String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static MfaOption delete(EntityManager em, KapuaId scopeId, KapuaId mfaOptionId) throws KapuaEntityNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorListResultImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorListResultImpl.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
+
+/**
+ * {@link MfaOptionListResult} implementation.
+ *
+ * @since 1.0.0
+ */
+public class MfaOptionMigratorListResultImpl extends KapuaListResultImpl<MfaOption> implements MfaOptionListResult {
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorQueryImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorQueryImpl.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
+
+/**
+ * {@link MfaOptionQuery} definition.
+ *
+ * @since 1.0.0
+ */
+public class MfaOptionMigratorQueryImpl extends AbstractKapuaNamedQuery implements MfaOptionQuery {
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
+    public MfaOptionMigratorQueryImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorQueryImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorQueryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.extras.migrator.encryption.authentication;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionQuery;
 
 /**
@@ -26,10 +25,9 @@ public class MfaOptionMigratorQueryImpl extends AbstractKapuaNamedQuery implemen
     /**
      * Constructor.
      *
-     * @param scopeId The {@link #getScopeId()}.
      * @since 1.0.0
      */
-    public MfaOptionMigratorQueryImpl(KapuaId scopeId) {
-        super(scopeId);
+    public MfaOptionMigratorQueryImpl() {
+        super();
     }
 }

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorServiceImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/authentication/MfaOptionMigratorServiceImpl.java
@@ -1,0 +1,92 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.authentication;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
+import org.eclipse.kapua.extras.migrator.encryption.MigratorEntityManagerFactory;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionListResult;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionService;
+
+import javax.inject.Singleton;
+
+/**
+ * {@link MfaOptionService} implementation.
+ *
+ * @since 1.0.0
+ */
+@Singleton
+public class MfaOptionMigratorServiceImpl extends AbstractKapuaService implements MfaOptionService {
+
+    public MfaOptionMigratorServiceImpl() {
+        super(MigratorEntityManagerFactory.getInstance(), null);
+    }
+
+    @Override
+    public MfaOption update(MfaOption mfaOption) throws KapuaException {
+        return entityManagerSession.doTransactedAction((em) -> MfaOptionMigratorDAO.update(em, mfaOption));
+    }
+
+    @Override
+    public MfaOptionListResult query(KapuaQuery query) throws KapuaException {
+        return entityManagerSession.doAction(em -> MfaOptionMigratorDAO.query(em, query));
+    }
+
+    @Override
+    public long count(KapuaQuery query) throws KapuaException {
+        return entityManagerSession.doAction(em -> MfaOptionMigratorDAO.count(em, query));
+    }
+
+    //
+    // Unsupported methods
+    //
+
+    @Override
+    public MfaOption create(MfaOptionCreator mfaOptionCreator) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MfaOption find(KapuaId scopeId, KapuaId mfaOptionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId mfaOptionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public MfaOption findByUserId(KapuaId scopeId, KapuaId userId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String enableTrust(MfaOption mfaOption) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String enableTrust(KapuaId scopeId, KapuaId mfaOptionId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void disableTrust(KapuaId scopeId, KapuaId mfaOptionId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepAttributeMigrator.java
@@ -12,19 +12,18 @@
  *******************************************************************************/
 package org.eclipse.kapua.extras.migrator.encryption.job;
 
-import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.api.AbstractEntityAttributeMigrator;
 import org.eclipse.kapua.extras.migrator.encryption.api.EntitySecretAttributeMigrator;
-import org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigratorQueryImpl;
-import org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigratorServiceImpl;
-import org.eclipse.kapua.model.KapuaEntityAttributes;
-import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.service.job.step.JobStep;
 
-import java.util.List;
-
-public class JobStepAttributeMigrator implements EntitySecretAttributeMigrator<JobStep> {
+public class JobStepAttributeMigrator extends AbstractEntityAttributeMigrator<JobStep> implements EntitySecretAttributeMigrator<JobStep> {
 
     private static final JobStepMigratorServiceImpl JOB_STEP_MIGRATOR_SERVICE = new JobStepMigratorServiceImpl();
+
+    public JobStepAttributeMigrator() {
+        super(JOB_STEP_MIGRATOR_SERVICE);
+    }
 
     @Override
     public String getEntityName() {
@@ -32,29 +31,7 @@ public class JobStepAttributeMigrator implements EntitySecretAttributeMigrator<J
     }
 
     @Override
-    public void migrate(List<JobStep> entitiesToMigrate) throws KapuaException {
-        for (JobStep jobStep : entitiesToMigrate) {
-            JOB_STEP_MIGRATOR_SERVICE.update(jobStep);
-        }
-    }
-
-    @Override
-    public List<JobStep> getChunk(int offset, int limit) throws KapuaException {
-        JobStepMigratorQueryImpl query = new JobStepMigratorQueryImpl(null);
-
-        // This is the most stable sorting even if it is not always indexed
-        query.setSortCriteria(query.fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
-
-        query.setOffset(offset);
-        query.setLimit(limit);
-
-        return JOB_STEP_MIGRATOR_SERVICE.query(query).getItems();
-    }
-
-    @Override
-    public long getTotalCount() throws KapuaException {
-        JobStepMigratorQueryImpl query = new JobStepMigratorQueryImpl(null);
-
-        return JOB_STEP_MIGRATOR_SERVICE.count(query);
+    protected KapuaQuery newEntityQuery() {
+        return new JobStepMigratorQueryImpl();
     }
 }

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepAttributeMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepAttributeMigrator.java
@@ -1,0 +1,60 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.extras.migrator.encryption.api.EntitySecretAttributeMigrator;
+import org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigratorQueryImpl;
+import org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigratorServiceImpl;
+import org.eclipse.kapua.model.KapuaEntityAttributes;
+import org.eclipse.kapua.model.query.SortOrder;
+import org.eclipse.kapua.service.job.step.JobStep;
+
+import java.util.List;
+
+public class JobStepAttributeMigrator implements EntitySecretAttributeMigrator<JobStep> {
+
+    private static final JobStepMigratorServiceImpl JOB_STEP_MIGRATOR_SERVICE = new JobStepMigratorServiceImpl();
+
+    @Override
+    public String getEntityName() {
+        return JobStep.TYPE;
+    }
+
+    @Override
+    public void migrate(List<JobStep> entitiesToMigrate) throws KapuaException {
+        for (JobStep jobStep : entitiesToMigrate) {
+            JOB_STEP_MIGRATOR_SERVICE.update(jobStep);
+        }
+    }
+
+    @Override
+    public List<JobStep> getChunk(int offset, int limit) throws KapuaException {
+        JobStepMigratorQueryImpl query = new JobStepMigratorQueryImpl(null);
+
+        // This is the most stable sorting even if it is not always indexed
+        query.setSortCriteria(query.fieldSortCriteria(KapuaEntityAttributes.CREATED_ON, SortOrder.ASCENDING));
+
+        query.setOffset(offset);
+        query.setLimit(limit);
+
+        return JOB_STEP_MIGRATOR_SERVICE.query(query).getItems();
+    }
+
+    @Override
+    public long getTotalCount() throws KapuaException {
+        JobStepMigratorQueryImpl query = new JobStepMigratorQueryImpl(null);
+
+        return JOB_STEP_MIGRATOR_SERVICE.count(query);
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigrator.java
@@ -1,0 +1,113 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+
+import javax.persistence.CollectionTable;
+import javax.persistence.ElementCollection;
+import javax.persistence.Entity;
+import javax.persistence.JoinColumn;
+import javax.persistence.Table;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * {@link JobStep} implementation.
+ *
+ * @since 2.0.0
+ */
+@Entity(name = "JobStep")
+@Table(name = "job_job_step")
+public class JobStepMigrator extends AbstractKapuaNamedEntity implements JobStep {
+
+    @ElementCollection
+    @CollectionTable(name = "job_job_step_properties", joinColumns = @JoinColumn(name = "step_id", referencedColumnName = "id"))
+    private List<JobStepPropertyMigrator> stepProperties;
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    public JobStepMigrator() {
+    }
+
+    /**
+     * Clone constructor.
+     *
+     * @param jobStep The {@link JobStep} to clone.
+     * @since 2.0.0
+     */
+    public JobStepMigrator(JobStep jobStep) {
+        super(jobStep);
+
+        setStepProperties(jobStep.getStepProperties());
+    }
+
+    @Override
+    public List<JobStepPropertyMigrator> getStepProperties() {
+        if (stepProperties == null) {
+            stepProperties = new ArrayList<>();
+        }
+
+        return stepProperties;
+    }
+
+    @Override
+    public void setStepProperties(List<JobStepProperty> jobStepProperties) {
+
+        this.stepProperties = new ArrayList<>();
+
+        for (JobStepProperty sp : jobStepProperties) {
+            this.stepProperties.add(JobStepPropertyMigrator.parse(sp));
+        }
+    }
+
+    //
+    // Attributes below do not require migration
+    //
+
+    @Override
+    public KapuaId getJobId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setJobId(KapuaId jobId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public int getStepIndex() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setStepIndex(int stepIndex) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public KapuaId getJobStepDefinitionId() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setJobStepDefinitionId(KapuaId jobDefinitionId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorDAO.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorDAO.java
@@ -1,0 +1,73 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.KapuaEntityNotFoundException;
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.jpa.EntityManager;
+import org.eclipse.kapua.commons.service.internal.ServiceDAO;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.JobStepCreator;
+import org.eclipse.kapua.service.job.step.JobStepListResult;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+
+/**
+ * JobStep DAO
+ *
+ * @since 2.0.0
+ */
+public class JobStepMigratorDAO {
+
+    private JobStepMigratorDAO() {
+    }
+
+    public static JobStep update(EntityManager em, JobStep jobStep) throws KapuaException {
+        JobStepMigrator jobStepImpl = (JobStepMigrator) jobStep;
+
+        for (JobStepProperty jobStepProperty : jobStepImpl.getStepProperties()) {
+            jobStepProperty.setPropertyValue(jobStepProperty.getPropertyValue());
+        }
+
+        return ServiceDAO.update(em, JobStepMigrator.class, jobStepImpl);
+    }
+
+    public static JobStepListResult query(EntityManager em, KapuaQuery jobStepQuery) throws KapuaException {
+        return ServiceDAO.query(em, JobStep.class, JobStepMigrator.class, new JobStepMigratorListResultImpl(), jobStepQuery);
+    }
+
+    public static long count(EntityManager em, KapuaQuery jobStepQuery) throws KapuaException {
+        return ServiceDAO.count(em, JobStep.class, JobStepMigrator.class, jobStepQuery);
+    }
+
+    //
+    // Unsupported methods
+    //
+
+    public static JobStep create(EntityManager em, JobStepCreator jobStepCreator) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static JobStep find(EntityManager em, KapuaId scopeId, KapuaId jobStepId) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static JobStep findByName(EntityManager em, String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    public static JobStep delete(EntityManager em, KapuaId scopeId, KapuaId jobStepId) throws KapuaEntityNotFoundException {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorListResultImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorListResultImpl.java
@@ -1,0 +1,25 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.commons.model.query.KapuaListResultImpl;
+import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.JobStepListResult;
+
+/**
+ * {@link JobStepListResult} implementation.
+ *
+ * @since 1.0.0
+ */
+public class JobStepMigratorListResultImpl extends KapuaListResultImpl<JobStep> implements JobStepListResult {
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorQueryImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorQueryImpl.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.extras.migrator.encryption.job;
 
 import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
-import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.service.job.step.JobStepQuery;
 
 /**
@@ -26,10 +25,9 @@ public class JobStepMigratorQueryImpl extends AbstractKapuaNamedQuery implements
     /**
      * Constructor.
      *
-     * @param scopeId The {@link #getScopeId()}.
      * @since 1.0.0
      */
-    public JobStepMigratorQueryImpl(KapuaId scopeId) {
-        super(scopeId);
+    public JobStepMigratorQueryImpl() {
+        super();
     }
 }

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorQueryImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorQueryImpl.java
@@ -1,0 +1,35 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.commons.model.query.AbstractKapuaNamedQuery;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.service.job.step.JobStepQuery;
+
+/**
+ * {@link JobStepQuery} definition.
+ *
+ * @since 1.0.0
+ */
+public class JobStepMigratorQueryImpl extends AbstractKapuaNamedQuery implements JobStepQuery {
+
+    /**
+     * Constructor.
+     *
+     * @param scopeId The {@link #getScopeId()}.
+     * @since 1.0.0
+     */
+    public JobStepMigratorQueryImpl(KapuaId scopeId) {
+        super(scopeId);
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorServiceImpl.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepMigratorServiceImpl.java
@@ -1,0 +1,72 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.KapuaException;
+import org.eclipse.kapua.commons.service.internal.AbstractKapuaService;
+import org.eclipse.kapua.extras.migrator.encryption.MigratorEntityManagerFactory;
+import org.eclipse.kapua.model.id.KapuaId;
+import org.eclipse.kapua.model.query.KapuaQuery;
+import org.eclipse.kapua.service.job.step.JobStep;
+import org.eclipse.kapua.service.job.step.JobStepCreator;
+import org.eclipse.kapua.service.job.step.JobStepListResult;
+import org.eclipse.kapua.service.job.step.JobStepService;
+
+import javax.inject.Singleton;
+
+/**
+ * {@link JobStepService} implementation.
+ *
+ * @since 1.0.0
+ */
+@Singleton
+public class JobStepMigratorServiceImpl extends AbstractKapuaService implements JobStepService {
+
+    public JobStepMigratorServiceImpl() {
+        super(MigratorEntityManagerFactory.getInstance(), null);
+    }
+
+    @Override
+    public JobStep update(JobStep jobStep) throws KapuaException {
+        return entityManagerSession.doTransactedAction((em) -> JobStepMigratorDAO.update(em, jobStep));
+    }
+
+    @Override
+    public JobStepListResult query(KapuaQuery query) throws KapuaException {
+        return entityManagerSession.doAction(em -> JobStepMigratorDAO.query(em, query));
+    }
+
+    @Override
+    public long count(KapuaQuery query) throws KapuaException {
+        return entityManagerSession.doAction(em -> JobStepMigratorDAO.count(em, query));
+    }
+
+    //
+    // Unsupported methods
+    //
+
+    @Override
+    public JobStep create(JobStepCreator jobStepCreator) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public JobStep find(KapuaId scopeId, KapuaId jobStepId) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void delete(KapuaId scopeId, KapuaId jobStepId) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepPropertyMigrator.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/job/JobStepPropertyMigrator.java
@@ -1,0 +1,193 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.job;
+
+import org.eclipse.kapua.extras.migrator.encryption.utils.SecretAttributeMigratorModelUtils;
+import org.eclipse.kapua.service.job.step.definition.JobStepProperty;
+
+import javax.persistence.Basic;
+import javax.persistence.Column;
+import javax.persistence.Embeddable;
+
+@Embeddable
+public class JobStepPropertyMigrator implements JobStepProperty {
+
+    @Basic
+    @Column(name = "name", nullable = false, updatable = false)
+    private String name;
+
+    @Basic
+    @Column(name = "property_type", nullable = false, updatable = false)
+    private String propertyType;
+
+    @Basic
+    @Column(name = "property_value")
+    private String propertyValue;
+
+    @Basic
+    @Column(name = "required", nullable = true, updatable = true)
+    private Boolean required;
+
+    @Basic
+    @Column(name = "secret", nullable = true, updatable = true)
+    private Boolean secret;
+
+    @Basic
+    @Column(name = "example_value", nullable = true, updatable = true)
+    private String propertyExampleValue;
+
+    @Basic
+    @Column(name = "min_length", nullable = true, updatable = true)
+    private Integer minLength;
+
+    @Basic
+    @Column(name = "max_length", nullable = true, updatable = true)
+    private Integer maxLength;
+
+    @Basic
+    @Column(name = "min_value", nullable = true, updatable = true)
+    private String minValue;
+
+    @Basic
+    @Column(name = "max_value", nullable = true, updatable = true)
+    private String maxValue;
+
+    @Basic
+    @Column(name = "validation_regex", nullable = true, updatable = true)
+    private String validationRegex;
+
+    public JobStepPropertyMigrator() {
+    }
+
+    private JobStepPropertyMigrator(JobStepProperty jobStepProperty) {
+        setPropertyValue(jobStepProperty.getPropertyValue());
+    }
+
+    @Override
+    public String getPropertyValue() {
+        return SecretAttributeMigratorModelUtils.read(propertyValue);
+    }
+
+    @Override
+    public void setPropertyValue(String propertyValue) {
+        this.propertyValue = SecretAttributeMigratorModelUtils.write(propertyValue);
+    }
+
+    public static JobStepPropertyMigrator parse(JobStepProperty jobStepProperty) {
+        return jobStepProperty != null ? (jobStepProperty instanceof JobStepPropertyMigrator ? (JobStepPropertyMigrator) jobStepProperty : new JobStepPropertyMigrator(jobStepProperty)) : null;
+    }
+
+    //
+    // Attributes below do not require migration
+    //
+
+    @Override
+    public String getName() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setName(String name) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getPropertyType() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setPropertyType(String propertyType) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getExampleValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setExampleValue(String exampleValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Boolean getRequired() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setRequired(Boolean required) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Boolean getSecret() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setSecret(Boolean se) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getMinLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMinLength(Integer minLength) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public Integer getMaxLength() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMaxLength(Integer maxLength) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMinValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMinValue(String minValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getMaxValue() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setMaxValue(String maxValue) {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public String getValidationRegex() {
+        throw new UnsupportedOperationException();
+    }
+
+    @Override
+    public void setValidationRegex(String validationRegex) {
+        throw new UnsupportedOperationException();
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettingKeys.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettingKeys.java
@@ -1,0 +1,70 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.settings;
+
+import org.eclipse.kapua.commons.setting.SettingKey;
+import org.eclipse.kapua.extras.migrator.encryption.authentication.MfaOptionMigrator;
+import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
+
+/**
+ * {@link SettingKey}s for {@link EncryptionMigrationSettings}.
+ *
+ * @since 2.0.0
+ */
+public enum EncryptionMigrationSettingKeys implements SettingKey {
+
+    /**
+     * The old encryption key.
+     *
+     * @since 2.0.0
+     */
+    OLD_ENCRYPTION_KEY("migrator.encryption.key.old"),
+
+    /**
+     * The old encryption key used in the {@link MfaOption#getMfaSecretKey()} encryption.
+     * <p>
+     * See {@link MfaOptionMigrator#getMfaSecretKey()}
+     *
+     * @since 2.0.0
+     */
+    MFA_OLD_ENCRYPTION_KEY("migrator.encryption.key.mfa"),
+
+    /**
+     * The old encryption key.
+     *
+     * @since 2.0.0
+     */
+    NEW_ENCRYPTION_KEY("migrator.encryption.key.new");
+
+    /**
+     * The key value of the {@link SettingKey}.
+     *
+     * @since 2.0.0
+     */
+    private final String key;
+
+    /**
+     * Constructor.
+     *
+     * @param key The key value of the {@link SettingKey}.
+     * @since 2.0.0
+     */
+    EncryptionMigrationSettingKeys(String key) {
+        this.key = key;
+    }
+
+    @Override
+    public String key() {
+        return key;
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettingKeys.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettingKeys.java
@@ -24,6 +24,13 @@ import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 public enum EncryptionMigrationSettingKeys implements SettingKey {
 
     /**
+     * Whether running in dry run mode ot not.
+     *
+     * @since 2.0.0
+     */
+    DRY_RUN("migrator.encryption.dryRun"),
+
+    /**
      * The old encryption key.
      *
      * @since 2.0.0

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettings.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/settings/EncryptionMigrationSettings.java
@@ -1,0 +1,57 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.settings;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * {@link EncryptionMigrationSettings} for {@code kapua-encryption-migrator} module.
+ *
+ * @see AbstractKapuaSetting
+ * @since 2.0.0
+ */
+public class EncryptionMigrationSettings extends AbstractKapuaSetting<EncryptionMigrationSettingKeys> {
+
+    /**
+     * Setting filename.
+     *
+     * @since 2.0.0
+     */
+    private static final String SETTINGS_RESOURCE = "encryption-migrator-settings.properties";
+
+    /**
+     * Singleton instance.
+     *
+     * @since 2.0.0
+     */
+    private static final EncryptionMigrationSettings INSTANCE = new EncryptionMigrationSettings();
+
+    /**
+     * Constructor.
+     *
+     * @since 2.0.0
+     */
+    private EncryptionMigrationSettings() {
+        super(SETTINGS_RESOURCE);
+    }
+
+    /**
+     * Gets a singleton instance of {@link EncryptionMigrationSettings}.
+     *
+     * @return A singleton instance of {@link EncryptionMigrationSettings}.
+     * @since 2.0.0
+     */
+    public static EncryptionMigrationSettings getInstance() {
+        return INSTANCE;
+    }
+}

--- a/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/utils/SecretAttributeMigratorModelUtils.java
+++ b/extras/encryption-migrator/src/main/java/org/eclipse/kapua/extras/migrator/encryption/utils/SecretAttributeMigratorModelUtils.java
@@ -1,0 +1,65 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.migrator.encryption.utils;
+
+import com.google.common.base.Strings;
+import org.eclipse.kapua.commons.crypto.CryptoUtil;
+import org.eclipse.kapua.commons.crypto.exception.AesDecryptionException;
+import org.eclipse.kapua.commons.crypto.exception.AesEncryptionException;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettingKeys;
+import org.eclipse.kapua.extras.migrator.encryption.settings.EncryptionMigrationSettings;
+
+import javax.persistence.PersistenceException;
+
+/**
+ * @since 2.0.0
+ */
+public class SecretAttributeMigratorModelUtils {
+
+    private static final String AES_V1 = "$aes$";
+
+    private static final String OLD_ENCRYPTION_KEY = EncryptionMigrationSettings.getInstance().getString(EncryptionMigrationSettingKeys.OLD_ENCRYPTION_KEY);
+    private static final String NEW_ENCRYPTION_KEY = EncryptionMigrationSettings.getInstance().getString(EncryptionMigrationSettingKeys.NEW_ENCRYPTION_KEY);
+
+    private SecretAttributeMigratorModelUtils() {
+    }
+
+    public static String read(String databaseValue) {
+        if (Strings.isNullOrEmpty(databaseValue)) {
+            return databaseValue;
+        }
+
+        // Handling encryption versions
+        if (databaseValue.startsWith(AES_V1)) {
+            try {
+                return CryptoUtil.decryptAes(databaseValue.substring(AES_V1.length()), OLD_ENCRYPTION_KEY);
+            } catch (AesDecryptionException e) {
+                throw new PersistenceException("Cannot read value from entity", e);
+            }
+        } else {
+            return databaseValue;
+        }
+    }
+
+    public static String write(String entityAttribute) {
+        if (Strings.isNullOrEmpty(entityAttribute)) {
+            return entityAttribute;
+        }
+
+        try {
+            return AES_V1 + CryptoUtil.encryptAes(entityAttribute, NEW_ENCRYPTION_KEY);
+        } catch (AesEncryptionException e) {
+            throw new PersistenceException("Cannot write value to entity", e);
+        }
+    }
+}

--- a/extras/encryption-migrator/src/main/resources/META-INF/persistence.xml
+++ b/extras/encryption-migrator/src/main/resources/META-INF/persistence.xml
@@ -1,0 +1,103 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<persistence xmlns="http://java.sun.com/xml/ns/persistence"
+             xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+             xsi:schemaLocation="http://java.sun.com/xml/ns/persistence http://java.sun.com/xml/ns/persistence/persistence_2_0.xsd"
+             version="2.0">
+    <persistence-unit name="kapua-encryption-migrator" transaction-type="RESOURCE_LOCAL">
+
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <class>org.eclipse.kapua.extras.migrator.encryption.authentication.MfaOptionMigrator</class>
+        <class>org.eclipse.kapua.extras.migrator.encryption.job.JobStepMigrator</class>
+
+        <!-- Base classes and External classes -->
+        <class>org.eclipse.kapua.extras.migrator.encryption.utils.SecretAttributeMigratorModelUtils</class>
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
+
+        <properties>
+            <property name="javax.persistence.lock.timeout" value="1000"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="kapua-authentication" transaction-type="RESOURCE_LOCAL">
+
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <!-- Authentication -->
+        <class>org.eclipse.kapua.service.authentication.credential.shiro.CredentialImpl</class>
+        <class>org.eclipse.kapua.service.authentication.token.shiro.AccessTokenImpl</class>
+        <class>org.eclipse.kapua.service.authentication.credential.mfa.shiro.MfaOptionImpl</class>
+        <class>org.eclipse.kapua.service.authentication.credential.mfa.shiro.ScratchCodeImpl</class>
+
+        <!-- Base classes and External classes -->
+        <class>org.eclipse.kapua.commons.jpa.SecretAttributeConverter</class>
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
+        <class>org.eclipse.kapua.commons.configuration.ServiceConfigImpl</class>
+
+
+        <!-- event -->
+        <class>org.eclipse.kapua.commons.service.event.store.internal.EventStoreRecordImpl</class>
+        <class>org.eclipse.kapua.commons.event.ServiceEventHousekeeper</class>
+
+        <properties>
+            <property name="javax.persistence.lock.timeout" value="1000"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
+        </properties>
+    </persistence-unit>
+
+    <persistence-unit name="kapua-authorization" transaction-type="RESOURCE_LOCAL">
+
+        <provider>org.eclipse.persistence.jpa.PersistenceProvider</provider>
+
+        <!-- Authorization -->
+        <class>org.eclipse.kapua.service.authorization.access.shiro.AccessInfoImpl</class>
+        <class>org.eclipse.kapua.service.authorization.access.shiro.AccessRoleImpl</class>
+        <class>org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionImpl</class>
+
+        <class>org.eclipse.kapua.service.authorization.domain.shiro.DomainImpl</class>
+
+        <class>org.eclipse.kapua.service.authorization.group.shiro.GroupImpl</class>
+
+        <class>org.eclipse.kapua.service.authorization.permission.shiro.PermissionImpl</class>
+
+        <class>org.eclipse.kapua.service.authorization.role.shiro.RoleImpl</class>
+        <class>org.eclipse.kapua.service.authorization.role.shiro.RolePermissionImpl</class>
+
+        <!-- Base classes and External classes -->
+        <class>org.eclipse.kapua.commons.jpa.SecretAttributeConverter</class>
+        <class>org.eclipse.kapua.commons.model.id.KapuaEid</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaNamedEntity</class>
+        <class>org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity</class>
+        <class>org.eclipse.kapua.commons.configuration.ServiceConfigImpl</class>
+
+        <!-- event -->
+        <class>org.eclipse.kapua.commons.event.service.internal.ServiceEventImpl</class>
+        <class>org.eclipse.kapua.commons.event.ServiceEventHousekeeper</class>
+
+        <properties>
+            <property name="javax.persistence.lock.timeout" value="1000"/>
+            <property name="eclipselink.logging.logger" value="org.eclipse.persistence.logging.slf4j.SLF4JLogger"/>
+        </properties>
+    </persistence-unit>
+</persistence>

--- a/extras/encryption-migrator/src/main/resources/encryption-migrator-settings.properties
+++ b/extras/encryption-migrator/src/main/resources/encryption-migrator-settings.properties
@@ -1,3 +1,5 @@
+migrator.encryption.dryRun=false
+
 migrator.encryption.key.old=changeMePlease!!
 migrator.encryption.key.new=changedMeThanks!
 

--- a/extras/encryption-migrator/src/main/resources/encryption-migrator-settings.properties
+++ b/extras/encryption-migrator/src/main/resources/encryption-migrator-settings.properties
@@ -1,0 +1,5 @@
+migrator.encryption.key.old=changeMePlease!!
+migrator.encryption.key.new=changedMeThanks!
+
+# This value was the old one used by the MfaOptionDAO when persisting the info
+migrator.encryption.key.mfa=rv;ipse329183!@#

--- a/extras/encryption-migrator/src/main/resources/liquibase/changelog-migration-tool-master.xml
+++ b/extras/encryption-migrator/src/main/resources/liquibase/changelog-migration-tool-master.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+                   xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                   xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.0.xsd">
+
+</databaseChangeLog>

--- a/extras/encryption-migrator/src/main/resources/locator.xml
+++ b/extras/encryption-migrator/src/main/resources/locator.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<!DOCTYPE xml>
+<locator-config>
+    <provided/>
+
+    <packages>
+        <package>org.eclipse.kapua.commons</package>
+        <package>org.eclipse.kapua.service</package>
+    </packages>
+</locator-config>

--- a/extras/encryption-migrator/src/main/resources/logback.xml
+++ b/extras/encryption-migrator/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="WARN"/>
+
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -27,6 +27,7 @@
     <modules>
         <module>foreignkeys</module>
         <module>es-migrator</module>
+        <module>encryption-migrator</module>
     </modules>
 
 </project>

--- a/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
+++ b/qa/common/src/main/java/org/eclipse/kapua/qa/common/BasicSteps.java
@@ -14,6 +14,7 @@
 package org.eclipse.kapua.qa.common;
 
 import org.apache.shiro.SecurityUtils;
+import org.eclipse.kapua.commons.crypto.setting.CryptoSettingKeys;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.commons.setting.system.SystemSetting;
@@ -322,6 +323,7 @@ public class BasicSteps extends TestBase {
         if (additionalOptions!=null) {
             System.setProperty(SystemSettingKey.DB_CONNECTION_ADDITIONAL_OPTIONS.key(), additionalOptions);
         }
+        System.setProperty(CryptoSettingKeys.CRYPTO_SECRET_KEY.key(), "kapuaTestsKey!!!");
         System.setProperty("certificate.jwt.private.key", jwtKey);
         System.setProperty("certificate.jwt.certificate", jwtCertificate);
         System.setProperty("broker.ip", brokerIp);

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -34,11 +34,9 @@ import com.spotify.docker.client.messages.Network;
 import com.spotify.docker.client.messages.NetworkConfig;
 import com.spotify.docker.client.messages.NetworkCreation;
 import com.spotify.docker.client.messages.PortBinding;
-
 import io.cucumber.java.en.And;
 import io.cucumber.java.en.Given;
 import io.cucumber.java.en.Then;
-
 import org.apache.activemq.command.BrokerInfo;
 import org.eclipse.kapua.qa.common.BasicSteps;
 import org.eclipse.kapua.qa.common.DBHelper;
@@ -219,8 +217,7 @@ public class DockerSteps {
                 logger.info("Consumers not ready after {}s... wait", (loops * WAIT_STEP / 1000));
             }
             logger.info("Consumers ready");
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             logger.error("Error while starting full docker environment: {}", e.getMessage(), e);
             throw e;
         }
@@ -258,8 +255,7 @@ public class DockerSteps {
             synchronized (this) {
                 this.wait(WAIT_FOR_JOB_ENGINE);
             }
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             logger.error("Error while starting base docker environment: {}", e.getMessage(), e);
             throw e;
         }
@@ -413,14 +409,14 @@ public class DockerSteps {
         List<Image> images = DockerUtil.getDockerClient().listImages(DockerClient.ListImagesParam.allImages());
         int count = 0;
         if ((images != null) && (images.size() > 0)) {
-             count = images.size();
-             logger.info("ids:");
-             for (Image image : images) {
+            count = images.size();
+            logger.info("ids:");
+            for (Image image : images) {
                 if (filterImageToPrint(image)) {
-                   StringBuilder builder = new StringBuilder();
-                   builder.append(image.id());
-                   image.repoTags().forEach(value -> builder.append("\t").append(value));
-                   logger.info("{}", builder.toString());
+                    StringBuilder builder = new StringBuilder();
+                    builder.append(image.id());
+                    image.repoTags().forEach(value -> builder.append("\t").append(value));
+                    logger.info("{}", builder.toString());
                 }
             }
         }
@@ -446,8 +442,7 @@ public class DockerSteps {
             containerList.forEach(container -> {
                 container.names().forEach((containerName) -> logger.info("\t\t{}", containerName));
             });
-        }
-        catch (DockerException | InterruptedException e) {
+        } catch (DockerException | InterruptedException e) {
             logger.warn("Cannot print container name for step '{}'", description, e);
         }
         logger.info("Print containers ({}) DONE - {}", count, description);
@@ -598,15 +593,14 @@ public class DockerSteps {
                     printContainerLog(name);
                 }
             }
-        }
-        else {
+        } else {
             logger.info("Print containers log in exit disabled.");
         }
     }
 
     private boolean isPrintContainer(String name) {
         return BasicSteps.JOB_ENGINE_CONTAINER_NAME.equals(name) ||
-            BasicSteps.MESSAGE_BROKER_CONTAINER_NAME.equals(name);
+                BasicSteps.MESSAGE_BROKER_CONTAINER_NAME.equals(name);
     }
 
     private void printContainerLog(String name) {
@@ -622,10 +616,10 @@ public class DockerSteps {
                         Logger brokerLogger = LoggerFactory.getLogger(name);
                         brokerLogger.info("\n===================================================\n START LOG FOR CONTAINER: {} (id: {})\n===================================================", name, container.id());
                         StringBuilder builder = new StringBuilder();
-                        int i=0;
+                        int i = 0;
                         while (logStream.hasNext()) {
                             builder.append(StandardCharsets.UTF_8.decode(logStream.next().content()).toString());
-                            if (++i%100 == 0) {
+                            if (++i % 100 == 0) {
                                 brokerLogger.info(builder.toString());
                                 builder = new StringBuilder();
                             }
@@ -686,6 +680,7 @@ public class DockerSteps {
                 "commons.eventbus.url=failover:(amqp://events-broker:5672)?jms.sendTimeout=1000",
                 "certificate.jwt.private.key=file:///var/opt/activemq/key.pk8",
                 "certificate.jwt.certificate=file:///var/opt/activemq/cert.pem",
+                "crypto.secret.key=kapuaTestsKey!!!",
                 String.format("broker.ip=%s", brokerIp));
         if (envVar != null) {
             envVars.addAll(envVar);
@@ -763,7 +758,8 @@ public class DockerSteps {
                 .exposedPorts(ports)
                 .env(
                         "commons.db.schema.update=true",
-                        "BROKER_HOST=message-broker"
+                        "BROKER_HOST=message-broker",
+                        "crypto.secret.key=kapuaTestsKey!!!"
                 )
                 .image("kapua/kapua-consumer-telemetry:" + KAPUA_VERSION)
                 .build();
@@ -790,7 +786,8 @@ public class DockerSteps {
                 .exposedPorts(ports)
                 .env(
                         "commons.db.schema.update=true",
-                        "BROKER_HOST=message-broker"
+                        "BROKER_HOST=message-broker",
+                        "crypto.secret.key=kapuaTestsKey!!!"
                 )
                 .image("kapua/kapua-consumer-lifecycle:" + KAPUA_VERSION)
                 .build();
@@ -855,6 +852,9 @@ public class DockerSteps {
         return ContainerConfig.builder()
                 .hostConfig(hostConfig)
                 .exposedPorts(String.valueOf(jobEnginePort))
+                .env(
+                        "crypto.secret.key=kapuaTestsKey!!!"
+                )
                 .image("kapua/kapua-job-engine:" + KAPUA_VERSION)
                 .build();
     }

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/mfa/shiro/MfaOptionImpl.java
@@ -12,7 +12,6 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.authentication.credential.mfa.shiro;
 
-import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.jpa.SecretAttributeConverter;
 import org.eclipse.kapua.commons.model.AbstractKapuaUpdatableEntity;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
@@ -39,6 +38,8 @@ import java.util.List;
 
 /**
  * {@link MfaOption} implementation.
+ *
+ * @since 1.3.0
  */
 @XmlRootElement
 @XmlAccessorType(XmlAccessType.PROPERTY)
@@ -75,6 +76,8 @@ public class MfaOptionImpl extends AbstractKapuaUpdatableEntity implements MfaOp
 
     /**
      * Constructor.
+     *
+     * @since 1.3.0
      */
     public MfaOptionImpl() {
         super();
@@ -83,7 +86,8 @@ public class MfaOptionImpl extends AbstractKapuaUpdatableEntity implements MfaOp
     /**
      * Constructor.
      *
-     * @param scopeId The scope {@link KapuaId} to set into the {@link MfaOption}.
+     * @param scopeId The {@link MfaOption#getScopeId()}
+     * @since 1.3.0
      */
     public MfaOptionImpl(KapuaId scopeId) {
         super(scopeId);
@@ -109,10 +113,10 @@ public class MfaOptionImpl extends AbstractKapuaUpdatableEntity implements MfaOp
     /**
      * Clone constructor.
      *
-     * @param mfaOption
-     * @throws KapuaException
+     * @param mfaOption The {@link MfaOption} to clone.
+     * @since 1.3.0
      */
-    public MfaOptionImpl(MfaOption mfaOption) throws KapuaException {
+    public MfaOptionImpl(MfaOption mfaOption) {
         super(mfaOption);
         setUserId(mfaOption.getUserId());
         setMfaSecretKey(mfaOption.getMfaSecretKey());


### PR DESCRIPTION
This PR introduces the Entity Attribute Migration tool. 

This tool must be run when upgrading to Kapua 2.0.0 and any other time that the `cipher.key` or `crypto.secret.key` are changed in a deployment
 
**Related Issue**
This PR integrates changes in #3549 

**Description of the solution adopted**
Added the migration of 

- `MfaOption.mfaSecretKey`
- `JobStepProperty.propertyValue`

**Screenshots**
_None_

**Any side note on the changes made**
Check migrator tool README.md on usage