### PR TITLE
Avoiding test antipattern in Kapua api

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/KapuaSerializableBodyWriterTest.java
@@ -33,8 +33,9 @@ import java.io.OutputStream;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Type;
 
+
 @Category(JUnitTests.class)
-public class KapuaSerializableBodyWriterTest extends Assert {
+public class KapuaSerializableBodyWriterTest {
 
     KapuaSerializableBodyWriter kapuaSerializableBodyWriter;
     Annotation[] annotations;
@@ -65,57 +66,57 @@ public class KapuaSerializableBodyWriterTest extends Assert {
 
     @Test
     public void isWriteableTest() {
-        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
+        Assert.assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullTypeTest() {
-        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(null, genericType, annotations, mediaType));
+        Assert.assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(null, genericType, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullGenericTypeTest() {
-        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, null, annotations, mediaType));
+        Assert.assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, null, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullAnnotationsTest() {
-        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, null, mediaType));
+        Assert.assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, null, mediaType));
     }
 
     @Test
     public void isWriteableNullMediaTypeTest() {
-        assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, null));
+        Assert.assertTrue("True expected.", kapuaSerializableBodyWriter.isWriteable(String.class, genericType, annotations, null));
     }
 
     @Test
     public void getSizeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullKapuaSerializableTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, null, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, null, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullGenericTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, null, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, null, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullAnnotationsTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, null, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, null, mediaType));
     }
 
     @Test
     public void getSizeNullMediaTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, null));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, kapuaSerializableBodyWriter.getSize(kapuaSerializable, String.class, genericType, annotations, null));
     }
 
     @Test(expected = WebApplicationException.class)
@@ -146,7 +147,7 @@ public class KapuaSerializableBodyWriterTest extends Assert {
         try {
             kapuaSerializableBodyWriter.writeTo(kapuaSerializable, String.class, genericType, annotations, mediaType, httpHeaders, outputStream);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/ListBodyWriterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/ListBodyWriterTest.java
@@ -34,8 +34,9 @@ import java.lang.reflect.Type;
 import java.util.LinkedList;
 import java.util.List;
 
+
 @Category(JUnitTests.class)
-public class ListBodyWriterTest extends Assert {
+public class ListBodyWriterTest {
 
     ListBodyWriter listBodyWriter;
     Type genericType;
@@ -66,57 +67,57 @@ public class ListBodyWriterTest extends Assert {
 
     @Test
     public void isWriteableTest() {
-        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
+        Assert.assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullTypeTest() {
-        assertTrue("True expected.", listBodyWriter.isWriteable(null, genericType, annotations, mediaType));
+        Assert.assertTrue("True expected.", listBodyWriter.isWriteable(null, genericType, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullGenericTypeTest() {
-        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, null, annotations, mediaType));
+        Assert.assertTrue("True expected.", listBodyWriter.isWriteable(String.class, null, annotations, mediaType));
     }
 
     @Test
     public void isWriteableNullAnnotationsTest() {
-        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, null, mediaType));
+        Assert.assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, null, mediaType));
     }
 
     @Test
     public void isWriteableNullMediaTypeTest() {
-        assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, null));
+        Assert.assertTrue("True expected.", listBodyWriter.isWriteable(String.class, genericType, annotations, null));
     }
 
     @Test
     public void getSizeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullListTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(null, String.class, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, null, genericType, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, null, genericType, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullGenericTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, null, annotations, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, null, annotations, mediaType));
     }
 
     @Test
     public void getSizeNullAnnotationsTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, null, mediaType));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, null, mediaType));
     }
 
     @Test
     public void getSizeNullMediaTypeTest() {
-        assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, null));
+        Assert.assertEquals("Expected and actual values should be the same.", 0, listBodyWriter.getSize(list, String.class, genericType, annotations, null));
     }
 
     @Test(expected = WebApplicationException.class)
@@ -147,7 +148,7 @@ public class ListBodyWriterTest extends Assert {
         try {
             listBodyWriter.writeTo(list, String.class, Mockito.mock(Type.class), annotations, mediaType, httpHeaders, outputStream);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolverTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/MoxyJsonConfigContextResolverTest.java
@@ -18,8 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MoxyJsonConfigContextResolverTest extends Assert {
+public class MoxyJsonConfigContextResolverTest {
 
     @Test
     public void moxyJsonConfigContextResolverTest() {
@@ -27,9 +28,9 @@ public class MoxyJsonConfigContextResolverTest extends Assert {
         MoxyJsonConfigContextResolver moxyJsonConfigContextResolver = new MoxyJsonConfigContextResolver();
 
         for (Class clazz : classes) {
-            assertTrue("True expected.", moxyJsonConfigContextResolver.getContext(clazz) instanceof MoxyJsonConfig);
-            assertEquals("Expected and actual values should be the same.", moxyJsonConfigContextResolver.config, moxyJsonConfigContextResolver.getContext(clazz));
-            assertEquals("Expected and actual values should be the same.", "{jaxb.formatted.output=false, eclipselink.json.namespace-separator=., eclipselink.json.include-root=false, eclipselink.json.wrapper-as-array-name=true, eclipselink.json.marshal-empty-collections=true}", moxyJsonConfigContextResolver.config.getMarshallerProperties().toString());
+            Assert.assertTrue("True expected.", moxyJsonConfigContextResolver.getContext(clazz) instanceof MoxyJsonConfig);
+            Assert.assertEquals("Expected and actual values should be the same.", moxyJsonConfigContextResolver.config, moxyJsonConfigContextResolver.getContext(clazz));
+            Assert.assertEquals("Expected and actual values should be the same.", "{jaxb.formatted.output=false, eclipselink.json.namespace-separator=., eclipselink.json.include-root=false, eclipselink.json.wrapper-as-array-name=true, eclipselink.json.marshal-empty-collections=true}", moxyJsonConfigContextResolver.config.getMarshallerProperties().toString());
         }
     }
 }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilterTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/auth/KapuaTokenAuthenticationFilterTest.java
@@ -22,8 +22,9 @@ import org.mockito.Mockito;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+
 @Category(JUnitTests.class)
-public class KapuaTokenAuthenticationFilterTest extends Assert {
+public class KapuaTokenAuthenticationFilterTest {
 
     HttpServletRequest request;
     HttpServletResponse response;
@@ -42,22 +43,22 @@ public class KapuaTokenAuthenticationFilterTest extends Assert {
     public void isAccessAllowedTrueTest() {
         Mockito.when(request.getMethod()).thenReturn("OPTIONS");
         for (Object mappedValue : mappedValues) {
-            assertTrue("True expected.", kapuaTokenAuthenticationFilter.isAccessAllowed(request, response, mappedValue));
+            Assert.assertTrue("True expected.", kapuaTokenAuthenticationFilter.isAccessAllowed(request, response, mappedValue));
         }
     }
 
     @Test
     public void onAccessDeniedTest() throws Exception {
-        assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, response));
+        Assert.assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, response));
     }
 
     @Test
     public void onAccessDeniedNullRequestTest() throws Exception {
-        assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(null, response));
+        Assert.assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(null, response));
     }
 
     @Test(expected = NullPointerException.class)
     public void onAccessDeniedNullResponseTest() throws Exception {
-        assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, null));
+        Assert.assertTrue("True expected.", kapuaTokenAuthenticationFilter.onAccessDenied(request, null));
     }
 }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class RestApiRuntimeExceptionTest extends Assert {
+public class RestApiRuntimeExceptionTest {
 
     RestApiErrorCodes errorCode;
     Object stringObject, intObject, charObject;
@@ -38,17 +39,17 @@ public class RestApiRuntimeExceptionTest extends Assert {
     public void restApiRuntimeExceptionCodeTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
     @Test(expected = NullPointerException.class)
     public void restApiRuntimeExceptionNullCodeTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null);
 
-        assertNull("Null expected.", restApiRuntimeException.getCode());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
         restApiRuntimeException.getMessage();
     }
 
@@ -56,17 +57,17 @@ public class RestApiRuntimeExceptionTest extends Assert {
     public void restApiRuntimeExceptionCodeArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, stringObject, intObject, charObject);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
     @Test(expected = NullPointerException.class)
     public void restApiRuntimeExceptionNullCodeArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, stringObject, intObject, charObject);
 
-        assertNull("Null expected.", restApiRuntimeException.getCode());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
         restApiRuntimeException.getMessage();
     }
 
@@ -74,26 +75,26 @@ public class RestApiRuntimeExceptionTest extends Assert {
     public void restApiRuntimeExceptionCodeNullArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, null);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
     @Test
     public void restApiRuntimeExceptionCodeCauseArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, cause, stringObject, intObject, charObject);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
-        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
     }
 
     @Test(expected = NullPointerException.class)
     public void restApiRuntimeExceptionNullCodeCauseArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, cause, stringObject, intObject, charObject);
 
-        assertNull("Null expected.", restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
 
         restApiRuntimeException.getMessage();
     }
@@ -102,17 +103,17 @@ public class RestApiRuntimeExceptionTest extends Assert {
     public void restApiRuntimeExceptionCodeNullCauseArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, null, stringObject, intObject, charObject);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
-        assertNull("Null expected.", restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: " + stringObject + ", " + intObject + ", " + charObject, restApiRuntimeException.getMessage());
+        Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
     @Test
     public void restApiRuntimeExceptionCodeCauseNullArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(errorCode, cause, null);
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
-        assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, restApiRuntimeException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: ", restApiRuntimeException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
     }
 }  

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SessionNotPopulatedExceptionTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/SessionNotPopulatedExceptionTest.java
@@ -17,15 +17,16 @@ package org.eclipse.kapua.app.api.core.exception;
         import org.junit.Test;
         import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class SessionNotPopulatedExceptionTest extends Assert {
+public class SessionNotPopulatedExceptionTest {
 
     @Test
     public void sessionNotPopulatedExceptionTest() {
         SessionNotPopulatedException sessionNotPopulatedException = new SessionNotPopulatedException();
 
-        assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, sessionNotPopulatedException.getCode());
-        assertNull("Null expected.", sessionNotPopulatedException.getCause());
-        assertEquals("Expected and actual values should be the same.", "Error: ", sessionNotPopulatedException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", RestApiErrorCodes.SESSION_NOT_POPULATED, sessionNotPopulatedException.getCode());
+        Assert.assertNull("Null expected.", sessionNotPopulatedException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "Error: ", sessionNotPopulatedException.getMessage());
     }
 }  

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalArgumentExceptionInfoTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class IllegalArgumentExceptionInfoTest extends Assert {
+public class IllegalArgumentExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -47,10 +48,10 @@ public class IllegalArgumentExceptionInfoTest extends Assert {
     public void illegalArgumentExceptionInfoWithoutParametersTest() {
         IllegalArgumentExceptionInfo illegalArgumentExceptionInfo = new IllegalArgumentExceptionInfo();
 
-        assertNull("Null expected.", illegalArgumentExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, illegalArgumentExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumenName());
-        assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumentValue());
+        Assert.assertNull("Null expected.", illegalArgumentExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, illegalArgumentExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumenName());
+        Assert.assertNull("Null expected.", illegalArgumentExceptionInfo.getArgumentValue());
     }
 
     @Test
@@ -58,10 +59,10 @@ public class IllegalArgumentExceptionInfoTest extends Assert {
         for (int i = 0; i < statusList.length; i++) {
             IllegalArgumentExceptionInfo illegalArgumentExceptionInfo = new IllegalArgumentExceptionInfo(statusList[i], kapuaIllegalArgumentException);
 
-            assertEquals("Expected and actual values should be the same.", "ILLEGAL_ARGUMENT", illegalArgumentExceptionInfo.getKapuaErrorCode());
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalArgumentExceptionInfo.getHttpErrorCode());
-            assertEquals("Expected and actual values should be the same.", "name", illegalArgumentExceptionInfo.getArgumenName());
-            assertEquals("Expected and actual values should be the same.", "value", illegalArgumentExceptionInfo.getArgumentValue());
+            Assert.assertEquals("Expected and actual values should be the same.", "ILLEGAL_ARGUMENT", illegalArgumentExceptionInfo.getKapuaErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalArgumentExceptionInfo.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "name", illegalArgumentExceptionInfo.getArgumenName());
+            Assert.assertEquals("Expected and actual values should be the same.", "value", illegalArgumentExceptionInfo.getArgumentValue());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/IllegalNullArgumentExceptionInfoTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class IllegalNullArgumentExceptionInfoTest extends Assert {
+public class IllegalNullArgumentExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -47,9 +48,9 @@ public class IllegalNullArgumentExceptionInfoTest extends Assert {
     public void illegalNullArgumentExceptionInfoWithoutParametersTest() {
         IllegalNullArgumentExceptionInfo illegalNullArgumentExceptionInfo = new IllegalNullArgumentExceptionInfo();
 
-        assertNull("Null expected.", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, illegalNullArgumentExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", illegalNullArgumentExceptionInfo.getArgumenName());
+        Assert.assertNull("Null expected.", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, illegalNullArgumentExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", illegalNullArgumentExceptionInfo.getArgumenName());
     }
 
     @Test
@@ -57,9 +58,9 @@ public class IllegalNullArgumentExceptionInfoTest extends Assert {
         for (int i = 0; i < statusList.length; i++) {
             IllegalNullArgumentExceptionInfo illegalNullArgumentExceptionInfo = new IllegalNullArgumentExceptionInfo(statusList[i], kapuaIllegalNullArgumentException);
 
-            assertEquals("Expected and actual values should be the same.", "ILLEGAL_NULL_ARGUMENT", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalNullArgumentExceptionInfo.getHttpErrorCode());
-            assertEquals("Expected and actual values should be the same.", "name", illegalNullArgumentExceptionInfo.getArgumenName());
+            Assert.assertEquals("Expected and actual values should be the same.", "ILLEGAL_NULL_ARGUMENT", illegalNullArgumentExceptionInfo.getKapuaErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], illegalNullArgumentExceptionInfo.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "name", illegalNullArgumentExceptionInfo.getArgumenName());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/InternalUserOnlyExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/InternalUserOnlyExceptionInfoTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class InternalUserOnlyExceptionInfoTest extends Assert {
+public class InternalUserOnlyExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -47,18 +48,18 @@ public class InternalUserOnlyExceptionInfoTest extends Assert {
     public void internalUserOnlyExceptionInfoWithoutParametersTest() {
         InternalUserOnlyExceptionInfo internalUserOnlyExceptionInfo = new InternalUserOnlyExceptionInfo();
 
-        assertNull("Null expected.", internalUserOnlyExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, internalUserOnlyExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", internalUserOnlyExceptionInfo.getMessage());
+        Assert.assertNull("Null expected.", internalUserOnlyExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, internalUserOnlyExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", internalUserOnlyExceptionInfo.getMessage());
     }
 
     @Test
     public void internalUserOnlyExceptionInfoStatusExceptionTest() {
         for (int i = 0; i < statusList.length; i++) {
             InternalUserOnlyExceptionInfo internalUserOnlyExceptionInfo = new InternalUserOnlyExceptionInfo(statusList[i], internalUserOnlyException);
-            assertEquals("Expected and actual values should be the same.", "INTERNAL_USER_ONLY", internalUserOnlyExceptionInfo.getKapuaErrorCode());
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], internalUserOnlyExceptionInfo.getHttpErrorCode());
-            assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyExceptionInfo.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "INTERNAL_USER_ONLY", internalUserOnlyExceptionInfo.getKapuaErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], internalUserOnlyExceptionInfo.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyExceptionInfo.getMessage());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/MfaRequiredExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/MfaRequiredExceptionInfoTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class MfaRequiredExceptionInfoTest extends Assert {
+public class MfaRequiredExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -60,9 +61,9 @@ public class MfaRequiredExceptionInfoTest extends Assert {
     public void mfaRequiredExceptionInfoWithoutParametersTest() {
         MfaRequiredExceptionInfo mfaRequiredExceptionInfo = new MfaRequiredExceptionInfo();
 
-        assertNull("Null expected.", mfaRequiredExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, mfaRequiredExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", mfaRequiredExceptionInfo.getMessage());
+        Assert.assertNull("Null expected.", mfaRequiredExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, mfaRequiredExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", mfaRequiredExceptionInfo.getMessage());
     }
 
     @Test
@@ -72,9 +73,9 @@ public class MfaRequiredExceptionInfoTest extends Assert {
                 kapuaException = new KapuaAuthenticationException(errorCodes[j]);
 
                 MfaRequiredExceptionInfo mfaRequiredExceptionInfo = new MfaRequiredExceptionInfo(statusList[i], kapuaException);
-                assertEquals("Expected and actual values should be the same.", expectedKapuaErrorCode[j], mfaRequiredExceptionInfo.getKapuaErrorCode());
-                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], mfaRequiredExceptionInfo.getHttpErrorCode());
-                assertEquals("Expected and actual values should be the same.", "Error: ", mfaRequiredExceptionInfo.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorCode[j], mfaRequiredExceptionInfo.getKapuaErrorCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], mfaRequiredExceptionInfo.getHttpErrorCode());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: ", mfaRequiredExceptionInfo.getMessage());
             }
         }
     }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SelfManagedOnlyExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SelfManagedOnlyExceptionInfoTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class SelfManagedOnlyExceptionInfoTest extends Assert {
+public class SelfManagedOnlyExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -47,18 +48,18 @@ public class SelfManagedOnlyExceptionInfoTest extends Assert {
     public void selfManagedOnlyExceptionInfoWithoutParametersTest() {
         SelfManagedOnlyExceptionInfo selfManagedOnlyExceptionInfo = new SelfManagedOnlyExceptionInfo();
 
-        assertNull("Null expected.", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, selfManagedOnlyExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", selfManagedOnlyExceptionInfo.getMessage());
+        Assert.assertNull("Null expected.", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, selfManagedOnlyExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", selfManagedOnlyExceptionInfo.getMessage());
     }
 
     @Test
     public void selfManagedOnlyExceptionInfoStatusExceptionTest() {
         for (int i = 0; i < statusList.length; i++) {
             SelfManagedOnlyExceptionInfo selfManagedOnlyExceptionInfo = new SelfManagedOnlyExceptionInfo(statusList[i], selfManagedOnlyException);
-            assertEquals("Expected and actual values should be the same.", "SELF_MANAGED_ONLY", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], selfManagedOnlyExceptionInfo.getHttpErrorCode());
-            assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyExceptionInfo.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "SELF_MANAGED_ONLY", selfManagedOnlyExceptionInfo.getKapuaErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], selfManagedOnlyExceptionInfo.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyExceptionInfo.getMessage());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/SubjectUnauthorizedExceptionInfoTest.java
@@ -23,8 +23,9 @@ import org.mockito.Mockito;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class SubjectUnauthorizedExceptionInfoTest extends Assert {
+public class SubjectUnauthorizedExceptionInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -51,9 +52,9 @@ public class SubjectUnauthorizedExceptionInfoTest extends Assert {
     public void subjectUnauthorizedExceptionInfoWithoutParametersTest() {
         SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo = new SubjectUnauthorizedExceptionInfo();
 
-        assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
-        assertEquals("Expected and actual values should be the same.", 0, subjectUnauthorizedExceptionInfo.getHttpErrorCode());
-        assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getPermission());
+        Assert.assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, subjectUnauthorizedExceptionInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", subjectUnauthorizedExceptionInfo.getPermission());
     }
 
     @Test
@@ -61,9 +62,9 @@ public class SubjectUnauthorizedExceptionInfoTest extends Assert {
         for (int i = 0; i < statusList.length; i++) {
             SubjectUnauthorizedExceptionInfo subjectUnauthorizedExceptionInfo = new SubjectUnauthorizedExceptionInfo(statusList[i], subjectUnauthorizedException);
 
-            assertEquals("Expected and actual values should be the same.", "SUBJECT_UNAUTHORIZED", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], subjectUnauthorizedExceptionInfo.getHttpErrorCode());
-            assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedExceptionInfo.getPermission());
+            Assert.assertEquals("Expected and actual values should be the same.", "SUBJECT_UNAUTHORIZED", subjectUnauthorizedExceptionInfo.getKapuaErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], subjectUnauthorizedExceptionInfo.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedExceptionInfo.getPermission());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfoTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/model/ThrowableInfoTest.java
@@ -20,8 +20,9 @@ import org.junit.experimental.categories.Category;
 
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class ThrowableInfoTest extends Assert {
+public class ThrowableInfoTest {
 
     Response.Status[] statusList;
     int[] expectedStatusCodes;
@@ -48,9 +49,9 @@ public class ThrowableInfoTest extends Assert {
     public void throwableInfoWithoutParametersTest() {
         ThrowableInfo throwableInfo = new ThrowableInfo();
 
-        assertEquals("Expected and actual values should be the same.", 0, throwableInfo.getHttpErrorCode());
-        assertNull("Null expected.", throwableInfo.getMessage());
-        assertNull("Null expected.", throwableInfo.getStackTrace());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, throwableInfo.getHttpErrorCode());
+        Assert.assertNull("Null expected.", throwableInfo.getMessage());
+        Assert.assertNull("Null expected.", throwableInfo.getStackTrace());
     }
 
     @Test
@@ -59,9 +60,9 @@ public class ThrowableInfoTest extends Assert {
             for (int j = 0; j < throwables.length; j++) {
                 ThrowableInfo throwableInfo = new ThrowableInfo(statusList[i], throwables[j]);
 
-                assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
-                assertEquals("Expected and actual values should be the same.", expectedMessage[j], throwableInfo.getMessage());
-                assertNull("Null expected.", throwableInfo.getStackTrace());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[j], throwableInfo.getMessage());
+                Assert.assertNull("Null expected.", throwableInfo.getStackTrace());
             }
         }
     }
@@ -75,9 +76,9 @@ public class ThrowableInfoTest extends Assert {
     public void throwableInfoNullThrowableTest() {
         for (int i = 0; i < statusList.length; i++) {
             ThrowableInfo throwableInfo = new ThrowableInfo(statusList[i], null);
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
-            assertNull("Null expected.", throwableInfo.getMessage());
-            assertNull("Null expected.", throwableInfo.getStackTrace());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo.getHttpErrorCode());
+            Assert.assertNull("Null expected.", throwableInfo.getMessage());
+            Assert.assertNull("Null expected.", throwableInfo.getStackTrace());
         }
     }
 
@@ -88,26 +89,26 @@ public class ThrowableInfoTest extends Assert {
 
         for (int i = 0; i < statusList.length; i++) {
             throwableInfo1.setHttpErrorCode(statusList[i]);
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo1.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo1.getHttpErrorCode());
         }
 
         try {
             throwableInfo1.setHttpErrorCode(null);
-            fail("Exception expected.");
+            Assert.fail("Exception expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
 
         for (int i = 0; i < statusList.length; i++) {
             throwableInfo2.setHttpErrorCode(statusList[i]);
-            assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo2.getHttpErrorCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedStatusCodes[i], throwableInfo2.getHttpErrorCode());
         }
 
         try {
             throwableInfo2.setHttpErrorCode(null);
-            fail("Exception expected.");
+            Assert.fail("Exception expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -119,12 +120,12 @@ public class ThrowableInfoTest extends Assert {
 
         for (int i = 0; i < messages.length; i++) {
             throwableInfo1.setMessage(messages[i]);
-            assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo1.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo1.getMessage());
         }
 
         for (int i = 0; i < messages.length; i++) {
             throwableInfo2.setMessage(messages[i]);
-            assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo2.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", messages[i], throwableInfo2.getMessage());
         }
     }
 } 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ByteArrayParamTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ByteArrayParamTest.java
@@ -17,8 +17,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class ByteArrayParamTest extends Assert {
+public class ByteArrayParamTest {
 
     @Test
     public void byteArrayParamTest() {

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/CountResultTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/CountResultTest.java
@@ -17,13 +17,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class CountResultTest extends Assert {
+public class CountResultTest {
 
     @Test
     public void countResultWithoutParameterTest() {
         CountResult countResult = new CountResult();
-        assertEquals("Expected and actual values should be the same.", 0, countResult.getCount());
+        Assert.assertEquals("Expected and actual values should be the same.", 0, countResult.getCount());
     }
 
     @Test
@@ -32,7 +33,7 @@ public class CountResultTest extends Assert {
 
         for (long countValue : countValues) {
             CountResult countResult = new CountResult(countValue);
-            assertEquals("Expected and actual values should be the same.", countValue, countResult.getCount());
+            Assert.assertEquals("Expected and actual values should be the same.", countValue, countResult.getCount());
         }
     }
 
@@ -46,8 +47,8 @@ public class CountResultTest extends Assert {
             countResult1.setCount(countValue);
             countResult2.setCount(countValue);
 
-            assertEquals("Expected and actual values should be the same.", countValue, countResult1.getCount());
-            assertEquals("Expected and actual values should be the same.", countValue, countResult2.getCount());
+            Assert.assertEquals("Expected and actual values should be the same.", countValue, countResult1.getCount());
+            Assert.assertEquals("Expected and actual values should be the same.", countValue, countResult2.getCount());
         }
     }
 } 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/DateParamTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/DateParamTest.java
@@ -18,8 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class DateParamTest extends Assert {
+public class DateParamTest {
 
     @Test
     public void dateParamTest() throws KapuaIllegalArgumentException {
@@ -27,7 +28,7 @@ public class DateParamTest extends Assert {
 
         for (int i = 0; i < dates.length; i++) {
             DateParam dateParam = new DateParam(dates[i]);
-            assertNotNull("Null not expected.", dateParam.getDate());
+            Assert.assertNotNull("Null not expected.", dateParam.getDate());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/EntityIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/EntityIdTest.java
@@ -19,8 +19,9 @@ import org.junit.experimental.categories.Category;
 
 import java.math.BigInteger;
 
+
 @Category(JUnitTests.class)
-public class EntityIdTest extends Assert {
+public class EntityIdTest {
 
     @Test
     public void entityIdTest() {
@@ -30,8 +31,8 @@ public class EntityIdTest extends Assert {
         for (int i = 0; i < compactEntityId.length; i++) {
             EntityId entityId = new EntityId(compactEntityId[i]);
 
-            assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.getId().toString());
-            assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.toString());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.getId().toString());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValues[i], entityId.toString());
         }
     }
 
@@ -49,15 +50,15 @@ public class EntityIdTest extends Assert {
     public void setAndGetIdToStringTest() {
         EntityId entityId = new EntityId("111");
 
-        assertEquals("Expected and actual values should be the same.", "-10403", entityId.getId().toString());
-        assertEquals("Expected and actual values should be the same.", "-10403", entityId.toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "-10403", entityId.getId().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "-10403", entityId.toString());
 
         entityId.setId(BigInteger.ONE);
-        assertEquals("Expected and actual values should be the same.", "1", entityId.getId().toString());
-        assertEquals("Expected and actual values should be the same.", "1", entityId.toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "1", entityId.getId().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "1", entityId.toString());
 
         entityId.setId(null);
-        assertNull("Null expected.", entityId.getId());
+        Assert.assertNull("Null expected.", entityId.getId());
     }
 
     @Test(expected = NullPointerException.class)

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/MetricTypeTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/MetricTypeTest.java
@@ -20,8 +20,9 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class MetricTypeTest extends Assert {
+public class MetricTypeTest {
 
     @Test
     public void metricTypeTest() throws KapuaIllegalArgumentException {
@@ -30,7 +31,7 @@ public class MetricTypeTest extends Assert {
 
         for (int i = 0; i < types.length; i++) {
             MetricType metricType = new MetricType(types[i]);
-            assertEquals("Expected and actual values should be the same.", expectedClasses[i], metricType.getType());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedClasses[i], metricType.getType());
         }
     }
 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ScopeIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/ScopeIdTest.java
@@ -25,8 +25,9 @@ import org.mockito.Mockito;
 import java.math.BigInteger;
 import java.util.Base64;
 
+
 @Category(JUnitTests.class)
-public class ScopeIdTest extends Assert {
+public class ScopeIdTest {
 
     @Test(expected = NullPointerException.class)
     public void scopeIdNullTest() {
@@ -41,14 +42,14 @@ public class ScopeIdTest extends Assert {
         Mockito.when(kapuaSession.getScopeId()).thenReturn(KapuaId.ONE);
         ScopeId scopeId = new ScopeId("_");
 
-        assertEquals("Expected and actual values should be the same.", BigInteger.ONE, scopeId.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", BigInteger.ONE, scopeId.getId());
     }
 
     @Test
     public void scopeIdDifferentIdsTest() {
         ScopeId scopeId = new ScopeId("scopeID");
 
-        assertEquals("Expected and actual values should be the same.", new BigInteger(Base64.getUrlDecoder().decode("scopeID")), scopeId.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", new BigInteger(Base64.getUrlDecoder().decode("scopeID")), scopeId.getId());
     }
 
     @Test(expected = SessionNotPopulatedException.class)
@@ -62,11 +63,11 @@ public class ScopeIdTest extends Assert {
         ScopeId scopeId = new ScopeId("scopeID");
 
         scopeId.setId(BigInteger.TEN);
-        assertEquals("Expected and actual values should be the same.", BigInteger.TEN, scopeId.getId());
-        assertEquals("Expected and actual values should be the same.", "10", scopeId.toString());
+        Assert.assertEquals("Expected and actual values should be the same.", BigInteger.TEN, scopeId.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", "10", scopeId.toString());
 
         scopeId.setId(null);
-        assertNull("Null expected.", scopeId.getId());
+        Assert.assertNull("Null expected.", scopeId.getId());
     }
 
     @Test(expected = NullPointerException.class)

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/StorableEntityIdTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/StorableEntityIdTest.java
@@ -17,8 +17,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class StorableEntityIdTest extends Assert {
+public class StorableEntityIdTest {
 
     @Test
     public void storableEntityIdWithParameterTest() {
@@ -26,8 +27,8 @@ public class StorableEntityIdTest extends Assert {
 
         for (String id : ids) {
             StorableEntityId storableEntityId = new StorableEntityId(id);
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId.getId());
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId.toString());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId.getId());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId.toString());
         }
     }
 
@@ -58,11 +59,11 @@ public class StorableEntityIdTest extends Assert {
             storableEntityId1.setId(id);
             storableEntityId2.setId(id);
 
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId1.getId());
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId1.toString());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId1.getId());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId1.toString());
 
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId2.getId());
-            assertEquals("Expected and actual values should be the same.", id, storableEntityId2.toString());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId2.getId());
+            Assert.assertEquals("Expected and actual values should be the same.", id, storableEntityId2.toString());
         }
     }
 } 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonDatastoreMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonDatastoreMessageTest.java
@@ -28,8 +28,9 @@ import org.mockito.Mockito;
 import java.util.Date;
 import java.util.UUID;
 
+
 @Category(JUnitTests.class)
-public class JsonDatastoreMessageTest extends Assert {
+public class JsonDatastoreMessageTest {
 
     DatastoreMessage datastoreMessage;
     UUID id;
@@ -93,17 +94,17 @@ public class JsonDatastoreMessageTest extends Assert {
     public void jsonDatastoreMessageWithParameterTest() {
         JsonDatastoreMessage jsonDatastoreMessage = new JsonDatastoreMessage(datastoreMessage);
 
-        assertEquals("Expected and actual values should be the same.", id, jsonDatastoreMessage.getId());
-        assertEquals("Expected and actual values should be the same.", storableId, jsonDatastoreMessage.getDatastoreId());
-        assertEquals("Expected and actual values should be the same.", timestamp, jsonDatastoreMessage.getTimestamp());
-        assertEquals("Expected and actual values should be the same.", scopeId, jsonDatastoreMessage.getScopeId());
-        assertEquals("Expected and actual values should be the same.", deviceId, jsonDatastoreMessage.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", clientId, jsonDatastoreMessage.getClientId());
-        assertEquals("Expected and actual values should be the same.", receivedOn, jsonDatastoreMessage.getReceivedOn());
-        assertEquals("Expected and actual values should be the same.", sentOn, jsonDatastoreMessage.getSentOn());
-        assertEquals("Expected and actual values should be the same.", capturedOn, jsonDatastoreMessage.getCapturedOn());
-        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonDatastoreMessage.getPosition());
-        assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonDatastoreMessage.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", id, jsonDatastoreMessage.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", storableId, jsonDatastoreMessage.getDatastoreId());
+        Assert.assertEquals("Expected and actual values should be the same.", timestamp, jsonDatastoreMessage.getTimestamp());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, jsonDatastoreMessage.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", deviceId, jsonDatastoreMessage.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, jsonDatastoreMessage.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", receivedOn, jsonDatastoreMessage.getReceivedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", sentOn, jsonDatastoreMessage.getSentOn());
+        Assert.assertEquals("Expected and actual values should be the same.", capturedOn, jsonDatastoreMessage.getCapturedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonDatastoreMessage.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonDatastoreMessage.getChannel());
         Assert.assertNotNull("NotNull expected.", jsonDatastoreMessage.getPayload());
     }
 
@@ -121,8 +122,8 @@ public class JsonDatastoreMessageTest extends Assert {
         jsonDatastoreMessage1.setDatastoreId(datastoreId);
         jsonDatastoreMessage2.setDatastoreId(datastoreId);
 
-        assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage1.getDatastoreId());
-        assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage2.getDatastoreId());
+        Assert.assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage1.getDatastoreId());
+        Assert.assertEquals("Expected and actual values should be the same.", datastoreId, jsonDatastoreMessage2.getDatastoreId());
 
         jsonDatastoreMessage1.setDatastoreId(null);
         jsonDatastoreMessage2.setDatastoreId(null);
@@ -141,8 +142,8 @@ public class JsonDatastoreMessageTest extends Assert {
             jsonDatastoreMessage1.setTimestamp(newTimestamp);
             jsonDatastoreMessage2.setTimestamp(newTimestamp);
 
-            assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage1.getTimestamp());
-            assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage2.getTimestamp());
+            Assert.assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage1.getTimestamp());
+            Assert.assertEquals("Expected and actual values should be the same.", newTimestamp, jsonDatastoreMessage2.getTimestamp());
         }
 
         jsonDatastoreMessage1.setTimestamp(null);

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonKapuaDataMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonKapuaDataMessageTest.java
@@ -30,8 +30,9 @@ import org.mockito.Mockito;
 import java.util.Date;
 import java.util.UUID;
 
+
 @Category(JUnitTests.class)
-public class JsonKapuaDataMessageTest extends Assert {
+public class JsonKapuaDataMessageTest {
 
     KapuaDataMessage kapuaDataMessage;
     UUID id;
@@ -97,15 +98,15 @@ public class JsonKapuaDataMessageTest extends Assert {
     public void jsonKapuaDataMessageWithParameterTest() {
         JsonKapuaDataMessage jsonKapuaDataMessage = new JsonKapuaDataMessage(kapuaDataMessage);
 
-        assertEquals("Expected and actual values should be the same.", id, jsonKapuaDataMessage.getId());
-        assertEquals("Expected and actual values should be the same.", scopeId, jsonKapuaDataMessage.getScopeId());
-        assertEquals("Expected and actual values should be the same.", deviceId, jsonKapuaDataMessage.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", clientId, jsonKapuaDataMessage.getClientId());
-        assertEquals("Expected and actual values should be the same.", receivedOn, jsonKapuaDataMessage.getReceivedOn());
-        assertEquals("Expected and actual values should be the same.", sentOn, jsonKapuaDataMessage.getSentOn());
-        assertEquals("Expected and actual values should be the same.", capturedOn, jsonKapuaDataMessage.getCapturedOn());
-        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonKapuaDataMessage.getPosition());
-        assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonKapuaDataMessage.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", id, jsonKapuaDataMessage.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, jsonKapuaDataMessage.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", deviceId, jsonKapuaDataMessage.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, jsonKapuaDataMessage.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", receivedOn, jsonKapuaDataMessage.getReceivedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", sentOn, jsonKapuaDataMessage.getSentOn());
+        Assert.assertEquals("Expected and actual values should be the same.", capturedOn, jsonKapuaDataMessage.getCapturedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonKapuaDataMessage.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaDataChannel, jsonKapuaDataMessage.getChannel());
         Assert.assertNotNull("NotNull expected.", jsonKapuaDataMessage.getPayload());
     }
 
@@ -121,8 +122,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setId(newId);
         jsonKapuaDataMessage2.setId(newId);
 
-        assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage1.getId());
-        assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage2.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage1.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonKapuaDataMessage2.getId());
 
         jsonKapuaDataMessage1.setId(null);
         jsonKapuaDataMessage2.setId(null);
@@ -138,8 +139,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setScopeId(newScopeId);
         jsonKapuaDataMessage2.setScopeId(newScopeId);
 
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage1.getScopeId());
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage2.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage1.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonKapuaDataMessage2.getScopeId());
 
         jsonKapuaDataMessage1.setScopeId(null);
         jsonKapuaDataMessage2.setScopeId(null);
@@ -155,8 +156,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setDeviceId(newDeviceId);
         jsonKapuaDataMessage2.setDeviceId(newDeviceId);
 
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage1.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage2.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage1.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonKapuaDataMessage2.getDeviceId());
 
         jsonKapuaDataMessage1.setDeviceId(null);
         jsonKapuaDataMessage2.setDeviceId(null);
@@ -173,8 +174,8 @@ public class JsonKapuaDataMessageTest extends Assert {
             jsonKapuaDataMessage1.setClientId(newClientID);
             jsonKapuaDataMessage2.setClientId(newClientID);
 
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage1.getClientId());
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage2.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage1.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonKapuaDataMessage2.getClientId());
         }
 
         jsonKapuaDataMessage1.setClientId(null);
@@ -190,8 +191,8 @@ public class JsonKapuaDataMessageTest extends Assert {
             jsonKapuaDataMessage1.setReceivedOn(newReceivedOn);
             jsonKapuaDataMessage2.setReceivedOn(newReceivedOn);
 
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage1.getReceivedOn());
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage2.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage1.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonKapuaDataMessage2.getReceivedOn());
         }
 
         jsonKapuaDataMessage1.setReceivedOn(null);
@@ -207,8 +208,8 @@ public class JsonKapuaDataMessageTest extends Assert {
             jsonKapuaDataMessage1.setSentOn(newSentOn);
             jsonKapuaDataMessage2.setSentOn(newSentOn);
 
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage1.getSentOn());
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage2.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage1.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonKapuaDataMessage2.getSentOn());
         }
 
         jsonKapuaDataMessage1.setSentOn(null);
@@ -224,8 +225,8 @@ public class JsonKapuaDataMessageTest extends Assert {
             jsonKapuaDataMessage1.setCapturedOn(newCapturedOn);
             jsonKapuaDataMessage2.setCapturedOn(newCapturedOn);
 
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage1.getCapturedOn());
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage2.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage1.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonKapuaDataMessage2.getCapturedOn());
         }
 
         jsonKapuaDataMessage1.setCapturedOn(null);
@@ -242,8 +243,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setPosition(newPosition);
         jsonKapuaDataMessage2.setPosition(newPosition);
 
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage1.getPosition());
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage2.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage1.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonKapuaDataMessage2.getPosition());
 
         jsonKapuaDataMessage1.setPosition(null);
         jsonKapuaDataMessage2.setPosition(null);
@@ -259,8 +260,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setChannel(newChannel);
         jsonKapuaDataMessage2.setChannel(newChannel);
 
-        assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage1.getChannel());
-        assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage2.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage1.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newChannel, jsonKapuaDataMessage2.getChannel());
 
         jsonKapuaDataMessage1.setChannel(null);
         jsonKapuaDataMessage2.setChannel(null);
@@ -276,8 +277,8 @@ public class JsonKapuaDataMessageTest extends Assert {
         jsonKapuaDataMessage1.setPayload(newJsonKapuaPayload);
         jsonKapuaDataMessage2.setPayload(newJsonKapuaPayload);
 
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage1.getPayload());
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage2.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage1.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonKapuaDataMessage2.getPayload());
 
         jsonKapuaDataMessage1.setPayload((JsonKapuaPayload) null);
         jsonKapuaDataMessage2.setPayload((JsonKapuaPayload) null);

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageListResultTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageListResultTest.java
@@ -23,8 +23,9 @@ import org.mockito.Mockito;
 import java.util.LinkedList;
 import java.util.List;
 
+
 @Category(JUnitTests.class)
-public class JsonMessageListResultTest extends Assert {
+public class JsonMessageListResultTest {
 
     ResultList<JsonDatastoreMessage> resultList;
     List expectedList;
@@ -58,8 +59,8 @@ public class JsonMessageListResultTest extends Assert {
     public void jsonMessageListResultWithParameterTest() {
         JsonMessageListResult jsonMessageListResult = new JsonMessageListResult(resultList);
 
-        assertEquals("Expected and actual values should be the same.", expectedList, jsonMessageListResult.getItems());
-        assertEquals("Expected and actual values should be the same.", (Long) 3L, jsonMessageListResult.getTotalCount());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedList, jsonMessageListResult.getItems());
+        Assert.assertEquals("Expected and actual values should be the same.", (Long) 3L, jsonMessageListResult.getTotalCount());
     }
 
     @Test(expected = NullPointerException.class)

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageQueryTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/data/JsonMessageQueryTest.java
@@ -26,8 +26,9 @@ import org.mockito.Mockito;
 import java.util.LinkedList;
 import java.util.List;
 
+
 @Category(JUnitTests.class)
-public class JsonMessageQueryTest extends Assert {
+public class JsonMessageQueryTest {
 
     KapuaId kapuaId;
     JsonMessageQuery jsonMessageQuery1, jsonMessageQuery2;
@@ -46,7 +47,7 @@ public class JsonMessageQueryTest extends Assert {
         JsonMessageQuery jsonMessageQuery = new JsonMessageQuery();
 
         Assert.assertNull("Null expected.", jsonMessageQuery.getScopeId());
-        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
         Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
         Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
     }
@@ -55,8 +56,8 @@ public class JsonMessageQueryTest extends Assert {
     public void jsonMessageQueryWithParameterTest() {
         JsonMessageQuery jsonMessageQuery = new JsonMessageQuery(kapuaId);
 
-        assertEquals("Expected and actual values should be the same.", kapuaId, jsonMessageQuery.getScopeId());
-        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaId, jsonMessageQuery.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
         Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
         Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
     }
@@ -66,7 +67,7 @@ public class JsonMessageQueryTest extends Assert {
         JsonMessageQuery jsonMessageQuery = new JsonMessageQuery(null);
 
         Assert.assertNull("Null expected.", jsonMessageQuery.getScopeId());
-        assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
+        Assert.assertEquals("Expected and actual values should be the same.", StorableFetchStyle.SOURCE_FULL, jsonMessageQuery.getFetchStyle());
         Assert.assertNotNull("NotNull expected.", jsonMessageQuery.getFetchAttributes());
         Assert.assertFalse("False expected.", jsonMessageQuery.isAskTotalCount());
     }
@@ -76,8 +77,8 @@ public class JsonMessageQueryTest extends Assert {
         jsonMessageQuery1.setScopeId(KapuaId.ANY);
         jsonMessageQuery2.setScopeId(KapuaId.ANY);
 
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery1.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery2.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery1.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, jsonMessageQuery2.getScopeId());
 
         jsonMessageQuery1.setScopeId(null);
         jsonMessageQuery2.setScopeId(null);
@@ -93,8 +94,8 @@ public class JsonMessageQueryTest extends Assert {
         jsonMessageQuery1.setPredicate(storablePredicate);
         jsonMessageQuery2.setPredicate(storablePredicate);
 
-        assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery1.getPredicate());
-        assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery2.getPredicate());
+        Assert.assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery1.getPredicate());
+        Assert.assertEquals("Expected and actual values should be the same.", storablePredicate, jsonMessageQuery2.getPredicate());
 
         jsonMessageQuery1.setPredicate(null);
         jsonMessageQuery2.setPredicate(null);
@@ -111,8 +112,8 @@ public class JsonMessageQueryTest extends Assert {
             jsonMessageQuery1.setOffset(offset);
             jsonMessageQuery2.setOffset(offset);
 
-            assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery1.getOffset());
-            assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery2.getOffset());
+            Assert.assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery1.getOffset());
+            Assert.assertEquals("Expected and actual values should be the same.", offset, jsonMessageQuery2.getOffset());
         }
 
         jsonMessageQuery1.setOffset(null);
@@ -130,8 +131,8 @@ public class JsonMessageQueryTest extends Assert {
             jsonMessageQuery1.setLimit(limit);
             jsonMessageQuery2.setLimit(limit);
 
-            assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery1.getLimit());
-            assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery2.getLimit());
+            Assert.assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery1.getLimit());
+            Assert.assertEquals("Expected and actual values should be the same.", limit, jsonMessageQuery2.getLimit());
         }
 
         jsonMessageQuery1.setLimit(null);
@@ -149,8 +150,8 @@ public class JsonMessageQueryTest extends Assert {
             jsonMessageQuery1.setAskTotalCount(askTotalCount);
             jsonMessageQuery2.setAskTotalCount(askTotalCount);
 
-            assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery1.isAskTotalCount());
-            assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery2.isAskTotalCount());
+            Assert.assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery1.isAskTotalCount());
+            Assert.assertEquals("Expected and actual values should be the same.", askTotalCount, jsonMessageQuery2.isAskTotalCount());
         }
     }
 
@@ -160,8 +161,8 @@ public class JsonMessageQueryTest extends Assert {
             jsonMessageQuery1.setFetchStyle(fetchStyle);
             jsonMessageQuery2.setFetchStyle(fetchStyle);
 
-            assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery1.getFetchStyle());
-            assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery2.getFetchStyle());
+            Assert.assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery1.getFetchStyle());
+            Assert.assertEquals("Expected and actual values should be the same.", fetchStyle, jsonMessageQuery2.getFetchStyle());
         }
         jsonMessageQuery1.setFetchStyle(null);
         jsonMessageQuery2.setFetchStyle(null);
@@ -187,8 +188,8 @@ public class JsonMessageQueryTest extends Assert {
         jsonMessageQuery1.setFetchAttributes(fetchAttributeNames);
         jsonMessageQuery2.setFetchAttributes(fetchAttributeNames);
 
-        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
-        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
 
         jsonMessageQuery1.addFetchAttributes(attributeName3);
         jsonMessageQuery2.addFetchAttributes(attributeName3);
@@ -196,8 +197,8 @@ public class JsonMessageQueryTest extends Assert {
         expectedValue.add(attributeName3);
         expectedValue.add(attributeName3);
 
-        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
-        assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery1.getFetchAttributes());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValue, jsonMessageQuery2.getFetchAttributes());
 
         jsonMessageQuery1.setFetchAttributes(null);
         jsonMessageQuery2.setFetchAttributes(null);
@@ -217,8 +218,8 @@ public class JsonMessageQueryTest extends Assert {
         jsonMessageQuery1.setSortFields(sortFields);
         jsonMessageQuery2.setSortFields(sortFields);
 
-        assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery1.getSortFields());
-        assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery2.getSortFields());
+        Assert.assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery1.getSortFields());
+        Assert.assertEquals("Expected and actual values should be the same.", sortFields, jsonMessageQuery2.getSortFields());
 
         jsonMessageQuery1.setSortFields(null);
         jsonMessageQuery2.setSortFields(null);
@@ -279,7 +280,7 @@ public class JsonMessageQueryTest extends Assert {
 
     @Test
     public void getFieldsTest() {
-        assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery1.getFields().length);
-        assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery2.getFields().length);
+        Assert.assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery1.getFields().length);
+        Assert.assertEquals("Expected and actual values should be the same.", 6, jsonMessageQuery2.getFields().length);
     }
 } 

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericRequestMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericRequestMessageTest.java
@@ -30,8 +30,9 @@ import org.mockito.Mockito;
 import java.util.Date;
 import java.util.UUID;
 
+
 @Category(JUnitTests.class)
-public class JsonGenericRequestMessageTest extends Assert {
+public class JsonGenericRequestMessageTest {
 
     GenericRequestMessage genericRequestMessage;
     UUID id;
@@ -83,32 +84,32 @@ public class JsonGenericRequestMessageTest extends Assert {
     public void jsonGenericRequestMessageWithoutParameterTest() {
         JsonGenericRequestMessage jsonGenericRequestMessage = new JsonGenericRequestMessage();
 
-        assertNull("Null expected.", jsonGenericRequestMessage.getId());
-        assertNull("Null expected.", jsonGenericRequestMessage.getScopeId());
-        assertNull("Null expected.", jsonGenericRequestMessage.getDeviceId());
-        assertNull("Null expected.", jsonGenericRequestMessage.getClientId());
-        assertNull("Null expected.", jsonGenericRequestMessage.getReceivedOn());
-        assertNull("Null expected.", jsonGenericRequestMessage.getSentOn());
-        assertNull("Null expected.", jsonGenericRequestMessage.getCapturedOn());
-        assertNull("Null expected.", jsonGenericRequestMessage.getPosition());
-        assertNull("Null expected.", jsonGenericRequestMessage.getChannel());
-        assertNull("Null expected.", jsonGenericRequestMessage.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage.getPayload());
     }
 
     @Test
     public void jsonGenericRequestMessageWithParameterTest() {
         JsonGenericRequestMessage jsonGenericRequestMessage = new JsonGenericRequestMessage(genericRequestMessage);
 
-        assertEquals("Expected and actual values should be the same.", id, jsonGenericRequestMessage.getId());
-        assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericRequestMessage.getScopeId());
-        assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericRequestMessage.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", clientId, jsonGenericRequestMessage.getClientId());
-        assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericRequestMessage.getReceivedOn());
-        assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericRequestMessage.getSentOn());
-        assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericRequestMessage.getCapturedOn());
-        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericRequestMessage.getPosition());
-        assertEquals("Expected and actual values should be the same.", genericRequestChannel, jsonGenericRequestMessage.getChannel());
-        assertNotNull("NotNull expected.", jsonGenericRequestMessage.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", id, jsonGenericRequestMessage.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericRequestMessage.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericRequestMessage.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, jsonGenericRequestMessage.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericRequestMessage.getReceivedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericRequestMessage.getSentOn());
+        Assert.assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericRequestMessage.getCapturedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericRequestMessage.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", genericRequestChannel, jsonGenericRequestMessage.getChannel());
+        Assert.assertNotNull("NotNull expected.", jsonGenericRequestMessage.getPayload());
     }
 
     @Test(expected = NullPointerException.class)
@@ -123,14 +124,14 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setId(newId);
         jsonGenericRequestMessage2.setId(newId);
 
-        assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage1.getId());
-        assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage2.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage1.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonGenericRequestMessage2.getId());
 
         jsonGenericRequestMessage1.setId(null);
         jsonGenericRequestMessage2.setId(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getId());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getId());
     }
 
     @Test
@@ -140,14 +141,14 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setScopeId(newScopeId);
         jsonGenericRequestMessage2.setScopeId(newScopeId);
 
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage1.getScopeId());
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage2.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage1.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericRequestMessage2.getScopeId());
 
         jsonGenericRequestMessage1.setScopeId(null);
         jsonGenericRequestMessage2.setScopeId(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getScopeId());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getScopeId());
     }
 
     @Test
@@ -157,14 +158,14 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setDeviceId(newDeviceId);
         jsonGenericRequestMessage2.setDeviceId(newDeviceId);
 
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage1.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage2.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage1.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericRequestMessage2.getDeviceId());
 
         jsonGenericRequestMessage1.setDeviceId(null);
         jsonGenericRequestMessage2.setDeviceId(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getDeviceId());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getDeviceId());
     }
 
     @Test
@@ -175,15 +176,15 @@ public class JsonGenericRequestMessageTest extends Assert {
             jsonGenericRequestMessage1.setClientId(newClientID);
             jsonGenericRequestMessage2.setClientId(newClientID);
 
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage1.getClientId());
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage2.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage1.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericRequestMessage2.getClientId());
         }
 
         jsonGenericRequestMessage1.setClientId(null);
         jsonGenericRequestMessage2.setClientId(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getClientId());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getClientId());
     }
 
     @Test
@@ -192,15 +193,15 @@ public class JsonGenericRequestMessageTest extends Assert {
             jsonGenericRequestMessage1.setReceivedOn(newReceivedOn);
             jsonGenericRequestMessage2.setReceivedOn(newReceivedOn);
 
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage1.getReceivedOn());
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage2.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage1.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericRequestMessage2.getReceivedOn());
         }
 
         jsonGenericRequestMessage1.setReceivedOn(null);
         jsonGenericRequestMessage2.setReceivedOn(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getReceivedOn());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getReceivedOn());
     }
 
     @Test
@@ -209,15 +210,15 @@ public class JsonGenericRequestMessageTest extends Assert {
             jsonGenericRequestMessage1.setSentOn(newSentOn);
             jsonGenericRequestMessage2.setSentOn(newSentOn);
 
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage1.getSentOn());
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage2.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage1.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericRequestMessage2.getSentOn());
         }
 
         jsonGenericRequestMessage1.setSentOn(null);
         jsonGenericRequestMessage2.setSentOn(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getSentOn());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getSentOn());
     }
 
     @Test
@@ -226,15 +227,15 @@ public class JsonGenericRequestMessageTest extends Assert {
             jsonGenericRequestMessage1.setCapturedOn(newCapturedOn);
             jsonGenericRequestMessage2.setCapturedOn(newCapturedOn);
 
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage1.getCapturedOn());
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage2.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage1.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericRequestMessage2.getCapturedOn());
         }
 
         jsonGenericRequestMessage1.setCapturedOn(null);
         jsonGenericRequestMessage2.setCapturedOn(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getCapturedOn());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getCapturedOn());
     }
 
     @Test
@@ -244,14 +245,14 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setPosition(newPosition);
         jsonGenericRequestMessage2.setPosition(newPosition);
 
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage1.getPosition());
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage2.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage1.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericRequestMessage2.getPosition());
 
         jsonGenericRequestMessage1.setPosition(null);
         jsonGenericRequestMessage2.setPosition(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getPosition());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getPosition());
     }
 
     @Test
@@ -261,14 +262,14 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setChannel(newGenericRequestChannel);
         jsonGenericRequestMessage2.setChannel(newGenericRequestChannel);
 
-        assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage1.getChannel());
-        assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage2.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage1.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newGenericRequestChannel, jsonGenericRequestMessage2.getChannel());
 
         jsonGenericRequestMessage1.setChannel(null);
         jsonGenericRequestMessage2.setChannel(null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getChannel());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getChannel());
     }
 
     @Test
@@ -278,21 +279,21 @@ public class JsonGenericRequestMessageTest extends Assert {
         jsonGenericRequestMessage1.setPayload(newJsonKapuaPayload);
         jsonGenericRequestMessage2.setPayload(newJsonKapuaPayload);
 
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage1.getPayload());
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage2.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage1.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericRequestMessage2.getPayload());
 
         jsonGenericRequestMessage1.setPayload((JsonKapuaPayload) null);
         jsonGenericRequestMessage2.setPayload((JsonKapuaPayload) null);
 
-        assertNull("Null expected.", jsonGenericRequestMessage1.getPayload());
-        assertNull("Null expected.", jsonGenericRequestMessage2.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage1.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericRequestMessage2.getPayload());
     }
 
     @Test(expected = NullPointerException.class)
     public void setAndGetKapuaPayloadMessageWithoutParametersTest() {
         jsonGenericRequestMessage1.setPayload(newKapuaPayload);
 
-        assertNotNull("NotNull expected.", jsonGenericRequestMessage1.getPayload());
+        Assert.assertNotNull("NotNull expected.", jsonGenericRequestMessage1.getPayload());
 
         jsonGenericRequestMessage1.setPayload((KapuaPayload) null);
     }
@@ -301,7 +302,7 @@ public class JsonGenericRequestMessageTest extends Assert {
     public void setAndGetKapuaPayloadMessageWithParameterTest() {
         jsonGenericRequestMessage2.setPayload(newKapuaPayload);
 
-        assertNotNull("NotNull expected.", jsonGenericRequestMessage2.getPayload());
+        Assert.assertNotNull("NotNull expected.", jsonGenericRequestMessage2.getPayload());
 
         jsonGenericRequestMessage2.setPayload((KapuaPayload) null);
     }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericResponseMessageTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/device/management/JsonGenericResponseMessageTest.java
@@ -30,8 +30,9 @@ import org.mockito.Mockito;
 import java.util.Date;
 import java.util.UUID;
 
+
 @Category(JUnitTests.class)
-public class JsonGenericResponseMessageTest extends Assert {
+public class JsonGenericResponseMessageTest {
 
     GenericResponseMessage genericResponseMessage;
     UUID id;
@@ -83,32 +84,32 @@ public class JsonGenericResponseMessageTest extends Assert {
     public void jsonGenericResponseMessageWithoutParameterTest() {
         JsonGenericResponseMessage jsonGenericResponseMessage = new JsonGenericResponseMessage();
 
-        assertNull("Null expected.", jsonGenericResponseMessage.getId());
-        assertNull("Null expected.", jsonGenericResponseMessage.getScopeId());
-        assertNull("Null expected.", jsonGenericResponseMessage.getDeviceId());
-        assertNull("Null expected.", jsonGenericResponseMessage.getClientId());
-        assertNull("Null expected.", jsonGenericResponseMessage.getReceivedOn());
-        assertNull("Null expected.", jsonGenericResponseMessage.getSentOn());
-        assertNull("Null expected.", jsonGenericResponseMessage.getCapturedOn());
-        assertNull("Null expected.", jsonGenericResponseMessage.getPosition());
-        assertNull("Null expected.", jsonGenericResponseMessage.getChannel());
-        assertNull("Null expected.", jsonGenericResponseMessage.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage.getPayload());
     }
 
     @Test
     public void jsonGenericResponseMessageWithParameterTest() {
         JsonGenericResponseMessage jsonGenericResponseMessage = new JsonGenericResponseMessage(genericResponseMessage);
 
-        assertEquals("Expected and actual values should be the same.", id, jsonGenericResponseMessage.getId());
-        assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericResponseMessage.getScopeId());
-        assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericResponseMessage.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", clientId, jsonGenericResponseMessage.getClientId());
-        assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericResponseMessage.getReceivedOn());
-        assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericResponseMessage.getSentOn());
-        assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericResponseMessage.getCapturedOn());
-        assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericResponseMessage.getPosition());
-        assertEquals("Expected and actual values should be the same.", genericResponseChannel, jsonGenericResponseMessage.getChannel());
-        assertNotNull("NotNull expected.", jsonGenericResponseMessage.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", id, jsonGenericResponseMessage.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, jsonGenericResponseMessage.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", deviceId, jsonGenericResponseMessage.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", clientId, jsonGenericResponseMessage.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same.", receivedOn, jsonGenericResponseMessage.getReceivedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", sentOn, jsonGenericResponseMessage.getSentOn());
+        Assert.assertEquals("Expected and actual values should be the same.", capturedOn, jsonGenericResponseMessage.getCapturedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaPosition, jsonGenericResponseMessage.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", genericResponseChannel, jsonGenericResponseMessage.getChannel());
+        Assert.assertNotNull("NotNull expected.", jsonGenericResponseMessage.getPayload());
     }
 
     @Test(expected = NullPointerException.class)
@@ -123,14 +124,14 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setId(newId);
         jsonGenericResponseMessage2.setId(newId);
 
-        assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage1.getId());
-        assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage2.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage1.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", newId, jsonGenericResponseMessage2.getId());
 
         jsonGenericResponseMessage1.setId(null);
         jsonGenericResponseMessage2.setId(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getId());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getId());
     }
 
     @Test
@@ -140,14 +141,14 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setScopeId(newScopeId);
         jsonGenericResponseMessage2.setScopeId(newScopeId);
 
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage1.getScopeId());
-        assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage2.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage1.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", newScopeId, jsonGenericResponseMessage2.getScopeId());
 
         jsonGenericResponseMessage1.setScopeId(null);
         jsonGenericResponseMessage2.setScopeId(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getScopeId());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getScopeId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getScopeId());
     }
 
     @Test
@@ -157,14 +158,14 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setDeviceId(newDeviceId);
         jsonGenericResponseMessage2.setDeviceId(newDeviceId);
 
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage1.getDeviceId());
-        assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage2.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage1.getDeviceId());
+        Assert.assertEquals("Expected and actual values should be the same.", newDeviceId, jsonGenericResponseMessage2.getDeviceId());
 
         jsonGenericResponseMessage1.setDeviceId(null);
         jsonGenericResponseMessage2.setDeviceId(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getDeviceId());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getDeviceId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getDeviceId());
     }
 
     @Test
@@ -175,15 +176,15 @@ public class JsonGenericResponseMessageTest extends Assert {
             jsonGenericResponseMessage1.setClientId(newClientID);
             jsonGenericResponseMessage2.setClientId(newClientID);
 
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage1.getClientId());
-            assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage2.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage1.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same.", newClientID, jsonGenericResponseMessage2.getClientId());
         }
 
         jsonGenericResponseMessage1.setClientId(null);
         jsonGenericResponseMessage2.setClientId(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getClientId());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getClientId());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getClientId());
     }
 
     @Test
@@ -192,15 +193,15 @@ public class JsonGenericResponseMessageTest extends Assert {
             jsonGenericResponseMessage1.setReceivedOn(newReceivedOn);
             jsonGenericResponseMessage2.setReceivedOn(newReceivedOn);
 
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage1.getReceivedOn());
-            assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage2.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage1.getReceivedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newReceivedOn, jsonGenericResponseMessage2.getReceivedOn());
         }
 
         jsonGenericResponseMessage1.setReceivedOn(null);
         jsonGenericResponseMessage2.setReceivedOn(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getReceivedOn());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getReceivedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getReceivedOn());
     }
 
     @Test
@@ -209,15 +210,15 @@ public class JsonGenericResponseMessageTest extends Assert {
             jsonGenericResponseMessage1.setSentOn(newSentOn);
             jsonGenericResponseMessage2.setSentOn(newSentOn);
 
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage1.getSentOn());
-            assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage2.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage1.getSentOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newSentOn, jsonGenericResponseMessage2.getSentOn());
         }
 
         jsonGenericResponseMessage1.setSentOn(null);
         jsonGenericResponseMessage2.setSentOn(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getSentOn());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getSentOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getSentOn());
     }
 
     @Test
@@ -226,15 +227,15 @@ public class JsonGenericResponseMessageTest extends Assert {
             jsonGenericResponseMessage1.setCapturedOn(newCapturedOn);
             jsonGenericResponseMessage2.setCapturedOn(newCapturedOn);
 
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage1.getCapturedOn());
-            assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage2.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage1.getCapturedOn());
+            Assert.assertEquals("Expected and actual values should be the same.", newCapturedOn, jsonGenericResponseMessage2.getCapturedOn());
         }
 
         jsonGenericResponseMessage1.setCapturedOn(null);
         jsonGenericResponseMessage2.setCapturedOn(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getCapturedOn());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getCapturedOn());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getCapturedOn());
     }
 
     @Test
@@ -244,14 +245,14 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setPosition(newPosition);
         jsonGenericResponseMessage2.setPosition(newPosition);
 
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage1.getPosition());
-        assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage2.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage1.getPosition());
+        Assert.assertEquals("Expected and actual values should be the same.", newPosition, jsonGenericResponseMessage2.getPosition());
 
         jsonGenericResponseMessage1.setPosition(null);
         jsonGenericResponseMessage2.setPosition(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getPosition());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getPosition());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getPosition());
     }
 
     @Test
@@ -261,14 +262,14 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setChannel(newGenericResponseChannel);
         jsonGenericResponseMessage2.setChannel(newGenericResponseChannel);
 
-        assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage1.getChannel());
-        assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage2.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage1.getChannel());
+        Assert.assertEquals("Expected and actual values should be the same.", newGenericResponseChannel, jsonGenericResponseMessage2.getChannel());
 
         jsonGenericResponseMessage1.setChannel(null);
         jsonGenericResponseMessage2.setChannel(null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getChannel());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getChannel());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getChannel());
     }
 
     @Test
@@ -278,21 +279,21 @@ public class JsonGenericResponseMessageTest extends Assert {
         jsonGenericResponseMessage1.setPayload(newJsonKapuaPayload);
         jsonGenericResponseMessage2.setPayload(newJsonKapuaPayload);
 
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage1.getPayload());
-        assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage2.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage1.getPayload());
+        Assert.assertEquals("Expected and actual values should be the same.", newJsonKapuaPayload, jsonGenericResponseMessage2.getPayload());
 
         jsonGenericResponseMessage1.setPayload((JsonKapuaPayload) null);
         jsonGenericResponseMessage2.setPayload((JsonKapuaPayload) null);
 
-        assertNull("Null expected.", jsonGenericResponseMessage1.getPayload());
-        assertNull("Null expected.", jsonGenericResponseMessage2.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage1.getPayload());
+        Assert.assertNull("Null expected.", jsonGenericResponseMessage2.getPayload());
     }
 
     @Test(expected = NullPointerException.class)
     public void setAndGetKapuaPayloadMessageWithoutParametersTest() {
         jsonGenericResponseMessage1.setPayload(newKapuaPayload);
 
-        assertNotNull("NotNull expected.", jsonGenericResponseMessage1.getPayload());
+        Assert.assertNotNull("NotNull expected.", jsonGenericResponseMessage1.getPayload());
 
         jsonGenericResponseMessage1.setPayload((KapuaPayload) null);
     }
@@ -301,7 +302,7 @@ public class JsonGenericResponseMessageTest extends Assert {
     public void setAndGetKapuaPayloadMessageWithParameterTest() {
         jsonGenericResponseMessage2.setPayload(newKapuaPayload);
 
-        assertNotNull("NotNull expected.", jsonGenericResponseMessage2.getPayload());
+        Assert.assertNotNull("NotNull expected.", jsonGenericResponseMessage2.getPayload());
 
         jsonGenericResponseMessage2.setPayload((KapuaPayload) null);
     }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/message/JsonKapuaPayloadTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/model/message/JsonKapuaPayloadTest.java
@@ -26,8 +26,9 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 
+
 @Category(JUnitTests.class)
-public class JsonKapuaPayloadTest extends Assert {
+public class JsonKapuaPayloadTest {
 
     KapuaPayload kapuaPayload;
     byte[] body;
@@ -44,8 +45,8 @@ public class JsonKapuaPayloadTest extends Assert {
     public void jsonKapuaPayloadWithoutParameterTest() {
         JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload();
 
-        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
-        assertNull("Null expected.", jsonKapuaPayload.getBody());
+        Assert.assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertNull("Null expected.", jsonKapuaPayload.getBody());
     }
 
     @Test
@@ -55,8 +56,8 @@ public class JsonKapuaPayloadTest extends Assert {
 
         JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
 
-        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
-        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+        Assert.assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
     }
 
     @Test
@@ -67,8 +68,8 @@ public class JsonKapuaPayloadTest extends Assert {
         Mockito.when(kapuaPayload.getMetrics()).thenReturn(map);
 
         JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
-        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
-        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+        Assert.assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
     }
 
     @Test
@@ -80,8 +81,8 @@ public class JsonKapuaPayloadTest extends Assert {
         Mockito.when(kapuaPayload.getMetrics()).thenReturn(map);
 
         JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
-        assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
-        assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
+        Assert.assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", body, jsonKapuaPayload.getBody());
     }
 
     @Test(expected = NullPointerException.class)
@@ -97,9 +98,9 @@ public class JsonKapuaPayloadTest extends Assert {
 
         metrics.add(jsonMetric);
 
-        assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertTrue("True expected.", jsonKapuaPayload.getMetrics().isEmpty());
         jsonKapuaPayload.setMetrics(metrics);
-        assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
+        Assert.assertFalse("False expected.", jsonKapuaPayload.getMetrics().isEmpty());
     }
 
     @Test
@@ -107,8 +108,8 @@ public class JsonKapuaPayloadTest extends Assert {
         JsonKapuaPayload jsonKapuaPayload = new JsonKapuaPayload(kapuaPayload);
         byte[] newBody = {1, 2, 3, 4, 5};
 
-        assertNull("Null expected.", jsonKapuaPayload.getBody());
+        Assert.assertNull("Null expected.", jsonKapuaPayload.getBody());
         jsonKapuaPayload.setBody(newBody);
-        assertEquals("Expected and actual values should be the same.", newBody, jsonKapuaPayload.getBody());
+        Assert.assertEquals("Expected and actual values should be the same.", newBody, jsonKapuaPayload.getBody());
     }
 }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/resources/AbstractKapuaResourceTest.java
@@ -23,8 +23,9 @@ import org.junit.experimental.categories.Category;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Response;
 
+
 @Category(JUnitTests.class)
-public class AbstractKapuaResourceTest extends Assert {
+public class AbstractKapuaResourceTest {
 
     private class AbstractKapuaResourceImpl extends AbstractKapuaResource {
 
@@ -42,7 +43,7 @@ public class AbstractKapuaResourceTest extends Assert {
     @Test
     public void returnNotNullEntityTest() {
         for (Object object : objects) {
-            assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnNotNullEntity(object));
+            Assert.assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnNotNullEntity(object));
         }
     }
 
@@ -50,27 +51,27 @@ public class AbstractKapuaResourceTest extends Assert {
     public void returnNotNullEntityNullTest() {
         try {
             abstractKapuaResource.returnNotNullEntity(null);
-            fail("WebApplicationException expected.");
+            Assert.fail("WebApplicationException expected.");
         } catch (Exception e) {
-            assertEquals("WebApplicationException expected.", new WebApplicationException(Response.Status.NOT_FOUND).toString(), e.toString());
+            Assert.assertEquals("WebApplicationException expected.", new WebApplicationException(Response.Status.NOT_FOUND).toString(), e.toString());
         }
     }
 
     @Test
     public void returnOkTest() {
-        assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=200, reason=OK, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnOk().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=200, reason=OK, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnOk().toString());
     }
 
     @Test
     public void returnNoContentTest() {
-        assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=204, reason=No Content, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnNoContent().toString());
+        Assert.assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=204, reason=No Content, hasEntity=false, closed=false, buffered=false}", abstractKapuaResource.returnNoContent().toString());
     }
 
     @Test
     public void returnCreatedTest() {
         for (Object object : objects) {
-            assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=201, reason=Created, hasEntity=true, closed=false, buffered=false}", abstractKapuaResource.returnCreated(object).toString());
-            assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnCreated(object).getEntity());
+            Assert.assertEquals("Expected and actual values should be the same.", "OutboundJaxrsResponse{status=201, reason=Created, hasEntity=true, closed=false, buffered=false}", abstractKapuaResource.returnCreated(object).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", object, abstractKapuaResource.returnCreated(object).getEntity());
         }
     }
 }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeysTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingKeysTest.java
@@ -17,12 +17,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaApiCoreSettingKeysTest extends Assert {
+public class KapuaApiCoreSettingKeysTest {
 
     @Test
     public void kapuaApiCoreSettingKeysTest(){
-        assertEquals("Expected and actual values should be the same.","api.path.param.scopeId.wildcard",KapuaApiCoreSettingKeys.API_PATH_PARAM_SCOPEID_WILDCARD.key());
-        assertEquals("Expected and actual values should be the same.","api.exception.stacktrace.show",KapuaApiCoreSettingKeys.API_EXCEPTION_STACKTRACE_SHOW.key());
+        Assert.assertEquals("Expected and actual values should be the same.","api.path.param.scopeId.wildcard",KapuaApiCoreSettingKeys.API_PATH_PARAM_SCOPEID_WILDCARD.key());
+        Assert.assertEquals("Expected and actual values should be the same.","api.exception.stacktrace.show",KapuaApiCoreSettingKeys.API_EXCEPTION_STACKTRACE_SHOW.key());
     }
 }

--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/settings/KapuaApiCoreSettingTest.java
@@ -20,19 +20,20 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class KapuaApiCoreSettingTest extends Assert {
+public class KapuaApiCoreSettingTest {
 
     @Test
     public void kapuaApiCoreSettingTest() throws Exception {
         Constructor<KapuaApiCoreSetting> kapuaApiCoreSetting = KapuaApiCoreSetting.class.getDeclaredConstructor();
         kapuaApiCoreSetting.setAccessible(true);
         kapuaApiCoreSetting.newInstance();
-        assertTrue("True expected.", Modifier.isPrivate(kapuaApiCoreSetting.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(kapuaApiCoreSetting.getModifiers()));
     }
 
     @Test
     public void getInstanceTest() {
-        assertTrue("True expected.", KapuaApiCoreSetting.getInstance() instanceof KapuaApiCoreSetting);
+        Assert.assertTrue("True expected.", KapuaApiCoreSetting.getInstance() instanceof KapuaApiCoreSetting);
     }
 }

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProviderTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiJAXBContextProviderTest.java
@@ -25,8 +25,9 @@ import javax.ws.rs.ext.ContextResolver;
 import javax.ws.rs.ext.Providers;
 import javax.xml.bind.JAXBContext;
 
+
 @Category(JUnitTests.class)
-public class RestApiJAXBContextProviderTest extends Assert {
+public class RestApiJAXBContextProviderTest {
 
     RestApiJAXBContextProvider restApiJAXBContextProvider;
     Providers providers;
@@ -47,9 +48,9 @@ public class RestApiJAXBContextProviderTest extends Assert {
 
         try {
             restApiJAXBContextProvider.getJAXBContext();
-            fail("KapuaException expected.");
+            Assert.fail("KapuaException expected.");
         } catch (Exception e) {
-            assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to find any provider..", e.toString());
+            Assert.assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to find any provider..", e.toString());
         }
     }
 
@@ -62,9 +63,9 @@ public class RestApiJAXBContextProviderTest extends Assert {
 
         try {
             restApiJAXBContextProvider.getJAXBContext();
-            fail("KapuaException expected.");
+            Assert.fail("KapuaException expected.");
         } catch (Exception e) {
-            assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to get a JAXBContext..", e.toString());
+            Assert.assertEquals("KapuaException expected.", "org.eclipse.kapua.KapuaException: An internal error occurred: Unable to get a JAXBContext..", e.toString());
         }
     }
 
@@ -75,6 +76,6 @@ public class RestApiJAXBContextProviderTest extends Assert {
         Mockito.when(providers.getContextResolver(JAXBContext.class, MediaType.APPLICATION_XML_TYPE)).thenReturn(contextResolver);
         Mockito.when(contextResolver.getContext(JAXBContext.class)).thenReturn(jaxbContext);
 
-        assertTrue("True expected.", restApiJAXBContextProvider.getJAXBContext() instanceof JAXBContext);
+        Assert.assertTrue("True expected.", restApiJAXBContextProvider.getJAXBContext() instanceof JAXBContext);
     }
 }

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiListenerTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApiListenerTest.java
@@ -21,8 +21,9 @@ import org.mockito.Mockito;
 
 import javax.servlet.ServletContextEvent;
 
+
 @Category(JUnitTests.class)
-public class RestApiListenerTest extends Assert {
+public class RestApiListenerTest {
 
     RestApiListener restApiListener;
     ServletContextEvent servletContextEvent;
@@ -38,7 +39,7 @@ public class RestApiListenerTest extends Assert {
         try {
             restApiListener.contextInitialized(servletContextEvent);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 
@@ -47,7 +48,7 @@ public class RestApiListenerTest extends Assert {
         try {
             restApiListener.contextInitialized(null);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 
@@ -56,7 +57,7 @@ public class RestApiListenerTest extends Assert {
         try {
             restApiListener.contextDestroyed(servletContextEvent);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 
@@ -65,7 +66,7 @@ public class RestApiListenerTest extends Assert {
         try {
             restApiListener.contextDestroyed(null);
         } catch (Exception e) {
-            fail("Exception not expected.");
+            Assert.fail("Exception not expected.");
         }
     }
 }

--- a/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApisApplicationTest.java
+++ b/rest-api/web/src/test/java/org/eclipse/kapua/app/api/web/RestApisApplicationTest.java
@@ -24,25 +24,26 @@ import org.junit.experimental.categories.Category;
 
 import javax.xml.bind.JAXBException;
 
+
 @Category(JUnitTests.class)
-public class RestApisApplicationTest extends Assert {
+public class RestApisApplicationTest {
 
     @Test
     public void restApisApplicationTest() throws JAXBException {
         RestApisApplication restApisApplication = new RestApisApplication();
 
-        assertEquals("{jersey.config.server.mediaTypeMappings={xml=application/xml, json=application/json}, jersey.config.server.wadl.disableWadl=true}", restApisApplication.getProperties().toString());
-        assertTrue("True expected.", restApisApplication.isRegistered(UriConnegFilter.class));
-        assertTrue("True expected.", restApisApplication.isRegistered(JaxbContextResolver.class));
-        assertTrue("True expected.", restApisApplication.isRegistered(RestApiJAXBContextProvider.class));
-        assertTrue("True expected.", restApisApplication.isRegistered(KapuaSerializableBodyWriter.class));
-        assertTrue("True expected.", restApisApplication.isRegistered(ListBodyWriter.class));
-        assertTrue("True expected.", restApisApplication.isRegistered(MoxyJsonConfigContextResolver.class));
+        Assert.assertEquals("{jersey.config.server.mediaTypeMappings={xml=application/xml, json=application/json}, jersey.config.server.wadl.disableWadl=true}", restApisApplication.getProperties().toString());
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(UriConnegFilter.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(JaxbContextResolver.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(RestApiJAXBContextProvider.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(KapuaSerializableBodyWriter.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(ListBodyWriter.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(MoxyJsonConfigContextResolver.class));
 
-        assertFalse("False expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
-        assertFalse("False expected.", restApisApplication.isRegistered(String.class));
+        Assert.assertFalse("False expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
+        Assert.assertFalse("False expected.", restApisApplication.isRegistered(String.class));
 
         restApisApplication.register(ContainerLifecycleListener.class);
-        assertTrue("True expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
+        Assert.assertTrue("True expected.", restApisApplication.isRegistered(ContainerLifecycleListener.class));
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/ExceptionMessageUtilsTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/ExceptionMessageUtilsTest.java
@@ -25,8 +25,9 @@ import java.lang.reflect.Modifier;
 import java.util.Locale;
 import java.util.MissingResourceException;
 
+
 @Category(JUnitTests.class)
-public class ExceptionMessageUtilsTest extends Assert {
+public class ExceptionMessageUtilsTest {
 
     String[] resourceBundleName;
     Locale locale;
@@ -52,7 +53,7 @@ public class ExceptionMessageUtilsTest extends Assert {
     @Test
     public void exceptionMessageUtilsTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<ExceptionMessageUtils> exceptionMessageUtils = ExceptionMessageUtils.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(exceptionMessageUtils.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(exceptionMessageUtils.getModifiers()));
         exceptionMessageUtils.setAccessible(true);
         exceptionMessageUtils.newInstance();
     }
@@ -60,14 +61,14 @@ public class ExceptionMessageUtilsTest extends Assert {
     @Test
     public void getLocalizedMessageTest() {
         for (int i = 0; i < resourceBundleName.length; i++) {
-            assertEquals("Expected and actual values should be the same.", kapuaGenericMessageWithObject[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, objectList));
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaGenericMessageWithObject[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, objectList));
         }
     }
 
     @Test
     public void getLocalizedMessageEmptyObjectListTest() {
         for (int i = 0; i < resourceBundleName.length; i++) {
-            assertEquals("Expected and actual values should be the same.", kapuaGenericMessage[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, emptyObjectList));
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaGenericMessage[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, emptyObjectList));
         }
     }
 
@@ -97,12 +98,12 @@ public class ExceptionMessageUtilsTest extends Assert {
     @Test
     public void getLocalizedMessageNullObjectTest() {
         for (int i = 0; i < resourceBundleName.length; i++) {
-            assertEquals("Expected and actual values should be the same.", kapuaGenericMessage[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, null));
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaGenericMessage[i], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[i], locale, kapuaErrorCode, null));
         }
     }
 
     @Test
     public void getLocalizedMessageNullKapuaErrorCodeSecondTest() {
-        assertEquals("Expected and actual values should be the same.", kapuaGenericMessageWithObject[1], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[1], locale, null, objectList));
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaGenericMessageWithObject[1], ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[1], locale, null, objectList));
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateExternalIdExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateExternalIdExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaDuplicateExternalIdExceptionTest extends Assert {
+public class KapuaDuplicateExternalIdExceptionTest {
 
     String[] duplicatedExternalId;
 
@@ -32,9 +33,9 @@ public class KapuaDuplicateExternalIdExceptionTest extends Assert {
     public void kapuaDuplicateExternalIdExceptionTest() {
         for (String id : duplicatedExternalId) {
             KapuaDuplicateExternalIdException kapuaDuplicateExternalIdException = new KapuaDuplicateExternalIdException(id);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.DUPLICATE_EXTERNAL_ID, kapuaDuplicateExternalIdException.getCode());
-            assertNull("Null expected", kapuaDuplicateExternalIdException.getCause());
-            assertEquals("Expected and actual values should be the same.", "An entity with the same external Id " + id + " already exists.", kapuaDuplicateExternalIdException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.DUPLICATE_EXTERNAL_ID, kapuaDuplicateExternalIdException.getCode());
+            Assert.assertNull("Null expected", kapuaDuplicateExternalIdException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An entity with the same external Id " + id + " already exists.", kapuaDuplicateExternalIdException.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountErrorTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateExternalIdInAnotherAccountErrorTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaDuplicateExternalIdInAnotherAccountErrorTest extends Assert {
+public class KapuaDuplicateExternalIdInAnotherAccountErrorTest {
 
     String[] duplicateExternalId;
 
@@ -32,9 +33,9 @@ public class KapuaDuplicateExternalIdInAnotherAccountErrorTest extends Assert {
     public void kapuaDuplicateExternalIdInAnotherAccountErrorTest() {
         for (String id : duplicateExternalId) {
             KapuaDuplicateExternalIdInAnotherAccountError kapuaDuplicateExternalIdInAnotherAccountError = new KapuaDuplicateExternalIdInAnotherAccountError(id);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.EXTERNAL_ID_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, kapuaDuplicateExternalIdInAnotherAccountError.getCode());
-            assertNull("Null expected", kapuaDuplicateExternalIdInAnotherAccountError.getCause());
-            assertEquals("Expected and actual values should be the same.", "An entity with the same external id " + id + " already exists in another account.", kapuaDuplicateExternalIdInAnotherAccountError.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.EXTERNAL_ID_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, kapuaDuplicateExternalIdInAnotherAccountError.getCode());
+            Assert.assertNull("Null expected", kapuaDuplicateExternalIdInAnotherAccountError.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An entity with the same external id " + id + " already exists in another account.", kapuaDuplicateExternalIdInAnotherAccountError.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateNameExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateNameExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaDuplicateNameExceptionTest extends Assert {
+public class KapuaDuplicateNameExceptionTest {
 
     String[] duplicatedNames;
 
@@ -32,9 +33,9 @@ public class KapuaDuplicateNameExceptionTest extends Assert {
     public void kapuaDuplicateNameExceptionStringParameterTest() {
         for (String duplicatedName : duplicatedNames) {
             KapuaDuplicateNameException kapuaDuplicateNameExceptions = new KapuaDuplicateNameException(duplicatedName);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.DUPLICATE_NAME, kapuaDuplicateNameExceptions.getCode());
-            assertNull("Null expected", kapuaDuplicateNameExceptions.getCause());
-            assertEquals("Expected and actual values should be the same.", "An entity with the same name " + duplicatedName + " already exists.", kapuaDuplicateNameExceptions.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.DUPLICATE_NAME, kapuaDuplicateNameExceptions.getCode());
+            Assert.assertNull("Null expected", kapuaDuplicateNameExceptions.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An entity with the same name " + duplicatedName + " already exists.", kapuaDuplicateNameExceptions.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountErrorTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaDuplicateNameInAnotherAccountErrorTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaDuplicateNameInAnotherAccountErrorTest extends Assert {
+public class KapuaDuplicateNameInAnotherAccountErrorTest {
 
     String[] duplicateNames;
 
@@ -32,9 +33,9 @@ public class KapuaDuplicateNameInAnotherAccountErrorTest extends Assert {
     public void kapuaDuplicateNameInAnotherAccountErrorTest() {
         for (String duplicateName : duplicateNames) {
             KapuaDuplicateNameInAnotherAccountError kapuaDuplicateNameInAnotherAccountError = new KapuaDuplicateNameInAnotherAccountError(duplicateName);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, kapuaDuplicateNameInAnotherAccountError.getCode());
-            assertNull("Null expected", kapuaDuplicateNameInAnotherAccountError.getCause());
-            assertEquals("Expected and actual values should be the same.", "An entity with the same name " + duplicateName + " already exists.", kapuaDuplicateNameInAnotherAccountError.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_ALREADY_EXIST_IN_ANOTHER_ACCOUNT, kapuaDuplicateNameInAnotherAccountError.getCode());
+            Assert.assertNull("Null expected", kapuaDuplicateNameInAnotherAccountError.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An entity with the same name " + duplicateName + " already exists.", kapuaDuplicateNameInAnotherAccountError.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaEntityCloneExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaEntityCloneExceptionTest.java
@@ -20,8 +20,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+
 @Category(JUnitTests.class)
-public class KapuaEntityCloneExceptionTest extends Assert {
+public class KapuaEntityCloneExceptionTest {
 
     String[] entityType;
     KapuaEntity[] kapuaEntity;
@@ -39,11 +40,11 @@ public class KapuaEntityCloneExceptionTest extends Assert {
         for (String type : entityType) {
             for (KapuaEntity entity : kapuaEntity) {
                 KapuaEntityCloneException kapuaEntityCloneException = new KapuaEntityCloneException(type, entity);
-                assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_CLONE_ERROR, kapuaEntityCloneException.getCode());
-                assertEquals("Expected and actual values should be the same.", type, kapuaEntityCloneException.getEntityType());
-                assertEquals("Expected and actual values should be the same.", entity, kapuaEntityCloneException.getEntity());
-                assertNull("Null expected.", kapuaEntityCloneException.getCause());
-                assertEquals("Expected and actual values should be the same.", "Severe error while cloning: " + type, kapuaEntityCloneException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_CLONE_ERROR, kapuaEntityCloneException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityCloneException.getEntityType());
+                Assert.assertEquals("Expected and actual values should be the same.", entity, kapuaEntityCloneException.getEntity());
+                Assert.assertNull("Null expected.", kapuaEntityCloneException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", "Severe error while cloning: " + type, kapuaEntityCloneException.getMessage());
             }
         }
     }
@@ -54,11 +55,11 @@ public class KapuaEntityCloneExceptionTest extends Assert {
             for (KapuaEntity entity : kapuaEntity) {
                 for (Throwable throwable : throwables) {
                     KapuaEntityCloneException kapuaEntityCloneException = new KapuaEntityCloneException(throwable, type, entity);
-                    assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_CLONE_ERROR, kapuaEntityCloneException.getCode());
-                    assertEquals("Expected and actual values should be the same.", type, kapuaEntityCloneException.getEntityType());
-                    assertEquals("Expected and actual values should be the same.", entity, kapuaEntityCloneException.getEntity());
-                    assertEquals("Expected and actual values should be the same.", throwable, kapuaEntityCloneException.getCause());
-                    assertEquals("Expected and actual values should be the same.", "Severe error while cloning: " + type, kapuaEntityCloneException.getMessage());
+                    Assert.assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_CLONE_ERROR, kapuaEntityCloneException.getCode());
+                    Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityCloneException.getEntityType());
+                    Assert.assertEquals("Expected and actual values should be the same.", entity, kapuaEntityCloneException.getEntity());
+                    Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaEntityCloneException.getCause());
+                    Assert.assertEquals("Expected and actual values should be the same.", "Severe error while cloning: " + type, kapuaEntityCloneException.getMessage());
                 }
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaEntityExistsExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaEntityExistsExceptionTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 
 import java.math.BigInteger;
 
+
 @Category(JUnitTests.class)
-public class KapuaEntityExistsExceptionTest extends Assert {
+public class KapuaEntityExistsExceptionTest {
 
     Throwable[] throwables;
     KapuaId[] ids;
@@ -39,10 +40,10 @@ public class KapuaEntityExistsExceptionTest extends Assert {
         for (Throwable throwable : throwables) {
             for (KapuaId id : ids) {
                 KapuaEntityExistsException kapuaEntityExistsException = new KapuaEntityExistsException(throwable, id);
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_ALREADY_EXISTS, kapuaEntityExistsException.getCode());
-                assertEquals("Expected and actual values should be the same.", id, kapuaEntityExistsException.getId());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaEntityExistsException.getCause());
-                assertEquals("Expected and actual values should be the same.", "Error: ", kapuaEntityExistsException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_ALREADY_EXISTS, kapuaEntityExistsException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", id, kapuaEntityExistsException.getId());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaEntityExistsException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaEntityExistsException.getMessage());
             }
         }
     }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaEntityNotFoundExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaEntityNotFoundExceptionTest.java
@@ -23,8 +23,9 @@ import org.junit.experimental.categories.Category;
 import java.math.BigInteger;
 
 
+
 @Category(JUnitTests.class)
-public class KapuaEntityNotFoundExceptionTest extends Assert {
+public class KapuaEntityNotFoundExceptionTest {
     String[] entityType;
     String[] entityName;
     KapuaId entityId;
@@ -41,12 +42,12 @@ public class KapuaEntityNotFoundExceptionTest extends Assert {
         for (String type : entityType) {
             for (String name : entityName) {
                 KapuaEntityNotFoundException kapuaEntityNotFoundException = new KapuaEntityNotFoundException(type, name);
-                assertEquals("Expected and actual values should be the same.", type, kapuaEntityNotFoundException.getEntityType());
-                assertEquals("Expected and actual values should be the same.", name, kapuaEntityNotFoundException.getEntityName());
-                assertNull("Null expected.", kapuaEntityNotFoundException.getEntityId());
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaEntityNotFoundException.getCode());
-                assertEquals("Expected and actual values should be the same.", "The entity of type " + type + " with id/name " + name + " was not found.", kapuaEntityNotFoundException.getMessage());
-                assertNull("Null expected.", kapuaEntityNotFoundException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityNotFoundException.getEntityType());
+                Assert.assertEquals("Expected and actual values should be the same.", name, kapuaEntityNotFoundException.getEntityName());
+                Assert.assertNull("Null expected.", kapuaEntityNotFoundException.getEntityId());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaEntityNotFoundException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + type + " with id/name " + name + " was not found.", kapuaEntityNotFoundException.getMessage());
+                Assert.assertNull("Null expected.", kapuaEntityNotFoundException.getCause());
             }
         }
     }
@@ -55,11 +56,11 @@ public class KapuaEntityNotFoundExceptionTest extends Assert {
     public void kapuaEntityNotFoundExceptionStringKapuaIdParametersTest() {
         for (String type : entityType) {
             KapuaEntityNotFoundException kapuaEntityNotFoundException = new KapuaEntityNotFoundException(type, entityId);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaEntityNotFoundException.getCode());
-            assertEquals("Expected and actual values should be the same.", type, kapuaEntityNotFoundException.getEntityType());
-            assertEquals("Expected and actual values should be the same.", entityId, kapuaEntityNotFoundException.getEntityId());
-            assertEquals("Expected and actual values should be the same.", "The entity of type " + type + " with id/name " + entityId.getId() + " was not found.", kapuaEntityNotFoundException.getMessage());
-            assertNull("Null expected.", kapuaEntityNotFoundException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaEntityNotFoundException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityNotFoundException.getEntityType());
+            Assert.assertEquals("Expected and actual values should be the same.", entityId, kapuaEntityNotFoundException.getEntityId());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + type + " with id/name " + entityId.getId() + " was not found.", kapuaEntityNotFoundException.getMessage());
+            Assert.assertNull("Null expected.", kapuaEntityNotFoundException.getCause());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaEntityUniquenessExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaEntityUniquenessExceptionTest.java
@@ -24,8 +24,9 @@ import java.util.List;
 import java.util.Map;
 
 
+
 @Category(JUnitTests.class)
-public class KapuaEntityUniquenessExceptionTest extends Assert {
+public class KapuaEntityUniquenessExceptionTest {
 
     String[] entityType;
     List<Map.Entry<String, Object>> uniquesFieldValues;
@@ -45,11 +46,11 @@ public class KapuaEntityUniquenessExceptionTest extends Assert {
     public void kapuaEntityUniquenessExceptionTest() {
         for (String type : entityType) {
             KapuaEntityUniquenessException kapuaEntityUniquenessException1 = new KapuaEntityUniquenessException(type, uniquesFieldValues);
-            assertEquals("Expected and actual values should be the same.", type, kapuaEntityUniquenessException1.getEntityType());
-            assertEquals("Expected and actual values should be the same.", uniquesFieldValues, kapuaEntityUniquenessException1.getUniquesFieldValues());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_UNIQUENESS, kapuaEntityUniquenessException1.getCode());
-            assertEquals("Expected and actual values should be the same.", "Error: " + uniquesFieldValues, kapuaEntityUniquenessException1.getMessage());
-            assertNull("Null expected.", kapuaEntityUniquenessException1.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityUniquenessException1.getEntityType());
+            Assert.assertEquals("Expected and actual values should be the same.", uniquesFieldValues, kapuaEntityUniquenessException1.getUniquesFieldValues());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_UNIQUENESS, kapuaEntityUniquenessException1.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: " + uniquesFieldValues, kapuaEntityUniquenessException1.getMessage());
+            Assert.assertNull("Null expected.", kapuaEntityUniquenessException1.getCause());
         }
     }
 
@@ -57,11 +58,11 @@ public class KapuaEntityUniquenessExceptionTest extends Assert {
     public void kapuaEntityUniquenessExceptionNullFieldValuesTest() {
         for (String type : entityType) {
             KapuaEntityUniquenessException kapuaEntityUniquenessException2 = new KapuaEntityUniquenessException(type, null);
-            assertEquals("Expected and actual values should be the same.", type, kapuaEntityUniquenessException2.getEntityType());
-            assertNull("Null expected.", kapuaEntityUniquenessException2.getUniquesFieldValues());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_UNIQUENESS, kapuaEntityUniquenessException2.getCode());
-            assertEquals("Expected and actual values should be the same.", "Error: null", kapuaEntityUniquenessException2.getMessage());
-            assertNull("Null expected.", kapuaEntityUniquenessException2.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", type, kapuaEntityUniquenessException2.getEntityType());
+            Assert.assertNull("Null expected.", kapuaEntityUniquenessException2.getUniquesFieldValues());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_UNIQUENESS, kapuaEntityUniquenessException2.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: null", kapuaEntityUniquenessException2.getMessage());
+            Assert.assertNull("Null expected.", kapuaEntityUniquenessException2.getCause());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaExceptionTest extends Assert {
+public class KapuaExceptionTest {
 
     String expectedErrorMessage;
     Object argument1, argument2, argument3;
@@ -41,90 +42,90 @@ public class KapuaExceptionTest extends Assert {
     public void kapuaExceptionKapuaErrorCodeParameterTest() {
         KapuaException kapuaException = new KapuaException(kapuaErrorCode);
 
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
-        assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
-        assertNull("Null expected.", kapuaException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
     }
 
     @Test
     public void kapuaExceptionNullKapuaErrorCodeParameterTest() {
         KapuaException kapuaException = new KapuaException(null);
-        assertNull("Null expected.", kapuaException.getCode());
-        assertNull("Null expected.", kapuaException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaException.getCode());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
         try {
             kapuaException.getMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
         try {
             kapuaException.getLocalizedMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
     @Test
     public void kapuaExceptionKapuaErrorCodeObjectParametersTest() {
         KapuaException kapuaException = new KapuaException(kapuaErrorCode, argument1, argument2, argument3);
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
-        assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getLocalizedMessage());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-        assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getLocalizedMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
     }
 
     @Test
     public void kapuaExceptionNullKapuaErrorCodeObjectParametersTest() {
         KapuaException kapuaException = new KapuaException(null, argument1, argument2, argument3);
-        assertNull("Null expected.", kapuaException.getCode());
-        assertNull("Null expected.", kapuaException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaException.getCode());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
         try {
             kapuaException.getMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
         try {
             kapuaException.getLocalizedMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
     @Test
     public void kapuaExceptionKapuaErrorCodeNullObjectParametersTest() {
         KapuaException kapuaException = new KapuaException(kapuaErrorCode, null);
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
-        assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-        assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
     }
 
     @Test
     public void kapuaExceptionNullKapuaErrorCodeNullObjectParametersTest() {
         KapuaException kapuaException = new KapuaException(null, null);
-        assertNull("Null expected.", kapuaException.getCode());
-        assertNull("Null expected.", kapuaException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaException.getCode());
+        Assert.assertNull("Null expected.", kapuaException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
         try {
             kapuaException.getMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
         try {
             kapuaException.getLocalizedMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -132,11 +133,11 @@ public class KapuaExceptionTest extends Assert {
     public void kapuaExceptionKapuaErrorCodeThrowableObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaException = new KapuaException(kapuaErrorCode, throwable, argument1, argument2, argument3);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
-            assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getMessage());
-            assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaException.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
         }
     }
 
@@ -144,20 +145,20 @@ public class KapuaExceptionTest extends Assert {
     public void kapuaExceptionNullKapuaErrorCodeThrowableObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaException = new KapuaException(null, throwable, argument1, argument2, argument3);
-            assertNull("Null expected.", kapuaException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", kapuaException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
             try {
                 kapuaException.getMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
             try {
                 kapuaException.getLocalizedMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -166,11 +167,11 @@ public class KapuaExceptionTest extends Assert {
     public void kapuaExceptionKapuaErrorCodeThrowableNullObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaException = new KapuaException(kapuaErrorCode, throwable, null);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
-            assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
-            assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaException.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
         }
     }
 
@@ -178,20 +179,20 @@ public class KapuaExceptionTest extends Assert {
     public void kapuaExceptionNullKapuaErrorCodeThrowableNullObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaException = new KapuaException(null, throwable, null);
-            assertNull("Null expected.", kapuaException.getCode());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
+            Assert.assertNull("Null expected.", kapuaException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
             try {
                 kapuaException.getMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
             try {
                 kapuaException.getLocalizedMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -203,13 +204,13 @@ public class KapuaExceptionTest extends Assert {
 
         for (Throwable throwable : cause) {
             for (String msg : messages) {
-                assertThat("Instance of KapuaException expected.", KapuaException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaException.class));
-                assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, throwable, msg).toString(), KapuaException.internalError(throwable, msg).toString());
-                assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(throwable, msg).getMessage());
-                assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(throwable, msg).getLocalizedMessage());
-                assertEquals("Expected and actual values should be the same.", throwable, KapuaException.internalError(throwable, msg).getCause());
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(throwable, msg).getCode());
-                assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(throwable, msg).getKapuaErrorMessagesBundle());
+                Assert.assertThat("Instance of KapuaException expected.", KapuaException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaException.class));
+                Assert.assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, throwable, msg).toString(), KapuaException.internalError(throwable, msg).toString());
+                Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(throwable, msg).getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(throwable, msg).getLocalizedMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, KapuaException.internalError(throwable, msg).getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(throwable, msg).getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(throwable, msg).getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -223,18 +224,18 @@ public class KapuaExceptionTest extends Assert {
         String[] arguments = {"Message", "java.lang.Throwable"};
 
         for (int i = 0; i < throwables.length; i++) {
-            assertThat("Instance of KapuaException expected.", KapuaException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaException.class));
-            assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, throwables[i], arguments[i]).toString(), KapuaException.internalError(throwables[i]).toString());
-            assertEquals("Expected and actual values should be the same.", expectedMessage[i], KapuaException.internalError(throwables[i]).getMessage());
-            assertEquals("Expected and actual values should be the same.", throwables[i], KapuaException.internalError(throwables[i]).getCause());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(throwables[i]).getCode());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(throwables[i]).getKapuaErrorMessagesBundle());
+            Assert.assertThat("Instance of KapuaException expected.", KapuaException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaException.class));
+            Assert.assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, throwables[i], arguments[i]).toString(), KapuaException.internalError(throwables[i]).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], KapuaException.internalError(throwables[i]).getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", throwables[i], KapuaException.internalError(throwables[i]).getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(throwables[i]).getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(throwables[i]).getKapuaErrorMessagesBundle());
         }
         try {
             KapuaException.internalError(nullThrowable);
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -243,12 +244,12 @@ public class KapuaExceptionTest extends Assert {
         String[] messages = {"Message", null};
 
         for (String msg : messages) {
-            assertThat("Instance of KapuaRuntimeException expected.", KapuaException.internalError(msg), IsInstanceOf.instanceOf(KapuaException.class));
-            assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, null, msg).toString(), KapuaException.internalError(msg).toString());
-            assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(msg).getMessage());
-            assertNull("Null expected.", KapuaException.internalError(msg).getCause());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(msg).getCode());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(msg).getKapuaErrorMessagesBundle());
+            Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaException.internalError(msg), IsInstanceOf.instanceOf(KapuaException.class));
+            Assert.assertEquals("Expected and actual values should be the same.", new KapuaException(KapuaErrorCodes.INTERNAL_ERROR, null, msg).toString(), KapuaException.internalError(msg).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaException.internalError(msg).getMessage());
+            Assert.assertNull("Null expected.", KapuaException.internalError(msg).getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaException.internalError(msg).getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaException.internalError(msg).getKapuaErrorMessagesBundle());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundleTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionWithoutBundleTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaExceptionWithoutBundleTest extends Assert {
+public class KapuaExceptionWithoutBundleTest {
 
     String expectedKapuaErrorMessagesBundle;
     Object argument1, argument2, argument3;
@@ -41,11 +42,11 @@ public class KapuaExceptionWithoutBundleTest extends Assert {
     public void kapuaExceptionWithoutBundleKapuaErrorCodeParameterTest() {
         for (KapuaErrorCode kapuaErrorCode : kapuaErrorCodes) {
             KapuaExceptionWithoutBundle kapuaExceptionWithoutBundle = new KapuaExceptionWithoutBundle(kapuaErrorCode);
-            assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
-            assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
-            assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
-            assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
+            Assert.assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -53,11 +54,11 @@ public class KapuaExceptionWithoutBundleTest extends Assert {
     public void kapuaExceptionWithoutBundleKapuaErrorCodeObjectParameterTest() {
         for (KapuaErrorCode kapuaErrorCode : kapuaErrorCodes) {
             KapuaExceptionWithoutBundle kapuaExceptionWithoutBundle = new KapuaExceptionWithoutBundle(kapuaErrorCode, argument1, argument2, argument3);
-            assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
-            assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
-            assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getMessage());
-            assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
+            Assert.assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -65,11 +66,11 @@ public class KapuaExceptionWithoutBundleTest extends Assert {
     public void kapuaExceptionWithoutBundleKapuaErrorCodeNullObjectParameterTest() {
         for (KapuaErrorCode kapuaErrorCode : kapuaErrorCodes) {
             KapuaExceptionWithoutBundle kapuaExceptionWithoutBundle = new KapuaExceptionWithoutBundle(kapuaErrorCode, null);
-            assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
-            assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
-            assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
-            assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
+            Assert.assertNull("Null expected.", kapuaExceptionWithoutBundle.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -78,11 +79,11 @@ public class KapuaExceptionWithoutBundleTest extends Assert {
         for (KapuaErrorCode kapuaErrorCode : kapuaErrorCodes) {
             for (Throwable throwable : throwables) {
                 KapuaExceptionWithoutBundle kapuaExceptionWithoutBundle = new KapuaExceptionWithoutBundle(kapuaErrorCode, throwable, argument1, argument2, argument3);
-                assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaExceptionWithoutBundle.getCause());
-                assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getMessage());
-                assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getLocalizedMessage());
-                assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaExceptionWithoutBundle.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: " + argument1 + ", " + argument2 + ", " + argument3, kapuaExceptionWithoutBundle.getLocalizedMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -92,11 +93,11 @@ public class KapuaExceptionWithoutBundleTest extends Assert {
         for (KapuaErrorCode kapuaErrorCode : kapuaErrorCodes) {
             for (Throwable throwable : throwables) {
                 KapuaExceptionWithoutBundle kapuaExceptionWithoutBundle = new KapuaExceptionWithoutBundle(kapuaErrorCode, throwable, null);
-                assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaExceptionWithoutBundle.getCause());
-                assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
-                assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
-                assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorCode, kapuaExceptionWithoutBundle.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaExceptionWithoutBundle.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", "Error: ", kapuaExceptionWithoutBundle.getLocalizedMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedKapuaErrorMessagesBundle, kapuaExceptionWithoutBundle.getKapuaErrorMessagesBundle());
             }
         }
     }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalAccessExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalAccessExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaIllegalAccessExceptionTest extends Assert {
+public class KapuaIllegalAccessExceptionTest {
 
     String[] operationName;
 
@@ -32,9 +33,9 @@ public class KapuaIllegalAccessExceptionTest extends Assert {
     public void kapuaIllegalAccessExceptionTest() {
         for (String name : operationName) {
             KapuaIllegalAccessException kapuaIllegalAccessException = new KapuaIllegalAccessException(name);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_ACCESS, kapuaIllegalAccessException.getCode());
-            assertEquals("Expected and actual values should be the same.", "The current subject is not authorized for " + name + ".", kapuaIllegalAccessException.getMessage());
-            assertNull("Null expected.", kapuaIllegalAccessException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_ACCESS, kapuaIllegalAccessException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The current subject is not authorized for " + name + ".", kapuaIllegalAccessException.getMessage());
+            Assert.assertNull("Null expected.", kapuaIllegalAccessException.getCause());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalArgumentExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalArgumentExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaIllegalArgumentExceptionTest extends Assert {
+public class KapuaIllegalArgumentExceptionTest {
 
     String[] argumentName;
     String[] argumentValue;
@@ -61,11 +62,11 @@ public class KapuaIllegalArgumentExceptionTest extends Assert {
         for (String name : argumentName) {
             for (String value : argumentValue) {
                 KapuaIllegalArgumentException kapuaIllegalArgumentException = new KapuaIllegalArgumentException(name, value);
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_ARGUMENT, kapuaIllegalArgumentException.getCode());
-                assertEquals("Expected and actual values should be the same.", name, kapuaIllegalArgumentException.getArgumentName());
-                assertEquals("Expected and actual values should be the same.", value, kapuaIllegalArgumentException.getArgumentValue());
-                assertEquals("Expected and actual values should be the same.", "An illegal value was provided for the argument " + name + ": " + value + ".", kapuaIllegalArgumentException.getMessage());
-                assertNull("Null expected.", kapuaIllegalArgumentException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_ARGUMENT, kapuaIllegalArgumentException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", name, kapuaIllegalArgumentException.getArgumentName());
+                Assert.assertEquals("Expected and actual values should be the same.", value, kapuaIllegalArgumentException.getArgumentValue());
+                Assert.assertEquals("Expected and actual values should be the same.", "An illegal value was provided for the argument " + name + ": " + value + ".", kapuaIllegalArgumentException.getMessage());
+                Assert.assertNull("Null expected.", kapuaIllegalArgumentException.getCause());
             }
         }
     }
@@ -102,11 +103,11 @@ public class KapuaIllegalArgumentExceptionTest extends Assert {
 
                 for (int i = 0; i < kapuaErrorCodes.length; i++) {
                     KapuaIllegalArgumentException kapuaIllegalArgumentException = new KapuaIllegalArgumentException(kapuaErrorCodes[i], name, value);
-                    assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], kapuaErrorCodes[i], kapuaIllegalArgumentException.getCode());
-                    assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], name, kapuaIllegalArgumentException.getArgumentName());
-                    assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], value, kapuaIllegalArgumentException.getArgumentValue());
-                    assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], message[i], kapuaIllegalArgumentException.getMessage());
-                    assertNull("Null expected for KapuaErrorCode: " + kapuaErrorCodes[i], kapuaIllegalArgumentException.getCause());
+                    Assert.assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], kapuaErrorCodes[i], kapuaIllegalArgumentException.getCode());
+                    Assert.assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], name, kapuaIllegalArgumentException.getArgumentName());
+                    Assert.assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], value, kapuaIllegalArgumentException.getArgumentValue());
+                    Assert.assertEquals("Expected and actual values should be the same for Kapua ErrorCode: " + kapuaErrorCodes[i], message[i], kapuaIllegalArgumentException.getMessage());
+                    Assert.assertNull("Null expected for KapuaErrorCode: " + kapuaErrorCodes[i], kapuaIllegalArgumentException.getCause());
                 }
             }
         }
@@ -117,10 +118,10 @@ public class KapuaIllegalArgumentExceptionTest extends Assert {
         for (String name : argumentName) {
             for (String value : argumentValue) {
                 KapuaIllegalArgumentException kapuaIllegalArgumentException = new KapuaIllegalArgumentException(null, name, value);
-                assertNull("Null expected.", kapuaIllegalArgumentException.getCode());
-                assertEquals("Expected and actual values should be the same.", name, kapuaIllegalArgumentException.getArgumentName());
-                assertEquals("Expected and actual values should be the same.", value, kapuaIllegalArgumentException.getArgumentValue());
-                assertNull("Null expected.", kapuaIllegalArgumentException.getCause());
+                Assert.assertNull("Null expected.", kapuaIllegalArgumentException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", name, kapuaIllegalArgumentException.getArgumentName());
+                Assert.assertEquals("Expected and actual values should be the same.", value, kapuaIllegalArgumentException.getArgumentValue());
+                Assert.assertNull("Null expected.", kapuaIllegalArgumentException.getCause());
                 kapuaIllegalArgumentException.getMessage();
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalNullArgumentExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalNullArgumentExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaIllegalNullArgumentExceptionTest extends Assert {
+public class KapuaIllegalNullArgumentExceptionTest {
 
     String[] argumentName;
 
@@ -32,11 +33,11 @@ public class KapuaIllegalNullArgumentExceptionTest extends Assert {
     public void kapuaIllegalNullArgumentExceptionTest() {
         for (String name : argumentName) {
             KapuaIllegalNullArgumentException kapuaIllegalNullArgumentException = new KapuaIllegalNullArgumentException(name);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_NULL_ARGUMENT, kapuaIllegalNullArgumentException.getCode());
-            assertEquals("Expected and actual values should be the same.", name, kapuaIllegalNullArgumentException.getArgumentName());
-            assertNull("Null expected.", kapuaIllegalNullArgumentException.getArgumentValue());
-            assertNull("Null expected.", kapuaIllegalNullArgumentException.getCause());
-            assertEquals("Expected and actual values should be the same.", "An illegal null value was provided for the argument " + name + ".", kapuaIllegalNullArgumentException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_NULL_ARGUMENT, kapuaIllegalNullArgumentException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", name, kapuaIllegalNullArgumentException.getArgumentName());
+            Assert.assertNull("Null expected.", kapuaIllegalNullArgumentException.getArgumentValue());
+            Assert.assertNull("Null expected.", kapuaIllegalNullArgumentException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An illegal null value was provided for the argument " + name + ".", kapuaIllegalNullArgumentException.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalStateExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalStateExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaIllegalStateExceptionTest extends Assert {
+public class KapuaIllegalStateExceptionTest {
 
     String[] message = {"Message", null};
     Throwable[] throwables = {new Throwable(), null};
@@ -34,9 +35,9 @@ public class KapuaIllegalStateExceptionTest extends Assert {
     public void kapuaIllegalStateExceptionStringParameterTest() {
         for (String msg : message) {
             KapuaIllegalStateException kapuaIllegalStateExceptionTest = new KapuaIllegalStateException(msg);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_STATE, kapuaIllegalStateExceptionTest.getCode());
-            assertEquals("Expected and actual values should be the same.", "The application is in an illegal state: " + msg + ".", kapuaIllegalStateExceptionTest.getMessage());
-            assertNull("Null expected.", kapuaIllegalStateExceptionTest.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_STATE, kapuaIllegalStateExceptionTest.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The application is in an illegal state: " + msg + ".", kapuaIllegalStateExceptionTest.getMessage());
+            Assert.assertNull("Null expected.", kapuaIllegalStateExceptionTest.getCause());
         }
     }
 
@@ -45,9 +46,9 @@ public class KapuaIllegalStateExceptionTest extends Assert {
         for (String msg : message) {
             for (Throwable throwable : throwables) {
                 KapuaIllegalStateException kapuaIllegalStateExceptionTest = new KapuaIllegalStateException(throwable, msg);
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_STATE, kapuaIllegalStateExceptionTest.getCode());
-                assertEquals("Expected and actual values should be the same.", "The application is in an illegal state: " + msg + ".", kapuaIllegalStateExceptionTest.getMessage());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaIllegalStateExceptionTest.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ILLEGAL_STATE, kapuaIllegalStateExceptionTest.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", "The application is in an illegal state: " + msg + ".", kapuaIllegalStateExceptionTest.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaIllegalStateExceptionTest.getCause());
             }
         }
     }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaMaxNumberOfItemsReachedExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaMaxNumberOfItemsReachedExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaMaxNumberOfItemsReachedExceptionTest extends Assert {
+public class KapuaMaxNumberOfItemsReachedExceptionTest {
 
     String[] argValue;
 
@@ -32,10 +33,10 @@ public class KapuaMaxNumberOfItemsReachedExceptionTest extends Assert {
     public void kapuaMaxNumberOfItemsReachedExceptionTest() {
         for (String value : argValue) {
             KapuaMaxNumberOfItemsReachedException kapuaMaxNumberOfItemsReachedException = new KapuaMaxNumberOfItemsReachedException(value);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.MAX_NUMBER_OF_ITEMS_REACHED, kapuaMaxNumberOfItemsReachedException.getCode());
-            assertEquals("Expected and actual values should be the same.", value, kapuaMaxNumberOfItemsReachedException.getEntityType());
-            assertEquals("Expected and actual values should be the same.", "Max number of " + value + " reached. Please increase the number or set InfiniteChild" + value + " parameter to True.", kapuaMaxNumberOfItemsReachedException.getMessage());
-            assertNull("Null expected.", kapuaMaxNumberOfItemsReachedException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.MAX_NUMBER_OF_ITEMS_REACHED, kapuaMaxNumberOfItemsReachedException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", value, kapuaMaxNumberOfItemsReachedException.getEntityType());
+            Assert.assertEquals("Expected and actual values should be the same.", "Max number of " + value + " reached. Please increase the number or set InfiniteChild" + value + " parameter to True.", kapuaMaxNumberOfItemsReachedException.getMessage());
+            Assert.assertNull("Null expected.", kapuaMaxNumberOfItemsReachedException.getCause());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaOptimisticLockingExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaOptimisticLockingExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaOptimisticLockingExceptionTest extends Assert {
+public class KapuaOptimisticLockingExceptionTest {
 
     Exception[] exceptions;
 
@@ -32,9 +33,9 @@ public class KapuaOptimisticLockingExceptionTest extends Assert {
     public void kapuaOptimisticLockingExceptionTest() {
         for (Exception exception : exceptions) {
             KapuaOptimisticLockingException kapuaOptimisticLockingException = new KapuaOptimisticLockingException(exception);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.OPTIMISTIC_LOCKING, kapuaOptimisticLockingException.getCode());
-            assertEquals("Expected and actual values should be the same.", exception, kapuaOptimisticLockingException.getCause());
-            assertEquals("Expected and actual values should be the same.", "The entity is out of state as it has been modified or deleted by another transaction.", kapuaOptimisticLockingException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.OPTIMISTIC_LOCKING, kapuaOptimisticLockingException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", exception, kapuaOptimisticLockingException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity is out of state as it has been modified or deleted by another transaction.", kapuaOptimisticLockingException.getMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaRuntimeExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaRuntimeExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaRuntimeExceptionTest extends Assert {
+public class KapuaRuntimeExceptionTest {
 
     String expectedErrorMessage;
     KapuaErrorCode kapuaErrorCode;
@@ -41,31 +42,31 @@ public class KapuaRuntimeExceptionTest extends Assert {
     public void kapuaRuntimeExceptionKapuaErrorCodeParameterTest() {
         KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(kapuaErrorCode);
 
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
-        assertNull("Null expected.", kapuaRuntimeException.getCause());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
     }
 
     @Test
     public void kapuaRuntimeExceptionNullKapuaErrorCodeParameterTest() {
         KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(null);
 
-        assertNull("Null expected.", kapuaRuntimeException.getCode());
-        assertNull("Null expected.", kapuaRuntimeException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
         try {
             kapuaRuntimeException.getMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
         try {
             kapuaRuntimeException.getLocalizedMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -73,42 +74,42 @@ public class KapuaRuntimeExceptionTest extends Assert {
     public void kapuaRuntimeExceptionKapuaErrorCodeObjectParametersTest() {
         KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(kapuaErrorCode, argument1, argument2, argument3);
 
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
-        assertNull("Null expected.", kapuaRuntimeException.getCause());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
     }
 
     @Test
     public void kapuaRuntimeExceptionKapuaErrorCodeNullObjectParametersTest() {
         KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(kapuaErrorCode, null);
 
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
-        assertNull("Null expected.", kapuaRuntimeException.getCause());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ADMIN_ROLE_DELETED_ERROR, kapuaRuntimeException.getCode());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "Operation not allowed on admin role.", kapuaRuntimeException.getLocalizedMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
     }
 
     @Test
     public void kapuaRuntimeExceptionNullKapuaErrorCodeObjectParametersTest() {
         KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(null, argument1, argument2, argument3);
 
-        assertNull("Null expected.", kapuaRuntimeException.getCode());
-        assertNull("Null expected.", kapuaRuntimeException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
+        Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
         try {
             kapuaRuntimeException.getMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
         try {
             kapuaRuntimeException.getLocalizedMessage();
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -116,11 +117,11 @@ public class KapuaRuntimeExceptionTest extends Assert {
     public void kapuaRuntimeExceptionKapuaErrorCodeThrowableObjectParametesTest() {
         for (Throwable throwable : throwables) {
             KapuaRuntimeException kapuaRuntimeException = new KapuaRuntimeException(KapuaErrorCodes.ENTITY_NOT_FOUND, throwable, argument1, argument2, argument3);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaRuntimeException.getCode());
-            assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaRuntimeException.getMessage());
-            assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaRuntimeException.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaRuntimeException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaRuntimeException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type " + argument1 + " with id/name " + argument2 + " was not found.", kapuaRuntimeException.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
         }
     }
 
@@ -128,20 +129,20 @@ public class KapuaRuntimeExceptionTest extends Assert {
     public void kapuaRuntimeExceptionNullKapuaErrorCodeThrowableObjectParametesTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaRuntimeException = new KapuaException(null, throwable, argument1, argument2, argument3);
-            assertNull("Null expected.", kapuaRuntimeException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
             try {
                 kapuaRuntimeException.getMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
             try {
                 kapuaRuntimeException.getLocalizedMessage();
-                fail("NullPointerException expected.");
+                Assert.fail("NullPointerException expected.");
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -150,11 +151,11 @@ public class KapuaRuntimeExceptionTest extends Assert {
     public void kapuaRuntimeExceptionKapuaErrorCodeThrowableNullObjectParametesTest() {
         for (Throwable throwable : throwables) {
             KapuaException kapuaRuntimeException = new KapuaException(KapuaErrorCodes.ENTITY_NOT_FOUND, throwable, null);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaRuntimeException.getCode());
-            assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaRuntimeException.getMessage());
-            assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaRuntimeException.getLocalizedMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.ENTITY_NOT_FOUND, kapuaRuntimeException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaRuntimeException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", "The entity of type {0} with id/name {1} was not found.", kapuaRuntimeException.getLocalizedMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
         }
     }
 
@@ -164,12 +165,12 @@ public class KapuaRuntimeExceptionTest extends Assert {
 
         for (Throwable throwable : throwables) {
             for (String msg : messages) {
-                assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
-                assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwable, msg).toString(), KapuaRuntimeException.internalError(throwable, msg).toString());
-                assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(throwable, msg).getMessage());
-                assertEquals("Expected and actual values should be the same.", throwable, KapuaRuntimeException.internalError(throwable, msg).getCause());
-                assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(throwable, msg).getCode());
-                assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(throwable, msg).getKapuaErrorMessagesBundle());
+        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+                Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwable, msg).toString(), KapuaRuntimeException.internalError(throwable, msg).toString());
+                Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(throwable, msg).getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, KapuaRuntimeException.internalError(throwable, msg).getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(throwable, msg).getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(throwable, msg).getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -183,18 +184,18 @@ public class KapuaRuntimeExceptionTest extends Assert {
         String[] arguments = {"Message", "java.lang.Throwable"};
 
         for (int i = 0; i < throwables.length; i++) {
-            assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
-            assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwables[i], arguments[i]).toString(), KapuaRuntimeException.internalError(throwables[i]).toString());
-            assertEquals("Expected and actual values should be the same.", expectedMessage[i], KapuaRuntimeException.internalError(throwables[i]).getMessage());
-            assertEquals("Expected and actual values should be the same.", throwables[i], KapuaRuntimeException.internalError(throwables[i]).getCause());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(throwables[i]).getCode());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(throwables[i]).getKapuaErrorMessagesBundle());
+        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+            Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwables[i], arguments[i]).toString(), KapuaRuntimeException.internalError(throwables[i]).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], KapuaRuntimeException.internalError(throwables[i]).getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", throwables[i], KapuaRuntimeException.internalError(throwables[i]).getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(throwables[i]).getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(throwables[i]).getKapuaErrorMessagesBundle());
         }
         try {
             KapuaRuntimeException.internalError(nullThrowable);
-            fail("NullPointerException expected.");
+            Assert.fail("NullPointerException expected.");
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -203,12 +204,12 @@ public class KapuaRuntimeExceptionTest extends Assert {
         String[] messages = {"Message", null};
 
         for (String msg : messages) {
-            assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
-            assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, null, msg).toString(), KapuaRuntimeException.internalError(msg).toString());
-            assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(msg).getMessage());
-            assertNull("Null expected.", KapuaRuntimeException.internalError(msg).getCause());
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(msg).getCode());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(msg).getKapuaErrorMessagesBundle());
+        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+            Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, null, msg).toString(), KapuaRuntimeException.internalError(msg).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(msg).getMessage());
+            Assert.assertNull("Null expected.", KapuaRuntimeException.internalError(msg).getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, KapuaRuntimeException.internalError(msg).getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, KapuaRuntimeException.internalError(msg).getKapuaErrorMessagesBundle());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaUnauthenticatedExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaUnauthenticatedExceptionTest.java
@@ -17,15 +17,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaUnauthenticatedExceptionTest extends Assert {
+public class KapuaUnauthenticatedExceptionTest {
 
     @Test
     public void kapuaUnauthenticatedExceptionTest() {
         KapuaUnauthenticatedException kapuaUnauthenticatedException = new KapuaUnauthenticatedException();
-        assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.UNAUTHENTICATED, kapuaUnauthenticatedException.getCode());
-        assertNull("Null expected.", kapuaUnauthenticatedException.getCause());
-        assertEquals("Expected and actual values should be the same.", "No authenticated Subject found in context.", kapuaUnauthenticatedException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.UNAUTHENTICATED, kapuaUnauthenticatedException.getCode());
+        Assert.assertNull("Null expected.", kapuaUnauthenticatedException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "No authenticated Subject found in context.", kapuaUnauthenticatedException.getMessage());
     }
 
     @Test(expected = KapuaUnauthenticatedException.class)

--- a/service/api/src/test/java/org/eclipse/kapua/entity/EntityPropertiesReadExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/entity/EntityPropertiesReadExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class EntityPropertiesReadExceptionTest extends Assert {
+public class EntityPropertiesReadExceptionTest {
 
     @Test
     public void entityPropertiesReadExceptionTest() {
@@ -32,10 +33,10 @@ public class EntityPropertiesReadExceptionTest extends Assert {
                 for (String properties : stringProperties) {
                     EntityPropertiesReadException entityPropertiesReadException = new EntityPropertiesReadException(ex, attribute, properties);
 
-                    assertEquals("Expected and actual values should be the same.", attribute, entityPropertiesReadException.getAttribute());
-                    assertEquals("Expected and actual values should be the same.", properties, entityPropertiesReadException.getStringProperties());
-                    assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_PROPERTIES_READ_ERROR, entityPropertiesReadException.getCode());
-                    assertEquals("Expected and actual values should be the same.", ex, entityPropertiesReadException.getCause());
+                    Assert.assertEquals("Expected and actual values should be the same.", attribute, entityPropertiesReadException.getAttribute());
+                    Assert.assertEquals("Expected and actual values should be the same.", properties, entityPropertiesReadException.getStringProperties());
+                    Assert.assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_PROPERTIES_READ_ERROR, entityPropertiesReadException.getCode());
+                    Assert.assertEquals("Expected and actual values should be the same.", ex, entityPropertiesReadException.getCause());
                 }
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/entity/EntityPropertiesWriteExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/entity/EntityPropertiesWriteExceptionTest.java
@@ -20,8 +20,9 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Properties;
 
+
 @Category(JUnitTests.class)
-public class EntityPropertiesWriteExceptionTest extends Assert {
+public class EntityPropertiesWriteExceptionTest {
 
     @Test
     public void entityPropertiesWriteExceptionTest() {
@@ -34,10 +35,10 @@ public class EntityPropertiesWriteExceptionTest extends Assert {
                 for (Properties property : properties) {
                     EntityPropertiesWriteException entityPropertiesWriteException = new EntityPropertiesWriteException(ex, attribute, property);
 
-                    assertEquals("Expected and actual values should be the same.", attribute, entityPropertiesWriteException.getAttribute());
-                    assertEquals("Expected and actual values should be the same.", property, entityPropertiesWriteException.getProperties());
-                    assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_PROPERTIES_WRITE_ERROR, entityPropertiesWriteException.getCode());
-                    assertEquals("Expected and actual values should be the same.", ex, entityPropertiesWriteException.getCause());
+                    Assert.assertEquals("Expected and actual values should be the same.", attribute, entityPropertiesWriteException.getAttribute());
+                    Assert.assertEquals("Expected and actual values should be the same.", property, entityPropertiesWriteException.getProperties());
+                    Assert.assertEquals("Expected and actual values should be the same.", KapuaRuntimeErrorCodes.ENTITY_PROPERTIES_WRITE_ERROR, entityPropertiesWriteException.getCode());
+                    Assert.assertEquals("Expected and actual values should be the same.", ex, entityPropertiesWriteException.getCause());
                 }
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/event/ServiceEventBusExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/event/ServiceEventBusExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class ServiceEventBusExceptionTest extends Assert {
+public class ServiceEventBusExceptionTest {
 
     @Test
     public void serviceEventBusExceptionThrowableCauseTest() {
@@ -27,9 +28,9 @@ public class ServiceEventBusExceptionTest extends Assert {
 
         for (Throwable throwable : throwables) {
             ServiceEventBusException serviceEventBusException = new ServiceEventBusException(throwable);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, serviceEventBusException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, serviceEventBusException.getCause());
-            assertEquals("Expected and actual values should be the same.", "An internal error occurred: {0}.", serviceEventBusException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, serviceEventBusException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, serviceEventBusException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: {0}.", serviceEventBusException.getMessage());
         }
     }
 
@@ -39,9 +40,9 @@ public class ServiceEventBusExceptionTest extends Assert {
 
         for (String message : messages) {
             ServiceEventBusException serviceEventBusException = new ServiceEventBusException(message);
-            assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, serviceEventBusException.getCode());
-            assertNull("Null expected.", serviceEventBusException.getCause());
-            assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + message + ".", serviceEventBusException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", KapuaErrorCodes.INTERNAL_ERROR, serviceEventBusException.getCode());
+            Assert.assertNull("Null expected.", serviceEventBusException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + message + ".", serviceEventBusException.getMessage());
         }
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/event/ServiceEventTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/event/ServiceEventTest.java
@@ -22,18 +22,19 @@ import org.junit.experimental.categories.Category;
 import java.math.BigInteger;
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class ServiceEventTest extends Assert {
+public class ServiceEventTest {
 
     @Test
     public void setAndGetIdTest() {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] ids = {"id", null};
 
-        assertNull("Null expected.", serviceEvent.getId());
+        Assert.assertNull("Null expected.", serviceEvent.getId());
         for (String id : ids) {
             serviceEvent.setId(id);
-            assertEquals("Expected and actual values should be the same.", id, serviceEvent.getId());
+            Assert.assertEquals("Expected and actual values should be the same.", id, serviceEvent.getId());
         }
     }
 
@@ -42,10 +43,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] contextIds = {"contextId.", null};
 
-        assertNull("Null expected", serviceEvent.getContextId());
+        Assert.assertNull("Null expected", serviceEvent.getContextId());
         for (String contextId : contextIds) {
             serviceEvent.setContextId(contextId);
-            assertEquals("Expected and actual values should be the same.", contextId, serviceEvent.getContextId());
+            Assert.assertEquals("Expected and actual values should be the same.", contextId, serviceEvent.getContextId());
         }
     }
 
@@ -54,10 +55,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         Date[] timestamps = {new Date(), null};
 
-        assertNull("Null expected.", serviceEvent.getTimestamp());
+        Assert.assertNull("Null expected.", serviceEvent.getTimestamp());
         for (Date timestamp : timestamps) {
             serviceEvent.setTimestamp(timestamp);
-            assertEquals("Expected and actual values should be the same.", timestamp, serviceEvent.getTimestamp());
+            Assert.assertEquals("Expected and actual values should be the same.", timestamp, serviceEvent.getTimestamp());
         }
     }
 
@@ -66,10 +67,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         KapuaId[] userIds = {new KapuaIdImpl(BigInteger.ONE), null};
 
-        assertNull("Null expected.", serviceEvent.getUserId());
+        Assert.assertNull("Null expected.", serviceEvent.getUserId());
         for (KapuaId userId : userIds) {
             serviceEvent.setUserId(userId);
-            assertEquals("Expected and actual values should be the same.", userId, serviceEvent.getUserId());
+            Assert.assertEquals("Expected and actual values should be the same.", userId, serviceEvent.getUserId());
         }
     }
 
@@ -78,10 +79,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] services = {"service", null};
 
-        assertNull("Null expected.", serviceEvent.getService());
+        Assert.assertNull("Null expected.", serviceEvent.getService());
         for (String service : services) {
             serviceEvent.setService(service);
-            assertEquals("Expected and actual values should be the same.", service, serviceEvent.getService());
+            Assert.assertEquals("Expected and actual values should be the same.", service, serviceEvent.getService());
         }
     }
 
@@ -90,10 +91,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] entityTypes = {"entityType", null};
 
-        assertNull("Null expected.", serviceEvent.getEntityType());
+        Assert.assertNull("Null expected.", serviceEvent.getEntityType());
         for (String entityType : entityTypes) {
             serviceEvent.setEntityType(entityType);
-            assertEquals("Expected and actual values should be the same.", entityType, serviceEvent.getEntityType());
+            Assert.assertEquals("Expected and actual values should be the same.", entityType, serviceEvent.getEntityType());
         }
     }
 
@@ -102,10 +103,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         KapuaId[] scopeIds = {new KapuaIdImpl(BigInteger.ONE), null};
 
-        assertNull("Null expected.", serviceEvent.getScopeId());
+        Assert.assertNull("Null expected.", serviceEvent.getScopeId());
         for (KapuaId scopeId : scopeIds) {
             serviceEvent.setScopeId(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, serviceEvent.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, serviceEvent.getScopeId());
         }
     }
 
@@ -114,10 +115,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         KapuaId[] entityScopeIds = {new KapuaIdImpl(BigInteger.ONE), null};
 
-        assertNull("Null expected.", serviceEvent.getEntityScopeId());
+        Assert.assertNull("Null expected.", serviceEvent.getEntityScopeId());
         for (KapuaId entityScopeId : entityScopeIds) {
             serviceEvent.setEntityScopeId(entityScopeId);
-            assertEquals("Expected and actual values should be the same.", entityScopeId, serviceEvent.getEntityScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", entityScopeId, serviceEvent.getEntityScopeId());
         }
     }
 
@@ -126,10 +127,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         KapuaId[] entityIds = {new KapuaIdImpl(BigInteger.ONE), null};
 
-        assertNull("Null expected", serviceEvent.getEntityId());
+        Assert.assertNull("Null expected", serviceEvent.getEntityId());
         for (KapuaId entityId : entityIds) {
             serviceEvent.setEntityId(entityId);
-            assertEquals("Expected and actual values should be the same.", entityId, serviceEvent.getEntityId());
+            Assert.assertEquals("Expected and actual values should be the same.", entityId, serviceEvent.getEntityId());
         }
     }
 
@@ -138,10 +139,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] operations = {"operation", null};
 
-        assertNull("Null expected.", serviceEvent.getOperation());
+        Assert.assertNull("Null expected.", serviceEvent.getOperation());
         for (String operation : operations) {
             serviceEvent.setOperation(operation);
-            assertEquals("Expected and actual values should be the same.", operation, serviceEvent.getOperation());
+            Assert.assertEquals("Expected and actual values should be the same.", operation, serviceEvent.getOperation());
         }
     }
 
@@ -150,10 +151,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] inputs = {"inputs", null};
 
-        assertNull("Null expected.", serviceEvent.getInputs());
+        Assert.assertNull("Null expected.", serviceEvent.getInputs());
         for (String input : inputs) {
             serviceEvent.setInputs(input);
-            assertEquals("Expected and actual values should be the same.", input, serviceEvent.getInputs());
+            Assert.assertEquals("Expected and actual values should be the same.", input, serviceEvent.getInputs());
         }
     }
 
@@ -162,10 +163,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] outputs = {"outputs", null};
 
-        assertNull("Null expected.", serviceEvent.getOutputs());
+        Assert.assertNull("Null expected.", serviceEvent.getOutputs());
         for (String output : outputs) {
             serviceEvent.setOutputs(output);
-            assertEquals("Expected and actual values should be the same.", output, serviceEvent.getOutputs());
+            Assert.assertEquals("Expected and actual values should be the same.", output, serviceEvent.getOutputs());
         }
     }
 
@@ -174,10 +175,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         ServiceEvent.EventStatus[] eventStatus = {null, ServiceEvent.EventStatus.TRIGGERED, ServiceEvent.EventStatus.SEND_ERROR, ServiceEvent.EventStatus.SENT};
 
-        assertNull("Null expected.", serviceEvent.getStatus());
+        Assert.assertNull("Null expected.", serviceEvent.getStatus());
         for (ServiceEvent.EventStatus status : eventStatus) {
             serviceEvent.setStatus(status);
-            assertEquals("Expected and actual values should be the same.", status, serviceEvent.getStatus());
+            Assert.assertEquals("Expected and actual values should be the same.", status, serviceEvent.getStatus());
         }
     }
 
@@ -186,10 +187,10 @@ public class ServiceEventTest extends Assert {
         ServiceEvent serviceEvent = new ServiceEvent();
         String[] notes = {"notes", null};
 
-        assertNull("Null expected.", serviceEvent.getNote());
+        Assert.assertNull("Null expected.", serviceEvent.getNote());
         for (String note : notes) {
             serviceEvent.setNote(note);
-            assertEquals("Expected and actual values should be the same.", note, serviceEvent.getNote());
+            Assert.assertEquals("Expected and actual values should be the same.", note, serviceEvent.getNote());
         }
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaLocatorExceptionTest extends Assert {
+public class KapuaLocatorExceptionTest {
 
     String expectedErrorMessage;
     KapuaLocatorErrorCodes[] kapuaLocatorErrorCodes;
@@ -49,19 +50,19 @@ public class KapuaLocatorExceptionTest extends Assert {
     public void kapuaLocatorExceptionKapuaLocatorErrorCodesParameterTest() {
         for (int i = 0; i < kapuaLocatorErrorCodes.length; i++) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(kapuaLocatorErrorCodes[i]);
-            assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
-            assertNull("Null expected.", kapuaLocatorException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
+            Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         }
     }
 
     @Test(expected = NullPointerException.class)
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesParameterTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null);
-        assertNull("Null expected.", kapuaLocatorException.getCode());
-        assertNull("Null expected.", kapuaLocatorException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         kapuaLocatorException.getMessage();
     }
 
@@ -69,10 +70,10 @@ public class KapuaLocatorExceptionTest extends Assert {
     public void kapuaLocatorExceptionKapuaLocatorErrorCodesObjectParametersTest() {
         for (int i = 0; i < kapuaLocatorErrorCodes.length; i++) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(kapuaLocatorErrorCodes[i], argument1, argument2, argument3);
-            assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
-            assertNull("Null expected.", kapuaLocatorException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedMessage[i], kapuaLocatorException.getMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
+            Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], kapuaLocatorException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -80,28 +81,28 @@ public class KapuaLocatorExceptionTest extends Assert {
     public void kapuaLocatorExceptionKapuaLocatorErrorCodesNullObjectParametersTest() {
         for (int i = 0; i < kapuaLocatorErrorCodes.length; i++) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(kapuaLocatorErrorCodes[i], null);
-            assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
-            assertNull("Null expected.", kapuaLocatorException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
+            Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         }
     }
 
     @Test(expected = NullPointerException.class)
     public void kapuaLocatorExceptionNullKapuaLocatorErrorCodesObjectParametersTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, argument1, argument2, argument3);
-        assertNull("Null expected.", kapuaLocatorException.getCode());
-        assertNull("Null expected.", kapuaLocatorException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         kapuaLocatorException.getMessage();
     }
 
     @Test(expected = NullPointerException.class)
     public void kapuaLocatorExceptionNullKapuaLocatorErrorCodesNullObjectParametersTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, null);
-        assertNull("Null expected.", kapuaLocatorException.getCode());
-        assertNull("Null expected.", kapuaLocatorException.getCause());
-        assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
+        Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
         kapuaLocatorException.getMessage();
     }
 
@@ -110,10 +111,10 @@ public class KapuaLocatorExceptionTest extends Assert {
         for (Throwable throwable : throwables) {
             for (int i = 0; i < kapuaLocatorErrorCodes.length; i++) {
                 KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(kapuaLocatorErrorCodes[i], throwable, argument1, argument2, argument3);
-                assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
-                assertEquals("Expected and actual values should be the same.", expectedMessage[i], kapuaLocatorException.getMessage());
-                assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], kapuaLocatorException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -123,10 +124,10 @@ public class KapuaLocatorExceptionTest extends Assert {
         for (Throwable throwable : throwables) {
             for (int i = 0; i < kapuaLocatorErrorCodes.length; i++) {
                 KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(kapuaLocatorErrorCodes[i], throwable, null);
-                assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
-                assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
-                assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaLocatorErrorCodes[i], kapuaLocatorException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedMessageNullArguments[i], kapuaLocatorException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -135,9 +136,9 @@ public class KapuaLocatorExceptionTest extends Assert {
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesThrowableObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, throwable, argument1, argument2, argument3);
-            assertNull("Null expected.", kapuaLocatorException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
             kapuaLocatorException.getMessage();
         }
     }
@@ -146,9 +147,9 @@ public class KapuaLocatorExceptionTest extends Assert {
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesThrowableNullObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, throwable, null);
-            assertNull("Null expected", kapuaLocatorException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
-            assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected", kapuaLocatorException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
             kapuaLocatorException.getMessage();
 
         }

--- a/service/api/src/test/java/org/eclipse/kapua/model/KapuaEntityAttributesTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/KapuaEntityAttributesTest.java
@@ -21,13 +21,14 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class KapuaEntityAttributesTest extends Assert {
+public class KapuaEntityAttributesTest {
 
     @Test
     public void kapuaEntityAttributesTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<KapuaEntityAttributes> kapuaEntityAttributes = KapuaEntityAttributes.class.getDeclaredConstructor();
-        assertTrue(Modifier.isProtected(kapuaEntityAttributes.getModifiers()));
+        Assert.assertTrue(Modifier.isProtected(kapuaEntityAttributes.getModifiers()));
         kapuaEntityAttributes.setAccessible(true);
         kapuaEntityAttributes.newInstance();
     }

--- a/service/api/src/test/java/org/eclipse/kapua/model/domain/AbstractDomainTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/domain/AbstractDomainTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class AbstractDomainTest extends Assert {
+public class AbstractDomainTest {
 
     private class AbstractDomainImpl extends AbstractDomain {
 
@@ -54,18 +55,18 @@ public class AbstractDomainTest extends Assert {
         AbstractDomain abstractDomain2 = new AbstractDomainImpl();
         Object[] objects = {0, 10, 100000, "String", 'c', -10, -1000000000, -100000000000L, 10L, 10.0f, null, 10.10d, true, false};
 
-        assertTrue("True expected.", abstractDomain1.equals(abstractDomain1));
-        assertFalse("False expected.", abstractDomain1.equals(null));
+        Assert.assertTrue("True expected.", abstractDomain1.equals(abstractDomain1));
+        Assert.assertFalse("False expected.", abstractDomain1.equals(null));
         for (Object object : objects) {
-            assertFalse("False expected.", abstractDomain1.equals(object));
+            Assert.assertFalse("False expected.", abstractDomain1.equals(object));
         }
-        assertTrue("True expected.", abstractDomain1.equals(abstractDomain2));
+        Assert.assertTrue("True expected.", abstractDomain1.equals(abstractDomain2));
     }
 
     @Test
     public void hashCodeTest() {
         AbstractDomain abstractDomain = new AbstractDomainImpl();
 
-        assertThat("Instance of Integer expected.", abstractDomain.hashCode(), IsInstanceOf.instanceOf(Integer.class));
+        Assert.assertThat("Instance of Integer expected.", abstractDomain.hashCode(), IsInstanceOf.instanceOf(Integer.class));
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/id/KapuaIdImplTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/id/KapuaIdImplTest.java
@@ -19,13 +19,14 @@ import org.junit.experimental.categories.Category;
 
 import java.math.BigInteger;
 
+
 @Category(JUnitTests.class)
-public class KapuaIdImplTest extends Assert {
+public class KapuaIdImplTest {
 
     @Test
     public void kapuaIdImplTest() {
         KapuaIdImpl kapuaIdImpl = new KapuaIdImpl(BigInteger.ONE);
-        assertEquals("Expected and actual values should be the same.", BigInteger.ONE, kapuaIdImpl.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", BigInteger.ONE, kapuaIdImpl.getId());
     }
 
     @Test(expected = IllegalArgumentException.class)
@@ -40,7 +41,7 @@ public class KapuaIdImplTest extends Assert {
 
         for (int i = 0; i < bigInteger.length; i++) {
             KapuaIdImpl kapuaIdImpl = new KapuaIdImpl(bigInteger[i]);
-            assertEquals("Expected and actual values should be the same.", expectedResult[i], kapuaIdImpl.hashCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedResult[i], kapuaIdImpl.hashCode());
         }
     }
 
@@ -51,12 +52,12 @@ public class KapuaIdImplTest extends Assert {
         KapuaIdImpl kapuaIdImpl3 = new KapuaIdImpl(BigInteger.ONE);
         Object[] objects = {0, 10, 100000, "String", 'c', -10, -1000000000, -100000000000L, 10L, 10.0f, null, 10.10d, true, false};
 
-        assertEquals("True expected.", kapuaIdImpl1, kapuaIdImpl1);
-        assertNotEquals("False expected", null, kapuaIdImpl1);
+        Assert.assertEquals("True expected.", kapuaIdImpl1, kapuaIdImpl1);
+        Assert.assertNotEquals("False expected", null, kapuaIdImpl1);
         for (Object object : objects) {
-            assertNotEquals("False expected", kapuaIdImpl1, object);
+            Assert.assertNotEquals("False expected", kapuaIdImpl1, object);
         }
-        assertNotEquals("False expected", kapuaIdImpl1, kapuaIdImpl2);
-        assertEquals("True expected", kapuaIdImpl1, kapuaIdImpl3);
+        Assert.assertNotEquals("False expected", kapuaIdImpl1, kapuaIdImpl2);
+        Assert.assertEquals("True expected", kapuaIdImpl1, kapuaIdImpl3);
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/query/SortOrderTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/query/SortOrderTest.java
@@ -18,8 +18,9 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class SortOrderTest extends Assert {
+public class SortOrderTest {
 
     @Test
     public void fromStringTest() throws KapuaIllegalArgumentException {
@@ -27,7 +28,7 @@ public class SortOrderTest extends Assert {
         SortOrder[] expectedValues = {SortOrder.ASCENDING, SortOrder.DESCENDING};
 
         for (int i = 0; i < stringValue.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedValues[i], SortOrder.fromString(stringValue[i]));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedValues[i], SortOrder.fromString(stringValue[i]));
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ByteArrayConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ByteArrayConverterTest.java
@@ -23,8 +23,9 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class ByteArrayConverterTest extends Assert {
+public class ByteArrayConverterTest {
 
     Byte[] byteClassArray;
     byte[] byteArray;
@@ -40,14 +41,14 @@ public class ByteArrayConverterTest extends Assert {
     @Test
     public void byteArrayConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<ByteArrayConverter> byteArrayConverter = ByteArrayConverter.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(byteArrayConverter.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(byteArrayConverter.getModifiers()));
         byteArrayConverter.setAccessible(true);
         byteArrayConverter.newInstance();
     }
 
     @Test
     public void toStringByteClassParameterTest() {
-        assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteClassArray));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteClassArray));
     }
 
     @Test(expected = NullPointerException.class)
@@ -57,7 +58,7 @@ public class ByteArrayConverterTest extends Assert {
 
     @Test
     public void toStringTest() {
-        assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteArray));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedString, ByteArrayConverter.toString(byteArray));
     }
 
     @Test(expected = NullPointerException.class)
@@ -68,7 +69,7 @@ public class ByteArrayConverterTest extends Assert {
     @Test
     public void fromStringTest() {
         String stringValue = "String Value";
-        assertThat("Instance of byte[] expected.", ByteArrayConverter.fromString(stringValue), IsInstanceOf.instanceOf(byte[].class));
+        Assert.assertThat("Instance of byte[] expected.", ByteArrayConverter.fromString(stringValue), IsInstanceOf.instanceOf(byte[].class));
     }
 
     @Test(expected = NullPointerException.class)

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectTypeConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectTypeConverterTest.java
@@ -23,13 +23,14 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class ObjectTypeConverterTest extends Assert {
+public class ObjectTypeConverterTest {
 
     @Test
     public void objectTypeConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<ObjectTypeConverter> objectTypeConverter = ObjectTypeConverter.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(objectTypeConverter.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(objectTypeConverter.getModifiers()));
         objectTypeConverter.setAccessible(true);
         objectTypeConverter.newInstance();
     }
@@ -39,13 +40,13 @@ public class ObjectTypeConverterTest extends Assert {
         Class[] classes = {String.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class, Byte[].class, KapuaIdImpl.class};
         String[] expectedString = {"string", "integer", "long", "float", "double", "boolean", "date", "binary", "binary", "org.eclipse.kapua.model.id.KapuaIdImpl"};
         for (int i = 0; i < classes.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectTypeConverter.toString(classes[i]));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectTypeConverter.toString(classes[i]));
         }
     }
 
     @Test
     public void toStringNullParameterTest() {
-        assertNull("Null expected.", ObjectTypeConverter.toString(null));
+        Assert.assertNull("Null expected.", ObjectTypeConverter.toString(null));
     }
 
     @Test
@@ -53,13 +54,13 @@ public class ObjectTypeConverterTest extends Assert {
         String[] stringValue = {"string", "integer", "int", "long", "float", "double", "boolean", "date", "binary", "org.eclipse.kapua.model.id.KapuaIdImpl"};
         Class[] expectedClasses = {String.class, Integer.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class, KapuaIdImpl.class};
         for (int i = 0; i < stringValue.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedClasses[i].toString(), ObjectTypeConverter.fromString(stringValue[i]).toString());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedClasses[i].toString(), ObjectTypeConverter.fromString(stringValue[i]).toString());
         }
     }
 
     @Test
     public void fromStringNullParameterTest() throws ClassNotFoundException {
-        assertNull("Null expected.", ObjectTypeConverter.fromString(null));
+        Assert.assertNull("Null expected.", ObjectTypeConverter.fromString(null));
     }
 
     @Test(expected = ClassNotFoundException.class)

--- a/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/type/ObjectValueConverterTest.java
@@ -23,13 +23,14 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class ObjectValueConverterTest extends Assert {
+public class ObjectValueConverterTest {
 
     @Test
     public void objectValueConverterTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<ObjectValueConverter> objectValueConverter = ObjectValueConverter.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(objectValueConverter.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(objectValueConverter.getModifiers()));
         objectValueConverter.setAccessible(true);
         objectValueConverter.newInstance();
     }
@@ -43,10 +44,10 @@ public class ObjectValueConverterTest extends Assert {
         Object object = new Object();
 
         for (int i = 0; i < objects.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectValueConverter.toString(objects[i]));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedString[i], ObjectValueConverter.toString(objects[i]));
         }
-        assertNull("Null expected.", ObjectValueConverter.toString(null));
-        assertEquals("Expected and actual values should be the same.", object.toString(), ObjectValueConverter.toString(object));
+        Assert.assertNull("Null expected.", ObjectValueConverter.toString(null));
+        Assert.assertEquals("Expected and actual values should be the same.", object.toString(), ObjectValueConverter.toString(object));
     }
 
     @Test
@@ -57,15 +58,15 @@ public class ObjectValueConverterTest extends Assert {
         Class[] byteClasses = {byte[].class, Byte[].class};
 
         for (int i = 0; i < stringValue.length; i++) {
-            assertEquals(expectedObjects[i], ObjectValueConverter.fromString(stringValue[i], classes[i]));
+            Assert.assertEquals(expectedObjects[i], ObjectValueConverter.fromString(stringValue[i], classes[i]));
         }
 
         for (Class byteClass : byteClasses) {
-            assertThat("Instance of byte[] expected.", ObjectValueConverter.fromString("byteArray", byteClass), IsInstanceOf.instanceOf(byte[].class));
+        Assert.assertThat("Instance of byte[] expected.", ObjectValueConverter.fromString("byteArray", byteClass), IsInstanceOf.instanceOf(byte[].class));
         }
 
         for (Class clazz : classes) {
-            assertNull(ObjectValueConverter.fromString(null, clazz));
+            Assert.assertNull(ObjectValueConverter.fromString(null, clazz));
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/BinaryXmlAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/BinaryXmlAdapterTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class BinaryXmlAdapterTest extends Assert {
+public class BinaryXmlAdapterTest {
 
     BinaryXmlAdapter binaryXmlAdapter;
 
@@ -33,22 +34,22 @@ public class BinaryXmlAdapterTest extends Assert {
     public void marshalTest() {
         byte[] byteArray = {-128, -10, 0, 1, 10, 127, 11};
         String expectedString = "gPYAAQp/Cw==";
-        assertEquals("Expected and actual values should be the same.", expectedString, binaryXmlAdapter.marshal(byteArray));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedString, binaryXmlAdapter.marshal(byteArray));
     }
 
     @Test
     public void marshalNullTest() {
-        assertNull("Null expected", binaryXmlAdapter.marshal(null));
+        Assert.assertNull("Null expected", binaryXmlAdapter.marshal(null));
     }
 
     @Test
     public void unmarshalTest() {
         String stringValue = "gPYAAQp/Cw==";
-        assertThat("Instance of byte[] expected.", binaryXmlAdapter.unmarshal(stringValue), IsInstanceOf.instanceOf(byte[].class));
+        Assert.assertThat("Instance of byte[] expected.", binaryXmlAdapter.unmarshal(stringValue), IsInstanceOf.instanceOf(byte[].class));
     }
 
     @Test
     public void unmarshalNullTest() {
-        assertNull("Null expected", binaryXmlAdapter.unmarshal(null));
+        Assert.assertNull("Null expected", binaryXmlAdapter.unmarshal(null));
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/DateXmlAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/DateXmlAdapterTest.java
@@ -22,8 +22,9 @@ import java.text.SimpleDateFormat;
 import java.util.Date;
 import java.util.TimeZone;
 
+
 @Category(JUnitTests.class)
-public class DateXmlAdapterTest extends Assert {
+public class DateXmlAdapterTest {
 
     DateXmlAdapter dateXmlAdapter;
     Date date;
@@ -39,12 +40,12 @@ public class DateXmlAdapterTest extends Assert {
         SimpleDateFormat dateFormat = new SimpleDateFormat(DateXmlAdapter.DATE_FORMAT);
         dateFormat.setTimeZone(TimeZone.getTimeZone(DateXmlAdapter.TIME_ZONE_UTC));
         String expectedString = dateFormat.format(date);
-        assertEquals("Expected and actual values should be the same.", expectedString, dateXmlAdapter.marshal(date));
+        Assert.assertEquals("Expected and actual values should be the same.", expectedString, dateXmlAdapter.marshal(date));
     }
 
     @Test
     public void marshalNullTest() throws Exception {
-        assertNull("Null expected", dateXmlAdapter.marshal(null));
+        Assert.assertNull("Null expected", dateXmlAdapter.marshal(null));
     }
 
     @Test
@@ -53,14 +54,14 @@ public class DateXmlAdapterTest extends Assert {
         dateFormat.setTimeZone(TimeZone.getTimeZone(DateXmlAdapter.TIME_ZONE_UTC));
         String dateStringValue = dateFormat.format(date);
 
-        assertEquals("Expected and actual values should be the same.", date, dateXmlAdapter.unmarshal(dateStringValue));
+        Assert.assertEquals("Expected and actual values should be the same.", date, dateXmlAdapter.unmarshal(dateStringValue));
     }
 
     @Test
     public void unmarshalNullOrEmptyStringsTest() {
         String[] nullOrEmptyStrings = {null, ""};
         for (String nullOrEmptyString : nullOrEmptyStrings) {
-            assertNull("Null expected", dateXmlAdapter.unmarshal(nullOrEmptyString));
+            Assert.assertNull("Null expected", dateXmlAdapter.unmarshal(nullOrEmptyString));
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/ObjectTypeXmlAdapterTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class ObjectTypeXmlAdapterTest extends Assert {
+public class ObjectTypeXmlAdapterTest {
 
     ObjectTypeXmlAdapter objectTypeXmlAdapter;
 
@@ -37,13 +38,13 @@ public class ObjectTypeXmlAdapterTest extends Assert {
         String[] expectedString = {"string", "integer", "long", "float", "double", "boolean", "date", "binary", "binary", "org.eclipse.kapua.model.id.KapuaIdImpl"};
 
         for (int i = 0; i < classes.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedString[i], objectTypeXmlAdapter.marshal(classes[i]));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedString[i], objectTypeXmlAdapter.marshal(classes[i]));
         }
     }
 
     @Test
     public void marshalNullTest() {
-        assertNull("Null expected.", objectTypeXmlAdapter.marshal(null));
+        Assert.assertNull("Null expected.", objectTypeXmlAdapter.marshal(null));
     }
 
     @Test
@@ -52,13 +53,13 @@ public class ObjectTypeXmlAdapterTest extends Assert {
         Class[] expectedClasses = {String.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, byte[].class, KapuaIdImpl.class};
 
         for (int i = 0; i < stringValue.length; i++) {
-            assertEquals("Expected and actual values should be the same.", expectedClasses[i], objectTypeXmlAdapter.unmarshal(stringValue[i]));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedClasses[i], objectTypeXmlAdapter.unmarshal(stringValue[i]));
         }
     }
 
     @Test
     public void unmarshalNullTest() throws ClassNotFoundException {
-        assertNull("Null expected.", objectTypeXmlAdapter.unmarshal(null));
+        Assert.assertNull("Null expected.", objectTypeXmlAdapter.unmarshal(null));
     }
 
     @Test(expected = ClassNotFoundException.class)

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObjectTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/XmlAdaptedNameTypeValueObjectTest.java
@@ -17,15 +17,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class XmlAdaptedNameTypeValueObjectTest extends Assert {
+public class XmlAdaptedNameTypeValueObjectTest {
 
     @Test
     public void xmlAdaptedNameTypeValueObjectTest() {
         XmlAdaptedNameTypeValueObject xmlAdaptedNameTypeValueObject = new XmlAdaptedNameTypeValueObject();
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getName());
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getName());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
     }
 
     @Test
@@ -35,7 +36,7 @@ public class XmlAdaptedNameTypeValueObjectTest extends Assert {
 
         for (String name : names) {
             xmlAdaptedNameTypeValueObject.setName(name);
-            assertEquals("Expected and actual values should be the same.", name, xmlAdaptedNameTypeValueObject.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", name, xmlAdaptedNameTypeValueObject.getName());
         }
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObjectTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/model/xml/XmlAdaptedTypeValueObjectTest.java
@@ -19,14 +19,15 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class XmlAdaptedTypeValueObjectTest extends Assert {
+public class XmlAdaptedTypeValueObjectTest {
 
     @Test
     public void xmlAdaptedNameTypeValueObjectTest() {
         XmlAdaptedNameTypeValueObject xmlAdaptedNameTypeValueObject = new XmlAdaptedNameTypeValueObject();
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
     }
 
     @Test
@@ -34,11 +35,11 @@ public class XmlAdaptedTypeValueObjectTest extends Assert {
         XmlAdaptedNameTypeValueObject xmlAdaptedNameTypeValueObject = new XmlAdaptedNameTypeValueObject();
         Class[] classes = {String.class, Integer.class, Long.class, Float.class, Double.class, Boolean.class, Date.class, Byte.class};
 
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValueType());
 
         for (Class clazz : classes) {
             xmlAdaptedNameTypeValueObject.setValueType(clazz);
-            assertEquals("Expected and actual values should be the same.", clazz, xmlAdaptedNameTypeValueObject.getValueType());
+            Assert.assertEquals("Expected and actual values should be the same.", clazz, xmlAdaptedNameTypeValueObject.getValueType());
         }
     }
 
@@ -47,11 +48,11 @@ public class XmlAdaptedTypeValueObjectTest extends Assert {
         XmlAdaptedNameTypeValueObject xmlAdaptedNameTypeValueObject = new XmlAdaptedNameTypeValueObject();
         String[] values = {"Name", null};
 
-        assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
+        Assert.assertNull("Null expected.", xmlAdaptedNameTypeValueObject.getValue());
 
         for (String value : values) {
             xmlAdaptedNameTypeValueObject.setValue(value);
-            assertEquals("Expected and actual values should be the same.", value, xmlAdaptedNameTypeValueObject.getValue());
+            Assert.assertEquals("Expected and actual values should be the same.", value, xmlAdaptedNameTypeValueObject.getValue());
         }
     }
 }

--- a/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdaptedTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdaptedTest.java
@@ -17,13 +17,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class ServiceXmlConfigPropertiesAdaptedTest extends Assert {
+public class ServiceXmlConfigPropertiesAdaptedTest {
 
     @Test
     public void serviceXmlConfigPropertiesAdaptedTest() {
         ServiceXmlConfigPropertiesAdapted serviceXmlConfigPropertiesAdapted = new ServiceXmlConfigPropertiesAdapted();
-        assertNull("Null expected.", serviceXmlConfigPropertiesAdapted.getProperties());
+        Assert.assertNull("Null expected.", serviceXmlConfigPropertiesAdapted.getProperties());
     }
 
     @Test
@@ -42,10 +43,10 @@ public class ServiceXmlConfigPropertiesAdaptedTest extends Assert {
                 for (ServiceXmlConfigPropertyAdapted.ConfigPropertyType type : configPropertyType) {
                     ServiceXmlConfigPropertyAdapted[] properties = {null, new ServiceXmlConfigPropertyAdapted(), new ServiceXmlConfigPropertyAdapted(name, type, value)};
                     serviceXmlConfigPropertiesAdapted.setProperties(properties);
-                    assertEquals("Expected and actual values should be the same.", properties, serviceXmlConfigPropertiesAdapted.getProperties());
+                    Assert.assertEquals("Expected and actual values should be the same.", properties, serviceXmlConfigPropertiesAdapted.getProperties());
 
                     serviceXmlConfigPropertiesAdapted.setProperties(null);
-                    assertNull("Null expected", serviceXmlConfigPropertiesAdapted.getProperties());
+                    Assert.assertNull("Null expected", serviceXmlConfigPropertiesAdapted.getProperties());
                 }
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapterTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertiesAdapterTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 import java.util.HashMap;
 import java.util.Map;
 
+
 @Category(JUnitTests.class)
-public class ServiceXmlConfigPropertiesAdapterTest extends Assert {
+public class ServiceXmlConfigPropertiesAdapterTest {
 
     ServiceXmlConfigPropertiesAdapter serviceXmlConfigPropertiesAdapter;
     Map[] expectedProperties;
@@ -82,13 +83,13 @@ public class ServiceXmlConfigPropertiesAdapterTest extends Assert {
 
         for (Object value : values) {
             props.put("key", value);
-            assertThat("Instance of ServiceXmlConfigPropertiesAdapted expected.", serviceXmlConfigPropertiesAdapter.marshal(props), IsInstanceOf.instanceOf(ServiceXmlConfigPropertiesAdapted.class));
+        Assert.assertThat("Instance of ServiceXmlConfigPropertiesAdapted expected.", serviceXmlConfigPropertiesAdapter.marshal(props), IsInstanceOf.instanceOf(ServiceXmlConfigPropertiesAdapted.class));
         }
     }
 
     @Test
     public void marshalNullPropsTest() {
-        assertThat("Instance of ServiceXmlConfigPropertiesAdapted expected.", serviceXmlConfigPropertiesAdapter.marshal(null), IsInstanceOf.instanceOf(ServiceXmlConfigPropertiesAdapted.class));
+        Assert.assertThat("Instance of ServiceXmlConfigPropertiesAdapted expected.", serviceXmlConfigPropertiesAdapter.marshal(null), IsInstanceOf.instanceOf(ServiceXmlConfigPropertiesAdapted.class));
     }
 
     @Test
@@ -108,19 +109,19 @@ public class ServiceXmlConfigPropertiesAdapterTest extends Assert {
             ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted2 = new ServiceXmlConfigPropertyAdapted(name, configPropertyType[i], stringValue);
             ServiceXmlConfigPropertyAdapted[] properties1 = {serviceXmlConfigPropertyAdapted1, serviceXmlConfigPropertyAdapted2};
 
-            assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
+        Assert.assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
 
             serviceXmlConfigPropertiesAdapted.setProperties(properties1);
 
-            assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
-            assertEquals("Expected and actual values should be the same.", expectedProperties[i], serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted));
+        Assert.assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
+            Assert.assertEquals("Expected and actual values should be the same.", expectedProperties[i], serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted));
 
             serviceXmlConfigPropertyAdapted1.setArray(true);
             serviceXmlConfigPropertyAdapted2.setArray(true);
             ServiceXmlConfigPropertyAdapted[] properties2 = {serviceXmlConfigPropertyAdapted1, serviceXmlConfigPropertyAdapted2};
             serviceXmlConfigPropertiesAdapted.setProperties(properties2);
 
-            assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
+        Assert.assertThat("Instance of Map expected.", serviceXmlConfigPropertiesAdapter.unmarshal(serviceXmlConfigPropertiesAdapted), IsInstanceOf.instanceOf(Map.class));
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdaptedTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/service/config/ServiceXmlConfigPropertyAdaptedTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
+public class ServiceXmlConfigPropertyAdaptedTest {
 
     ServiceXmlConfigPropertyAdapted.ConfigPropertyType[] configPropertyType;
     String[][] stringValues;
@@ -38,11 +39,11 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
     @Test
     public void serviceXmlConfigPropertyAdaptedTest() {
         ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted = new ServiceXmlConfigPropertyAdapted();
-        assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getName());
-        assertFalse("False expected.", serviceXmlConfigPropertyAdapted.getArray());
-        assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getType());
-        assertFalse("False expected.", serviceXmlConfigPropertyAdapted.isEncrypted());
-        assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getValues());
+        Assert.assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getName());
+        Assert.assertFalse("False expected.", serviceXmlConfigPropertyAdapted.getArray());
+        Assert.assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getType());
+        Assert.assertFalse("False expected.", serviceXmlConfigPropertyAdapted.isEncrypted());
+        Assert.assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getValues());
     }
 
     @Test
@@ -51,11 +52,11 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
             for (ServiceXmlConfigPropertyAdapted.ConfigPropertyType type : configPropertyType) {
                 for (String[] value : stringValues) {
                     ServiceXmlConfigPropertyAdapted serviceXmlConfigPropertyAdapted = new ServiceXmlConfigPropertyAdapted(name, type, value);
-                    assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getName());
-                    assertFalse("False expected.", serviceXmlConfigPropertyAdapted.getArray());
-                    assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted.getType());
-                    assertFalse("False expected", serviceXmlConfigPropertyAdapted.isEncrypted());
-                    assertEquals("Expected and actual values should be the same.", value, serviceXmlConfigPropertyAdapted.getValues());
+                    Assert.assertNull("Null expected.", serviceXmlConfigPropertyAdapted.getName());
+                    Assert.assertFalse("False expected.", serviceXmlConfigPropertyAdapted.getArray());
+                    Assert.assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted.getType());
+                    Assert.assertFalse("False expected", serviceXmlConfigPropertyAdapted.isEncrypted());
+                    Assert.assertEquals("Expected and actual values should be the same.", value, serviceXmlConfigPropertyAdapted.getValues());
                 }
             }
         }
@@ -73,8 +74,8 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
                     for (String newName : newNames) {
                         serviceXmlConfigPropertyAdapted1.setName(newName);
                         serviceXmlConfigPropertyAdapted2.setName(newName);
-                        assertEquals("Expected and actual values should be the same.", newName, serviceXmlConfigPropertyAdapted1.getName());
-                        assertEquals("Expected and actual values should be the same.", newName, serviceXmlConfigPropertyAdapted2.getName());
+                        Assert.assertEquals("Expected and actual values should be the same.", newName, serviceXmlConfigPropertyAdapted1.getName());
+                        Assert.assertEquals("Expected and actual values should be the same.", newName, serviceXmlConfigPropertyAdapted2.getName());
                     }
                 }
             }
@@ -93,8 +94,8 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
                     for (Boolean array : arrays) {
                         serviceXmlConfigPropertyAdapted1.setArray(array);
                         serviceXmlConfigPropertyAdapted2.setArray(array);
-                        assertEquals("Expected and actual values should be the same.", array, serviceXmlConfigPropertyAdapted1.getArray());
-                        assertEquals("Expected and actual values should be the same.", array, serviceXmlConfigPropertyAdapted2.getArray());
+                        Assert.assertEquals("Expected and actual values should be the same.", array, serviceXmlConfigPropertyAdapted1.getArray());
+                        Assert.assertEquals("Expected and actual values should be the same.", array, serviceXmlConfigPropertyAdapted2.getArray());
                     }
                 }
             }
@@ -110,8 +111,8 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
                 for (ServiceXmlConfigPropertyAdapted.ConfigPropertyType type : configPropertyType) {
                     serviceXmlConfigPropertyAdapted1.setType(type);
                     serviceXmlConfigPropertyAdapted2.setType(type);
-                    assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted1.getType());
-                    assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted2.getType());
+                    Assert.assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted1.getType());
+                    Assert.assertEquals("Expected and actual values should be the same.", type, serviceXmlConfigPropertyAdapted2.getType());
                 }
             }
         }
@@ -129,8 +130,8 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
                     for (Boolean encrypted : isEncrypted) {
                         serviceXmlConfigPropertyAdapted1.setEncrypted(encrypted);
                         serviceXmlConfigPropertyAdapted2.setEncrypted(encrypted);
-                        assertEquals("Expected and actual values should be the same.", encrypted, serviceXmlConfigPropertyAdapted1.isEncrypted());
-                        assertEquals("Expected and actual values should be the same.", encrypted, serviceXmlConfigPropertyAdapted2.isEncrypted());
+                        Assert.assertEquals("Expected and actual values should be the same.", encrypted, serviceXmlConfigPropertyAdapted1.isEncrypted());
+                        Assert.assertEquals("Expected and actual values should be the same.", encrypted, serviceXmlConfigPropertyAdapted2.isEncrypted());
                     }
                 }
             }
@@ -149,8 +150,8 @@ public class ServiceXmlConfigPropertyAdaptedTest extends Assert {
                     for (String[] newValue : newValues) {
                         serviceXmlConfigPropertyAdapted1.setValues(newValue);
                         serviceXmlConfigPropertyAdapted2.setValues(newValue);
-                        assertEquals("Expected and actual values should be the same.", newValue, serviceXmlConfigPropertyAdapted1.getValues());
-                        assertEquals("Expected and actual values should be the same.", newValue, serviceXmlConfigPropertyAdapted2.getValues());
+                        Assert.assertEquals("Expected and actual values should be the same.", newValue, serviceXmlConfigPropertyAdapted1.getValues());
+                        Assert.assertEquals("Expected and actual values should be the same.", newValue, serviceXmlConfigPropertyAdapted2.getValues());
                     }
                 }
             }


### PR DESCRIPTION
Refactoring to avoid test classes to extend Assert - part 5

Signed-off-by: dseurotech <davide.salvador@eurotech.com>