### PR TITLE
Implement custom ES Rest Client error handler

### DIFF
--- a/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/AbstractElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-api/src/main/java/org/eclipse/kapua/service/elasticsearch/client/AbstractElasticsearchClient.java
@@ -25,7 +25,7 @@ public abstract class AbstractElasticsearchClient<C extends Closeable> implement
 
     protected String clientType;
 
-    private C client;
+    protected C client;
 
     private ElasticsearchClientConfiguration clientConfiguration;
     private ModelContext modelContext;

--- a/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
+++ b/service/commons/elasticsearch/client-rest/src/main/java/org/eclipse/kapua/service/elasticsearch/client/rest/RestElasticsearchClient.java
@@ -118,7 +118,13 @@ public class RestElasticsearchClient extends AbstractElasticsearchClient<RestCli
 
     @Override
     public void close() {
-        // No resources to close
+        if(client != null) {
+            try {
+                client.close();
+            } catch (IOException e) {
+                LOG.error("Error closing client", e);
+            }
+        }
     }
 
     @Override


### PR DESCRIPTION
Brief description of the PR.
This pr adds a proper error handler for the Rest client as suggested by this issue:
https://github.com/elastic/elasticsearch/issues/49124

**Related Issue**
fix #3563

**Description of the solution adopted**
The custom error handler should prevent the I/O reactor to be stopped by an error coming from the underlying layer.

**Screenshots**
none

**Any side note on the changes made**
none
