### PR TITLE
DatastoreException malformed error message

### DIFF
--- a/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/model/utils/MappingUtils.java
+++ b/service/commons/storable/api/src/main/java/org/eclipse/kapua/service/storable/model/utils/MappingUtils.java
@@ -24,6 +24,8 @@ import org.eclipse.kapua.service.storable.exception.MappingException;
 import org.eclipse.kapua.service.storable.exception.UnsupportedTypeMappingException;
 import org.eclipse.kapua.service.storable.model.id.StorableId;
 import org.eclipse.kapua.service.storable.model.query.predicate.StorablePredicate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.text.ParseException;
 import java.util.Arrays;
@@ -38,6 +40,7 @@ import java.util.Date;
 public class MappingUtils {
 
     private final static JsonNodeFactory JSON_NODE_FACTORY = JsonNodeFactory.instance;
+    private static final Logger LOG = LoggerFactory.getLogger(MappingUtils.class);
 
     private MappingUtils() {
     }
@@ -75,6 +78,13 @@ public class MappingUtils {
             try {
                 node.set(name, JSON_NODE_FACTORY.textNode(KapuaDateUtils.formatDate((Date) value)));
             } catch (ParseException e) {
+                LOG.warn(
+                    "The value of mapping {} of value {} is not compatible with type {}. Error: {}",
+                    name,
+                    value,
+                    Date.class,
+                    e.getMessage()
+                );
                 throw new InvalidValueMappingException(e, name, value, Date.class);
             }
         } else if (value instanceof StorableId) {

--- a/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
+++ b/service/datastore/internal/src/main/java/org/eclipse/kapua/service/datastore/internal/MessageStoreServiceImpl.java
@@ -132,7 +132,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         } catch (Exception e) {
             metricGenericErrorCount.inc();
             metricQueueGenericErrorCount.inc();
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         } finally {
             metricDataSaveTimeContext.stop();
         }
@@ -162,7 +162,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         } catch (Exception e) {
             metricGenericErrorCount.inc();
             metricQueueGenericErrorCount.inc();
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         } finally {
             metricDataSaveTimeContext.stop();
         }
@@ -179,7 +179,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             return messageStoreFacade.find(scopeId, id, fetchStyle);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         }
     }
 
@@ -190,7 +190,11 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             return messageStoreFacade.query(query);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getCause().getMessage());
+            throw new DatastoreException(
+                KapuaErrorCodes.INTERNAL_ERROR,
+                e,
+                e.getCause().getMessage() != null ? e.getCause().getMessage() : e.getMessage()
+            );
         }
     }
 
@@ -201,7 +205,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             return messageStoreFacade.count(query);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         }
     }
 
@@ -212,7 +216,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             messageStoreFacade.delete(scopeId, id);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         }
     }
 
@@ -225,7 +229,7 @@ public class MessageStoreServiceImpl extends AbstractKapuaConfigurableService im
         try {
             messageStoreFacade.delete(query);
         } catch (Exception e) {
-            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e);
+            throw new DatastoreException(KapuaErrorCodes.INTERNAL_ERROR, e, e.getMessage());
         }
     }
 


### PR DESCRIPTION
**Brief description of the PR**
While the `DatastoreException` is raised with an `INTERNAL_ERROR` code, in the log it is printed as 
`org.eclipse.kapua.service.datastore.internal.mediator.DatastoreException: An internal error occurred: {0}`.
This PR is to fix the malformed printed error message.