### PR TITLE
fix npe implicit casting on configurable resources checks (1.7.x)

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/configuration/AbstractKapuaConfigurableResourceLimitedService.java
@@ -215,9 +215,9 @@ public abstract class AbstractKapuaConfigurableResourceLimitedService<E extends 
                     // maxNumberChildEntities can be null if such property is disabled via the
                     // isPropertyEnabled() method in the service implementation. In such case,
                     // it makes sense to treat the service as it had 0 available entities
-                    boolean childAllowInfiniteChildEntities = (Boolean) childConfigValues.get("infiniteChildEntities");
-                    Integer childMaxNumberChildEntities = (Integer) childConfigValues.get("maxNumberChildEntities");
-                    childCount += childAllowInfiniteChildEntities ? Integer.MAX_VALUE : (childMaxNumberChildEntities != null ? childMaxNumberChildEntities : 0);
+                    boolean childAllowInfiniteChildEntities = (boolean) childConfigValues.getOrDefault("infiniteChildEntities", false);
+                    Integer childMaxNumberChildEntities = (Integer) childConfigValues.getOrDefault("maxNumberChildEntities", 0);
+                    childCount += childAllowInfiniteChildEntities ? Integer.MAX_VALUE : childMaxNumberChildEntities;
                 }
 
                 // Max allowed for this account


### PR DESCRIPTION
Signed-off-by: riccardomodanese <riccardo.modanese@eurotech.com>
Fix NPE while implicit casting values on configurable resources checks

**Related Issue**
none

**Description of the solution adopted**
none

**Screenshots**
none

**Any side note on the changes made**
none