### PR TITLE
Added mapping for CRYPTO_SECRET_KEY in Docker compose

### DIFF
--- a/assembly/api/docker/Dockerfile
+++ b/assembly/api/docker/Dockerfile
@@ -43,6 +43,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Djavax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory \
                -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
                -Djob.engine.client.auth.mode=access_token \
+               -Dcipher.key=\${CIPHER_KEY} \
+               -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
                \${JETTY_DEBUG_OPTS}"
 
 USER 0

--- a/assembly/broker/docker/Dockerfile
+++ b/assembly/broker/docker/Dockerfile
@@ -43,6 +43,8 @@ ENV ACTIVEMQ_OPTS "-Dcommons.db.schema.update=true \
                    -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
                    -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
                    -Djob.engine.client.auth.mode=trusted \
+                   -Dcipher.key=\${CIPHER_KEY} \
+                   -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
                    -Dorg.apache.activemq.SERIALIZABLE_PACKAGES=\${AMQ_SERIALIZABLE_PACKAGES:-java.lang,java.math,java.util,org.apache.activemq,org.fusesource.hawtbuf,org.eclipse.kapua}"
 
 EXPOSE 1883 1893 5672 8883 61614 61615 8161

--- a/assembly/console/docker/Dockerfile
+++ b/assembly/console/docker/Dockerfile
@@ -41,6 +41,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
                -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
                -Djob.engine.client.auth.mode=access_token \
+               -Dcipher.key=\${CIPHER_KEY} \
+               -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
                \${JETTY_DEBUG_OPTS}"
 
 USER 0

--- a/assembly/consumer/lifecycle/docker/Dockerfile
+++ b/assembly/consumer/lifecycle/docker/Dockerfile
@@ -36,7 +36,9 @@ ENV JAVA_OPTS -Dcommons.db.schema.update=true \
               -Dconsumer.jaxb_context_class_name=org.eclipse.kapua.consumer.lifecycle.LifecycleJAXBContextProvider \
               -Djob.engine.base.url=\${JOB_ENGINE_BASE_ADDR} \
               -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
-              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem
+              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
+              -Dcipher.key=\${CIPHER_KEY} \
+              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}
 
 EXPOSE 8080
 

--- a/assembly/consumer/telemetry/docker/Dockerfile
+++ b/assembly/consumer/telemetry/docker/Dockerfile
@@ -40,7 +40,9 @@ ENV JAVA_OPTS -Dcommons.db.schema.update=true \
               -Dbroker.host=\${BROKER_ADDR} \
               -Dbroker.port=\${BROKER_PORT} \
               -Dcertificate.jwt.private.key=file:///etc/opt/kapua/key.pk8 \
-              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem
+              -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
+              -Dcipher.key=\${CIPHER_KEY} \
+              -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY}
 
 EXPOSE 8080
 

--- a/assembly/job-engine/docker/Dockerfile
+++ b/assembly/job-engine/docker/Dockerfile
@@ -38,6 +38,8 @@ ENV JAVA_OPTS "-Dcommons.db.schema.update=true \
                -Dcertificate.jwt.certificate=file:///etc/opt/kapua/cert.pem \
                -Ddatastore.disable=\${KAPUA_DISABLE_DATASTORE:-false} \
                -Djavax.xml.bind.context.factory=org.eclipse.persistence.jaxb.JAXBContextFactory \
+               -Dcipher.key=\${CIPHER_KEY} \
+               -Dcrypto.secret.key=\${CRYPTO_SECRET_KEY} \
                \${JETTY_DEBUG_OPTS}"
 
 USER 0

--- a/commons/src/main/java/org/eclipse/kapua/commons/crypto/setting/CryptoSettingKeys.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/crypto/setting/CryptoSettingKeys.java
@@ -18,7 +18,7 @@ import org.eclipse.kapua.commons.setting.SettingKey;
 /**
  * {@link SettingKey}s for {@link CryptoSettings}.
  *
- * @since 2.0.0 "crypto.secret.key=kapuaTestsKey!!!",
+ * @since 2.0.0
  */
 public enum CryptoSettingKeys implements SettingKey {
 

--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -37,6 +37,7 @@ services:
       - db
       - events-broker
     environment:
+      - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CRT
@@ -58,6 +59,7 @@ services:
       - message-broker
     environment:
       - BROKER_URL
+      - CRYPTO_SECRET_KEY
       - LOGBACK_LOG_LEVEL
   consumer-lifecycle:
     container_name: consumer-lifecycle
@@ -70,6 +72,7 @@ services:
       - message-broker
     environment:
       - BROKER_URL
+      - CRYPTO_SECRET_KEY
       - LOGBACK_LOG_LEVEL
   kapua-console:
     container_name: kapua-console
@@ -83,6 +86,7 @@ services:
       - events-broker
       - message-broker
     environment:
+      - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CA
@@ -115,6 +119,7 @@ services:
       - events-broker
       - message-broker
     environment:
+      - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CA
@@ -134,6 +139,7 @@ services:
       - events-broker
       - message-broker
     environment:
+      - CRYPTO_SECRET_KEY
       - KAPUA_DISABLE_SSL
       - KAPUA_DISABLE_DATASTORE
       - KAPUA_CA

--- a/deployment/docker/unix/docker-common.sh
+++ b/deployment/docker/unix/docker-common.sh
@@ -16,3 +16,4 @@
 SCRIPT_DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 export IMAGE_VERSION=${IMAGE_VERSION:=latest}
+export CRYPTO_SECRET_KEY="${CRYPTO_SECRET_KEY:=dockerSecretKey!}"

--- a/deployment/docker/win/docker-common.ps1
+++ b/deployment/docker/win/docker-common.ps1
@@ -14,3 +14,7 @@
 if (!$ENV:IMAGE_VERSION) {
 	$ENV:IMAGE_VERSION = "latest"
 }
+
+if (!$ENV:CRYPTO_SECRET_KEY) {
+	$ENV:CRYPTO_SECRET_KEY = "dockerSecretKey!"
+}

--- a/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
+++ b/qa/integration-steps/src/main/java/org/eclipse/kapua/qa/integration/steps/DockerSteps.java
@@ -680,7 +680,7 @@ public class DockerSteps {
                 "commons.eventbus.url=failover:(amqp://events-broker:5672)?jms.sendTimeout=1000",
                 "certificate.jwt.private.key=file:///var/opt/activemq/key.pk8",
                 "certificate.jwt.certificate=file:///var/opt/activemq/cert.pem",
-                "crypto.secret.key=kapuaTestsKey!!!",
+                "CRYPTO_SECRET_KEY=kapuaTestsKey!!!",
                 String.format("broker.ip=%s", brokerIp));
         if (envVar != null) {
             envVars.addAll(envVar);
@@ -759,7 +759,7 @@ public class DockerSteps {
                 .env(
                         "commons.db.schema.update=true",
                         "BROKER_HOST=message-broker",
-                        "crypto.secret.key=kapuaTestsKey!!!"
+                        "CRYPTO_SECRET_KEY=kapuaTestsKey!!!"
                 )
                 .image("kapua/kapua-consumer-telemetry:" + KAPUA_VERSION)
                 .build();
@@ -787,7 +787,7 @@ public class DockerSteps {
                 .env(
                         "commons.db.schema.update=true",
                         "BROKER_HOST=message-broker",
-                        "crypto.secret.key=kapuaTestsKey!!!"
+                        "CRYPTO_SECRET_KEY=kapuaTestsKey!!!"
                 )
                 .image("kapua/kapua-consumer-lifecycle:" + KAPUA_VERSION)
                 .build();
@@ -853,7 +853,7 @@ public class DockerSteps {
                 .hostConfig(hostConfig)
                 .exposedPorts(String.valueOf(jobEnginePort))
                 .env(
-                        "crypto.secret.key=kapuaTestsKey!!!"
+                        "CRYPTO_SECRET_KEY=kapuaTestsKey!!!"
                 )
                 .image("kapua/kapua-job-engine:" + KAPUA_VERSION)
                 .build();


### PR DESCRIPTION
This PR integrates changes made in #3549 and #3551 with mapping new properties in Docker compose deployment

**Related Issue**
Integrates changes made in #3549 and #3551

**Description of the solution adopted**
Added mapping of CRYPTO_SECRET_KEY in Docker Compose deployment

**Screenshots**
_None_

**Any side note on the changes made**
_None_