### PR TITLE
Add missing mandatory field "targetScopeId" in swagger documentation for role endpoints

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/role/role.yaml
+++ b/rest-api/resources/src/main/resources/openapi/role/role.yaml
@@ -61,6 +61,7 @@ components:
               - domain: broker
                 action: connect
                 forwardable: true
+                targetScopeId: AQ
     roleListResult:
       allOf:
         - $ref: '../openapi.yaml#/components/schemas/kapuaListResult'


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3592, i.e. adds the missing mandatory field `targetScopeId` in the swager documentation for the affected endpoints.