### PR TITLE
Crypto utils tests

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/crypto/CryptoUtil.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/crypto/CryptoUtil.java
@@ -187,7 +187,7 @@ public class CryptoUtil {
      * @return The decoded {@link String} value.
      * @since 1.0.0
      */
-    public static String decodeBase64(String value) {
+    public static String decodeBase64(@NotNull String value) {
         byte[] decodedBytes = DatatypeConverter.parseBase64Binary(value);
         return new String(decodedBytes, StandardCharsets.UTF_8);
     }
@@ -199,7 +199,7 @@ public class CryptoUtil {
      * @return The encoded {@link Base64} value.
      * @since 1.0.0
      */
-    public static String encodeBase64(String value) {
+    public static String encodeBase64(@NotNull String value) {
         byte[] bytesValue = value.getBytes(StandardCharsets.UTF_8);
         return DatatypeConverter.printBase64Binary(bytesValue);
     }
@@ -253,7 +253,7 @@ public class CryptoUtil {
      * @return The {@link Cipher} for the given secret key.
      * @since 2.0.0
      */
-    private static synchronized Cipher getDecryptCipherForKey(String alternativeSecretKey) {
+    private static synchronized Cipher getDecryptCipherForKey(@NotNull String alternativeSecretKey) {
         return ALTERNATIVES_AES_CIPHERS_DECRYPT.computeIfAbsent(alternativeSecretKey, secretKey -> {
             try {
                 Key key = new SecretKeySpec(secretKey.getBytes(), AES_ALGORITHM);
@@ -279,7 +279,7 @@ public class CryptoUtil {
      * @return The {@link Cipher} for the given secret key.
      * @since 2.0.0
      */
-    private static synchronized Cipher getEncryptCipherForKey(String alternativeSecretKey) {
+    private static synchronized Cipher getEncryptCipherForKey(@NotNull String alternativeSecretKey) {
         return ALTERNATIVES_AES_CIPHERS_ENCRYPT.computeIfAbsent(alternativeSecretKey, secretKey -> {
             try {
                 Key key = new SecretKeySpec(secretKey.getBytes(), AES_ALGORITHM);

--- a/commons/src/test/java/org/eclipse/kapua/commons/crypto/CryptoUtilTest.java
+++ b/commons/src/test/java/org/eclipse/kapua/commons/crypto/CryptoUtilTest.java
@@ -1,0 +1,129 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.crypto;
+
+import org.eclipse.kapua.commons.crypto.exception.AesDecryptionException;
+import org.eclipse.kapua.commons.crypto.exception.AesEncryptionException;
+import org.eclipse.kapua.commons.crypto.exception.InvalidSecretKeyRuntimeException;
+import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.junit.Assert;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * Test for {@link CryptoUtil}.
+ *
+ * @since 2.0.0
+ */
+@Category(JUnitTests.class)
+public class CryptoUtilTest extends Assert {
+
+    private static final String PLAIN_VALUE = "aPlainValue";
+    private static final String ALTERNATIVE_KEY = "alternativeKey!!";
+
+    //
+    // SHA1
+    //
+
+    @Test
+    public void testSha1Hashing() throws NoSuchAlgorithmException {
+        String hashedValue = CryptoUtil.sha1Hash(PLAIN_VALUE);
+
+        assertNotNull(hashedValue);
+        assertEquals("3VAfPtmZ+ldn8WsYl+hsDlITf+k=", hashedValue);
+    }
+
+
+    //
+    // AES
+    //
+
+    @Test
+    public void testAesCryptDecrypt() throws AesEncryptionException, AesDecryptionException {
+        String encryptedValue = CryptoUtil.encryptAes(PLAIN_VALUE);
+
+        assertNotNull(encryptedValue);
+        assertEquals("AVopb0Rbmz9P3XAuWmp/mA==", encryptedValue);
+
+        String decryptedValue = CryptoUtil.decryptAes(encryptedValue);
+        assertNotNull(decryptedValue);
+        assertEquals(PLAIN_VALUE, decryptedValue);
+    }
+
+    @Test
+    public void testAesCryptDecryptAlternativeKey() throws AesEncryptionException, AesDecryptionException {
+        String encryptedValue = CryptoUtil.encryptAes(PLAIN_VALUE, ALTERNATIVE_KEY);
+
+        assertNotNull(encryptedValue);
+        assertEquals("kYwVe4immFI/SuaSupaMxw==", encryptedValue);
+
+        String decryptedValue = CryptoUtil.decryptAes(encryptedValue, ALTERNATIVE_KEY);
+        assertNotNull(decryptedValue);
+        assertEquals(PLAIN_VALUE, decryptedValue);
+    }
+
+    @Test
+    public void testAesCryptDecryptDifferentKeys() throws AesEncryptionException, AesDecryptionException {
+        String encryptedValue1 = CryptoUtil.encryptAes(PLAIN_VALUE);
+        String encryptedValue2 = CryptoUtil.encryptAes(PLAIN_VALUE, ALTERNATIVE_KEY);
+
+        assertNotNull(encryptedValue1);
+        assertNotNull(encryptedValue2);
+        assertNotEquals(encryptedValue1, encryptedValue2);
+
+        String decryptedValue1 = CryptoUtil.decryptAes(encryptedValue1);
+        String decryptedValue2 = CryptoUtil.decryptAes(encryptedValue2, ALTERNATIVE_KEY);
+
+        assertNotNull(decryptedValue1);
+        assertNotNull(decryptedValue2);
+        assertEquals(decryptedValue1, decryptedValue2);
+    }
+
+    @Test(expected = InvalidSecretKeyRuntimeException.class)
+    public void testAesEncryptInvalidAlternativeKey() throws AesEncryptionException {
+        CryptoUtil.encryptAes(PLAIN_VALUE, "notAValidKey");
+    }
+
+    @Test(expected = InvalidSecretKeyRuntimeException.class)
+    public void testAesDecryptInvalidAlternativeKey() throws AesDecryptionException {
+        CryptoUtil.decryptAes(PLAIN_VALUE, "notAValidValue");
+    }
+
+    @Test(expected = AesDecryptionException.class)
+    public void testAesDecryptInvalidRandomValue() throws AesDecryptionException {
+        CryptoUtil.decryptAes("notAValidValue");
+    }
+
+    @Test(expected = AesDecryptionException.class)
+    public void testAesDecryptInvalidEncryptedValue() throws AesDecryptionException {
+        CryptoUtil.decryptAes("kYwVe4immFI/SuaSupaMxw==");
+    }
+
+    //
+    // Base64
+    //
+
+    @Test
+    public void testBase64EncodeDecode() {
+        String encodedValue = CryptoUtil.encodeBase64(PLAIN_VALUE);
+
+        assertNotNull(encodedValue);
+        assertEquals("YVBsYWluVmFsdWU=", encodedValue);
+
+        String decodedValue = CryptoUtil.decodeBase64(encodedValue);
+        assertNotNull(decodedValue);
+        assertEquals(PLAIN_VALUE, decodedValue);
+    }
+}

--- a/commons/src/test/resources/crypto-settings.properties
+++ b/commons/src/test/resources/crypto-settings.properties
@@ -1,0 +1,18 @@
+###############################################################################
+# Copyright (c) 2022 Eurotech and/or its affiliates and others
+#
+# This program and the accompanying materials are made
+# available under the terms of the Eclipse Public License 2.0
+# which is available at https://www.eclipse.org/legal/epl-2.0/
+#
+# SPDX-License-Identifier: EPL-2.0
+#
+# Contributors:
+#     Eurotech - initial API and implementation
+#
+###############################################################################
+crypto.secret.key=kapuaTestsKey!!!
+crypto.secret.enforce.change=true
+
+# This key is from `kapua-security-shiro` module.
+cipher.key=rv;ipse329183!@#


### PR DESCRIPTION
This PR adds test for CryptoUtil class.

The aim, other than the basic testing, is to ensure that components used to encrypt/decrypt will be compatible between releases and component version upgrades.

**Related Issue**
_None_

**Description of the solution adopted**
Added tests!

**Screenshots**
_None_

**Any side note on the changes made**
_None_