### PR TITLE
Console password tip report the special chars allowed

### DIFF
--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ConsoleMessages.properties
@@ -88,7 +88,7 @@ newPassword=New Password
 confirmPassword=Confirm Password
 changePasswordConfirmation=Password changed successfully!
 changePasswordError=Error while changing password: {0}
-dialogAddTooltipCredentialPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character.
+dialogAddTooltipCredentialPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | '\' ! " £ $ % & @ / [ ] ( ) '{' '}' = ? ^ '' > < , ; . : - _ * + € ^ ` ~
 changePasswordErrorWrongOldPassword=Invalid Old Password.
 changePasswordErrorWrongOldPasswordOrMfaCode=Invalid Old Password or Authentication Code.
 

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -33,8 +33,8 @@ name_space_colonRegexMsg=Name must be at least 3 characters and can contain alph
 name_space_colonToolTipMsg=Must be at least 3 characters and can contain alphanumeric characters combined with dash, underscore and/or space and/or colon.
 name_space_colonRequiredMsg=Name is required.
 
-passwordRegexMsg=Passwords must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character.
-passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character.
+passwordRegexMsg=Passwords must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | '\' ! " £ $ % & @ / [ ] ( ) '{' '}' = ? ^ '' > < , ; . : - _ * + € ^ ` ~
+passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | \ ! " £ $ % & @ / [ ] ( ) { } = ? ^ ' > < , ; . : - _ * + € ^ ` ~
 passwordRequiredMsg=Password is required.
 passwordDoesNotMatch=Password values do not match.
 

--- a/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
+++ b/console/module/api/src/main/resources/org/eclipse/kapua/app/console/module/api/client/messages/ValidationMessages.properties
@@ -34,7 +34,7 @@ name_space_colonToolTipMsg=Must be at least 3 characters and can contain alphanu
 name_space_colonRequiredMsg=Name is required.
 
 passwordRegexMsg=Passwords must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | '\' ! " £ $ % & @ / [ ] ( ) '{' '}' = ? ^ '' > < , ; . : - _ * + € ^ ` ~
-passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | \ ! " £ $ % & @ / [ ] ( ) { } = ? ^ ' > < , ; . : - _ * + € ^ ` ~
+passwordToolTipMsg=Must be {0} to 255 characters long and contain at least one lower case letter, one upper case letter, one digit and one special character.
 passwordRequiredMsg=Password is required.
 passwordDoesNotMatch=Password values do not match.
 

--- a/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
+++ b/console/module/authentication/src/main/resources/org/eclipse/kapua/app/console/module/authentication/client/messages/ConsoleCredentialMessages.properties
@@ -47,7 +47,7 @@ dialogAddFieldSubjectType=Subject Type
 dialogAddFieldSubject=Username
 dialogAddFieldPassword=Password
 dialogAddFieldConfirmPassword=Confirm Password
-dialogAddTooltipCredentialPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character.
+dialogAddTooltipCredentialPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | '\' ! " £ $ % & @ / [ ] ( ) '{' '}' = ? ^ '' > < , ; . : - _ * + € ^ ` ~
 dialogAddFieldExpirationDate=Expiration Date
 dialogAddFieldExpirationDateTooltip=Set the expiration date for the credential. It should be in format DD/MM/YYYY.
 dialogAddFieldExpirationDatePasswordTooltip=Set the expiration date for the password. It should be in format DD/MM/YYYY.

--- a/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
+++ b/console/module/user/src/main/resources/org/eclipse/kapua/app/console/module/user/client/messages/ConsoleUserMessages.properties
@@ -52,7 +52,7 @@ dialogAddFieldNameTooltip=Username must be at least 3 characters long and can co
 dialogAddFieldNameEditDialogTooltip=User''s unique name.
 dialogAddFieldPassword=Password
 dialogAddFieldConfirmPassword=Confirm Password
-dialogAddTooltipPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character.
+dialogAddTooltipPassword=Password must be {0} to 255 characters long and must contain at least one lower case letter, one upper case letter, one digit and one special character. Allowed special characters: # | '\' ! " £ $ % & @ / [ ] ( ) '{' '}' = ? ^ '' > < , ; . : - _ * + € ^ ` ~
 dialogAddFieldDisplayName=Display Name
 dialogAddFieldDisplayNameTooltip=Enter a display name for more complete profile of the user.
 dialogAddFieldEmail=Email


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3567, i.e. display a list of allowed special characters for the password fields.