### PR TITLE
Swagger date format according to OpenAPI standard

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account-scopeId-accountId.yaml
@@ -55,7 +55,7 @@ paths:
               type: account
               optlock: 2
               name: acme-inc
-              expirationDate: '2019-31-12T00:00:00.000Z'
+              expirationDate: '2019-12-31T00:00:00.000Z'
               organization:
                 addressLine1: 123 Looney Tunes Drive
                 addressLine2: Block 1

--- a/rest-api/resources/src/main/resources/openapi/account/account.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account.yaml
@@ -91,7 +91,7 @@ components:
             modifiedBy: AQ
             optlock: 2
             name: acme-inc
-            expirationDate: '2019-31-12T00:00:00.000Z'
+            expirationDate: '2019-12-31T00:00:00.000Z'
             organization:
               addressLine1: 123 Looney Tunes Drive
               addressLine2: Block 1
@@ -165,7 +165,7 @@ components:
             organizationCountry: United States
             organizationPersonName: Wile Ethelbert Coyote
             organizationPhoneNumber: +1 (555) 123 4567
-            expirationDate: '2019-31-12T00:00:00.000Z'
+            expirationDate: '2019-12-31T00:00:00.000Z'
     accountListResult:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'

--- a/rest-api/resources/src/main/resources/openapi/user/user.yaml
+++ b/rest-api/resources/src/main/resources/openapi/user/user.yaml
@@ -153,7 +153,7 @@ components:
         email: donald.duck@duckburg.org
         phoneNumber: '+1 (555) 816 1851'
         userType: INTERNAL
-        expirationDate: '2019-31-12T00:00:00.000Z'
+        expirationDate: '2019-12-31T00:00:00.000Z'
     mfaOption:
       value:
         type: mfaOption


### PR DESCRIPTION
**Brief description of the PR.**
This PR fixes #3588.
The OpenAPI date type (https://swagger.io/docs/specification/data-models/data-types/) follows the RFC3339 standard, thus the day must be after the month (https://www.rfc-editor.org/rfc/rfc3339#section-5.6)
