### PR TITLE
Change wrong property name "phoneNamber" to correct "organizationPhoneNumber" in swagger

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/account/account.yaml
+++ b/rest-api/resources/src/main/resources/openapi/account/account.yaml
@@ -164,7 +164,7 @@ components:
             organizationStateProvinceCounty: Green County, GC
             organizationCountry: United States
             organizationPersonName: Wile Ethelbert Coyote
-            phoneNumber: +1 (555) 123 4567
+            organizationPhoneNumber: +1 (555) 123 4567
             expirationDate: '2019-31-12T00:00:00.000Z'
     accountListResult:
       allOf:


### PR DESCRIPTION
***Brief description of the PR.***
This PR fixes #3590, i.e. fix the swagger documentation for accounts at `POST /{scopeId}/accounts`, which mistakenly reports `phoneNumber` instead of `organizationPhoneNumber` as the name of the field.
If the first of the two is used then the field is ignored and the value is not set in the account organization.
