### PR TITLE
Fixed UserCreator.status mapping and references

### DIFF
--- a/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
+++ b/console/module/user/src/main/java/org/eclipse/kapua/app/console/module/user/server/GwtUserServiceImpl.java
@@ -115,7 +115,7 @@ public class GwtUserServiceImpl extends KapuaRemoteServiceServlet implements Gwt
             userCreator.setEmail(gwtUserCreator.getEmail());
             userCreator.setPhoneNumber(gwtUserCreator.getPhoneNumber());
             userCreator.setExpirationDate(gwtUserCreator.getExpirationDate());
-            userCreator.setUserStatus(GwtKapuaUserModelConverter.convertUserStatus(gwtUserCreator.getUserStatus()));
+            userCreator.setStatus(GwtKapuaUserModelConverter.convertUserStatus(gwtUserCreator.getUserStatus()));
             userCreator.setExternalId(gwtUserCreator.getExternalId());
             userCreator.setExternalUsername(gwtUserCreator.getExternalUsername());
 

--- a/qa/integration/src/test/resources/features/rest/user/RestUser.feature
+++ b/qa/integration/src/test/resources/features/rest/user/RestUser.feature
@@ -14,14 +14,14 @@
 Feature: REST API tests for User
   REST API test of Kapua User API.
 
-@setup
+  @setup
   Scenario: Start event broker for all scenarios
     Given Start Event Broker
     And Start Jetty Server on host "127.0.0.1" at port "8081"
 
   Scenario: Simple Jetty with rest-api war
-    Jetty with api.war is already started, now just login with sys user and
-    call GET on users to retrieve list of all users.
+  Jetty with api.war is already started, now just login with sys user and
+  call GET on users to retrieve list of all users.
 
     Given Server with host "127.0.0.1" on port "8081"
     When REST POST call at "/v1/authentication/user" with JSON "{"password": "kapua-password", "username": "kapua-sys"}"
@@ -38,14 +38,14 @@ Feature: REST API tests for User
 #    And REST response containing AccessToken
 #    And REST POST call at "/v1/AQ/accounts" with JSON "{"expirationDate": "2030-02-21T12:05:00.000Z", "organizationName": "Org A", "organizationPersonName": "Person Name", "organizationEmail": "person@org-a.com", "organizationPhoneNumber": "555-123-456", "organizationAddressLine1": "Address A", "organizationAddressLine2": "NA",  "organizationCity": "Ljubljana", "organizationZipPostCode": "1000", "organizationStateProvinceCounty": "Province", "organizationCountry": "Slovenia", "name": "Person Name","entityAttributes": {}, "scopeId": "1"}"
 #    Then REST response containing Account
-#    And REST POST call at "/v1/$lastAccountCompactId$/users" with JSON "{"displayName": "User A", "email": "user.a@comp-a.com", "phoneNumber": "555-123-456", "userType": "INTERNAL", "externalId": "", "expirationDate": "2030-02-21T12:05:00.000Z", "userStatus": "ENABLED", "name": "usera", "entityAttributes": {}, "scopeId": "$lastAccountId$"}"
+#    And REST POST call at "/v1/$lastAccountCompactId$/users" with JSON "{"displayName": "User A", "email": "user.a@comp-a.com", "phoneNumber": "555-123-456", "userType": "INTERNAL", "externalId": "", "expirationDate": "2030-02-21T12:05:00.000Z", "status": "ENABLED", "name": "usera", "entityAttributes": {}, "scopeId": "$lastAccountId$"}"
 #
 
   Scenario: Bug when user can retrieve user in another account if it has other account's user id
-    Prepare two different accounts with each having single user.
-    Login into account A.
-    Fetch user in that account and keep his ID.
-    Login into account B and search for user from previous step with its ID.
+  Prepare two different accounts with each having single user.
+  Login into account A.
+  Fetch user in that account and keep his ID.
+  Login into account B and search for user from previous step with its ID.
 
     Given Server with host "127.0.0.1" on port "8081"
 # ------ Service steps ------
@@ -130,8 +130,8 @@ Feature: REST API tests for User
     Then REST response code is 404
 
   Scenario: Retrieve all users and check if limitExceed value is true
-    Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 0 entries,
-    then the limitExceed value must be true.
+  Login with sys user and call GET on users to retrieve list of all users. Specify a limit of 0 entries,
+  then the limitExceed value must be true.
 
     Given Server with host "127.0.0.1" on port "8081"
     Given An authenticated user

--- a/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
+++ b/service/user/api/src/main/java/org/eclipse/kapua/service/user/UserCreator.java
@@ -132,8 +132,8 @@ public interface UserCreator extends KapuaNamedEntityCreator<User> {
 
     void setExpirationDate(Date expirationDate);
 
-    @XmlElement(name = "userStatus")
-    UserStatus getUserStatus();
+    @XmlElement(name = "status")
+    UserStatus getStatus();
 
-    void setUserStatus(UserStatus userStatus);
+    void setStatus(UserStatus status);
 }

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserCreatorImpl.java
@@ -30,7 +30,7 @@ public class UserCreatorImpl extends AbstractKapuaNamedEntityCreator<User> imple
 
     private static final long serialVersionUID = 4664940282892151008L;
 
-    private UserStatus userStatus;
+    private UserStatus status;
     private String displayName;
     private String email;
     private String phoneNumber;
@@ -48,7 +48,7 @@ public class UserCreatorImpl extends AbstractKapuaNamedEntityCreator<User> imple
     public UserCreatorImpl(KapuaId accountId, String name) {
         super(accountId, name);
 
-        setUserStatus(UserStatus.ENABLED);
+        setStatus(UserStatus.ENABLED);
         setUserType(UserType.INTERNAL);
     }
 
@@ -57,13 +57,13 @@ public class UserCreatorImpl extends AbstractKapuaNamedEntityCreator<User> imple
     }
 
     @Override
-    public UserStatus getUserStatus() {
-        return userStatus;
+    public UserStatus getStatus() {
+        return status;
     }
 
     @Override
-    public void setUserStatus(UserStatus userStatus) {
-        this.userStatus = userStatus;
+    public void setStatus(UserStatus status) {
+        this.status = status;
     }
 
     @Override

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserDAO.java
@@ -50,7 +50,7 @@ public class UserDAO extends ServiceDAO {
         userImpl.setUserType(userCreator.getUserType());
         userImpl.setExternalId(userCreator.getExternalId());
         userImpl.setExternalUsername(userCreator.getExternalUsername());
-        userImpl.setStatus(userCreator.getUserStatus());
+        userImpl.setStatus(userCreator.getStatus());
         userImpl.setExpirationDate(userCreator.getExpirationDate());
 
         return ServiceDAO.create(em, userImpl);

--- a/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
+++ b/service/user/internal/src/main/java/org/eclipse/kapua/service/user/internal/UserServiceImpl.java
@@ -87,7 +87,7 @@ public class UserServiceImpl extends AbstractKapuaConfigurableResourceLimitedSer
         ArgumentValidator.notEmptyOrNull(userCreator.getName(), "userCreator.name");
         ArgumentValidator.match(userCreator.getName(), CommonsValidationRegex.NAME_REGEXP, "userCreator.name");
         ArgumentValidator.match(userCreator.getEmail(), CommonsValidationRegex.EMAIL_REGEXP, "userCreator.email");
-        ArgumentValidator.notNull(userCreator.getUserStatus(), "userCreator.userStatus");
+        ArgumentValidator.notNull(userCreator.getStatus(), "userCreator.status");
 
         ArgumentValidator.notNull(userCreator.getUserType(), "userCreator.userType");
         if (userCreator.getUserType() == UserType.EXTERNAL) {

--- a/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
+++ b/service/user/test-steps/src/main/java/org/eclipse/kapua/service/user/steps/UserServiceSteps.java
@@ -12,6 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.service.user.steps;
 
+import com.google.inject.Singleton;
+import io.cucumber.java.After;
+import io.cucumber.java.Before;
+import io.cucumber.java.Scenario;
+import io.cucumber.java.en.And;
+import io.cucumber.java.en.Given;
+import io.cucumber.java.en.Then;
+import io.cucumber.java.en.When;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.commons.model.id.KapuaEid;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
@@ -35,12 +43,12 @@ import org.eclipse.kapua.service.authentication.LoginCredentials;
 import org.eclipse.kapua.service.authentication.credential.Credential;
 import org.eclipse.kapua.service.authentication.credential.CredentialAttributes;
 import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
-import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
 import org.eclipse.kapua.service.authentication.credential.CredentialFactory;
+import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
+import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 import org.eclipse.kapua.service.authentication.credential.CredentialService;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
-import org.eclipse.kapua.service.authentication.credential.CredentialQuery;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOption;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionCreator;
 import org.eclipse.kapua.service.authentication.credential.mfa.MfaOptionFactory;
@@ -51,33 +59,23 @@ import org.eclipse.kapua.service.authentication.credential.shiro.CredentialQuery
 import org.eclipse.kapua.service.authorization.access.AccessInfoCreator;
 import org.eclipse.kapua.service.authorization.access.AccessInfoFactory;
 import org.eclipse.kapua.service.authorization.access.AccessInfoService;
-import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionQueryImpl;
-import org.eclipse.kapua.service.authorization.access.AccessPermissionService;
-import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
 import org.eclipse.kapua.service.authorization.access.AccessPermission;
 import org.eclipse.kapua.service.authorization.access.AccessPermissionAttributes;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionQuery;
+import org.eclipse.kapua.service.authorization.access.AccessPermissionService;
+import org.eclipse.kapua.service.authorization.access.shiro.AccessPermissionQueryImpl;
 import org.eclipse.kapua.service.authorization.domain.DomainRegistryService;
 import org.eclipse.kapua.service.authorization.permission.Permission;
 import org.eclipse.kapua.service.authorization.permission.PermissionFactory;
 import org.eclipse.kapua.service.user.User;
+import org.eclipse.kapua.service.user.UserAttributes;
 import org.eclipse.kapua.service.user.UserCreator;
 import org.eclipse.kapua.service.user.UserFactory;
 import org.eclipse.kapua.service.user.UserListResult;
 import org.eclipse.kapua.service.user.UserQuery;
 import org.eclipse.kapua.service.user.UserService;
 import org.eclipse.kapua.service.user.UserStatus;
-import org.eclipse.kapua.service.user.UserAttributes;
 import org.junit.Assert;
-
-import com.google.inject.Singleton;
-
-import io.cucumber.java.After;
-import io.cucumber.java.Before;
-import io.cucumber.java.Scenario;
-import io.cucumber.java.en.And;
-import io.cucumber.java.en.Given;
-import io.cucumber.java.en.Then;
-import io.cucumber.java.en.When;
 
 import javax.inject.Inject;
 import java.math.BigInteger;
@@ -144,7 +142,7 @@ public class UserServiceSteps extends TestBase {
     // Definition of Cucumber scenario steps
     // *************************************
 
-    @After(value="@setup")
+    @After(value = "@setup")
     public void setServices() {
         KapuaLocator locator = KapuaLocator.getInstance();
         userService = locator.getService(UserService.class);
@@ -175,7 +173,7 @@ public class UserServiceSteps extends TestBase {
         uc.setDisplayName(displayName);
         uc.setEmail(userEmail);
         uc.setPhoneNumber("+1 555 123 4567");
-        uc.setUserStatus(UserStatus.ENABLED);
+        uc.setStatus(UserStatus.ENABLED);
         stepData.put(USER_CREATOR, uc);
         scenario.log("User " + userName + " created.");
     }
@@ -354,7 +352,7 @@ public class UserServiceSteps extends TestBase {
     @When("I count users in scope {int}")
     public void countUsersInScope(int scopeId) throws Exception {
         UserQuery query = userFactory.newQuery(new KapuaEid(BigInteger.valueOf(scopeId)));
-        stepData.updateCount((int)userService.count(query));
+        stepData.updateCount((int) userService.count(query));
     }
 
     @Then("I count {int} (user/users)")
@@ -905,7 +903,7 @@ public class UserServiceSteps extends TestBase {
         Assert.assertNotNull(user.getCreatedOn());
         Assert.assertNotNull(user.getCreatedBy());
         Assert.assertNotNull(user.getModifiedOn());
-        Assert. assertNotNull(user.getModifiedBy());
+        Assert.assertNotNull(user.getModifiedBy());
         if ((cucUser.getDisplayName() != null) && (cucUser.getDisplayName().length() > 0)) {
             Assert.assertEquals(cucUser.getDisplayName(), user.getDisplayName());
         }
@@ -1027,7 +1025,7 @@ public class UserServiceSteps extends TestBase {
                 LocalDate localDate1 = t1.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
                 LocalDate localDate2 = t2.toInstant().atZone(ZoneId.systemDefault()).toLocalDate();
                 if (localDate1.getYear() == localDate2.getYear() && localDate1.getMonthValue() == localDate2.getMonthValue()
-                    && localDate1.getDayOfMonth() == localDate2.getDayOfMonth()) {
+                        && localDate1.getDayOfMonth() == localDate2.getDayOfMonth()) {
                     matchUserData(foundUserItem.getUser(), userItem);
                     userChecks = true;
                     break;
@@ -1048,7 +1046,7 @@ public class UserServiceSteps extends TestBase {
         UserListResult queryResult = userService.query(query);
         iFoundUsers = new HashSet<>();
         List<User> users = queryResult.getItems();
-        for (User userItems : users){
+        for (User userItems : users) {
             iFoundUsers.add(new ComparableUser(userItems));
         }
         stepData.put(USER_LIST, iFoundUsers);
@@ -1087,7 +1085,7 @@ public class UserServiceSteps extends TestBase {
         UserListResult queryResult = userService.query(query);
         iFoundUsers = new HashSet<>();
         List<User> users = queryResult.getItems();
-        for (User userItems : users){
+        for (User userItems : users) {
             iFoundUsers.add(new ComparableUser(userItems));
         }
         stepData.put(USER_LIST, iFoundUsers);
@@ -1121,8 +1119,8 @@ public class UserServiceSteps extends TestBase {
     @And("I find users with phone number {string}")
     public void iFindUsersWithPhoneNumber(String phoneNumber) {
         UserListResult users = (UserListResult) stepData.get(FOUND_USERS);
-        for (User user : users.getItems()){
-            Assert.assertEquals(user.getPhoneNumber(),(phoneNumber));
+        for (User user : users.getItems()) {
+            Assert.assertEquals(user.getPhoneNumber(), (phoneNumber));
         }
         stepData.put(USER_LIST, users);
     }
@@ -1194,19 +1192,19 @@ public class UserServiceSteps extends TestBase {
 
     @And("I search users with email {string}")
     public void iSearchForUsersWithEmail(String email) throws Throwable {
-       UserQuery userQuery = userFactory.newQuery(DEFAULT_ID);
-       userQuery.setPredicate(userQuery.attributePredicate(UserAttributes.EMAIL, email, AttributePredicate.Operator.EQUAL));
-       UserListResult userListResult = userService.query(userQuery);
-       stepData.put(FOUND_USERS, userListResult);
+        UserQuery userQuery = userFactory.newQuery(DEFAULT_ID);
+        userQuery.setPredicate(userQuery.attributePredicate(UserAttributes.EMAIL, email, AttributePredicate.Operator.EQUAL));
+        UserListResult userListResult = userService.query(userQuery);
+        stepData.put(FOUND_USERS, userListResult);
     }
 
     @Then("I find users with email {string}")
     public void iFindUsersWithEmail(String email) {
-       UserListResult users = (UserListResult) stepData.get(FOUND_USERS);
-       for (User user : users.getItems()){
-           Assert.assertEquals(user.getEmail(), (email));
-       }
-       stepData.put(USER_LIST, users);
+        UserListResult users = (UserListResult) stepData.get(FOUND_USERS);
+        for (User user : users.getItems()) {
+            Assert.assertEquals(user.getEmail(), (email));
+        }
+        stepData.put(USER_LIST, users);
     }
 
     @And("^I enable mfa$")


### PR DESCRIPTION
This PR fixes the mapping and references of `UserCreator.status` field.

**Related Issue**
_None_

**Description of the solution adopted**
Renamed UserCreator.userStatus to `UserCreator.status`

**Screenshots**
_None_

**Any side note on the changes made**
_None_