### PR TITLE
Prevent disabled device connection to the broker

### DIFF
--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -471,7 +471,7 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                     accessToken.getScopeId(), info.getClientId()
                 )
             );
-            if (DeviceStatus.DISABLED.equals(device.getStatus())) {
+            if (device != null && DeviceStatus.DISABLED.equals(device.getStatus())) {
                 logger.warn("Device {} is disabled", info.getClientId());
                 throw new SecurityException("Device is disabled");
             }

--- a/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
+++ b/broker/core/src/main/java/org/eclipse/kapua/broker/core/plugin/KapuaSecurityBrokerFilter.java
@@ -71,6 +71,9 @@ import org.eclipse.kapua.service.authentication.LoginCredentials;
 import org.eclipse.kapua.service.authentication.KapuaAuthenticationErrorCodes;
 import org.eclipse.kapua.service.authentication.shiro.KapuaAuthenticationException;
 import org.eclipse.kapua.service.authentication.token.AccessToken;
+import org.eclipse.kapua.service.device.registry.Device;
+import org.eclipse.kapua.service.device.registry.DeviceRegistryService;
+import org.eclipse.kapua.service.device.registry.DeviceStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -159,6 +162,8 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
     private AuthenticationService authenticationService = KapuaLocator.getInstance().getService(AuthenticationService.class);
     private CredentialsFactory credentialsFactory = KapuaLocator.getInstance().getFactory(CredentialsFactory.class);
     private AccountService accountService = KapuaLocator.getInstance().getService(AccountService.class);
+    private DeviceRegistryService
+        deviceRegistryService = KapuaLocator.getInstance().getService(DeviceRegistryService.class);
 
     private Map<String, Object> options;
 
@@ -460,6 +465,16 @@ public class KapuaSecurityBrokerFilter extends BrokerFilter {
                     account.getName(), info, (((TransportConnector) context.getConnector()).getName()));
             kapuaSecurityContext.updateOldConnectionId(CONNECTION_MAP.get(kapuaSecurityContext.getFullClientId()));
             loginShiroLoginTimeContext.stop();
+
+            Device device = KapuaSecurityUtils.doPrivileged(() ->
+                deviceRegistryService.findByClientId(
+                    accessToken.getScopeId(), info.getClientId()
+                )
+            );
+            if (DeviceStatus.DISABLED.equals(device.getStatus())) {
+                logger.warn("Device {} is disabled", info.getClientId());
+                throw new SecurityException("Device is disabled");
+            }
 
             CONNECTION_MAP.put(kapuaSecurityContext.getFullClientId(), info.getConnectionId().getValue());
 

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -576,6 +576,35 @@ Feature: Device Registry Integration
     Then No exception was thrown
     Then I logout
 
+  Scenario: Creating a device with disabled status and trying to connect to the broker.
+  Login as kapua-sys, create a device with its status set to DISABLED.
+  Then, trying to connect to the broker with a client who's client id equals to the created
+  device. Should result in an authentication failure.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a device with parameters
+      | clientId | displayName       | modelId         | serialNumber | status   | scopeId |
+      | dev-123  | dply-Name_123@#$% | ReliaGate 10-20 | 12541234ABC  | DISABLED | 1       |
+    Then No exception was thrown
+    Then I logout
+    Given I expect the exception "MqttSecurityException" with the text "Not authorized to connect"
+    When Client with name "dev-123" with client id "dev-123" user "kapua-broker" password "kapua-password" is connected
+    Then An exception was thrown
+
+  Scenario: Creating a device with enabled status and trying to connect to the broker.
+  Login as kapua-sys, create a device with its status set to ENABLED.
+  Then, trying to connect to the broker with a client who's client id equals to the created
+  device. Should not result in an authentication failure.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I create a device with parameters
+      | clientId | displayName       | modelId         | serialNumber | status   | scopeId |
+      | dev-123  | dply-Name_123@#$% | ReliaGate 10-20 | 12541234ABC  | ENABLED | 1       |
+    Then No exception was thrown
+    Then I logout
+    When Client with name "dev-12" with client id "dev-12" user "kapua-broker" password "kapua-password" is connected
+    Then No exception was thrown
+
   Scenario: Creating A Device With Enabled Status
   Login as kapua-sys, go to devices, create a device with its status set to ENABLED.
   Kapua should not return errors.

--- a/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
+++ b/qa/integration/src/test/resources/features/device/DeviceServiceI9n.feature
@@ -14,7 +14,7 @@
 @env_docker
 
 Feature: Device Registry Integration
-  Device Registy integration test scenarios. These scenarios test higher level device service functionality
+  Device Registry integration test scenarios. These scenarios test higher level device service functionality
   with all services live.
 
 @setup

--- a/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
+++ b/service/device/registry/test-steps/src/main/java/org/eclipse/kapua/service/device/registry/steps/BrokerSteps.java
@@ -438,19 +438,14 @@ public class BrokerSteps extends TestBase {
     public void clientConnect(String clientName, String clientId, String user, String password) throws Exception {
         MqttClient mqttClient = null;
         MqttConnectOptions clientOpts = new MqttConnectOptions();
+        primeException();
         try {
-            mqttClient = new MqttClient(BROKER_URI, clientId,
-                    new MemoryPersistence());
-        } catch (MqttException e) {
-            logger.error("Error: {}", e.getMessage(), e);
-        }
-        clientOpts.setUserName(user);
-        clientOpts.setPassword(password.toCharArray());
-        try {
+            mqttClient = new MqttClient(BROKER_URI, clientId, new MemoryPersistence());
+            clientOpts.setUserName(user);
+            clientOpts.setPassword(password.toCharArray());
             mqttClient.connect(clientOpts);
         } catch (MqttException e) {
-            logger.error("Error: {}", e.getMessage(), e);
-            throw new Exception("Mqtt test client not connected.");
+            verifyException(e);
         }
         stepData.put(clientName, mqttClient);
     }


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3619, i.e. enable a check in order to avoid disabled device connection to the broker.