### PR TITLE
Remove encoding for password changing

### DIFF
--- a/console/module/authentication/pom.xml
+++ b/console/module/authentication/pom.xml
@@ -36,6 +36,11 @@
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-security-authentication-api</artifactId>
         </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredential.java
+++ b/console/module/authentication/src/main/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredential.java
@@ -106,7 +106,7 @@ public class GwtCredential extends GwtUpdatableEntityModel {
     }
 
     public void setCredentialKey(String credentialKey) {
-        set("credentialKey", credentialKey);
+        set("credentialKey", credentialKey, false);
     }
 
     public String getUsername() {

--- a/console/module/authentication/src/test/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialTest.java
+++ b/console/module/authentication/src/test/java/org/eclipse/kapua/app/console/module/authentication/shared/model/GwtCredentialTest.java
@@ -1,0 +1,28 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.app.console.module.authentication.shared.model;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+public class GwtCredentialTest {
+
+    @Test
+    public void shouldSetCorrectPassword() {
+        GwtCredential gwtCredential = new GwtCredential();
+        String password = "foo%!`\"";
+        gwtCredential.setCredentialKey(password);
+        Assert.assertEquals(password, gwtCredential.getCredentialKey());
+    }
+
+}


### PR DESCRIPTION
**Brief description of the PR**
This PR fixes #3569, i.e. removes the encoding for special characters while updating a user password.