### PR TITLE
Add password checks when modifying user credentials

### DIFF
--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -214,6 +214,7 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
         ArgumentValidator.notNull(credential.getCredentialType(), "credential.credentialType");
         ArgumentValidator.notEmptyOrNull(credential.getCredentialKey(), "credential.credentialKey");
 
+        // These check are not correct, since they're applied to an already encrypted password
         if (CredentialType.PASSWORD == credential.getCredentialType()) {
             //
             // Validate Password length

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -214,20 +214,22 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
         ArgumentValidator.notNull(credential.getCredentialType(), "credential.credentialType");
         ArgumentValidator.notEmptyOrNull(credential.getCredentialKey(), "credential.credentialKey");
 
-        // FIXME These check are not correct, since they're applied to an already encrypted password
-        if (CredentialType.PASSWORD == credential.getCredentialType()) {
-            //
-            // Validate Password length
-            int minPasswordLength = getMinimumPasswordLength(credential.getScopeId());
-            if (credential.getCredentialKey().length() < minPasswordLength ||
-                    credential.getCredentialKey().length() > SYSTEM_MAXIMUM_PASSWORD_LENGTH) {
-                throw new PasswordLengthException(minPasswordLength, SYSTEM_MAXIMUM_PASSWORD_LENGTH);
-            }
-
-            //
-            // Validate Password regex
-            ArgumentValidator.match(credential.getCredentialKey(), CommonsValidationRegex.PASSWORD_REGEXP, "credential.credentialKey");
-        }
+        // FIXME These check are not correct, since they're applied to an
+        //  already encrypted password. Checks are moved temporary to
+        //  GwtCredentialServiceImpl#update
+//        if (CredentialType.PASSWORD == credential.getCredentialType()) {
+//            //
+//            // Validate Password length
+//            int minPasswordLength = getMinimumPasswordLength(credential.getScopeId());
+//            if (credential.getCredentialKey().length() < minPasswordLength ||
+//                    credential.getCredentialKey().length() > SYSTEM_MAXIMUM_PASSWORD_LENGTH) {
+//                throw new PasswordLengthException(minPasswordLength, SYSTEM_MAXIMUM_PASSWORD_LENGTH);
+//            }
+//
+//            //
+//            // Validate Password regex
+//            ArgumentValidator.match(credential.getCredentialKey(), CommonsValidationRegex.PASSWORD_REGEXP, "credential.credentialKey");
+//        }
 
         //
         // Check access

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/credential/shiro/CredentialServiceImpl.java
@@ -214,7 +214,7 @@ public class CredentialServiceImpl extends AbstractKapuaConfigurableService impl
         ArgumentValidator.notNull(credential.getCredentialType(), "credential.credentialType");
         ArgumentValidator.notEmptyOrNull(credential.getCredentialKey(), "credential.credentialKey");
 
-        // These check are not correct, since they're applied to an already encrypted password
+        // FIXME These check are not correct, since they're applied to an already encrypted password
         if (CredentialType.PASSWORD == credential.getCredentialType()) {
             //
             // Validate Password length


### PR DESCRIPTION
**Brief description of the PR.**
This PR fixes #3603, i.e. add the password's check on credential update.
These checks were already present in `CredentialServiceImpl` class, but there they were useless since they were applied to the already encrypted password.
This PR is not intended to be permanent, since a refactoring is needed (the check and the encryption should not be done in a gwt class).