### PR TITLE
Set loglevel for Cache Configuration Printer

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/service/internal/cache/KapuaCacheManager.java
@@ -104,6 +104,7 @@ public class KapuaCacheManager {
         ConfigurationPrinter
                 .create()
                 .withLogger(LOGGER)
+                .withLogLevel(ConfigurationPrinter.LogLevel.INFO)
                 .withTitle("Cache Configuration")
                 .addParameter("Caching provider class name", CACHING_PROVIDER_CLASS_NAME)
                 .addParameter("Default caching provider class name", DEFAULT_CACHING_PROVIDER_CLASS_NAME)


### PR DESCRIPTION
Brief description of the PR.
ConfigurationPrinter not configured with log level

**Related Issue**

**Description of the solution adopted**
Set INFO as LogLevel

**Screenshots**

**Any side note on the changes made**
