### PR TITLE
Test classes not longer extending Assert for broker tests

### DIFF
--- a/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainTest.java
+++ b/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class BrokerDomainTest extends Assert {
+public class BrokerDomainTest {
 
     BrokerDomain brokerDomain;
     BrokerDomain secondBrokerDomain;
@@ -34,29 +35,29 @@ public class BrokerDomainTest extends Assert {
 
     @Test
     public void getNameTest() {
-        assertEquals("Expected and actual values should be the same.", "broker", brokerDomain.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "broker", brokerDomain.getName());
     }
 
     @Test
     public void getActionsTest() {
-        assertEquals("Expected and actual values should be the same.", "[connect]", brokerDomain.getActions().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "[connect]", brokerDomain.getActions().toString());
     }
 
     @Test
     public void getGroupableTest() {
-        assertFalse("False expected.", brokerDomain.getGroupable());
+        Assert.assertFalse("False expected.", brokerDomain.getGroupable());
     }
 
     @Test
     public void equalsTest() {
-        assertTrue("True expected.", brokerDomain.equals(secondBrokerDomain));
+        Assert.assertTrue("True expected.", brokerDomain.equals(secondBrokerDomain));
         for (Object object : objects) {
-            assertFalse("False expected.", brokerDomain.equals(object));
+            Assert.assertFalse("False expected.", brokerDomain.equals(object));
         }
     }
 
     @Test
     public void hashCodeTest() {
-        assertNotNull("NotNull expected.", brokerDomain.hashCode());
+        Assert.assertNotNull("NotNull expected.", brokerDomain.hashCode());
     }
 }

--- a/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainsTest.java
+++ b/broker/api/src/test/java/org/eclipse/kapua/broker/BrokerDomainsTest.java
@@ -20,13 +20,14 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class BrokerDomainsTest extends Assert {
+public class BrokerDomainsTest {
 
     @Test
     public void brokerDomainsTest() throws Exception {
         Constructor<BrokerDomains> brokerDomains = BrokerDomains.class.getDeclaredConstructor();
-        assertTrue("True expected.", Modifier.isPrivate(brokerDomains.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(brokerDomains.getModifiers()));
         brokerDomains.setAccessible(true);
         brokerDomains.newInstance();
     }
@@ -34,6 +35,6 @@ public class BrokerDomainsTest extends Assert {
     @Test
     public void brokerDomainTest() {
         BrokerDomain brokerDomain = BrokerDomains.BROKER_DOMAIN;
-        assertNotNull("NotNull expected.", brokerDomain);
+        Assert.assertNotNull("NotNull expected.", brokerDomain);
     }
 }

--- a/broker/client/src/test/java/org/eclipse/kapua/broker/client/protocol/ProtocolDescriptorTest.java
+++ b/broker/client/src/test/java/org/eclipse/kapua/broker/client/protocol/ProtocolDescriptorTest.java
@@ -25,8 +25,9 @@ import org.junit.experimental.categories.Category;
 import java.util.HashMap;
 import java.util.Map;
 
+
 @Category(JUnitTests.class)
-public class ProtocolDescriptorTest extends Assert {
+public class ProtocolDescriptorTest {
 
     @Before
     public void resetSettings() throws KapuaException {
@@ -36,26 +37,26 @@ public class ProtocolDescriptorTest extends Assert {
     @Test
     public void nonNullProviderTest() {
         ProtocolDescriptorProvider provider = ProtocolDescriptorProviders.getInstance();
-        assertNotNull("Null not expected.", provider);
+        Assert.assertNotNull("Null not expected.", provider);
     }
 
     @Test
     public void defaultDescriptorFromProviderTest() {
         ProtocolDescriptorProvider provider = ProtocolDescriptorProviders.getInstance();
         ProtocolDescriptor descriptor = provider.getDescriptor("foo");
-        assertNotNull("Null not expected.", descriptor);
+        Assert.assertNotNull("Null not expected.", descriptor);
     }
 
     @Test
     public void getDescriptorFromProvidersClassTest() {
-        assertNotNull("Null not expected.", ProtocolDescriptorProviders.getDescriptor("foo"));
+        Assert.assertNotNull("Null not expected.", ProtocolDescriptorProviders.getDescriptor("foo"));
     }
 
     @Test
     public void getTransportProtocolTest() {
         ProtocolDescriptorProvider provider = ProtocolDescriptorProviders.getInstance();
         ProtocolDescriptor descriptor = provider.getDescriptor("foo");
-        assertEquals("Expected and actual values should be the same.", "MQTT", descriptor.getTransportProtocol());
+        Assert.assertEquals("Expected and actual values should be the same.", "MQTT", descriptor.getTransportProtocol());
     }
 
     @Test
@@ -66,7 +67,7 @@ public class ProtocolDescriptorTest extends Assert {
         Tests.runWithProperties(properties, () -> {
             DefaultProtocolDescriptionProvider provider = new DefaultProtocolDescriptionProvider();
             ProtocolDescriptor descriptor = provider.getDescriptor("foo");
-            assertNull("Null expected.", descriptor);
+            Assert.assertNull("Null expected.", descriptor);
         });
     }
 
@@ -86,7 +87,7 @@ public class ProtocolDescriptorTest extends Assert {
         Tests.runWithProperties(properties, () -> {
             DefaultProtocolDescriptionProvider provider = new DefaultProtocolDescriptionProvider();
             ProtocolDescriptor descriptor = provider.getDescriptor("foo");
-            assertNotNull("Null not expected.", descriptor);
+            Assert.assertNotNull("Null not expected.", descriptor);
         });
     }
 
@@ -99,7 +100,7 @@ public class ProtocolDescriptorTest extends Assert {
         Tests.runWithProperties(properties, () -> {
             DefaultProtocolDescriptionProvider provider = new DefaultProtocolDescriptionProvider();
             ProtocolDescriptor descriptor = provider.getDescriptor("foo");
-            assertNull("Null expected.", descriptor);
+            Assert.assertNull("Null expected.", descriptor);
         });
     }
 
@@ -111,16 +112,16 @@ public class ProtocolDescriptorTest extends Assert {
 
         Tests.runWithProperties(properties, () -> {
             DefaultProtocolDescriptionProvider provider = new DefaultProtocolDescriptionProvider();
-            assertNull("Null expected.", provider.getDescriptor("foo"));
+            Assert.assertNull("Null expected.", provider.getDescriptor("foo"));
 
             ProtocolDescriptor descriptor = provider.getDescriptor("mqtt");
-            assertNotNull("Null not expected.", descriptor);
+            Assert.assertNotNull("Null not expected.", descriptor);
 
-            assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MessageType.APP));
-            assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MessageType.APP));
+            Assert.assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.service.device.call.message.kura.lifecycle.KuraAppsMessage.class, descriptor.getDeviceClass(MessageType.APP));
+            Assert.assertEquals("Expected and actual values should be the same.", org.eclipse.kapua.message.device.lifecycle.KapuaAppsMessage.class, descriptor.getKapuaClass(MessageType.APP));
 
-            assertNull("Null expected.", descriptor.getDeviceClass(MessageType.DATA));
-            assertNull("Null expected.", descriptor.getKapuaClass(MessageType.DATA));
+            Assert.assertNull("Null expected.", descriptor.getDeviceClass(MessageType.DATA));
+            Assert.assertNull("Null expected.", descriptor.getKapuaClass(MessageType.DATA));
         });
     }
 

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/CredentialsTest.java
@@ -23,8 +23,9 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+
 @Category(JUnitTests.class)
-public class CredentialsTest extends Assert {
+public class CredentialsTest {
 
     String specialSymbolsAndNumbers = "1234567890~!@$%^&*()_+, .?-/[];':<>";
     String[] stringLengths = new String[]{"", "a", "abc", "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjqwer", "qwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjqwerqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjklzxcvbnmqwertyuiopasdfghjqwer"};
@@ -34,38 +35,38 @@ public class CredentialsTest extends Assert {
         Constructor<Credentials> credentialsConstructor = Credentials.class.getDeclaredConstructor();
         credentialsConstructor.setAccessible(true);
         Credentials credentials = credentialsConstructor.newInstance();
-        assertThat("Instance of Credentials.java expected", credentials, IsInstanceOf.instanceOf(Credentials.class));
+        Assert.assertThat("Instance of Credentials.java expected", credentials, IsInstanceOf.instanceOf(Credentials.class));
     }
 
     @Test
     public void firstUserAndPasswordValidTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword("username", "password");
-        assertEquals("Expected and actual values should be the same!", "username", userAndPassword.getUsername());
-        assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
-        assertNotNull("The value should not be null!", userAndPassword.getPassword());
+        Assert.assertEquals("Expected and actual values should be the same!", "username", userAndPassword.getUsername());
+        Assert.assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
+        Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
     }
 
     @Test
     public void firstUserAndPasswordAllNullTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword(null, (String) null);
-        assertNull("Null expected!", userAndPassword.getUsername());
-        assertNull("Null expected!", userAndPassword.getPassword());
+        Assert.assertNull("Null expected!", userAndPassword.getUsername());
+        Assert.assertNull("Null expected!", userAndPassword.getPassword());
     }
 
     @Test
     public void usernameNullTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword(null, "password");
-        assertNull("Null expected!", userAndPassword.getUsername());
-        assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
-        assertNotNull("The value should not be null!", userAndPassword.getPassword());
+        Assert.assertNull("Null expected!", userAndPassword.getUsername());
+        Assert.assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
+        Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
     }
 
     @Test
     public void passwordNullTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword("username", (String) null);
-        assertEquals("Expected and actual values should be the same!", "username", userAndPassword.getUsername());
-        assertNull("Null expected!", userAndPassword.getPassword());
-        assertNull("Null expected!", userAndPassword.getPasswordAsString());
+        Assert.assertEquals("Expected and actual values should be the same!", "username", userAndPassword.getUsername());
+        Assert.assertNull("Null expected!", userAndPassword.getPassword());
+        Assert.assertNull("Null expected!", userAndPassword.getPasswordAsString());
 
     }
 
@@ -73,8 +74,8 @@ public class CredentialsTest extends Assert {
     public void firstUserAndPasswordCharacterTest() {
         for (int i=0; i<specialSymbolsAndNumbers.length(); i++) {
             UserAndPassword userAndPassword = Credentials.userAndPassword("username" + specialSymbolsAndNumbers.charAt(i), "password" + specialSymbolsAndNumbers.charAt(i));
-            assertEquals("Expected and actual values should be the same!", "username" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getUsername());
-            assertEquals("Expected and actual values should be the same!", "password" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getPasswordAsString());
+            Assert.assertEquals("Expected and actual values should be the same!", "username" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getUsername());
+            Assert.assertEquals("Expected and actual values should be the same!", "password" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getPasswordAsString());
         }
     }
 
@@ -82,50 +83,50 @@ public class CredentialsTest extends Assert {
     public void firstUserAndPasswordStringLengthTest() {
         for(String value : stringLengths) {
             UserAndPassword userAndPassword = Credentials.userAndPassword(value, value);
-            assertEquals("Expected and actual values should be the same!", value, userAndPassword.getUsername());
-            assertEquals("Expected and actual values should be the same!", value, userAndPassword.getPasswordAsString());
+            Assert.assertEquals("Expected and actual values should be the same!", value, userAndPassword.getUsername());
+            Assert.assertEquals("Expected and actual values should be the same!", value, userAndPassword.getPasswordAsString());
         }
     }
 
     @Test
     public void secondUserAndPasswordValidTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword("user", "password".toCharArray());
-        assertEquals("Expected and actual values should be the same!", "user", userAndPassword.getUsername());
-        assertNotNull("The value should not be null!", userAndPassword.getPassword());
-        assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
+        Assert.assertEquals("Expected and actual values should be the same!", "user", userAndPassword.getUsername());
+        Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
+        Assert.assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
     }
 
     @Test
     public void secondUserAndPasswordAllNullTest() {
         UserAndPassword userAndPassword = Credentials.userAndPassword(null, (char[]) null);
-        assertNull("Null expected!", userAndPassword.getUsername());
-        assertNull("Null expected!", userAndPassword.getPassword());
-        assertNull("Null expected!", userAndPassword.getPasswordAsString());
+        Assert.assertNull("Null expected!", userAndPassword.getUsername());
+        Assert.assertNull("Null expected!", userAndPassword.getPassword());
+        Assert.assertNull("Null expected!", userAndPassword.getPasswordAsString());
     }
 
     @Test
     public void usernameNullTest2() {
         UserAndPassword userAndPassword = Credentials.userAndPassword(null, "password".toCharArray());
-        assertNull("Null expected!", userAndPassword.getUsername());
-        assertNotNull("The value should not be null!", userAndPassword.getPassword());
-        assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
+        Assert.assertNull("Null expected!", userAndPassword.getUsername());
+        Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
+        Assert.assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
     }
 
     @Test
     public void passwordNullTest2() {
         UserAndPassword userAndPassword = Credentials.userAndPassword("user", (char[]) null);
-        assertEquals("Expected and actual values should be the same!", "user", userAndPassword.getUsername());
-        assertNull("Null expected!", userAndPassword.getPassword());
-        assertNull("Null expected!", userAndPassword.getPasswordAsString());
+        Assert.assertEquals("Expected and actual values should be the same!", "user", userAndPassword.getUsername());
+        Assert.assertNull("Null expected!", userAndPassword.getPassword());
+        Assert.assertNull("Null expected!", userAndPassword.getPasswordAsString());
     }
 
     @Test
     public void secondUserAndPasswordCharacterTest() {
         for (int i=0; i<specialSymbolsAndNumbers.length(); i++) {
             UserAndPassword userAndPassword = Credentials.userAndPassword("username" + specialSymbolsAndNumbers.charAt(i), "password".toCharArray());
-            assertEquals("Expected and actual values should be the same!", "username" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getUsername());
-            assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
-            assertNotNull("The value should not be null!", userAndPassword.getPassword());
+            Assert.assertEquals("Expected and actual values should be the same!", "username" + specialSymbolsAndNumbers.charAt(i), userAndPassword.getUsername());
+            Assert.assertEquals("Expected and actual values should be the same!", "password", userAndPassword.getPasswordAsString());
+            Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
         }
     }
 
@@ -133,9 +134,9 @@ public class CredentialsTest extends Assert {
     public void secondUserAndPasswordCharacterLengthTest() {
         for(String value : stringLengths) {
             UserAndPassword userAndPassword = Credentials.userAndPassword(value, value.toCharArray());
-            assertEquals("Expected and actual values should be the same!", value, userAndPassword.getUsername());
-            assertEquals("Expected and actual values should be the same!", value, userAndPassword.getPasswordAsString());
-            assertNotNull("The value should not be null!", userAndPassword.getPassword());
+            Assert.assertEquals("Expected and actual values should be the same!", value, userAndPassword.getUsername());
+            Assert.assertEquals("Expected and actual values should be the same!", value, userAndPassword.getPasswordAsString());
+            Assert.assertNotNull("The value should not be null!", userAndPassword.getPassword());
         }
     }
 }

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/PayloadTest.java
@@ -23,8 +23,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class PayloadTest extends Assert {
+public class PayloadTest {
 
     Object[] objectValues = new Object[]{1, 2147483647, -2147483648, true, false, 3.4028235E38, 1.4E-45, 1.7976931348623157E308, 4.9E-324, 9223372036854775807L, -9223372036854775808L, "String", 'S'};
     String[] keys = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844"};
@@ -34,10 +35,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = new Payload.Builder().timestamp(Instant.now()).put(keyValue, objValue).build();
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }
@@ -62,10 +63,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = new Payload.Builder().timestamp(Instant.now()).values(Collections.singletonMap(keyValue, objValue)).build();
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }
@@ -75,22 +76,22 @@ public class PayloadTest extends Assert {
         Payload.Builder builder = new Payload.Builder();
         Payload payload = builder.build();
         String expectedString = "[Payload - timestamp: " + payload.getTimestamp() +", values: " + payload.getValues() +"]";
-        assertEquals("Expected and actual values should be the same!", expectedString, payload.toString());
+        Assert.assertEquals("Expected and actual values should be the same!", expectedString, payload.toString());
     }
 
     @Test
     public void builderTimestampTest(){
         Payload.Builder builder = new Payload.Builder();
         Payload payload = builder.build();
-        assertEquals("Expected and actual values should be the same!", builder,builder.timestamp(payload.getTimestamp()));
-        assertEquals("Expected and actual values should be the same!", builder.timestamp(),builder.timestamp(payload.getTimestamp()).timestamp());
+        Assert.assertEquals("Expected and actual values should be the same!", builder,builder.timestamp(payload.getTimestamp()));
+        Assert.assertEquals("Expected and actual values should be the same!", builder.timestamp(),builder.timestamp(payload.getTimestamp()).timestamp());
     }
 
     @Test
     public void payloadBuilderValuesTest() {
         final Map<String, Object> expectedValues = new HashMap<>();
         Payload.Builder builder = new Payload.Builder();
-        assertEquals("Expected and actual values should be the same!", expectedValues, builder.values());
+        Assert.assertEquals("Expected and actual values should be the same!", expectedValues, builder.values());
     }
 
     @Test(expected = NullPointerException.class)
@@ -118,10 +119,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = Payload.of(keyValue, objValue);
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }
@@ -131,10 +132,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = Payload.of(Collections.singletonMap(keyValue, objValue));
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }
@@ -144,10 +145,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = Payload.of(Instant.now(), keyValue, objValue);
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }
@@ -157,10 +158,10 @@ public class PayloadTest extends Assert {
         for (Object objValue : objectValues) {
             for (String keyValue : keys) {
                 Payload payload = Payload.of(Instant.now(), Collections.singletonMap(keyValue, objValue));
-                assertNotNull("Object should not be null!", payload);
-                assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
-                assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
-                assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
+                Assert.assertNotNull("Object should not be null!", payload);
+                Assert.assertEquals("Expected and actual values should be the same!", 1, payload.getValues().size());
+                Assert.assertEquals("Expected and actual values should be the same!", objValue, payload.getValues().get(keyValue));
+                Assert.assertFalse("No exception expected!", Instant.now().isBefore(payload.getTimestamp()));
             }
         }
     }

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TopicTest.java
@@ -25,8 +25,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class TopicTest extends Assert {
+public class TopicTest {
 
     String[] stringValues = {"!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844"};
 
@@ -34,41 +35,41 @@ public class TopicTest extends Assert {
     public void topicOfOneParameterValidTest() {
         for (String value : stringValues) {
             Topic topic = Topic.of(new LinkedList<>(Arrays.asList(value, value)));
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
     }
 
     @Test
     public void topicOfOneParameterNullTest() {
         Topic topic = Topic.of(null);
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
     }
 
     @Test
     public void topicOfTwoParameterEmptyTest() {
         Topic topic = Topic.of(Collections.emptyList());
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
     }
 
     @Test
     public void topicOfTwoParameterValidTest() {
         for (String value : stringValues) {
             Topic topic = Topic.of(value);
-            assertEquals("Expected and actual values should be the same!", Collections.singletonList(value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Collections.singletonList(value), topic.getSegments());
         }
         for (String value : stringValues) {
             Topic topic = Topic.of(value, value);
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
     }
 
     @Test
     public void topicOfTwoParameterNullTest() {
         Topic topic = Topic.of(null);
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
         for (String value : stringValues) {
             Topic topic2 = Topic.of(null, value);
-            assertNull("Null expected!", topic2);
+            Assert.assertNull("Null expected!", topic2);
         }
     }
 
@@ -111,70 +112,70 @@ public class TopicTest extends Assert {
     public void splitValidTest() {
         for (String value : stringValues) {
             Topic topic = Topic.split(value + "/" + value);
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
         for (String value : stringValues) {
             Topic topic = Topic.split(value + "//" + value);
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
         for (String value : stringValues) {
             Topic topic = Topic.split("/" + value + "//" + value);
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
         for (String value : stringValues) {
             Topic topic = Topic.split("/" + value + "//" + value + "//");
-            assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
+            Assert.assertEquals("Expected and actual values should be the same!", Arrays.asList(value, value), topic.getSegments());
         }
     }
 
     @Test
     public void splitValidTestNullOutcomeTest() {
         Topic topic = Topic.split("//");
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
     }
 
     @Test
     public void splitNullTest() {
         Topic topic = Topic.split(null);
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
     }
 
     @Test
     public void splitEmptyTest() {
         Topic topic = Topic.split("");
-        assertNull("Null expected!", topic);
+        Assert.assertNull("Null expected!", topic);
     }
 
     @Test
     public void splitTest() {
         Topic topic1 = Topic.split("foo/bar/baz");
         Topic topic2 = Topic.split("foo/bar/baz");
-        assertEquals("Expected and actual values should be the same!", topic1, topic2);
+        Assert.assertEquals("Expected and actual values should be the same!", topic1, topic2);
     }
 
     @Test
     public void splitAndOfTest() {
         Topic topic1 = Topic.split("foo/bar/baz");
         Topic topic2 = Topic.of("foo", "bar", "baz");
-        assertEquals("Expected and actual values should be the same!", topic1, topic2);
+        Assert.assertEquals("Expected and actual values should be the same!", topic1, topic2);
     }
 
     @Test
     public void splitInvalidTest() {
         Topic topic1 = Topic.split("foo/bar");
         Topic topic2 = Topic.split("foo/baz");
-        assertNotEquals("Expected and actual values should be the same!", topic1, topic2);
+        Assert.assertNotEquals("Expected and actual values should be the same!", topic1, topic2);
     }
 
     @Test
     public void streamValidTest() {
         String result = Topic.split("foo/bar").stream().collect(Collectors.joining());
-        assertEquals("Expected and actual values should be the same!", "foobar", result);
+        Assert.assertEquals("Expected and actual values should be the same!", "foobar", result);
     }
 
     @Test
     public void toStringTest() {
-        assertEquals("Expected and actual values should be the same!", "foo/bar", Topic.of("foo", "bar").toString());
+        Assert.assertEquals("Expected and actual values should be the same!", "foo/bar", Topic.of("foo", "bar").toString());
     }
 
     @Test
@@ -183,8 +184,8 @@ public class TopicTest extends Assert {
         map.put(Topic.of("foo", "bar"), 1);
         map.put(Topic.of("foo", "baz"), 2);
 
-        assertEquals("Expected and actual values should be the same!", 1, map.get(Topic.split("foo/bar")));
-        assertEquals("Expected and actual values should be the same!", 2, map.get(Topic.split("foo/baz")));
+        Assert.assertEquals("Expected and actual values should be the same!", 1, map.get(Topic.split("foo/bar")));
+        Assert.assertEquals("Expected and actual values should be the same!", 2, map.get(Topic.split("foo/baz")));
     }
 
     @Test
@@ -194,10 +195,10 @@ public class TopicTest extends Assert {
         Topic topic3 = Topic.split("StringString");
         Object object = new Object();
 
-        assertTrue("True expected!",topic1.equals(topic1));
-        assertFalse("False expected!", topic1.equals(null));
-        assertFalse("False expected!", topic1.equals(object));
-        assertTrue("True expected!", topic1.equals(topic2));
-        assertFalse("False expected!", topic1.equals(topic3));
+        Assert.assertTrue("True expected!",topic1.equals(topic1));
+        Assert.assertFalse("False expected!", topic1.equals(null));
+        Assert.assertFalse("False expected!", topic1.equals(object));
+        Assert.assertTrue("True expected!", topic1.equals(topic2));
+        Assert.assertFalse("False expected!", topic1.equals(topic3));
     }
 }

--- a/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TransmissionExceptionTest.java
+++ b/client/gateway/api/src/test/java/org/eclipse/kapua/client/gateway/TransmissionExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class TransmissionExceptionTest extends Assert {
+public class TransmissionExceptionTest {
 
     TransmissionException transmissionException;
     Throwable throwable;
@@ -36,65 +37,65 @@ public class TransmissionExceptionTest extends Assert {
     @Test
     public void transmissionExceptionDefaultConstructorTest() {
         TransmissionException transmissionException = new TransmissionException();
-        assertThat("Expected and actual values should be the same!", transmissionException, IsInstanceOf.instanceOf(TransmissionException.class));
+        Assert.assertThat("Expected and actual values should be the same!", transmissionException, IsInstanceOf.instanceOf(TransmissionException.class));
     }
 
     @Test
     public void transmissionExceptionTwoParameterConstructorValidTest() {
         for (String value : stringValues) {
             transmissionException = new TransmissionException(value, throwable);
-            assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
-            assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
         }
     }
 
     @Test
     public void transmissionExceptionTwoParametersNullMessageTest() {
         transmissionException = new TransmissionException(null, throwable);
-        assertNull("Null expected!", transmissionException.getMessage());
-        assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
+        Assert.assertNull("Null expected!", transmissionException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
     }
 
     @Test
     public void transmissionExceptionTwoParametersNullCauseTest() {
         for (String value : stringValues) {
             transmissionException = new TransmissionException(value, null);
-            assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
-            assertNull("Null expected!", transmissionException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
+            Assert.assertNull("Null expected!", transmissionException.getCause());
         }
     }
 
     @Test
     public void transmissionExceptionTwoParametersNullTest() {
         transmissionException = new TransmissionException(null, null);
-        assertNull("Null expected!", transmissionException.getMessage());
-        assertNull("Null expected!", transmissionException.getCause());
+        Assert.assertNull("Null expected!", transmissionException.getMessage());
+        Assert.assertNull("Null expected!", transmissionException.getCause());
     }
 
     @Test
     public void transmissionExceptionMessageConstructorValidTest() {
         for (String value : stringValues) {
             transmissionException = new TransmissionException(value);
-            assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same!", value, transmissionException.getMessage());
         }
     }
 
     @Test
     public void transmissionExceptionMessageConstructorNullTest() {
         transmissionException = new TransmissionException((String) null);
-        assertNull("Null expected!", transmissionException.getMessage());
+        Assert.assertNull("Null expected!", transmissionException.getMessage());
     }
 
     @Test
     public void transmissionExceptionThrowableConstructorValidTest() {
         transmissionException = new TransmissionException(throwable);
-        assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
     }
 
     @Test
     public void transmissionExceptionThrowableConstructorNullTest() {
         transmissionException = new TransmissionException(throwable);
-        assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, transmissionException.getCause());
     }
 
     @Test (expected = TransmissionException.class)

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraBinaryPayloadCodecTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraBinaryPayloadCodecTest.java
@@ -24,8 +24,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+
 @Category(JUnitTests.class)
-public class KuraBinaryPayloadCodecTest extends Assert {
+public class KuraBinaryPayloadCodecTest {
 
     KuraBinaryPayloadCodec.Builder builder;
     Payload payload;
@@ -38,8 +39,8 @@ public class KuraBinaryPayloadCodecTest extends Assert {
 
     @Test
     public void builderBuildTest() {
-        assertNotNull("Null not expected", builder);
-        assertThat("Instance of KuraBinaryPayloadCodec expected.", builder.build(), IsInstanceOf.instanceOf(KuraBinaryPayloadCodec.class));
+        Assert.assertNotNull("Null not expected", builder);
+        Assert.assertThat("Instance of KuraBinaryPayloadCodec expected.", builder.build(), IsInstanceOf.instanceOf(KuraBinaryPayloadCodec.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -52,8 +53,8 @@ public class KuraBinaryPayloadCodecTest extends Assert {
     public void encodeNullBufferTest() throws Exception {
         Mockito.when(payload.getTimestamp()).thenReturn(Instant.ofEpochSecond(10L));
 
-        assertNotNull("Null not expected.", builder.build().encode(payload, null));
-        assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, null), IsInstanceOf.instanceOf(ByteBuffer.class));
+        Assert.assertNotNull("Null not expected.", builder.build().encode(payload, null));
+        Assert.assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, null), IsInstanceOf.instanceOf(ByteBuffer.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -66,8 +67,8 @@ public class KuraBinaryPayloadCodecTest extends Assert {
         ByteBuffer byteBuffer = Mockito.mock(ByteBuffer.class);
         Mockito.when(payload.getTimestamp()).thenReturn(Instant.ofEpochSecond(10L));
 
-        assertNotNull("Null not expected.", builder.build().encode(payload, byteBuffer));
-        assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, byteBuffer), IsInstanceOf.instanceOf(ByteBuffer.class));
+        Assert.assertNotNull("Null not expected.", builder.build().encode(payload, byteBuffer));
+        Assert.assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, byteBuffer), IsInstanceOf.instanceOf(ByteBuffer.class));
     }
 
     @Test
@@ -75,8 +76,8 @@ public class KuraBinaryPayloadCodecTest extends Assert {
         ByteBuffer byteBuffer = ByteBuffer.allocate(100);
         Mockito.when(payload.getTimestamp()).thenReturn(Instant.ofEpochSecond(10L));
 
-        assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, byteBuffer), IsInstanceOf.instanceOf(ByteBuffer.class));
-        assertEquals("Expected and actual values should be the same.", 100, builder.build().encode(payload, byteBuffer).limit());
+        Assert.assertThat("Instance of ByteBuffer expected.", builder.build().encode(payload, byteBuffer), IsInstanceOf.instanceOf(ByteBuffer.class));
+        Assert.assertEquals("Expected and actual values should be the same.", 100, builder.build().encode(payload, byteBuffer).limit());
     }
 
     @Test(expected = NullPointerException.class)
@@ -88,7 +89,7 @@ public class KuraBinaryPayloadCodecTest extends Assert {
     public void decodeTest() throws Exception {
         ByteBuffer byteBuffer = Mockito.mock(ByteBuffer.class);
 
-        assertNotNull("Null not expected.", builder.build().decode(byteBuffer));
-        assertThat("Instance of Payload expected.", builder.build().decode(byteBuffer), IsInstanceOf.instanceOf(Payload.class));
+        Assert.assertNotNull("Null not expected.", builder.build().decode(byteBuffer));
+        Assert.assertThat("Instance of Payload expected.", builder.build().decode(byteBuffer), IsInstanceOf.instanceOf(Payload.class));
     }
 }

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraBirthCertificateModuleTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraBirthCertificateModuleTest.java
@@ -29,8 +29,9 @@ import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Optional;
 
+
 @Category(JUnitTests.class)
-public class KuraBirthCertificateModuleTest extends Assert {
+public class KuraBirthCertificateModuleTest {
 
     Map<String, String> values;
     Map<String, String> expectedValues;
@@ -55,7 +56,7 @@ public class KuraBirthCertificateModuleTest extends Assert {
 
         KuraBirthCertificateModule.Provider.JVM.provideData(values);
 
-        assertEquals("Expected and actual values should be the same.", expectedValues, values);
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValues, values);
     }
 
     @Test(expected = NullPointerException.class)
@@ -70,7 +71,7 @@ public class KuraBirthCertificateModuleTest extends Assert {
 
         KuraBirthCertificateModule.Provider.RUNTIME.provideData(values);
 
-        assertEquals("Expected and actual values should be the same.", expectedValues, values);
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValues, values);
     }
 
     @Test(expected = NullPointerException.class)
@@ -85,7 +86,7 @@ public class KuraBirthCertificateModuleTest extends Assert {
 
         builder.defaultProviders();
 
-        assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
     }
 
     @Test(expected = NullPointerException.class)
@@ -100,7 +101,7 @@ public class KuraBirthCertificateModuleTest extends Assert {
 
         builder.provider(provider);
 
-        assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
     }
 
     @Test(expected = NullPointerException.class)
@@ -124,17 +125,17 @@ public class KuraBirthCertificateModuleTest extends Assert {
 
         builder.providers(providers);
 
-        assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedProviders, builder.providers());
     }
 
     @Test
     public void builderBuildTest() {
-        assertThat("Instance of KuraBirthCertificateModule expected.", builder.build(), IsInstanceOf.instanceOf(KuraBirthCertificateModule.class));
+        Assert.assertThat("Instance of KuraBirthCertificateModule expected.", builder.build(), IsInstanceOf.instanceOf(KuraBirthCertificateModule.class));
     }
 
     @Test
     public void newBuilderNullTest() {
-        assertThat("Instance of Builder expected.", KuraBirthCertificateModule.newBuilder(null), IsInstanceOf.instanceOf(KuraBirthCertificateModule.Builder.class));
+        Assert.assertThat("Instance of Builder expected.", KuraBirthCertificateModule.newBuilder(null), IsInstanceOf.instanceOf(KuraBirthCertificateModule.Builder.class));
     }
 
     @Test
@@ -146,7 +147,7 @@ public class KuraBirthCertificateModuleTest extends Assert {
         try {
             builder.build().initialize(moduleContext);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraNamespaceTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/KuraNamespaceTest.java
@@ -21,8 +21,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KuraNamespaceTest extends Assert {
+public class KuraNamespaceTest {
 
     Builder builder;
     String accountName;
@@ -47,7 +48,7 @@ public class KuraNamespaceTest extends Assert {
 
     @Test
     public void builderAccountNameStringParameterTest() {
-        assertThat("Instance of Builder expected.", builder.accountName(accountName), IsInstanceOf.instanceOf(Builder.class));
+        Assert.assertThat("Instance of Builder expected.", builder.accountName(accountName), IsInstanceOf.instanceOf(Builder.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -64,12 +65,12 @@ public class KuraNamespaceTest extends Assert {
 
     @Test
     public void builderAccountNameTest() {
-        assertEquals("Expected and actual values should be the same.", accountName, builder.accountName(accountName).accountName());
+        Assert.assertEquals("Expected and actual values should be the same.", accountName, builder.accountName(accountName).accountName());
     }
 
     @Test
     public void builderBuildTest() {
-        assertThat("Instance of KuraNamespace expected.", kuraNamespace, IsInstanceOf.instanceOf(KuraNamespace.class));
+        Assert.assertThat("Instance of KuraNamespace expected.", kuraNamespace, IsInstanceOf.instanceOf(KuraNamespace.class));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -115,6 +116,6 @@ public class KuraNamespaceTest extends Assert {
     public void dataTopicTest() {
         String expectedString = accountName + "/" + clientId + "/" + applicationId + "/" + path;
 
-        assertEquals("Expected and actual values should be the same.", expectedString, kuraNamespace.dataTopic(clientId, applicationId, topic));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedString, kuraNamespace.dataTopic(clientId, applicationId, topic));
     }
 }

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/internal/MetricsTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/kura/internal/MetricsTest.java
@@ -29,8 +29,9 @@ import java.util.List;
 import java.util.HashMap;
 import java.util.TreeMap;
 
+
 @Category(JUnitTests.class)
-public class MetricsTest extends Assert {
+public class MetricsTest {
 
     KuraPayloadProto.KuraPayload.Builder builder;
 
@@ -61,14 +62,14 @@ public class MetricsTest extends Assert {
         expectedBuilder.setType(KuraPayloadProto.KuraPayload.KuraMetric.ValueType.STRING);
         expectedBuilder.setStringValue("value");
 
-        assertTrue("True expected.", builder.getMetricList().isEmpty());
-        assertEquals("Expected and actual values should be the same.", expectedList, builder.getMetricList());
+        Assert.assertTrue("True expected.", builder.getMetricList().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedList, builder.getMetricList());
 
         Metrics.buildMetrics(builder, metrics);
         expectedList.add(expectedBuilder);
 
-        assertFalse("False expected.", builder.getMetricList().isEmpty());
-        assertEquals("Expected and actual values should be the same.", expectedList.toString(), builder.getMetricList().toString());
+        Assert.assertFalse("False expected.", builder.getMetricList().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedList.toString(), builder.getMetricList().toString());
     }
 
     @Test
@@ -77,7 +78,7 @@ public class MetricsTest extends Assert {
 
         Metrics.buildBody(builder, null);
 
-        assertEquals("Expected and actual values should be the same.", expectedByteString.toString(), builder.getBody().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedByteString.toString(), builder.getBody().toString());
     }
 
     @Test(expected = NullPointerException.class)
@@ -93,7 +94,7 @@ public class MetricsTest extends Assert {
 
         Metrics.buildBody(builder, body);
 
-        assertNotEquals("Expected and actual values should not be the same.", expectedByteString.toString(), builder.getBody().toString());
+        Assert.assertNotEquals("Expected and actual values should not be the same.", expectedByteString.toString(), builder.getBody().toString());
     }
 
     @Test(expected = NullPointerException.class)
@@ -118,7 +119,7 @@ public class MetricsTest extends Assert {
         String key = "Key";
 
         Metrics.addMetric(builder, key, null);
-        assertTrue("True expected.", builder.getMetricList().isEmpty());
+        Assert.assertTrue("True expected.", builder.getMetricList().isEmpty());
     }
 
     @Test
@@ -127,10 +128,10 @@ public class MetricsTest extends Assert {
         byte[] byteArray = {1, 2, 3};
         Object[] values = {true, 10, "String", 10L, 10.10d, 10f, byteArray};
 
-        assertTrue("True expected.", builder.getMetricList().isEmpty());
+        Assert.assertTrue("True expected.", builder.getMetricList().isEmpty());
         for (Object value : values) {
             Metrics.addMetric(builder, key, value);
-            assertFalse("False expected.", builder.getMetricList().isEmpty());
+            Assert.assertFalse("False expected.", builder.getMetricList().isEmpty());
         }
     }
 
@@ -143,7 +144,7 @@ public class MetricsTest extends Assert {
 
     @Test
     public void extractMetricsNullKuraPayloadTest() {
-        assertNull("Null expected.", Metrics.extractMetrics((KuraPayloadProto.KuraPayload) null));
+        Assert.assertNull("Null expected.", Metrics.extractMetrics((KuraPayloadProto.KuraPayload) null));
     }
 
     @Test
@@ -153,13 +154,13 @@ public class MetricsTest extends Assert {
         Map<String, Object> expectedResult = new TreeMap<>();
         expectedResult.put("name", kuraMetric.getBoolValue());
 
-        assertEquals("Expected and actual values should be the same.", expectedResult, Metrics.extractMetrics(payload));
-        assertThat("Instance of Map expected.", Metrics.extractMetrics(payload), IsInstanceOf.instanceOf(Map.class));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedResult, Metrics.extractMetrics(payload));
+        Assert.assertThat("Instance of Map expected.", Metrics.extractMetrics(payload), IsInstanceOf.instanceOf(Map.class));
     }
 
     @Test
     public void extractMetricsNullKuraMetricListTest() {
-        assertNull("Null expected.", Metrics.extractMetrics((List<KuraPayloadProto.KuraPayload.KuraMetric>) null));
+        Assert.assertNull("Null expected.", Metrics.extractMetrics((List<KuraPayloadProto.KuraPayload.KuraMetric>) null));
     }
 
     @Test
@@ -180,14 +181,14 @@ public class MetricsTest extends Assert {
             kuraMetricList.add(kuraMetric);
             expectedResult.put(name, value[i]);
 
-            assertEquals("Expected and actual values should be the same.", expectedResult, Metrics.extractMetrics(kuraMetricList));
-            assertThat("Instance of Map expected.", Metrics.extractMetrics(kuraMetricList), IsInstanceOf.instanceOf(Map.class));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedResult, Metrics.extractMetrics(kuraMetricList));
+        Assert.assertThat("Instance of Map expected.", Metrics.extractMetrics(kuraMetricList), IsInstanceOf.instanceOf(Map.class));
             expectedResultWholeList.put(name, kuraMetric.getStringValue());
         }
 
         //whole list
-        assertEquals("Expected and actual values should be the same.", expectedResultWholeList, Metrics.extractMetrics(kuraMetricList));
-        assertThat("Instance of Map expected.", Metrics.extractMetrics(kuraMetricList), IsInstanceOf.instanceOf(Map.class));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedResultWholeList, Metrics.extractMetrics(kuraMetricList));
+        Assert.assertThat("Instance of Map expected.", Metrics.extractMetrics(kuraMetricList), IsInstanceOf.instanceOf(Map.class));
     }
 
     @Test
@@ -199,19 +200,19 @@ public class MetricsTest extends Assert {
         String differentKey = "Second key";
         String[] expectedValue = {null, "value", null};
 
-        assertNull("Null expected.", Metrics.getAsString(metricsWithoutKey, key));
+        Assert.assertNull("Null expected.", Metrics.getAsString(metricsWithoutKey, key));
 
         for (int i = 0; i < value.length; i++) {
             metrics.put("Key", value[i]);
-            assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key));
-            assertNull("Null expected.", Metrics.getAsString(metrics, differentKey));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key));
+            Assert.assertNull("Null expected.", Metrics.getAsString(metrics, differentKey));
         }
     }
 
     @Test(expected = NullPointerException.class)
     public void getAsStringNullMetricsKeyTest() {
         String key = "Key";
-        assertNull("Null expected.", Metrics.getAsString(null, key));
+        Assert.assertNull("Null expected.", Metrics.getAsString(null, key));
     }
 
     @Test
@@ -219,12 +220,12 @@ public class MetricsTest extends Assert {
         Map<String, Object> metrics = new HashMap<>();
         String key = "Key";
 
-        assertNull("Null expected.", Metrics.getAsString(metrics, null));
+        Assert.assertNull("Null expected.", Metrics.getAsString(metrics, null));
 
         metrics.put(null, "value");
-        assertEquals("Expected and actual values should be the same.", "value", Metrics.getAsString(metrics, null));
+        Assert.assertEquals("Expected and actual values should be the same.", "value", Metrics.getAsString(metrics, null));
         metrics.put(key, null);
-        assertEquals("Expected and actual values should be the same.", "value", Metrics.getAsString(metrics, null));
+        Assert.assertEquals("Expected and actual values should be the same.", "value", Metrics.getAsString(metrics, null));
     }
 
     @Test
@@ -237,12 +238,12 @@ public class MetricsTest extends Assert {
         String defaultValue = "Default Value";
         String[] expectedValue = {defaultValue, "value", defaultValue};
 
-        assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metricsWithoutKey, key, defaultValue));
+        Assert.assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metricsWithoutKey, key, defaultValue));
 
         for (int i = 0; i < value.length; i++) {
             metrics.put("Key", value[i]);
-            assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key, defaultValue));
-            assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metrics, differentKey, defaultValue));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key, defaultValue));
+            Assert.assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metrics, differentKey, defaultValue));
         }
     }
 
@@ -250,7 +251,7 @@ public class MetricsTest extends Assert {
     public void getAsStringNullMetricsKeyDefaultValueTest() {
         String key = "Key";
         String defaultValue = "Default Value";
-        assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(null, key, defaultValue));
+        Assert.assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(null, key, defaultValue));
     }
 
     @Test
@@ -260,7 +261,7 @@ public class MetricsTest extends Assert {
         String defaultValue = "Default Value";
         for (int i = 0; i < value.length; i++) {
             metrics.put("Key", value[i]);
-            assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metrics, null, defaultValue));
+            Assert.assertEquals("Expected and actual values should be the same.", defaultValue, Metrics.getAsString(metrics, null, defaultValue));
         }
     }
 
@@ -273,12 +274,12 @@ public class MetricsTest extends Assert {
         String differentKey = "Second key";
         String[] expectedValue = {null, "value", null};
 
-        assertNull("Null expected.", Metrics.getAsString(metricsWithoutKey, key, null));
+        Assert.assertNull("Null expected.", Metrics.getAsString(metricsWithoutKey, key, null));
 
         for (int i = 0; i < value.length; i++) {
             metrics.put("Key", value[i]);
-            assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key, null));
-            assertNull("Null expected.", Metrics.getAsString(metrics, differentKey, null));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValue[i], Metrics.getAsString(metrics, key, null));
+            Assert.assertNull("Null expected.", Metrics.getAsString(metrics, differentKey, null));
         }
     }
 }

--- a/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/profile/kura/KuraMqttProfileTest.java
+++ b/client/gateway/profile/kura/src/test/java/org/eclipse/kapua/client/gateway/profile/kura/KuraMqttProfileTest.java
@@ -26,8 +26,9 @@ import org.mockito.Mockito;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 
+
 @Category(JUnitTests.class)
-public class KuraMqttProfileTest extends Assert {
+public class KuraMqttProfileTest {
 
     Supplier supplier;
     KuraMqttProfile kuraMqttProfile;
@@ -57,27 +58,27 @@ public class KuraMqttProfileTest extends Assert {
 
     @Test
     public void newProfileTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile, IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile, IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void accountNameTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.accountName(accountName), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.accountName(accountName), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void accountNameNullTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.accountName(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.accountName(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void brokerUrlTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.brokerUrl(brokerUrl), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.brokerUrl(brokerUrl), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void brokerUrlNullTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.brokerUrl(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.brokerUrl(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
@@ -92,29 +93,29 @@ public class KuraMqttProfileTest extends Assert {
 
     @Test
     public void clientIdTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.clientId(clientId), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.clientId(clientId), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void clientIdNullTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.clientId(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.clientId(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void credentialsTest() {
         Credentials.UserAndPassword userAndPassword = Credentials.userAndPassword(username, password);
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.credentials(userAndPassword), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.credentials(userAndPassword), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
     @Test
     public void credentialsNullTest() {
-        assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.credentials(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
+        Assert.assertThat("Instance of KuraMqttProfile expected.", kuraMqttProfile.credentials(null), IsInstanceOf.instanceOf(KuraMqttProfile.class));
     }
 
 
     @Test
     public void buildNullCustomizerTest() throws Exception {
-        assertThat("Instance of Client expected.", kuraMqttProfile.accountName(accountName)
+        Assert.assertThat("Instance of Client expected.", kuraMqttProfile.accountName(accountName)
                 .brokerUrl(brokerUrl)
                 .clientId(clientId)
                 .credentials(Credentials.userAndPassword(username, password))
@@ -123,7 +124,7 @@ public class KuraMqttProfileTest extends Assert {
 
     @Test
     public void buildTest() throws Exception {
-        assertThat("Instance of Client expected.", kuraMqttProfile.accountName(accountName)
+        Assert.assertThat("Instance of Client expected.", kuraMqttProfile.accountName(accountName)
                 .brokerUrl(brokerUrl)
                 .clientId(clientId)
                 .credentials(Credentials.userAndPassword(username, password))

--- a/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannelTest.java
+++ b/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/FuseChannelTest.java
@@ -34,8 +34,9 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class FuseChannelTest extends Assert {
+public class FuseChannelTest {
 
     private FuseChannel.Builder builder;
 
@@ -52,19 +53,19 @@ public class FuseChannelTest extends Assert {
     @Test
     public void builderBuilderTest() {
         FuseChannel.Builder builderExpected = new FuseChannel.Builder();
-        assertEquals("Actual and expected values should be the same.", builderExpected, builderExpected.builder());
+        Assert.assertEquals("Actual and expected values should be the same.", builderExpected, builderExpected.builder());
     }
 
     @Test
     public void builderBuildTest() throws Exception {
         builder.credentials(Credentials.userAndPassword("kapua-sys", new char[]{'a', 'b', 'c'}));
-        assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
+        Assert.assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
     }
 
     @Test
     public void builderBuildCredentialsNullTest() throws Exception {
         builder.credentials(null);
-        assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
+        Assert.assertThat("Instance of FuseChannel expected.", builder.build(), IsInstanceOf.instanceOf(FuseChannel.class));
     }
 
     @Test

--- a/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/CallbacksTest.java
+++ b/client/gateway/provider/fuse/src/test/java/org/eclipse/kapua/client/gateway/mqtt/fuse/internal/CallbacksTest.java
@@ -24,13 +24,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.concurrent.CompletableFuture;
 
+
 @Category(JUnitTests.class)
-public class CallbacksTest extends Assert {
+public class CallbacksTest {
 
     @Test
     public void callbacksTest() throws IllegalAccessException, InvocationTargetException, InstantiationException, NoSuchMethodException {
         Constructor<Callbacks> constructor = Callbacks.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }

--- a/client/gateway/provider/mqtt/src/test/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannelTest.java
+++ b/client/gateway/provider/mqtt/src/test/java/org/eclipse/kapua/client/gateway/mqtt/AbstractMqttChannelTest.java
@@ -36,8 +36,9 @@ import java.util.List;
 import java.util.Set;
 import java.util.concurrent.CompletionStage;
 
+
 @Category(JUnitTests.class)
-public class AbstractMqttChannelTest extends Assert {
+public class AbstractMqttChannelTest {
 
     private BinaryPayloadCodec codec;
     private MqttNamespace namespace;
@@ -101,68 +102,68 @@ public class AbstractMqttChannelTest extends Assert {
 
     @Test
     public void builderCodecTest() {
-        assertNull("Expected null value.", builder.codec());
+        Assert.assertNull("Expected null value.", builder.codec());
         builder.codec(codec);
-        assertEquals("Expected and actual values should be the same.", codec, builder.codec());
-        assertThat("Instance of BinaryPayloadCodec expected", builder.codec(), IsInstanceOf.instanceOf(BinaryPayloadCodec.class));
+        Assert.assertEquals("Expected and actual values should be the same.", codec, builder.codec());
+        Assert.assertThat("Instance of BinaryPayloadCodec expected", builder.codec(), IsInstanceOf.instanceOf(BinaryPayloadCodec.class));
     }
 
     @Test
     public void builderCodecNullTest() {
         builder.codec(null);
-        assertNull("Expected null value.", builder.codec());
+        Assert.assertNull("Expected null value.", builder.codec());
     }
 
     @Test
     public void builderNamespaceTest() {
-        assertNull("Expected null value.", builder.namespace());
+        Assert.assertNull("Expected null value.", builder.namespace());
         builder.namespace(namespace);
-        assertEquals("Expected and actual values should be the same.", namespace, builder.namespace());
-        assertThat("Instance of MqttNamespace expected", builder.namespace(), IsInstanceOf.instanceOf(MqttNamespace.class));
+        Assert.assertEquals("Expected and actual values should be the same.", namespace, builder.namespace());
+        Assert.assertThat("Instance of MqttNamespace expected", builder.namespace(), IsInstanceOf.instanceOf(MqttNamespace.class));
     }
 
     @Test
     public void builderNamespaceNullTest() {
         builder.namespace(null);
-        assertNull("Expected null value.", builder.namespace());
+        Assert.assertNull("Expected null value.", builder.namespace());
     }
 
     @Test
     public void builderClientIdTest() {
-        assertNull("Expected null value.", builder.clientId());
+        Assert.assertNull("Expected null value.", builder.clientId());
         builder.clientId(clientId);
-        assertEquals("Expected and actual values should be the same.", clientId, builder.clientId());
-        assertThat("Instance of String expected", builder.clientId(), IsInstanceOf.instanceOf(String.class));
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, builder.clientId());
+        Assert.assertThat("Instance of String expected", builder.clientId(), IsInstanceOf.instanceOf(String.class));
     }
 
     @Test
     public void builderClientIdNullTest() {
         builder.clientId(null);
-        assertNull("Expected null value.", builder.clientId());
+        Assert.assertNull("Expected null value.", builder.clientId());
     }
 
     @Test
     public void builderCredentialsTest() {
-        assertNull("Expected null value.", builder.credentials());
+        Assert.assertNull("Expected null value.", builder.credentials());
         final Credentials.UserAndPassword userAndPassword = Credentials.userAndPassword("kapua-broker", "kapua-password");
         builder.credentials(userAndPassword);
-        assertEquals("Expected and actual values should be the same.", userAndPassword, builder.credentials());
-        assertThat("Instance of Credentials.UserAndPassword expected", builder.credentials(), IsInstanceOf.instanceOf(Credentials.UserAndPassword.class));
+        Assert.assertEquals("Expected and actual values should be the same.", userAndPassword, builder.credentials());
+        Assert.assertThat("Instance of Credentials.UserAndPassword expected", builder.credentials(), IsInstanceOf.instanceOf(Credentials.UserAndPassword.class));
     }
 
     @Test
     public void builderCredentialsNullTest() {
         builder.credentials(null);
-        assertNull("Expected null value.", builder.credentials());
+        Assert.assertNull("Expected null value.", builder.credentials());
     }
 
     @Test
     public void builderBrokerStringIdTest() throws URISyntaxException {
-        assertNull("Expected null value.", builder.broker());
+        Assert.assertNull("Expected null value.", builder.broker());
         final String broker = "broker";
         builder.broker(broker);
-        assertEquals("Expected and actual values should be the same.", new URI(broker), builder.broker());
-        assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
+        Assert.assertEquals("Expected and actual values should be the same.", new URI(broker), builder.broker());
+        Assert.assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
 
     }
 
@@ -174,11 +175,11 @@ public class AbstractMqttChannelTest extends Assert {
 
     @Test
     public void builderBrokerURIIdTest() throws URISyntaxException {
-        assertNull("Expected null value.", builder.broker());
+        Assert.assertNull("Expected null value.", builder.broker());
         final URI broker = new URI("string");
         builder.broker(broker);
-        assertEquals("Expected and actual values should be the same.", broker, builder.broker());
-        assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
+        Assert.assertEquals("Expected and actual values should be the same.", broker, builder.broker());
+        Assert.assertThat("Instance of URI expected", builder.broker(), IsInstanceOf.instanceOf(URI.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -189,36 +190,36 @@ public class AbstractMqttChannelTest extends Assert {
 
     @Test
     public void abstractMqttChannelTest() {
-        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
-        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
     }
 
     @Test
     public void abstractMqttChannelCodecNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, namespace, clientId);
-        assertNull("Expected null value.", mqttChannel.getCodec());
-        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+        Assert.assertNull("Expected null value.", mqttChannel.getCodec());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
     }
 
     @Test
     public void abstractMqttChannelNamespaceNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, null, clientId);
-        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
-        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
     }
 
     @Test
     public void abstractMqttChannelNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, null, null);
-        assertNull("Expected null value.", mqttChannel.getCodec());
-        assertNull("Expected null value.", mqttChannel.getMqttClientId());
+        Assert.assertNull("Expected null value.", mqttChannel.getCodec());
+        Assert.assertNull("Expected null value.", mqttChannel.getMqttClientId());
     }
 
     @Test
     public void abstractMqttChannelClientIdNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, namespace, null);
-        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
-        assertNull("Expected null.", mqttChannel.getMqttClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        Assert.assertNull("Expected null.", mqttChannel.getMqttClientId());
     }
 
     @Test
@@ -241,7 +242,7 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("0123456789");
         final Topic topic = Topic.of(segments);
         final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
-        assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, buffer));
+        Assert.assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, buffer));
     }
 
     @Test
@@ -252,14 +253,14 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("0123456789");
         final Topic topic = Topic.of(segments);
         final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
-        assertNull("Expected null value.", mqttChannel.publish(null, topic, buffer));
+        Assert.assertNull("Expected null value.", mqttChannel.publish(null, topic, buffer));
     }
 
     @Test
     public void publishTopicNullTest() {
         final String applicationId = "appId";
         final ByteBuffer buffer = Mockito.mock(ByteBuffer.class);
-        assertNull("Expected null value.", mqttChannel.publish(applicationId, null, buffer));
+        Assert.assertNull("Expected null value.", mqttChannel.publish(applicationId, null, buffer));
     }
 
     @Test
@@ -270,7 +271,7 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("STRING");
         segments.add("0123456789");
         final Topic topic = Topic.of(segments);
-        assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, null));
+        Assert.assertNull("Expected null value.", mqttChannel.publish(applicationId, topic, null));
     }
 
     @Test
@@ -290,14 +291,14 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final Payload payload = Mockito.mock(Payload.class);
-        assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(null, topic, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(null, topic, payload), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test
     public void handlePublishTopicNullTest() {
         final String applicationId = "appId";
         final Payload payload = Mockito.mock(Payload.class);
-        assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(applicationId, null, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", mqttChannel.handlePublish(applicationId, null, payload), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -317,7 +318,7 @@ public class AbstractMqttChannelTest extends Assert {
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, errorHandler));
+        Assert.assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, errorHandler));
     }
 
     @Test
@@ -327,7 +328,7 @@ public class AbstractMqttChannelTest extends Assert {
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertNull("Expected null value.", mqttChannel.handleSubscribe(null, topic, messageHandler, errorHandler));
+        Assert.assertNull("Expected null value.", mqttChannel.handleSubscribe(null, topic, messageHandler, errorHandler));
     }
 
     @Test
@@ -335,7 +336,7 @@ public class AbstractMqttChannelTest extends Assert {
         final String applicationId = "appId";
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, null, messageHandler, errorHandler));
+        Assert.assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, null, messageHandler, errorHandler));
     }
 
     @Test
@@ -345,7 +346,7 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, null, errorHandler));
+        Assert.assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, null, errorHandler));
     }
 
     @Test
@@ -355,7 +356,7 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
-        assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, null));
+        Assert.assertNull("Expected null value.", mqttChannel.handleSubscribe(applicationId, topic, messageHandler, null));
     }
 
     @Test
@@ -373,7 +374,7 @@ public class AbstractMqttChannelTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final MqttMessageHandler messageHandler = Mockito.mock(MqttMessageHandler.class);
-        assertNull("Expected null value.", mqttChannel.subscribe(applicationId, topic, messageHandler));
+        Assert.assertNull("Expected null value.", mqttChannel.subscribe(applicationId, topic, messageHandler));
     }
 
     @Test
@@ -407,23 +408,23 @@ public class AbstractMqttChannelTest extends Assert {
 
     @Test
     public void getMqttClientIdTest() {
-        assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, mqttChannel.getMqttClientId());
     }
 
     @Test
     public void getMqttClientIdNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(codec, namespace, null);
-        assertNull("Expected null value.", mqttChannel.getMqttClientId());
+        Assert.assertNull("Expected null value.", mqttChannel.getMqttClientId());
     }
 
     @Test
     public void getCodecTest() {
-        assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
+        Assert.assertEquals("Expected and actual values should be the same.", codec, mqttChannel.getCodec());
     }
 
     @Test
     public void getCodecNullTest() {
         AbstractMqttChannel mqttChannel = new ActualMqttChannel(null, namespace, clientId);
-        assertNull("Expected null value.", mqttChannel.getCodec());
+        Assert.assertNull("Expected null value.", mqttChannel.getCodec());
     }
 }

--- a/client/gateway/provider/paho/src/test/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/ListenersTest.java
+++ b/client/gateway/provider/paho/src/test/java/org/eclipse/kapua/client/gateway/mqtt/paho/internal/ListenersTest.java
@@ -28,9 +28,9 @@ import java.lang.reflect.Modifier;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Consumer;
 
-@Category(JUnitTests.class)
-public class ListenersTest extends Assert {
 
+@Category(JUnitTests.class)
+public class ListenersTest {
     private Runnable success;
     private Consumer<Throwable> failure;
     private IMqttToken asyncActionToken;
@@ -49,7 +49,7 @@ public class ListenersTest extends Assert {
     @Test
     public void listenersTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<Listeners> constructor = Listeners.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }
@@ -62,17 +62,17 @@ public class ListenersTest extends Assert {
 
     @Test
     public void toListenerRunnableIdAndConsumerIdTest() {
-        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
+        Assert.assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
     }
 
     @Test
     public void toListenerRunnableIdNullAndConsumerIdTest() {
-        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
+        Assert.assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null, failure), IsInstanceOf.instanceOf(IMqttActionListener.class));
     }
 
     @Test
     public void toListenerRunnableIdAndConsumerIdNullTest() {
-        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, null), IsInstanceOf.instanceOf(IMqttActionListener.class));
+        Assert.assertThat("Instance of IMqttActionListener expected", Listeners.toListener(success, null), IsInstanceOf.instanceOf(IMqttActionListener.class));
     }
 
     @Test
@@ -139,11 +139,11 @@ public class ListenersTest extends Assert {
 
     @Test
     public void toListenerCompletableFutureIdTest() {
-        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(future), IsInstanceOf.instanceOf(IMqttActionListener.class));
+        Assert.assertThat("Instance of IMqttActionListener expected", Listeners.toListener(future), IsInstanceOf.instanceOf(IMqttActionListener.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void toListenerCompletableFutureIdNullTest() {
-        assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null), IsInstanceOf.instanceOf(IMqttActionListener.class));
+        Assert.assertThat("Instance of IMqttActionListener expected", Listeners.toListener(null), IsInstanceOf.instanceOf(IMqttActionListener.class));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/AbstractClientTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/AbstractClientTest.java
@@ -41,7 +41,7 @@ import java.util.concurrent.ScheduledExecutorService;
 
 @Category(JUnitTests.class)
 @RunWith(value = Parameterized.class)
-public class AbstractClientTest extends Assert {
+public class AbstractClientTest {
 
     private ScheduledExecutorService executor;
     private Module module;
@@ -107,8 +107,8 @@ public class AbstractClientTest extends Assert {
 
     @Test
     public void abstractClientTest() {
-        assertEquals("Expected and actual values should be the same.", executor, abstractClient.executor);
-        assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
+        Assert.assertEquals("Expected and actual values should be the same.", executor, abstractClient.executor);
+        Assert.assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
     }
 
     @Test
@@ -116,8 +116,8 @@ public class AbstractClientTest extends Assert {
         final Set<Module> modules = new HashSet<>();
         modules.add(Mockito.mock(Module.class));
         AbstractClient abstractClient = new ActualClient(null, modules);
-        assertNull("Expected null value.", abstractClient.executor);
-        assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
+        Assert.assertNull("Expected null value.", abstractClient.executor);
+        Assert.assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -128,25 +128,25 @@ public class AbstractClientTest extends Assert {
     @Test(expected = NullPointerException.class)
     public void abstractClientExecutorAndModulesNullTest() {
         AbstractClient abstractClient = new ActualClient(null, null);
-        assertNull("Expected null value.", abstractClient.executor);
-        assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
+        Assert.assertNull("Expected null value.", abstractClient.executor);
+        Assert.assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
     }
 
     @Test(expected = ClassNotFoundException.class)
     public void adaptModuleContextTest() throws ClassNotFoundException {
         Class<Integer> clazz = (Class<Integer>) Class.forName("className");
-        assertEquals("Expected and actual values should be the same.", Optional.empty(), abstractClient.adaptModuleContext(clazz));
+        Assert.assertEquals("Expected and actual values should be the same.", Optional.empty(), abstractClient.adaptModuleContext(clazz));
     }
 
     @Test
     public void adaptModuleContextClazzNullTest() {
-        assertEquals("Expected and actual values should be the same.", Optional.empty(), abstractClient.adaptModuleContext(null));
+        Assert.assertEquals("Expected and actual values should be the same.", Optional.empty(), abstractClient.adaptModuleContext(null));
     }
 
     @Test
     public void transportTest() {
-        assertNotNull("Expected not null value.", abstractClient.transport());
-        assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
+        Assert.assertNotNull("Expected not null value.", abstractClient.transport());
+        Assert.assertThat("Instance of TransportAsync expected", abstractClient.transport(), IsInstanceOf.instanceOf(TransportAsync.class));
     }
 
     @Test
@@ -163,30 +163,30 @@ public class AbstractClientTest extends Assert {
 
     @Test
     public void buildApplicationTest() {
-        assertThat("Instance of Application.Builder expected", abstractClient.buildApplication(applicationId), IsInstanceOf.instanceOf(Application.Builder.class));
+        Assert.assertThat("Instance of Application.Builder expected", abstractClient.buildApplication(applicationId), IsInstanceOf.instanceOf(Application.Builder.class));
     }
 
     @Test
     public void buildApplicationBuildTest() {
-        assertThat("Instance of Application expected", abstractClient.buildApplication(applicationId).build(), IsInstanceOf.instanceOf(Application.class));
+        Assert.assertThat("Instance of Application expected", abstractClient.buildApplication(applicationId).build(), IsInstanceOf.instanceOf(Application.class));
     }
 
     @Test
     public void internalBuildApplicationTest() {
         final Application.Builder builder = Mockito.mock(Application.Builder.class);
-        assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(builder, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
+        Assert.assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(builder, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
     }
 
     @Test(expected = IllegalStateException.class)
     public void internalBuildApplicationExceptionPartTest() {
         final Application.Builder builder = Mockito.mock(Application.Builder.class);
         abstractClient.buildApplication(applicationId).build();
-        assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(builder, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
+        Assert.assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(builder, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
     }
 
     @Test
     public void internalBuildApplicationBuilderNullTest() {
-        assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(null, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
+        Assert.assertThat("Instance of DefaultApplication expected", abstractClient.internalBuildApplication(null, applicationId), IsInstanceOf.instanceOf(DefaultApplication.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -196,14 +196,14 @@ public class AbstractClientTest extends Assert {
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, messageHandler, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, messageHandler, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void internalSubscribeContextAndTopicNullTest() {
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, null, messageHandler, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, null, messageHandler, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -212,7 +212,7 @@ public class AbstractClientTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, null, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, null, errorHandler), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -221,7 +221,7 @@ public class AbstractClientTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, messageHandler, null), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalSubscribe(null, applicationId, topic, messageHandler, null), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test
@@ -231,7 +231,7 @@ public class AbstractClientTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final Payload payload = Mockito.mock(Payload.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, topic, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, topic, payload), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test
@@ -240,14 +240,14 @@ public class AbstractClientTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final Payload payload = Mockito.mock(Payload.class);
-        assertNull(abstractClient.internalPublish(null, applicationId, topic, payload));
+        Assert.assertNull(abstractClient.internalPublish(null, applicationId, topic, payload));
     }
 
     @Test
     public void internalPublishTopicNullTest() {
         final AbstractClient.Context context = Mockito.mock(AbstractClient.Context.class);
         final Payload payload = Mockito.mock(Payload.class);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, null, payload), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, null, payload), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test
@@ -256,7 +256,7 @@ public class AbstractClientTest extends Assert {
         List<String> segments = new ArrayList<>();
         segments.add("string");
         final Topic topic = Topic.of(segments);
-        assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, topic,null), IsInstanceOf.instanceOf(CompletionStage.class));
+        Assert.assertThat("Instance of CompletionStage expected", abstractClient.internalPublish(context, applicationId, topic,null), IsInstanceOf.instanceOf(CompletionStage.class));
     }
 
     @Test
@@ -264,20 +264,20 @@ public class AbstractClientTest extends Assert {
         final Application.Builder builder = Mockito.mock(Application.Builder.class);
         final AbstractClient.Context context = Mockito.mock(AbstractClient.Context.class);
         DefaultApplication defaultApplicationExpected = new DefaultApplication(context);
-        assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(builder, context).transport());
+        Assert.assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(builder, context).transport());
     }
 
     @Test
     public void createApplicationBuilderNullTest() {
         final AbstractClient.Context context = Mockito.mock(AbstractClient.Context.class);
         DefaultApplication defaultApplicationExpected = new DefaultApplication(context);
-        assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(null, context).transport());
+        Assert.assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(null, context).transport());
     }
 
     @Test(expected = NullPointerException.class)
     public void createApplicationContextNullTest() {
         final Application.Builder builder = Mockito.mock(Application.Builder.class);
         DefaultApplication defaultApplicationExpected = new DefaultApplication(null);
-        assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(builder, null).transport());
+        Assert.assertEquals("Expected and actual values should be the same.", defaultApplicationExpected.transport(), abstractClient.createApplication(builder, null).transport());
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultApplicationTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultApplicationTest.java
@@ -27,8 +27,9 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Category(JUnitTests.class)
-public class DefaultApplicationTest extends Assert {
+public class DefaultApplicationTest {
 
     private AbstractClient.Context context;
     private DefaultApplication defaultApplication;
@@ -41,12 +42,12 @@ public class DefaultApplicationTest extends Assert {
 
     @Test
     public void defaultApplicationContextIdTest() {
-        assertThat("Instance of DefaultApplication expected.", defaultApplication, IsInstanceOf.instanceOf(DefaultApplication.class));
+        Assert.assertThat("Instance of DefaultApplication expected.", defaultApplication, IsInstanceOf.instanceOf(DefaultApplication.class));
     }
 
     @Test
     public void transportTest() {
-        assertEquals("Expected and actual values should be the same.", context.transport(), defaultApplication.transport());
+        Assert.assertEquals("Expected and actual values should be the same.", context.transport(), defaultApplication.transport());
     }
 
     @Test
@@ -54,12 +55,12 @@ public class DefaultApplicationTest extends Assert {
         List<String> segments = new ArrayList<>();
         segments.add("string");
         Topic topic = Topic.of(segments);
-        assertThat("Instance of DefaultData expected.", defaultApplication.data(topic), IsInstanceOf.instanceOf(DefaultData.class));
+        Assert.assertThat("Instance of DefaultData expected.", defaultApplication.data(topic), IsInstanceOf.instanceOf(DefaultData.class));
     }
 
     @Test
     public void dataNullTest() {
-        assertThat("Instance of DefaultData expected.", defaultApplication.data(null), IsInstanceOf.instanceOf(DefaultData.class));
+        Assert.assertThat("Instance of DefaultData expected.", defaultApplication.data(null), IsInstanceOf.instanceOf(DefaultData.class));
     }
 
     @Test
@@ -74,13 +75,13 @@ public class DefaultApplicationTest extends Assert {
         segments.add("string");
         Topic topic = Topic.of(segments);
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", context.publish(topic, payload), defaultApplication.publish(topic, payload));
+        Assert.assertEquals("Expected and actual values should be the same.", context.publish(topic, payload), defaultApplication.publish(topic, payload));
     }
 
     @Test
     public void publishTopicNullTest() {
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", context.publish(null, payload), defaultApplication.publish(null, payload));
+        Assert.assertEquals("Expected and actual values should be the same.", context.publish(null, payload), defaultApplication.publish(null, payload));
     }
 
     @Test
@@ -88,12 +89,12 @@ public class DefaultApplicationTest extends Assert {
         List<String> segments = new ArrayList<>();
         segments.add("string");
         Topic topic = Topic.of(segments);
-        assertEquals("Expected and actual values should be the same.", context.publish(topic, null), defaultApplication.publish(topic, null));
+        Assert.assertEquals("Expected and actual values should be the same.", context.publish(topic, null), defaultApplication.publish(topic, null));
     }
 
     @Test
     public void publishTopicAndPayloadNullTest() {
-        assertEquals("Expected and actual values should be the same.", context.publish(null, null), defaultApplication.publish(null, null));
+        Assert.assertEquals("Expected and actual values should be the same.", context.publish(null, null), defaultApplication.publish(null, null));
     }
 
     @Test
@@ -103,14 +104,14 @@ public class DefaultApplicationTest extends Assert {
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", context.subscribe(topic, messageHandler, errorHandler), defaultApplication.subscribe(topic, messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", context.subscribe(topic, messageHandler, errorHandler), defaultApplication.subscribe(topic, messageHandler, errorHandler));
     }
 
     @Test
     public void subscribeTopicNullTest() throws Exception {
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", context.subscribe(null, messageHandler, errorHandler), defaultApplication.subscribe(null, messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", context.subscribe(null, messageHandler, errorHandler), defaultApplication.subscribe(null, messageHandler, errorHandler));
     }
 
     @Test
@@ -119,7 +120,7 @@ public class DefaultApplicationTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", context.subscribe(topic, null, errorHandler), defaultApplication.subscribe(topic, null, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", context.subscribe(topic, null, errorHandler), defaultApplication.subscribe(topic, null, errorHandler));
     }
 
     @Test
@@ -128,11 +129,11 @@ public class DefaultApplicationTest extends Assert {
         segments.add("string");
         final Topic topic = Topic.of(segments);
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
-        assertEquals("Expected and actual values should be the same.", context.subscribe(topic, messageHandler, null), defaultApplication.subscribe(topic, messageHandler, null));
+        Assert.assertEquals("Expected and actual values should be the same.", context.subscribe(topic, messageHandler, null), defaultApplication.subscribe(topic, messageHandler, null));
     }
 
     @Test
     public void subscribeNullTest() throws Exception {
-        assertEquals("Expected and actual values should be the same.", context.subscribe(null, null, null), defaultApplication.subscribe(null, null, null));
+        Assert.assertEquals("Expected and actual values should be the same.", context.subscribe(null, null, null), defaultApplication.subscribe(null, null, null));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultClientTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultClientTest.java
@@ -30,27 +30,28 @@ import java.util.Set;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 
+
 @Category(JUnitTests.class)
-public class DefaultClientTest extends Assert {
+public class DefaultClientTest {
 
     @Test
     public void builderChannelIdTest() {
         Channel channel = Mockito.mock(Channel.class);
         DefaultClient.Builder builder = new DefaultClient.Builder(channel);
-        assertEquals("Expected and actual values should be the same.", builder, builder.module(Mockito.mock(Module.class)));
+        Assert.assertEquals("Expected and actual values should be the same.", builder, builder.module(Mockito.mock(Module.class)));
     }
 
     @Test(expected = NullPointerException.class)
     public void builderChannelIdNullTest() {
         DefaultClient.Builder builder = new DefaultClient.Builder(null);
-        assertEquals("Expected and actual values should be the same.", builder, builder.module(Mockito.mock(Module.class)));
+        Assert.assertEquals("Expected and actual values should be the same.", builder, builder.module(Mockito.mock(Module.class)));
     }
 
     @Test
     public void builderTest() {
         Channel channel = Mockito.mock(Channel.class);
         DefaultClient.Builder builder = new DefaultClient.Builder(channel);
-        assertEquals("Expected and actual values should be the same.", builder, builder.builder());
+        Assert.assertEquals("Expected and actual values should be the same.", builder, builder.builder());
     }
 
     @Test
@@ -63,7 +64,7 @@ public class DefaultClientTest extends Assert {
         modules.add(Mockito.mock(Module.class));
         DefaultClient client = new DefaultClient(channel, executorService, modules);
         client.init();
-        assertEquals("Expected and actual values should be the same.", client.executor.isShutdown(), defaultClientActual.executor.isShutdown());
+        Assert.assertEquals("Expected and actual values should be the same.", client.executor.isShutdown(), defaultClientActual.executor.isShutdown());
     }
 
     @Test
@@ -73,7 +74,7 @@ public class DefaultClientTest extends Assert {
         final Set<Module> modules = new HashSet<>();
         modules.add(Mockito.mock(Module.class));
         DefaultClient client = new DefaultClient(channel, executorService, modules);
-        assertEquals("Expected and actual values should be the same.", executorService, client.executor);
+        Assert.assertEquals("Expected and actual values should be the same.", executorService, client.executor);
     }
 
     @Test(expected = NullPointerException.class)
@@ -90,7 +91,7 @@ public class DefaultClientTest extends Assert {
         final Set<Module> modules = new HashSet<>();
         modules.add(Mockito.mock(Module.class));
         DefaultClient client = new DefaultClient(channel, null, modules);
-        assertNull("Expected null.", client.executor);
+        Assert.assertNull("Expected null.", client.executor);
     }
 
     @Test(expected = NullPointerException.class)
@@ -98,7 +99,7 @@ public class DefaultClientTest extends Assert {
         final Channel channel = Mockito.mock(Channel.class);
         final ScheduledExecutorService executorService = Mockito.mock(ScheduledExecutorService.class);
         DefaultClient client = new DefaultClient(channel, executorService, null);
-        assertEquals("Expected and actual values should be the same.", executorService, client.executor);
+        Assert.assertEquals("Expected and actual values should be the same.", executorService, client.executor);
     }
 
     @Test
@@ -109,7 +110,7 @@ public class DefaultClientTest extends Assert {
         modules.add(Mockito.mock(Module.class));
         DefaultClient client = new DefaultClient(channel, executorService, modules);
         client.close();
-        assertNull("Expected null.", client.executor.submit(Mockito.mock(Runnable.class)));
+        Assert.assertNull("Expected null.", client.executor.submit(Mockito.mock(Runnable.class)));
     }
 
     @Test(expected = ClassNotFoundException.class)
@@ -136,7 +137,7 @@ public class DefaultClientTest extends Assert {
         Topic topic = Topic.of(segments);
         MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, messageHandler, errorHandler), client.handleSubscribe(applicationId, topic, messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, messageHandler, errorHandler), client.handleSubscribe(applicationId, topic, messageHandler, errorHandler));
     }
 
     @Test
@@ -151,7 +152,7 @@ public class DefaultClientTest extends Assert {
         Topic topic = Topic.of(segments);
         MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(null, topic, messageHandler, errorHandler), client.handleSubscribe(null, topic, messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(null, topic, messageHandler, errorHandler), client.handleSubscribe(null, topic, messageHandler, errorHandler));
     }
 
     @Test
@@ -164,7 +165,7 @@ public class DefaultClientTest extends Assert {
         String applicationId = "id";
         MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, null, messageHandler, errorHandler), client.handleSubscribe(applicationId, null, messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, null, messageHandler, errorHandler), client.handleSubscribe(applicationId, null, messageHandler, errorHandler));
     }
 
     @Test
@@ -179,7 +180,7 @@ public class DefaultClientTest extends Assert {
         segments.add("string");
         Topic topic = Topic.of(segments);
         ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, null, errorHandler), client.handleSubscribe(applicationId, topic, null, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, null, errorHandler), client.handleSubscribe(applicationId, topic, null, errorHandler));
     }
 
     @Test
@@ -194,7 +195,7 @@ public class DefaultClientTest extends Assert {
         segments.add("string");
         Topic topic = Topic.of(segments);
         MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, messageHandler, null), client.handleSubscribe(applicationId, topic, messageHandler, null));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, messageHandler, null), client.handleSubscribe(applicationId, topic, messageHandler, null));
     }
 
     @Test
@@ -209,7 +210,7 @@ public class DefaultClientTest extends Assert {
         segments.add("string");
         Topic topic = Topic.of(segments);
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, topic, payload), client.handlePublish(applicationId, topic, payload));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, topic, payload), client.handlePublish(applicationId, topic, payload));
     }
 
     @Test
@@ -223,7 +224,7 @@ public class DefaultClientTest extends Assert {
         segments.add("string");
         Topic topic = Topic.of(segments);
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", channel.handlePublish(null, topic, payload), client.handlePublish(null, topic, payload));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handlePublish(null, topic, payload), client.handlePublish(null, topic, payload));
     }
 
     @Test
@@ -235,7 +236,7 @@ public class DefaultClientTest extends Assert {
         DefaultClient client = new DefaultClient(channel, executorService, modules);
         String applicationId = "id";
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, null, payload), client.handlePublish(applicationId, null, payload));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, null, payload), client.handlePublish(applicationId, null, payload));
     }
 
     @Test
@@ -249,7 +250,7 @@ public class DefaultClientTest extends Assert {
         List<String> segments = new ArrayList<>();
         segments.add("string");
         Topic topic = Topic.of(segments);
-        assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, topic, null), client.handlePublish(applicationId, topic, null));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handlePublish(applicationId, topic, null), client.handlePublish(applicationId, topic, null));
     }
 
     @Test
@@ -266,7 +267,7 @@ public class DefaultClientTest extends Assert {
         Collection<Topic> topics = new ArrayList<>();
         topics.add(topic);
         client.handleUnsubscribe(applicationId, topics);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(applicationId, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(applicationId, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
     }
 
     @Test
@@ -282,7 +283,7 @@ public class DefaultClientTest extends Assert {
         Collection<Topic> topics = new ArrayList<>();
         topics.add(topic);
         client.handleUnsubscribe(null, topics);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(null, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(null, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(null, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(null, topic, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
     }
 
     @Test
@@ -294,6 +295,6 @@ public class DefaultClientTest extends Assert {
         DefaultClient client = new DefaultClient(channel, executorService, modules);
         String applicationId = "id";
         client.handleUnsubscribe(applicationId, null);
-        assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, null, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(applicationId, null, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
+        Assert.assertEquals("Expected and actual values should be the same.", channel.handleSubscribe(applicationId, null, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)), client.handleSubscribe(applicationId, null, Mockito.mock(MessageHandler.class), Mockito.mock(ErrorHandler.class)));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultDataTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/DefaultDataTest.java
@@ -26,8 +26,9 @@ import org.mockito.Mockito;
 import java.util.ArrayList;
 import java.util.List;
 
+
 @Category(JUnitTests.class)
-public class DefaultDataTest extends Assert {
+public class DefaultDataTest {
 
     private DefaultApplication application;
     private List<String> segments;
@@ -45,20 +46,20 @@ public class DefaultDataTest extends Assert {
 
     @Test
     public void sendNullTest() {
-        assertEquals("Expected and actual values should be the same.", application.publish(topic, null), data.send((Payload) null));
+        Assert.assertEquals("Expected and actual values should be the same.", application.publish(topic, null), data.send((Payload) null));
     }
 
     @Test
     public void sendTest() {
         Payload payload = Mockito.mock(Payload.class);
-        assertEquals("Expected and actual values should be the same.", application.publish(topic, payload), data.send(payload));
+        Assert.assertEquals("Expected and actual values should be the same.", application.publish(topic, payload), data.send(payload));
     }
 
     @Test
     public void subscribeTest() throws Exception {
         final MessageHandler messageHandler = Mockito.mock(MessageHandler.class);
         final ErrorHandler<Exception> errorHandler = Mockito.mock(ErrorHandler.class);
-        assertEquals("Expected and actual values should be the same.", application.subscribe(topic, messageHandler, errorHandler), data.subscribe(messageHandler, errorHandler));
+        Assert.assertEquals("Expected and actual values should be the same.", application.subscribe(topic, messageHandler, errorHandler), data.subscribe(messageHandler, errorHandler));
     }
 
     @Test(expected = NullPointerException.class)

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/BuffersTest.java
@@ -24,20 +24,21 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.nio.ByteBuffer;
 
+
 @Category(JUnitTests.class)
-public class BuffersTest extends Assert {
+public class BuffersTest {
 
     @Test
     public void buffersTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<Buffers> constructor = Buffers.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }
 
     @Test
     public void wrapByteArrayDataNullTest() {
-        assertEquals("Expected and actual value should be the same", null, Buffers.wrap(null));
+        Assert.assertEquals("Expected and actual value should be the same", null, Buffers.wrap(null));
     }
 
     @Test
@@ -45,17 +46,17 @@ public class BuffersTest extends Assert {
         final byte[] byteArray = new byte[]{1, 3, 5, 7, 9};
         final ByteBuffer byteBuffer = ByteBuffer.wrap(byteArray);
         byteBuffer.position(byteBuffer.limit());
-        assertEquals("Expected and actual value should be the same", byteBuffer, Buffers.wrap(byteArray));
+        Assert.assertEquals("Expected and actual value should be the same", byteBuffer, Buffers.wrap(byteArray));
     }
 
     @Test
     public void toByteArrayBufferNullTest() {
-        assertEquals("Expected and actual value should be the same", null, Buffers.toByteArray(null));
+        Assert.assertEquals("Expected and actual value should be the same", null, Buffers.toByteArray(null));
     }
 
     @Test
     public void toByteArrayTest() {
         ByteBuffer byteBuffer = Mockito.mock(ByteBuffer.class);
-        assertThat("Instance of Buffers expected.", Buffers.toByteArray(byteBuffer), IsInstanceOf.instanceOf(byte[].class));
+        Assert.assertThat("Instance of Buffers expected.", Buffers.toByteArray(byteBuffer), IsInstanceOf.instanceOf(byte[].class));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/FuturesTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/FuturesTest.java
@@ -25,26 +25,27 @@ import java.lang.reflect.Modifier;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.CompletionStage;
 
+
 @Category(JUnitTests.class)
-public class FuturesTest extends Assert {
+public class FuturesTest {
 
     @Test
     public void futuresTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<Futures> constructor = Futures.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }
 
     @Test(expected = NullPointerException.class)
     public void completedExceptionallyThrowableNullTest() {
-        assertThat("Instance of CompletableFuture expected", Futures.completedExceptionally(null), IsInstanceOf.instanceOf(CompletableFuture.class));
+        Assert.assertThat("Instance of CompletableFuture expected", Futures.completedExceptionally(null), IsInstanceOf.instanceOf(CompletableFuture.class));
     }
 
     @Test
     public void completedExceptionallyTest() {
         Throwable error = new Throwable();
-        assertThat("Instance of CompletableFuture expected", Futures.completedExceptionally(error), IsInstanceOf.instanceOf(CompletableFuture.class));
+        Assert.assertThat("Instance of CompletableFuture expected", Futures.completedExceptionally(error), IsInstanceOf.instanceOf(CompletableFuture.class));
     }
 
     @Test(expected = InvocationTargetException.class)
@@ -52,6 +53,6 @@ public class FuturesTest extends Assert {
         Method method = Futures.class.getDeclaredMethod("reportTo", CompletionStage.class, CompletableFuture.class);
         method.setAccessible(true);
         CompletionStage<String> completionStageNull = (CompletionStage<String>) method.invoke(null, null, null);
-        assertNull(completionStageNull);
+        Assert.assertNull(completionStageNull);
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/MoreExecutorsTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/MoreExecutorsTest.java
@@ -34,8 +34,9 @@ import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 
+
 @Category(JUnitTests.class)
-public class MoreExecutorsTest extends Assert {
+public class MoreExecutorsTest {
 
     ScheduledExecutorService executorService = Executors.newSingleThreadScheduledExecutor();
     ScheduledExecutorService executor = MoreExecutors.preventShutdown(executorService);
@@ -43,20 +44,20 @@ public class MoreExecutorsTest extends Assert {
     @Test
     public void moreExecutorsTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<MoreExecutors> constructor = MoreExecutors.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(constructor.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(constructor.getModifiers()));
         constructor.setAccessible(true);
         constructor.newInstance();
     }
 
     @Test
     public void preventShutdownTest() {
-        assertNotNull("Actual value shouldn't be null", MoreExecutors.preventShutdown(executorService));
-        assertThat("Instance of ScheduledExecutorService expected.", MoreExecutors.preventShutdown(executorService), IsInstanceOf.instanceOf(ScheduledExecutorService.class));
+        Assert.assertNotNull("Actual value shouldn't be null", MoreExecutors.preventShutdown(executorService));
+        Assert.assertThat("Instance of ScheduledExecutorService expected.", MoreExecutors.preventShutdown(executorService), IsInstanceOf.instanceOf(ScheduledExecutorService.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void preventShutdownNullExecutorTest() {
-        assertNotNull("Actual value shouldn't be null", MoreExecutors.preventShutdown(null));
+        Assert.assertNotNull("Actual value shouldn't be null", MoreExecutors.preventShutdown(null));
     }
 
     @Test
@@ -64,41 +65,41 @@ public class MoreExecutorsTest extends Assert {
         Runnable command = Mockito.mock(Runnable.class);
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleRunnableIdNullTest() {
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule((Runnable)null, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule((Runnable)null, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleRunnableIdUnitNullTest() {
         Runnable command = Mockito.mock(Runnable.class);
         long delay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
     public void scheduleRunnableIdDelayNullTest() {
         Runnable command = Mockito.mock(Runnable.class);
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(command, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
     public void executeTest() {
         Runnable command = Mockito.mock(Runnable.class);
         executor.execute(command);
-        assertFalse(executor.isShutdown());
+        Assert.assertFalse(executor.isShutdown());
     }
 
     @Test(expected = NullPointerException.class)
     public void executeNullTest() {
         executor.execute(null);
-        assertFalse(executor.isShutdown());
+        Assert.assertFalse(executor.isShutdown());
     }
 
     @Test
@@ -106,28 +107,28 @@ public class MoreExecutorsTest extends Assert {
         Callable<Integer> callable = Mockito.mock(Callable.class);
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleCallableIdNullTest() {
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule((Callable)null, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule((Callable)null, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleCallableIdUnitNullTest() {
         Callable<Integer> callable = Mockito.mock(Callable.class);
         long delay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
     public void scheduleCallableIdDelayNullTest() {
         Callable<Integer> callable = Mockito.mock(Callable.class);
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.schedule(callable, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
@@ -135,28 +136,28 @@ public class MoreExecutorsTest extends Assert {
         Runnable command = Mockito.mock(Runnable.class);
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, delay, 1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, delay, 1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleAtFixedRateRunnableIdNullTest() {
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(null, delay, 1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(null, delay, 1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void scheduleAtFixedRateUnitIdNullTest() {
         Runnable command = Mockito.mock(Runnable.class);
         long delay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, delay,1, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, delay,1, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
     public void scheduleAtFixedRateDelayIdNullTest() {
         Runnable command = Mockito.mock(Runnable.class);
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, 0,1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleAtFixedRate(command, 0,1, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = UnsupportedOperationException.class)
@@ -175,7 +176,7 @@ public class MoreExecutorsTest extends Assert {
         long initialDelay = 1L;
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -183,7 +184,7 @@ public class MoreExecutorsTest extends Assert {
         long initialDelay = 1L;
         long delay = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(null, initialDelay, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(null, initialDelay, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -191,7 +192,7 @@ public class MoreExecutorsTest extends Assert {
         Runnable runnable = Mockito.mock(Runnable.class);
         long initialDelay = 1L;
         long delay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, delay, null), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
@@ -199,7 +200,7 @@ public class MoreExecutorsTest extends Assert {
         Runnable runnable = Mockito.mock(Runnable.class);
         TimeUnit unit = TimeUnit.MINUTES;
         long delay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, 0, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, 0, delay, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -207,71 +208,71 @@ public class MoreExecutorsTest extends Assert {
         Runnable runnable = Mockito.mock(Runnable.class);
         TimeUnit unit = TimeUnit.MINUTES;
         long initialDelay = 1L;
-        assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
+        Assert.assertThat("Instance of ScheduledFuture expected.", executor.scheduleWithFixedDelay(runnable, initialDelay, 0, unit), IsInstanceOf.instanceOf(ScheduledFuture.class));
     }
 
     @Test
     public void isShutdownTest() {
-        assertFalse("Expected false", executor.isShutdown());
+        Assert.assertFalse("Expected false", executor.isShutdown());
     }
 
     @Test
     public void isTerminatedTest() {
-        assertFalse("Expected false", executor.isTerminated());
+        Assert.assertFalse("Expected false", executor.isTerminated());
     }
 
     @Test
     public void awaitTerminationTest() throws InterruptedException {
         long timeout = 5L;
         TimeUnit unit = TimeUnit.SECONDS;
-        assertFalse("Expected false", executor.awaitTermination(timeout, unit));
+        Assert.assertFalse("Expected false", executor.awaitTermination(timeout, unit));
     }
 
     @Test(expected = NullPointerException.class)
     public void awaitTerminationUnitIdNullTest() throws InterruptedException {
         long timeout = 1L;
-        assertFalse("Expected false", executor.awaitTermination(timeout, null));
+        Assert.assertFalse("Expected false", executor.awaitTermination(timeout, null));
     }
 
     @Test(expected = NullPointerException.class)
     public void submitCallableIdNullTest() {
-        assertThat("Instance of Future expected.", executor.submit((Callable)null), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit((Callable)null), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void submitCallableIdTest() {
         Callable<Integer> callable = Mockito.mock(Callable.class);
-        assertThat("Instance of Future expected.", executor.submit(callable), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit(callable), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void submitRunnableAndTIdTest() {
         Runnable runnable = Mockito.mock(Runnable.class);
         String result = "result";
-        assertThat("Instance of Future expected.", executor.submit(runnable, result), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit(runnable, result), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void submitRunnableNullAndTIdTest() {
         String result = "result";
-        assertThat("Instance of Future expected.", executor.submit((Runnable)null, result), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit((Runnable)null, result), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void submitRunnableAndTNullIdTest() {
         Runnable runnable = Mockito.mock(Runnable.class);
-        assertThat("Instance of Future expected.", executor.submit(runnable, null), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit(runnable, null), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void submitRunnableIdTest() {
         Runnable runnable = Mockito.mock(Runnable.class);
-        assertThat("Instance of Future expected.", executor.submit(runnable), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit(runnable), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void submitRunnableIdNullTest() {
-        assertThat("Instance of Future expected.", executor.submit((Runnable)null), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected.", executor.submit((Runnable)null), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
@@ -279,12 +280,12 @@ public class MoreExecutorsTest extends Assert {
         Collection<Callable<Object>> tasks = new ArrayList<>();
         tasks.add(Mockito.mock(Callable.class));
         tasks.add(Mockito.mock(Callable.class));
-        assertThat("Instance of List expected.", executor.invokeAll(tasks), IsInstanceOf.instanceOf(List.class));
+        Assert.assertThat("Instance of List expected.", executor.invokeAll(tasks), IsInstanceOf.instanceOf(List.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void invokeAllTasksIdNullTest() throws InterruptedException {
-        assertThat("Instance of List expected.", executor.invokeAll(null), IsInstanceOf.instanceOf(List.class));
+        Assert.assertThat("Instance of List expected.", executor.invokeAll(null), IsInstanceOf.instanceOf(List.class));
     }
 
     @Test
@@ -294,14 +295,14 @@ public class MoreExecutorsTest extends Assert {
         tasks.add(Mockito.mock(Callable.class));
         long timeout = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of List expected.", executor.invokeAll(tasks, timeout, unit), IsInstanceOf.instanceOf(List.class));
+        Assert.assertThat("Instance of List expected.", executor.invokeAll(tasks, timeout, unit), IsInstanceOf.instanceOf(List.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void invokeAllTasksNullTimeoutAndUnitIdTest() throws InterruptedException {
         long timeout = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertThat("Instance of List expected.", executor.invokeAll(null, timeout, unit), IsInstanceOf.instanceOf(List.class));
+        Assert.assertThat("Instance of List expected.", executor.invokeAll(null, timeout, unit), IsInstanceOf.instanceOf(List.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -310,7 +311,7 @@ public class MoreExecutorsTest extends Assert {
         tasks.add(Mockito.mock(Callable.class));
         tasks.add(Mockito.mock(Callable.class));
         long timeout = 1L;
-        assertThat("Instance of List expected.", executor.invokeAll(tasks, timeout, null), IsInstanceOf.instanceOf(List.class));
+        Assert.assertThat("Instance of List expected.", executor.invokeAll(tasks, timeout, null), IsInstanceOf.instanceOf(List.class));
     }
 
     @Test
@@ -318,7 +319,7 @@ public class MoreExecutorsTest extends Assert {
         Collection<Callable<Object>> tasks = new ArrayList<>();
         tasks.add(Mockito.mock(Callable.class));
         tasks.add(Mockito.mock(Callable.class));
-        assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks), executorService.invokeAny(tasks));
+        Assert.assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks), executorService.invokeAny(tasks));
     }
 
     @Test
@@ -328,7 +329,7 @@ public class MoreExecutorsTest extends Assert {
         tasks.add(Mockito.mock(Callable.class));
         long timeout = 1L;
         TimeUnit unit = TimeUnit.MINUTES;
-        assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks, timeout, unit), executorService.invokeAny(tasks, timeout, unit));
+        Assert.assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks, timeout, unit), executorService.invokeAny(tasks, timeout, unit));
     }
 
     @Test(expected = NullPointerException.class)
@@ -337,6 +338,6 @@ public class MoreExecutorsTest extends Assert {
         tasks.add(Mockito.mock(Callable.class));
         tasks.add(Mockito.mock(Callable.class));
         long timeout = 1L;
-        assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks, timeout, null), executorService.invokeAny(tasks, timeout, null));
+        Assert.assertEquals("Actual and expected values are not the same", executor.invokeAny(tasks, timeout, null), executorService.invokeAny(tasks, timeout, null));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/StringsTest.java
@@ -13,7 +13,6 @@
 package org.eclipse.kapua.client.gateway.spi.util;
 
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
@@ -25,7 +24,7 @@ import java.util.Collection;
 
 @Category(JUnitTests.class)
 @RunWith(value = Parameterized.class)
-public class StringsTest extends Assert {
+public class StringsTest {
 
     private final String string;
 

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportAsyncTest.java
@@ -23,35 +23,36 @@ import org.mockito.Mockito;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 
+
 @Category(JUnitTests.class)
-public class TransportAsyncTest extends Assert {
+public class TransportAsyncTest {
 
     final ExecutorService executorService = Mockito.mock(ExecutorService.class);
     TransportAsync transportAsync = new TransportAsync(executorService);
 
     @Test
     public void transportAsyncExecutorIdTest() {
-        assertThat("Instance of TransportAsync expected.", transportAsync, IsInstanceOf.instanceOf(TransportAsync.class));
+        Assert.assertThat("Instance of TransportAsync expected.", transportAsync, IsInstanceOf.instanceOf(TransportAsync.class));
     }
 
     @Test
     public void handleConnectedTest() {
-        assertThat("Instance of Future expected", transportAsync.handleConnected(), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected", transportAsync.handleConnected(), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void handleDisconnectedTest() {
-        assertThat("Instance of Future expected", transportAsync.handleDisconnected(), IsInstanceOf.instanceOf(Future.class));
+        Assert.assertThat("Instance of Future expected", transportAsync.handleDisconnected(), IsInstanceOf.instanceOf(Future.class));
     }
 
     @Test
     public void listenTest() {
         final Transport.Listener listener = Mockito.mock(Transport.Listener.class);
-        assertThat("Instance of ListenerHandle expected.", transportAsync.listen(listener), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
+        Assert.assertThat("Instance of ListenerHandle expected.", transportAsync.listen(listener), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
     }
 
     @Test
     public void listenListenerNullTest() {
-        assertThat("Instance of ListenerHandle expected.", transportAsync.listen(null), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
+        Assert.assertThat("Instance of ListenerHandle expected.", transportAsync.listen(null), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
     }
 }

--- a/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
+++ b/client/gateway/spi/src/test/java/org/eclipse/kapua/client/gateway/spi/util/TransportProxyTest.java
@@ -22,8 +22,9 @@ import org.mockito.Mockito;
 
 import java.util.concurrent.Executor;
 
+
 @Category(JUnitTests.class)
-public class TransportProxyTest extends Assert {
+public class TransportProxyTest {
 
     @Test(expected = IllegalStateException.class)
     public void closeTest() {
@@ -31,7 +32,7 @@ public class TransportProxyTest extends Assert {
         final Executor executor = Mockito.mock(Executor.class);
         TransportProxy transportProxy = TransportProxy.proxy(transport, executor);
         transportProxy.close();
-        assertNull(transportProxy.listen(Mockito.mock(Transport.Listener.class)));
+        Assert.assertNull(transportProxy.listen(Mockito.mock(Transport.Listener.class)));
     }
 
     @Test
@@ -40,7 +41,7 @@ public class TransportProxyTest extends Assert {
         final Executor executor = Mockito.mock(Executor.class);
         TransportProxy transportProxy = TransportProxy.proxy(transport, executor);
         final Transport.Listener listener = Mockito.mock(Transport.Listener.class);
-        assertThat("Instance of ListenerHandle expected.", transportProxy.listen(listener), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
+        Assert.assertThat("Instance of ListenerHandle expected.", transportProxy.listen(listener), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -48,30 +49,30 @@ public class TransportProxyTest extends Assert {
         final Transport transport = Mockito.mock(Transport.class);
         final Executor executor = Mockito.mock(Executor.class);
         TransportProxy transportProxy = TransportProxy.proxy(transport, executor);
-        assertThat("Instance of ListenerHandle expected.", transportProxy.listen(null), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
+        Assert.assertThat("Instance of ListenerHandle expected.", transportProxy.listen(null), IsInstanceOf.instanceOf(Transport.ListenerHandle.class));
     }
 
     @Test
     public void proxyTest() {
         final Transport transport = Mockito.mock(Transport.class);
         final Executor executor = Mockito.mock(Executor.class);
-        assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(transport, executor), IsInstanceOf.instanceOf(TransportProxy.class));
+        Assert.assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(transport, executor), IsInstanceOf.instanceOf(TransportProxy.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void proxyTransportNullTest() {
         final Executor executor = Mockito.mock(Executor.class);
-        assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(null, executor), IsInstanceOf.instanceOf(TransportProxy.class));
+        Assert.assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(null, executor), IsInstanceOf.instanceOf(TransportProxy.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void proxyExecutorNullTest() {
         final Transport transport = Mockito.mock(Transport.class);
-        assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(transport, null), IsInstanceOf.instanceOf(TransportProxy.class));
+        Assert.assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(transport, null), IsInstanceOf.instanceOf(TransportProxy.class));
     }
 
     @Test(expected = NullPointerException.class)
     public void proxyTransportNullAndExecutorNullTest() {
-        assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(null, null), IsInstanceOf.instanceOf(TransportProxy.class));
+        Assert.assertThat("Instance of TransportProxy expected.", TransportProxy.proxy(null, null), IsInstanceOf.instanceOf(TransportProxy.class));
     }
 }


### PR DESCRIPTION
Refactoring to avoid test classes to extend Assert - part 1

Signed-off-by: dseurotech <davide.salvador@eurotech.com>