### PR TITLE
Added Eclipse Dash Tool step in Kapua CI GitHub workflow

### DIFF
--- a/.github/workflows/github-actions.yaml
+++ b/.github/workflows/github-actions.yaml
@@ -1,4 +1,4 @@
-name: kapua-continuous-integration
+name: Kapua CI
 on: [ push, pull_request ] # Triggers the workflow on push or pull request events
 
 env:
@@ -26,6 +26,13 @@ jobs:
       - run: docker images -a  # used as log (should show only github environment standard docker images; if kapua images are present, something is wrong)
       - run: mvn -B ${BUILD_OPTS} -DskipTests clean install
       - run: bash <(curl -s https://codecov.io/bash)
+  license-check:
+    # Documentation: https://github.com/eclipse/dash-licenses#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests
+    uses: eclipse/dash-licenses/.github/workflows/mavenLicenseCheck.yml@master
+    with:
+      projectId: iot.kapua
+    secrets:
+      gitlabAPIToken: ${{ secrets.IOT_KAPUA_GITLAB_API_TOKEN }} # We should ask Eclipse to add this secret at some point. Currently, we do not want to do automatic license vetting submission.
   test-brokerAcl:
     needs: build-kapua
     runs-on: ubuntu-latest


### PR DESCRIPTION
This PR adds the Eclipse Dash Tool license check on the Kapua Ci GitHub workflow. 

This will automate the license vetting check for each dependency added/upgraded. 

**Related Issue**
_None_

**Description of the solution adopted**
Added the Reusable Github workflow for automatic license check and IP Team Review Requests.

Documentation at: [Eclipse Dash License Tool readme](https://github.com/eclipse/dash-licenses#reusable-github-workflow-for-automatic-license-check-and-ip-team-review-requests)

**Screenshots**
_None_

**Any side note on the changes made**
_None_