### PR TITLE
Upgraded Shiro dependencies from 1.8.0 to 1.10.0 - CVE-2022-40664 CVE-2022-32532

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,7 +104,7 @@
         <quartz-scheduler.version>2.3.2</quartz-scheduler.version>
         <reflections.version>0.9.12</reflections.version>
         <scada-utils.version>0.4.0</scada-utils.version>
-        <shiro.version>1.8.0</shiro.version>
+        <shiro.version>1.10.0</shiro.version>
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>


### PR DESCRIPTION
This PR upgrades the version of Apache Shiro dependencies from 1.8.0 to 1.10.0 solving following CVEs

- CVE-2022-40664
- CVE-2022-32532

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded version 

**Screenshots**
_None_

**Any side note on the changes made**
No other dependencies outside of the Apache Shiro's ones has been updated