### PR TITLE
Change serialNumber type to string in the documentation's example

### DIFF
--- a/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device-scopeId-deviceId.yaml
@@ -55,7 +55,7 @@ paths:
               optlock: 1
               status: ENABLED
               displayName: Test Device
-              serialNumber: 1234567890
+              serialNumber: "1234567890"
               modelId: Test Model
               biosVersion: N/A
               firmwareVersion: N/A

--- a/rest-api/resources/src/main/resources/openapi/device/device.yaml
+++ b/rest-api/resources/src/main/resources/openapi/device/device.yaml
@@ -160,7 +160,7 @@ components:
         clientId: testDevice
         status: ENABLED
         displayName: Test Device
-        serialNumber: 1234567890
+        serialNumber: "1234567890"
         modelId: Test Model
         biosVersion: N/A
         firmwareVersion: N/A
@@ -270,7 +270,7 @@ components:
             clientId: testDevice
             status: ENABLED
             displayName: Test Device
-            serialNumber: 1234567890
+            serialNumber: "1234567890"
             modelId: Test Model
             biosVersion: N/A
             firmwareVersion: N/A


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3624, i.e. corrects the value of the serialNumber `1234567890` to `"1234567890"` in the examples.