### PR TITLE
Further test refactorings in kapua - no semantic changes

### DIFF
--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessPermissionQueryImplTest.java
@@ -18,30 +18,31 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class AccessPermissionQueryImplTest extends Assert {
+public class AccessPermissionQueryImplTest {
 
     @Test
     public void accessPermissionQueryImplWithoutParametersTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl();
-        assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
-        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
-        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
+        Assert.assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        Assert.assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessPermissionQueryImplScopeIdParameterTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionQueryImpl.getScopeId());
-        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
-        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessPermissionQueryImpl.getScopeId());
+        Assert.assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        Assert.assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessPermissionQueryImplNullScopeIdParameterTest() {
         AccessPermissionQueryImpl accessPermissionQueryImpl = new AccessPermissionQueryImpl(null);
-        assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
-        assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
-        assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", accessPermissionQueryImpl.getScopeId());
+        Assert.assertNull("accessPermissionQueryImpl.sortCriteria", accessPermissionQueryImpl.getSortCriteria());
+        Assert.assertNotNull("accessPermissionQueryImpl.defaultSortCriteria", accessPermissionQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCacheFactoryTest.java
@@ -20,20 +20,21 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class AccessRoleCacheFactoryTest extends Assert {
+public class AccessRoleCacheFactoryTest {
 
     @Test
     public void accessRoleCacheFactoryTest() throws Exception {
         Constructor<AccessRoleCacheFactory> accessRoleCacheFactory = AccessRoleCacheFactory.class.getDeclaredConstructor();
         accessRoleCacheFactory.setAccessible(true);
         accessRoleCacheFactory.newInstance();
-        assertTrue("True expected.", Modifier.isPrivate(accessRoleCacheFactory.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(accessRoleCacheFactory.getModifiers()));
     }
 
     @Test
     public void getInstanceTest() {
-        assertTrue("True expected.", AccessRoleCacheFactory.getInstance() instanceof AccessRoleCacheFactory);
-        assertEquals("Expected and actual values should be the same.", "AccessRoleId", AccessRoleCacheFactory.getInstance().getEntityIdCacheName());
+        Assert.assertTrue("True expected.", AccessRoleCacheFactory.getInstance() instanceof AccessRoleCacheFactory);
+        Assert.assertEquals("Expected and actual values should be the same.", "AccessRoleId", AccessRoleCacheFactory.getInstance().getEntityIdCacheName());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleCreatorImplTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class AccessRoleCreatorImplTest extends Assert {
+public class AccessRoleCreatorImplTest {
 
     AccessRoleCreatorImpl accessRoleCreatorImpl;
 
@@ -31,34 +32,34 @@ public class AccessRoleCreatorImplTest extends Assert {
 
     @Test
     public void accessRoleCreatorImplTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getScopeId());
-        assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
-        assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
     }
 
     @Test
     public void accessRoleCreatorImplNullTest() {
         AccessRoleCreatorImpl accessRoleCreatorImplNullId = new AccessRoleCreatorImpl(null);
-        assertNull("Null expected.", accessRoleCreatorImplNullId.getScopeId());
-        assertNull("Null expected.", accessRoleCreatorImplNullId.getAccessInfoId());
-        assertNull("Null expected.", accessRoleCreatorImplNullId.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImplNullId.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImplNullId.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImplNullId.getRoleId());
     }
 
     @Test
     public void setAndGetAccessInfoIdTest() {
         accessRoleCreatorImpl.setAccessInfoId(KapuaId.ANY);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleCreatorImpl.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleCreatorImpl.getAccessInfoId());
 
         accessRoleCreatorImpl.setAccessInfoId(null);
-        assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImpl.getAccessInfoId());
     }
 
     @Test
     public void setAndGetRoleIdTest() {
         accessRoleCreatorImpl.setRoleId(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreatorImpl.getRoleId());
 
         accessRoleCreatorImpl.setRoleId(null);
-        assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleCreatorImpl.getRoleId());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleFactoryImplTest.java
@@ -27,8 +27,9 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class AccessRoleFactoryImplTest extends Assert {
+public class AccessRoleFactoryImplTest {
 
     AccessRoleFactoryImpl accessRoleFactoryImpl;
     AccessRole accessRole;
@@ -51,43 +52,43 @@ public class AccessRoleFactoryImplTest extends Assert {
     @Test
     public void newEntityTest() {
         AccessRole accessRole = accessRoleFactoryImpl.newEntity(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRole.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRole.getScopeId());
     }
 
     @Test
     public void newEntityNullTest() {
         AccessRole accessRole = accessRoleFactoryImpl.newEntity(null);
-        assertNull("Null expected.", accessRole.getScopeId());
+        Assert.assertNull("Null expected.", accessRole.getScopeId());
     }
 
     @Test
     public void newCreatorTest() {
         AccessRoleCreator accessRoleCreator = accessRoleFactoryImpl.newCreator(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreator.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleCreator.getScopeId());
     }
 
     @Test
     public void newCreatorNullTest() {
         AccessRoleCreator accessRoleCreator = accessRoleFactoryImpl.newCreator(null);
-        assertNull("Null expected.", accessRoleCreator.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleCreator.getScopeId());
     }
 
     @Test
     public void newQueryTest() {
         AccessRoleQuery accessRoleQuery = accessRoleFactoryImpl.newQuery(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQuery.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQuery.getScopeId());
     }
 
     @Test
     public void newQueryNullTest() {
         AccessRoleQuery accessRoleQuery = accessRoleFactoryImpl.newQuery(null);
-        assertNull("Null expected.", accessRoleQuery.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleQuery.getScopeId());
     }
 
     @Test
     public void newListResultTest() {
         AccessRoleListResult accessRoleListResult = accessRoleFactoryImpl.newListResult();
-        assertTrue("True expected.", accessRoleListResult.isEmpty());
+        Assert.assertTrue("True expected.", accessRoleListResult.isEmpty());
     }
 
     @Test
@@ -95,12 +96,12 @@ public class AccessRoleFactoryImplTest extends Assert {
         accessRoleFactoryImpl.clone(accessRole);
 
         AccessRole resultAccessRole = accessRoleFactoryImpl.clone(accessRole);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, resultAccessRole.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getAccessInfoId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, resultAccessRole.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultAccessRole.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultAccessRole.getRoleId());
     }
 
     @Test(expected = KapuaEntityCloneException.class)

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleImplTest.java
@@ -24,8 +24,9 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class AccessRoleImplTest extends Assert {
+public class AccessRoleImplTest {
 
     AccessRoleImpl accessRoleImpl1, accessRoleImpl2, accessRoleImpl;
     AccessRole accessRole;
@@ -50,34 +51,34 @@ public class AccessRoleImplTest extends Assert {
 
     @Test
     public void accessRoleImplWithoutParametersTest() {
-        assertNull("Null expected.", accessRoleImpl1.getScopeId());
-        assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
-        assertNull("Null expected.", accessRoleImpl1.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleImpl1.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImpl1.getRoleId());
     }
 
     @Test
     public void accessRoleImplScopeIdParameterTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl2.getScopeId());
-        assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
-        assertNull("Null expected.", accessRoleImpl2.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl2.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImpl2.getRoleId());
     }
 
     @Test
     public void accessRoleImplNullScopeIdParameterTest() {
         AccessRoleImpl accessRoleImplNullScopeId = new AccessRoleImpl((KapuaId) null);
-        assertNull("Null expected.", accessRoleImplNullScopeId.getScopeId());
-        assertNull("Null expected.", accessRoleImplNullScopeId.getAccessInfoId());
-        assertNull("Null expected.", accessRoleImplNullScopeId.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleImplNullScopeId.getScopeId());
+        Assert.assertNull("Null expected.", accessRoleImplNullScopeId.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImplNullScopeId.getRoleId());
     }
 
     @Test
     public void accessRoleImplAccessRoleParameterTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, accessRoleImpl.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getAccessInfoId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, accessRoleImpl.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleImpl.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
     }
 
     @Test(expected = NullPointerException.class)
@@ -90,16 +91,16 @@ public class AccessRoleImplTest extends Assert {
         accessRoleImpl1.setAccessInfoId(KapuaId.ANY);
         accessRoleImpl2.setAccessInfoId(KapuaId.ANY);
         accessRoleImpl.setAccessInfoId(KapuaId.ANY);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getAccessInfoId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getAccessInfoId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getAccessInfoId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getAccessInfoId());
 
         accessRoleImpl1.setAccessInfoId(null);
         accessRoleImpl2.setAccessInfoId(null);
         accessRoleImpl.setAccessInfoId(null);
-        assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
-        assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
-        assertNull("Null expected.", accessRoleImpl.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImpl1.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImpl2.getAccessInfoId());
+        Assert.assertNull("Null expected.", accessRoleImpl.getAccessInfoId());
     }
 
     @Test
@@ -107,86 +108,86 @@ public class AccessRoleImplTest extends Assert {
         accessRoleImpl1.setRoleId(KapuaId.ANY);
         accessRoleImpl2.setRoleId(KapuaId.ANY);
         accessRoleImpl.setRoleId(KapuaId.ANY);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getRoleId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getRoleId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl1.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl2.getRoleId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, accessRoleImpl.getRoleId());
 
         accessRoleImpl1.setRoleId(null);
         accessRoleImpl2.setRoleId(null);
         accessRoleImpl.setRoleId(null);
-        assertNull("Null expected.", accessRoleImpl1.getRoleId());
-        assertNull("Null expected.", accessRoleImpl2.getRoleId());
-        assertNull("Null expected.", accessRoleImpl.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleImpl1.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleImpl2.getRoleId());
+        Assert.assertNull("Null expected.", accessRoleImpl.getRoleId());
     }
 
     @Test
     public void hashCodeNullAccessInfoIdNullRoleIdTest() {
-        assertEquals("Expected and actual values should be the same.", 961, accessRoleImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 961, accessRoleImpl1.hashCode());
     }
 
     @Test
     public void hashCodeNullRoleIdTest() {
         accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", 1953, accessRoleImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 1953, accessRoleImpl1.hashCode());
     }
 
     @Test
     public void hashCodeNullAccessInfoIdTest() {
         accessRoleImpl1.setRoleId(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", 993, accessRoleImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 993, accessRoleImpl1.hashCode());
     }
 
     @Test
     public void hashCodeTest() {
         accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
         accessRoleImpl1.setRoleId(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", 1985, accessRoleImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 1985, accessRoleImpl1.hashCode());
     }
 
     @Test
     public void equalsSameObjectTest() {
-        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl1));
+        Assert.assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl1));
     }
 
     @Test
     public void equalsNullObjectTest() {
-        assertFalse("False expected.", accessRoleImpl1.equals(null));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(null));
     }
 
     @Test
     public void equalsObjectTest() {
-        assertFalse("False expected.", accessRoleImpl1.equals(new Object()));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(new Object()));
     }
 
     @Test
     public void equalsNullAccessInfoIdsNullRoleIdsTest() {
-        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
     public void equalsNullThisAccessInfoIdNullRoleIdsTest() {
         accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
-        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
     public void equalsNullAccessInfoIdsNullThisRoleIdTest() {
         accessRoleImpl2.setRoleId(KapuaId.ANY);
-        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
     public void equalsDifferentAccessInfoIdsTest() {
         accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
         accessRoleImpl1.setAccessInfoId(KapuaId.ANY);
-        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
     public void equalsEqualAccessInfoIdsNullRoleIdsTest() {
         accessRoleImpl1.setAccessInfoId(KapuaId.ONE);
         accessRoleImpl2.setAccessInfoId(KapuaId.ONE);
-        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
@@ -196,7 +197,7 @@ public class AccessRoleImplTest extends Assert {
         accessRoleImpl1.setRoleId(KapuaId.ANY);
         accessRoleImpl2.setRoleId(KapuaId.ONE);
 
-        assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertFalse("False expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 
     @Test
@@ -206,6 +207,6 @@ public class AccessRoleImplTest extends Assert {
         accessRoleImpl1.setRoleId(KapuaId.ONE);
         accessRoleImpl2.setRoleId(KapuaId.ONE);
 
-        assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
+        Assert.assertTrue("True expected.", accessRoleImpl1.equals(accessRoleImpl2));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/access/shiro/AccessRoleQueryImplTest.java
@@ -18,22 +18,23 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class AccessRoleQueryImplTest extends Assert {
+public class AccessRoleQueryImplTest {
 
     @Test
     public void accessRoleQueryImplWithoutParametersTest() {
         AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl();
-        assertNull("Null expected.", accessRoleQueryImpl.getScopeId());
-        assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
-        assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", accessRoleQueryImpl.getScopeId());
+        Assert.assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
+        Assert.assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void accessRoleQueryImplScopeIdParameterTest() {
         AccessRoleQueryImpl accessRoleQueryImpl = new AccessRoleQueryImpl(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQueryImpl.getScopeId());
-        assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
-        assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, accessRoleQueryImpl.getScopeId());
+        Assert.assertNull("accessRoleQueryImpl.sortCriteria", accessRoleQueryImpl.getSortCriteria());
+        Assert.assertNotNull("accessRoleQueryImpl.defaultSortCriteria", accessRoleQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainCreatorImplTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class DomainCreatorImplTest extends Assert {
+public class DomainCreatorImplTest {
 
     @Test
     public void domainCreatorImplTest() {
@@ -30,20 +31,20 @@ public class DomainCreatorImplTest extends Assert {
 
         for (String name : names) {
             DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl(name);
-            assertNull("Null expected.", domainCreatorImpl.getScopeId());
-            assertEquals("Expected and actual values should be the same.", name, domainCreatorImpl.getName());
-            assertNull("Null expected.", domainCreatorImpl.getActions());
-            assertFalse("False expected.", domainCreatorImpl.getGroupable());
+            Assert.assertNull("Null expected.", domainCreatorImpl.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, domainCreatorImpl.getName());
+            Assert.assertNull("Null expected.", domainCreatorImpl.getActions());
+            Assert.assertFalse("False expected.", domainCreatorImpl.getGroupable());
         }
     }
 
     @Test
     public void domainCreatorImplNullTest() {
         DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl(null);
-        assertNull("Null expected.", domainCreatorImpl.getScopeId());
-        assertNull("Null expected.", domainCreatorImpl.getName());
-        assertNull("Null expected.", domainCreatorImpl.getActions());
-        assertFalse("False expected.", domainCreatorImpl.getGroupable());
+        Assert.assertNull("Null expected.", domainCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", domainCreatorImpl.getName());
+        Assert.assertNull("Null expected.", domainCreatorImpl.getActions());
+        Assert.assertFalse("False expected.", domainCreatorImpl.getGroupable());
     }
 
     @Test
@@ -53,10 +54,10 @@ public class DomainCreatorImplTest extends Assert {
         DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl("name");
         for (String newName : newNames) {
             domainCreatorImpl.setName(newName);
-            assertEquals("Expected and actual values should be the same.", newName, domainCreatorImpl.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", newName, domainCreatorImpl.getName());
         }
         domainCreatorImpl.setName(null);
-        assertNull("Null expected.", domainCreatorImpl.getName());
+        Assert.assertNull("Null expected.", domainCreatorImpl.getName());
     }
 
     @Test
@@ -65,7 +66,7 @@ public class DomainCreatorImplTest extends Assert {
         DomainCreatorImpl domainCreatorImpl = new DomainCreatorImpl("name");
 
         domainCreatorImpl.setActions(actions);
-        assertTrue("True expected", domainCreatorImpl.getActions().isEmpty());
+        Assert.assertTrue("True expected", domainCreatorImpl.getActions().isEmpty());
 
         actions.add(Actions.read);
         actions.add(Actions.delete);
@@ -73,10 +74,10 @@ public class DomainCreatorImplTest extends Assert {
         actions.add(Actions.execute);
         actions.add(Actions.write);
         domainCreatorImpl.setActions(actions);
-        assertEquals("Expected and actual values should be the same.", 5, domainCreatorImpl.getActions().size());
+        Assert.assertEquals("Expected and actual values should be the same.", 5, domainCreatorImpl.getActions().size());
 
         domainCreatorImpl.setActions(null);
-        assertNull("Null expected.", domainCreatorImpl.getActions());
+        Assert.assertNull("Null expected.", domainCreatorImpl.getActions());
     }
 
     @Test
@@ -86,7 +87,7 @@ public class DomainCreatorImplTest extends Assert {
 
         for (boolean groupable : groupables) {
             domainCreatorImpl.setGroupable(groupable);
-            assertEquals("Expected and actual values should be the same.", groupable, domainCreatorImpl.getGroupable());
+            Assert.assertEquals("Expected and actual values should be the same.", groupable, domainCreatorImpl.getGroupable());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainFactoryImplTest.java
@@ -30,8 +30,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class DomainFactoryImplTest extends Assert {
+public class DomainFactoryImplTest {
 
     DomainFactoryImpl domainFactoryImpl;
 
@@ -46,50 +47,50 @@ public class DomainFactoryImplTest extends Assert {
 
         for (String name : names) {
             DomainCreator domainCreator = domainFactoryImpl.newCreator(name);
-            assertEquals("Expected and actual values should be the same.", name, domainCreator.getName());
-            assertNull("Null expected.", domainCreator.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, domainCreator.getName());
+            Assert.assertNull("Null expected.", domainCreator.getScopeId());
         }
     }
 
     @Test
     public void newCreatorNullNameParameterTest() {
         DomainCreator domainCreator = domainFactoryImpl.newCreator((String) null);
-        assertNull("Null expected.", domainCreator.getName());
-        assertNull("Null expected.", domainCreator.getScopeId());
+        Assert.assertNull("Null expected.", domainCreator.getName());
+        Assert.assertNull("Null expected.", domainCreator.getScopeId());
     }
 
     @Test
     public void newListResultTest() {
         DomainListResult domainListResult = domainFactoryImpl.newListResult();
-        assertTrue("True expected.", domainListResult.isEmpty());
+        Assert.assertTrue("True expected.", domainListResult.isEmpty());
     }
 
     @Test
     public void newQueryTest() {
         DomainQuery domainQuery = domainFactoryImpl.newQuery(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQuery.getScopeId());
-        assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
-        assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQuery.getScopeId());
+        Assert.assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
+        Assert.assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
     }
 
     @Test
     public void newQueryNullTest() {
         DomainQuery domainQuery = domainFactoryImpl.newQuery(null);
-        assertNull("Null expected.", domainQuery.getScopeId());
-        assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
-        assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", domainQuery.getScopeId());
+        Assert.assertNull("domainQuery.sortCriteria", domainQuery.getSortCriteria());
+        Assert.assertNotNull("domainQuery.defaultSortCriteria", domainQuery.getDefaultSortCriteria());
     }
 
     @Test
     public void newEntityTest() {
         Domain domain = domainFactoryImpl.newEntity(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domain.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domain.getScopeId());
     }
 
     @Test
     public void newEntityNullTest() {
         Domain domain = domainFactoryImpl.newEntity(null);
-        assertNull("Null expected.", domain.getScopeId());
+        Assert.assertNull("Null expected.", domain.getScopeId());
     }
 
     @Test(expected = NotImplementedException.class)
@@ -117,13 +118,13 @@ public class DomainFactoryImplTest extends Assert {
         Mockito.when(domain.getGroupable()).thenReturn(true);
 
         Domain resultDomain = domainFactoryImpl.clone(domain);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultDomain.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, resultDomain.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", "name", resultDomain.getName());
-        assertEquals("Expected and actual values should be the same.", actions, resultDomain.getActions());
-        assertEquals("Expected and actual values should be the same.", true, resultDomain.getGroupable());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultDomain.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultDomain.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, resultDomain.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", "name", resultDomain.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", actions, resultDomain.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", true, resultDomain.getGroupable());
     }
 
     @Test(expected = NullPointerException.class)

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainImplTest.java
@@ -26,8 +26,9 @@ import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class DomainImplTest extends Assert {
+public class DomainImplTest {
 
     Domain domain;
     Date createdOn;
@@ -55,38 +56,38 @@ public class DomainImplTest extends Assert {
 
     @Test
     public void domainImplWithoutParametersTest() {
-        assertNull("Null expected.", domainImpl1.getScopeId());
-        assertNull("Null expected.", domainImpl1.getName());
-        assertNull("Null expected.", domainImpl1.getActions());
-        assertFalse("False expected.", domainImpl1.getGroupable());
+        Assert.assertNull("Null expected.", domainImpl1.getScopeId());
+        Assert.assertNull("Null expected.", domainImpl1.getName());
+        Assert.assertNull("Null expected.", domainImpl1.getActions());
+        Assert.assertFalse("False expected.", domainImpl1.getGroupable());
     }
 
     @Test
     public void domainImplScopeIdParameterTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl2.getScopeId());
-        assertNull("Null expected.", domainImpl2.getName());
-        assertNull("Null expected.", domainImpl2.getActions());
-        assertFalse("False expected.", domainImpl2.getGroupable());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl2.getScopeId());
+        Assert.assertNull("Null expected.", domainImpl2.getName());
+        Assert.assertNull("Null expected.", domainImpl2.getActions());
+        Assert.assertFalse("False expected.", domainImpl2.getGroupable());
     }
 
     @Test
     public void domainImplNullScopeIdParameterTest() {
         DomainImpl domainImpl = new DomainImpl((KapuaId) null);
-        assertNull("Null expected.", domainImpl.getScopeId());
-        assertNull("Null expected.", domainImpl.getName());
-        assertNull("Null expected.", domainImpl.getActions());
-        assertFalse("False expected.", domainImpl.getGroupable());
+        Assert.assertNull("Null expected.", domainImpl.getScopeId());
+        Assert.assertNull("Null expected.", domainImpl.getName());
+        Assert.assertNull("Null expected.", domainImpl.getActions());
+        Assert.assertFalse("False expected.", domainImpl.getGroupable());
     }
 
     @Test
     public void domainImplDomainParameterTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, domainImpl3.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, domainImpl3.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", "name", domainImpl3.getName());
-        assertEquals("Expected and actual values should be the same.", actions, domainImpl3.getActions());
-        assertTrue("True expected.", domainImpl3.getGroupable());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, domainImpl3.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainImpl3.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, domainImpl3.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", "name", domainImpl3.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", actions, domainImpl3.getActions());
+        Assert.assertTrue("True expected.", domainImpl3.getGroupable());
     }
 
     @Test(expected = NullPointerException.class)
@@ -102,17 +103,17 @@ public class DomainImplTest extends Assert {
             domainImpl1.setName(newName);
             domainImpl2.setName(newName);
             domainImpl3.setName(newName);
-            assertEquals("Expected and actual values should be the same.", newName, domainImpl1.getName());
-            assertEquals("Expected and actual values should be the same.", newName, domainImpl2.getName());
-            assertEquals("Expected and actual values should be the same.", newName, domainImpl3.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", newName, domainImpl1.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", newName, domainImpl2.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", newName, domainImpl3.getName());
         }
 
         domainImpl1.setName(null);
         domainImpl2.setName(null);
         domainImpl3.setName(null);
-        assertNull("Null expected.", domainImpl1.getName());
-        assertNull("Null expected.", domainImpl2.getName());
-        assertNull("Null expected.", domainImpl3.getName());
+        Assert.assertNull("Null expected.", domainImpl1.getName());
+        Assert.assertNull("Null expected.", domainImpl2.getName());
+        Assert.assertNull("Null expected.", domainImpl3.getName());
     }
 
     @Test
@@ -122,12 +123,12 @@ public class DomainImplTest extends Assert {
         domainImpl1.setActions(newActions);
         domainImpl2.setActions(newActions);
         domainImpl3.setActions(newActions);
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
-        assertTrue("True expected", domainImpl1.getActions().isEmpty());
-        assertTrue("True expected", domainImpl2.getActions().isEmpty());
-        assertTrue("True expected", domainImpl3.getActions().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
+        Assert.assertTrue("True expected", domainImpl1.getActions().isEmpty());
+        Assert.assertTrue("True expected", domainImpl2.getActions().isEmpty());
+        Assert.assertTrue("True expected", domainImpl3.getActions().isEmpty());
 
         newActions.add(Actions.read);
         newActions.add(Actions.delete);
@@ -138,19 +139,19 @@ public class DomainImplTest extends Assert {
         domainImpl2.setActions(newActions);
         domainImpl3.setActions(newActions);
 
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
-        assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
-        assertEquals("Expected and actual values should be the same.", 5, domainImpl1.getActions().size());
-        assertEquals("Expected and actual values should be the same.", 5, domainImpl2.getActions().size());
-        assertEquals("Expected and actual values should be the same.", 5, domainImpl3.getActions().size());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl1.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl2.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", newActions, domainImpl3.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", 5, domainImpl1.getActions().size());
+        Assert.assertEquals("Expected and actual values should be the same.", 5, domainImpl2.getActions().size());
+        Assert.assertEquals("Expected and actual values should be the same.", 5, domainImpl3.getActions().size());
 
         domainImpl1.setActions(null);
         domainImpl2.setActions(null);
         domainImpl3.setActions(null);
-        assertNull("Null expected.", domainImpl1.getActions());
-        assertNull("Null expected.", domainImpl2.getActions());
-        assertNull("Null expected.", domainImpl3.getActions());
+        Assert.assertNull("Null expected.", domainImpl1.getActions());
+        Assert.assertNull("Null expected.", domainImpl2.getActions());
+        Assert.assertNull("Null expected.", domainImpl3.getActions());
     }
 
     @Test
@@ -162,25 +163,25 @@ public class DomainImplTest extends Assert {
             domainImpl2.setGroupable(groupable);
             domainImpl3.setGroupable(groupable);
 
-            assertEquals("Expected and actual values should be the same.", groupable, domainImpl1.getGroupable());
-            assertEquals("Expected and actual values should be the same.", groupable, domainImpl2.getGroupable());
-            assertEquals("Expected and actual values should be the same.", groupable, domainImpl3.getGroupable());
+            Assert.assertEquals("Expected and actual values should be the same.", groupable, domainImpl1.getGroupable());
+            Assert.assertEquals("Expected and actual values should be the same.", groupable, domainImpl2.getGroupable());
+            Assert.assertEquals("Expected and actual values should be the same.", groupable, domainImpl3.getGroupable());
         }
     }
 
     @Test
     public void equalsSameObjectTest() {
-        assertTrue("True expected.", domainImpl1.equals(domainImpl1));
+        Assert.assertTrue("True expected.", domainImpl1.equals(domainImpl1));
     }
 
     @Test
     public void equalsNullTest() {
-        assertFalse("False expected.", domainImpl1.equals(null));
+        Assert.assertFalse("False expected.", domainImpl1.equals(null));
     }
 
     @Test
     public void equalsObjectTest() {
-        assertFalse("False expected.", domainImpl1.equals(new Object()));
+        Assert.assertFalse("False expected.", domainImpl1.equals(new Object()));
     }
 
     @Test
@@ -192,7 +193,7 @@ public class DomainImplTest extends Assert {
         domainImpl1.setActions(actions);
         domainImpl2.setActions(actions);
 
-        assertTrue("True expected.", domainImpl1.equals(domainImpl2));
+        Assert.assertTrue("True expected.", domainImpl1.equals(domainImpl2));
     }
 
     @Test
@@ -204,7 +205,7 @@ public class DomainImplTest extends Assert {
         domainImpl1.setActions(actions);
         domainImpl2.setActions(actions);
 
-        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+        Assert.assertFalse("False expected.", domainImpl1.equals(domainImpl2));
     }
 
     @Test
@@ -216,7 +217,7 @@ public class DomainImplTest extends Assert {
         domainImpl1.setActions(actions);
         domainImpl2.setActions(actions);
 
-        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+        Assert.assertFalse("False expected.", domainImpl1.equals(domainImpl2));
     }
 
     @Test
@@ -229,24 +230,24 @@ public class DomainImplTest extends Assert {
         domainImpl1.setActions(actions);
         domainImpl2.setActions(new HashSet<>());
 
-        assertFalse("False expected.", domainImpl1.equals(domainImpl2));
+        Assert.assertFalse("False expected.", domainImpl1.equals(domainImpl2));
     }
 
     @Test
     public void hashCodeTest() {
-        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
     }
 
     @Test
     public void hashCodeNameTest() {
         domainImpl1.setName("name");
-        assertEquals("Expected and actual values should be the same.", -1052803841, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", -1052803841, domainImpl1.hashCode());
     }
 
     @Test
     public void hashCodeEmptyActionsTest() {
         domainImpl1.setActions(actions);
-        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
     }
 
     @Test
@@ -258,19 +259,19 @@ public class DomainImplTest extends Assert {
         actions.add(Actions.write);
         domainImpl1.setActions(actions);
 
-        assertEquals("Expected and actual values should be the same.", 31 * actions.hashCode() + 31028, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31 * actions.hashCode() + 31028, domainImpl1.hashCode());
     }
 
     @Test
     public void hashCodeGroupableTrueTest() {
         domainImpl1.setGroupable(true);
-        assertEquals("Expected and actual values should be the same.", 31022, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31022, domainImpl1.hashCode());
     }
 
     @Test
     public void hashCodeGroupableFalseTest() {
         domainImpl1.setGroupable(false);
-        assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31028, domainImpl1.hashCode());
     }
 
     @Test
@@ -278,6 +279,6 @@ public class DomainImplTest extends Assert {
         domainImpl1.setName("name");
         domainImpl1.setActions(actions);
         domainImpl1.setGroupable(true);
-        assertEquals("Expected and actual values should be the same.", -1052803847, domainImpl1.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", -1052803847, domainImpl1.hashCode());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/domain/shiro/DomainQueryImplTest.java
@@ -18,24 +18,25 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class DomainQueryImplTest extends Assert {
+public class DomainQueryImplTest {
 
     @Test
     public void domainQueryImplWithoutParametersTest() {
         DomainQueryImpl domainQueryImpl = new DomainQueryImpl();
-        assertNull("Null expected.", domainQueryImpl.getScopeId());
+        Assert.assertNull("Null expected.", domainQueryImpl.getScopeId());
     }
 
     @Test
     public void domainQueryImplScopeIdParameterTest() {
         DomainQueryImpl domainQueryImpl = new DomainQueryImpl(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQueryImpl.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, domainQueryImpl.getScopeId());
     }
 
     @Test
     public void domainQueryImplNullScopeIdParameterTest() {
         DomainQueryImpl domainQueryImpl = new DomainQueryImpl(null);
-        assertNull("Null expected.", domainQueryImpl.getScopeId());
+        Assert.assertNull("Null expected.", domainQueryImpl.getScopeId());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupCreatorImplTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class GroupCreatorImplTest extends Assert {
+public class GroupCreatorImplTest {
 
     String[] names;
     KapuaId scopeId;
@@ -35,8 +36,8 @@ public class GroupCreatorImplTest extends Assert {
     public void groupCreatorImplScopeIdNameParametersTest() {
         for (String name : names) {
             GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId, name);
-            assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
-            assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
         }
     }
 
@@ -44,36 +45,36 @@ public class GroupCreatorImplTest extends Assert {
     public void groupCreatorImplNullScopeIdNameParametersTest() {
         for (String name : names) {
             GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null, name);
-            assertNull("Null expected.", groupCreatorImpl.getScopeId());
-            assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
+            Assert.assertNull("Null expected.", groupCreatorImpl.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, groupCreatorImpl.getName());
         }
     }
 
     @Test
     public void groupCreatorImplScopeIdNullNameParametersTest() {
         GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId, null);
-        assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
-        assertNull("Null expected.", groupCreatorImpl.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getName());
     }
 
     @Test
     public void groupCreatorImplNullScopeIdNullNameParametersTest() {
         GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null, null);
-        assertNull("Null expected.", groupCreatorImpl.getScopeId());
-        assertNull("Null expected.", groupCreatorImpl.getName());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getName());
     }
 
     @Test
     public void groupCreatorImplScopeIdParameterTest() {
         GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(scopeId);
-        assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
-        assertNull("Null expected.", groupCreatorImpl.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getName());
     }
 
     @Test
     public void groupCreatorImplNullScopeIdParameterTest() {
         GroupCreatorImpl groupCreatorImpl = new GroupCreatorImpl(null);
-        assertNull("Null expected.", groupCreatorImpl.getScopeId());
-        assertNull("Null expected.", groupCreatorImpl.getName());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupCreatorImpl.getName());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupFactoryImplTest.java
@@ -27,8 +27,9 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class GroupFactoryImplTest extends Assert {
+public class GroupFactoryImplTest {
 
     GroupFactoryImpl groupFactoryImpl;
     KapuaId scopeId;
@@ -60,8 +61,8 @@ public class GroupFactoryImplTest extends Assert {
     public void newCreatorScopeIdNameParametersTest() {
         for (String name : names) {
             GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId, name);
-            assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
-            assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
         }
     }
 
@@ -69,72 +70,72 @@ public class GroupFactoryImplTest extends Assert {
     public void newCreatorNullScopeIdNameParametersTest() {
         for (String name : names) {
             GroupCreator groupCreator = groupFactoryImpl.newCreator(null, name);
-            assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
-            assertNull("Null expected.", groupCreator.getScopeId());
+            Assert.assertEquals("Expected and actual values should be the same.", name, groupCreator.getName());
+            Assert.assertNull("Null expected.", groupCreator.getScopeId());
         }
     }
 
     @Test
     public void newCreatorScopeIdNullNameParametersTest() {
         GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId, null);
-        assertNull("Null expected.", groupCreator.getName());
-        assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+        Assert.assertNull("Null expected.", groupCreator.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
     }
 
     @Test
     public void newEntityTest() {
         Group group = groupFactoryImpl.newEntity(scopeId);
-        assertEquals("Expected and actual values should be the same.", scopeId, group.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, group.getScopeId());
     }
 
     @Test
     public void newEntityNullTest() {
         Group group = groupFactoryImpl.newEntity(null);
-        assertNull("Null expected.", group.getScopeId());
+        Assert.assertNull("Null expected.", group.getScopeId());
     }
 
     @Test
     public void newListResultTest() {
         GroupListResult groupListResult = groupFactoryImpl.newListResult();
-        assertTrue("True expected.", groupListResult.isEmpty());
+        Assert.assertTrue("True expected.", groupListResult.isEmpty());
     }
 
     @Test
     public void newQueryTest() {
         GroupQuery groupQuery = groupFactoryImpl.newQuery(scopeId);
-        assertEquals("Expected and actual values should be the same.", scopeId, groupQuery.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupQuery.getScopeId());
     }
 
     @Test
     public void newQueryNullTest() {
         GroupQuery groupQuery = groupFactoryImpl.newQuery(null);
-        assertNull("Null expected.", groupQuery.getScopeId());
+        Assert.assertNull("Null expected.", groupQuery.getScopeId());
     }
 
     @Test
     public void newCreatorTest() {
         GroupCreator groupCreator = groupFactoryImpl.newCreator(scopeId);
-        assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, groupCreator.getScopeId());
     }
 
     @Test
     public void newCreatorNullTest() {
         GroupCreator groupCreator = groupFactoryImpl.newCreator(null);
-        assertNull("Null expected.", groupCreator.getScopeId());
+        Assert.assertNull("Null expected.", groupCreator.getScopeId());
     }
 
     @Test
     public void cloneTest() {
         Group resultGroup = groupFactoryImpl.clone(group);
-        assertEquals("Expected and actual values should be the same.", "group name", resultGroup.getName());
-        assertEquals("Expected and actual values should be the same.", "description", resultGroup.getDescription());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, resultGroup.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getModifiedBy());
-        assertEquals("Expected and actual values should be the same.", modifiedOn, resultGroup.getModifiedOn());
-        assertEquals("Expected and actual values should be the same.", 11, resultGroup.getOptlock());
+        Assert.assertEquals("Expected and actual values should be the same.", "group name", resultGroup.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "description", resultGroup.getDescription());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultGroup.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, resultGroup.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultGroup.getModifiedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", modifiedOn, resultGroup.getModifiedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", 11, resultGroup.getOptlock());
     }
 
     @Test(expected = KapuaEntityCloneException.class)

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupImplTest.java
@@ -23,25 +23,26 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class GroupImplTest extends Assert {
+public class GroupImplTest {
 
     @Test
     public void groupImplWithoutParametersTest() {
         GroupImpl groupImpl = new GroupImpl();
-        assertNull("Null expected.", groupImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupImpl.getScopeId());
     }
 
     @Test
     public void groupImplScopeIdParameterTest() {
         GroupImpl groupImpl = new GroupImpl(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getScopeId());
     }
 
     @Test
     public void groupImplNullScopeIdParameterTest() {
         GroupImpl groupImpl = new GroupImpl((KapuaId) null);
-        assertNull("Null expected.", groupImpl.getScopeId());
+        Assert.assertNull("Null expected.", groupImpl.getScopeId());
     }
 
     @Test
@@ -61,15 +62,15 @@ public class GroupImplTest extends Assert {
         Mockito.when(group.getOptlock()).thenReturn(11);
 
         GroupImpl groupImpl = new GroupImpl(group);
-        assertEquals("Expected and actual values should be the same.", "group name", groupImpl.getName());
-        assertEquals("Expected and actual values should be the same.", "description", groupImpl.getDescription());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, groupImpl.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getModifiedBy());
-        assertEquals("Expected and actual values should be the same.", modifiedOn, groupImpl.getModifiedOn());
-        assertEquals("Expected and actual values should be the same.", 11, groupImpl.getOptlock());
+        Assert.assertEquals("Expected and actual values should be the same.", "group name", groupImpl.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "description", groupImpl.getDescription());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupImpl.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, groupImpl.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, groupImpl.getModifiedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", modifiedOn, groupImpl.getModifiedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", 11, groupImpl.getOptlock());
     }
 
     @Test(expected = NullPointerException.class)

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/group/shiro/GroupQueryImplTest.java
@@ -18,22 +18,23 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class GroupQueryImplTest extends Assert {
+public class GroupQueryImplTest {
 
     @Test
     public void groupQueryImplTest() {
         GroupQueryImpl groupQueryImpl = new GroupQueryImpl(KapuaId.ONE);
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupQueryImpl.getScopeId());
-        assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
-        assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, groupQueryImpl.getScopeId());
+        Assert.assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
+        Assert.assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
     public void groupQueryImplNullTest() {
         GroupQueryImpl groupQueryImpl = new GroupQueryImpl(null);
-        assertNull("Null expected.", groupQueryImpl.getScopeId());
-        assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
-        assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", groupQueryImpl.getScopeId());
+        Assert.assertNull("groupQueryImpl.sortCriteria", groupQueryImpl.getSortCriteria());
+        Assert.assertNotNull("groupQueryImpl.defaultSortCriteria", groupQueryImpl.getDefaultSortCriteria());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCacheFactoryTest.java
@@ -20,20 +20,21 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class RoleCacheFactoryTest extends Assert {
+public class RoleCacheFactoryTest {
 
     @Test
     public void roleCacheFactoryTest() throws Exception {
         Constructor<RoleCacheFactory> roleCacheFactory = RoleCacheFactory.class.getDeclaredConstructor();
         roleCacheFactory.setAccessible(true);
         roleCacheFactory.newInstance();
-        assertTrue("True expected.", Modifier.isPrivate(roleCacheFactory.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(roleCacheFactory.getModifiers()));
     }
 
     @Test
     public void getInstanceTest() {
-        assertTrue("True expected.", RoleCacheFactory.getInstance() instanceof RoleCacheFactory);
-        assertEquals("Expected and actual values should be the same.", "RoleId", RoleCacheFactory.getInstance().getEntityIdCacheName());
+        Assert.assertTrue("True expected.", RoleCacheFactory.getInstance() instanceof RoleCacheFactory);
+        Assert.assertEquals("Expected and actual values should be the same.", "RoleId", RoleCacheFactory.getInstance().getEntityIdCacheName());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleCreatorImplTest.java
@@ -24,8 +24,9 @@ import org.mockito.Mockito;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class RoleCreatorImplTest extends Assert {
+public class RoleCreatorImplTest {
 
     RoleCreatorImpl roleCreatorImpl;
     Set<Permission> permissions;
@@ -44,15 +45,15 @@ public class RoleCreatorImplTest extends Assert {
         KapuaId[] scopeIds = {KapuaId.ONE, null};
         for (KapuaId scopeId : scopeIds) {
             RoleCreatorImpl roleCreatorImpl = new RoleCreatorImpl(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, roleCreatorImpl.getScopeId());
-            assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleCreatorImpl.getScopeId());
+            Assert.assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
         }
     }
 
     @Test
     public void setAndGetEmptyPermissionsTest() {
         roleCreatorImpl.setPermissions(permissions);
-        assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+        Assert.assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
     }
 
     @Test
@@ -62,14 +63,14 @@ public class RoleCreatorImplTest extends Assert {
         permissions.add(null);
 
         roleCreatorImpl.setPermissions(permissions);
-        assertFalse("False expected.", roleCreatorImpl.getPermissions().isEmpty());
-        assertEquals("Expected and actual values should be the same.", permissions, roleCreatorImpl.getPermissions());
-        assertEquals("Expected and actual values should be the same.", 3, roleCreatorImpl.getPermissions().size());
+        Assert.assertFalse("False expected.", roleCreatorImpl.getPermissions().isEmpty());
+        Assert.assertEquals("Expected and actual values should be the same.", permissions, roleCreatorImpl.getPermissions());
+        Assert.assertEquals("Expected and actual values should be the same.", 3, roleCreatorImpl.getPermissions().size());
     }
 
     @Test
     public void setAndGetNullPermissionsTest() {
         roleCreatorImpl.setPermissions(null);
-        assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
+        Assert.assertTrue("True expected.", roleCreatorImpl.getPermissions().isEmpty());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleFactoryImplTest.java
@@ -27,8 +27,9 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class RoleFactoryImplTest extends Assert {
+public class RoleFactoryImplTest {
 
     RoleFactoryImpl roleFactoryImpl;
     KapuaId scopeId;
@@ -56,64 +57,64 @@ public class RoleFactoryImplTest extends Assert {
 
     @Test
     public void newEntityTest() {
-        assertTrue("True expected.", roleFactoryImpl.newEntity(scopeId) instanceof Role);
-        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newEntity(scopeId).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newEntity(scopeId) instanceof Role);
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newEntity(scopeId).getScopeId());
     }
 
     @Test
     public void newEntityNullTest() {
-        assertTrue("True expected.", roleFactoryImpl.newEntity(null) instanceof Role);
-        assertNull("Null expected.", roleFactoryImpl.newEntity(null).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newEntity(null) instanceof Role);
+        Assert.assertNull("Null expected.", roleFactoryImpl.newEntity(null).getScopeId());
     }
 
     @Test
     public void newCreatorTest() {
-        assertTrue("True expected.", roleFactoryImpl.newCreator(scopeId) instanceof RoleCreator);
-        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newCreator(scopeId).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newCreator(scopeId) instanceof RoleCreator);
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newCreator(scopeId).getScopeId());
     }
 
     @Test
     public void newCreatorNullTest() {
-        assertTrue("True expected.", roleFactoryImpl.newCreator(null) instanceof RoleCreator);
-        assertNull("Null expected.", roleFactoryImpl.newCreator(null).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newCreator(null) instanceof RoleCreator);
+        Assert.assertNull("Null expected.", roleFactoryImpl.newCreator(null).getScopeId());
     }
 
     @Test
     public void newQueryTest() {
-        assertTrue("True expected.", roleFactoryImpl.newQuery(scopeId) instanceof RoleQuery);
-        assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newQuery(scopeId).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newQuery(scopeId) instanceof RoleQuery);
+        Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleFactoryImpl.newQuery(scopeId).getScopeId());
     }
 
     @Test
     public void newQueryNullTest() {
-        assertTrue("True expected.", roleFactoryImpl.newQuery(null) instanceof RoleQuery);
-        assertNull("Null expected.", roleFactoryImpl.newQuery(null).getScopeId());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newQuery(null) instanceof RoleQuery);
+        Assert.assertNull("Null expected.", roleFactoryImpl.newQuery(null).getScopeId());
     }
 
     @Test
     public void newListResultTest() {
-        assertTrue("True expected.", roleFactoryImpl.newListResult() instanceof RoleListResult);
-        assertTrue("True expected.", roleFactoryImpl.newListResult().isEmpty());
+        Assert.assertTrue("True expected.", roleFactoryImpl.newListResult() instanceof RoleListResult);
+        Assert.assertTrue("True expected.", roleFactoryImpl.newListResult().isEmpty());
     }
 
     @Test
     public void newRolePermissionTest() {
-        assertTrue("True expected.", roleFactoryImpl.newRolePermission() instanceof RolePermission);
+        Assert.assertTrue("True expected.", roleFactoryImpl.newRolePermission() instanceof RolePermission);
     }
 
     @Test
     public void cloneTest() {
         Role resultRole = roleFactoryImpl.clone(role);
 
-        assertEquals("Expected and actual values should be the same.", "role name", resultRole.getName());
-        assertEquals("Expected and actual values should be the same.", "role description", resultRole.getDescription());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, resultRole.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getModifiedBy());
-        assertEquals("Expected and actual values should be the same.", modifiedOn, resultRole.getModifiedOn());
-        assertEquals("Expected and actual values should be the same.", 11, resultRole.getOptlock());
+        Assert.assertEquals("Expected and actual values should be the same.", "role name", resultRole.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "role description", resultRole.getDescription());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, resultRole.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, resultRole.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, resultRole.getModifiedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", modifiedOn, resultRole.getModifiedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", 11, resultRole.getOptlock());
     }
 
     @Test
@@ -121,7 +122,7 @@ public class RoleFactoryImplTest extends Assert {
         try {
             roleFactoryImpl.clone(null);
         } catch (Exception e) {
-            assertEquals("Expected and actual values should be the same", "org.eclipse.kapua.KapuaEntityCloneException: Severe error while cloning: role", e.toString());
+            Assert.assertEquals("Expected and actual values should be the same", "org.eclipse.kapua.KapuaEntityCloneException: Severe error while cloning: role", e.toString());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleImplTest.java
@@ -24,8 +24,9 @@ import org.mockito.Mockito;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class RoleImplTest extends Assert {
+public class RoleImplTest {
 
     RoleImpl role1, role2;
 
@@ -38,9 +39,9 @@ public class RoleImplTest extends Assert {
     @Test
     public void roleImplWithoutParametersTest() {
         RoleImpl roleImpl = new RoleImpl();
-        assertNull("Null expected.", roleImpl.getScopeId());
-        assertNull("Null expected.", roleImpl.getName());
-        assertNull("Null expected.", roleImpl.getDescription());
+        Assert.assertNull("Null expected.", roleImpl.getScopeId());
+        Assert.assertNull("Null expected.", roleImpl.getName());
+        Assert.assertNull("Null expected.", roleImpl.getDescription());
     }
 
     @Test
@@ -49,9 +50,9 @@ public class RoleImplTest extends Assert {
 
         for (KapuaId scopeId : scopeIds) {
             RoleImpl roleImpl = new RoleImpl(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, roleImpl.getScopeId());
-            assertNull("Null expected.", roleImpl.getName());
-            assertNull("Null expected.", roleImpl.getDescription());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleImpl.getScopeId());
+            Assert.assertNull("Null expected.", roleImpl.getName());
+            Assert.assertNull("Null expected.", roleImpl.getDescription());
         }
     }
 
@@ -72,15 +73,15 @@ public class RoleImplTest extends Assert {
         Mockito.when(role.getOptlock()).thenReturn(11);
 
         RoleImpl roleImpl = new RoleImpl(role);
-        assertEquals("Expected and actual values should be the same.", "role name", roleImpl.getName());
-        assertEquals("Expected and actual values should be the same.", "role description", roleImpl.getDescription());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getScopeId());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getCreatedBy());
-        assertEquals("Expected and actual values should be the same.", createdOn, roleImpl.getCreatedOn());
-        assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getModifiedBy());
-        assertEquals("Expected and actual values should be the same.", modifiedOn, roleImpl.getModifiedOn());
-        assertEquals("Expected and actual values should be the same.", 11, roleImpl.getOptlock());
+        Assert.assertEquals("Expected and actual values should be the same.", "role name", roleImpl.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "role description", roleImpl.getDescription());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getScopeId());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ONE, roleImpl.getCreatedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", createdOn, roleImpl.getCreatedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaId.ANY, roleImpl.getModifiedBy());
+        Assert.assertEquals("Expected and actual values should be the same.", modifiedOn, roleImpl.getModifiedOn());
+        Assert.assertEquals("Expected and actual values should be the same.", 11, roleImpl.getOptlock());
     }
 
     @Test(expected = NullPointerException.class)
@@ -91,7 +92,7 @@ public class RoleImplTest extends Assert {
     @Test
     public void hashCodeNullNameTest() {
         RoleImpl role = new RoleImpl();
-        assertEquals("Expected and actual values should be the same.", 31, role.hashCode());
+        Assert.assertEquals("Expected and actual values should be the same.", 31, role.hashCode());
     }
 
     @Test
@@ -101,47 +102,47 @@ public class RoleImplTest extends Assert {
         int[] expectedResult = {31, 467704822, -586547515, -576050570, 589188417, -894904038, -1874261591, 12362811};
         for (int i = 0; i < names.length; i++) {
             role.setName(names[i]);
-            assertEquals("Expected and actual values should be the same.", expectedResult[i], role.hashCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedResult[i], role.hashCode());
         }
     }
 
     @Test
     public void equalsSameObjectTest() {
-        assertTrue("True expected.", role1.equals(role1));
+        Assert.assertTrue("True expected.", role1.equals(role1));
     }
 
     @Test
     public void equalsNullObjectTest() {
-        assertFalse("False expected.", role1.equals(null));
+        Assert.assertFalse("False expected.", role1.equals(null));
     }
 
     @Test
     public void equalsObjectTest() {
-        assertFalse("False expected.", role1.equals(new Object()));
+        Assert.assertFalse("False expected.", role1.equals(new Object()));
     }
 
     @Test
     public void equalsNullBothNamesTest() {
-        assertTrue("True expected.", role1.equals(role2));
+        Assert.assertTrue("True expected.", role1.equals(role2));
     }
 
     @Test
     public void equalsNullNameTest() {
         role2.setName("name2");
-        assertFalse("False expected.", role1.equals(role2));
+        Assert.assertFalse("False expected.", role1.equals(role2));
     }
 
     @Test
     public void equalsDifferentNamesTest() {
         role1.setName("name1");
         role2.setName("name2");
-        assertFalse("False expected.", role1.equals(role2));
+        Assert.assertFalse("False expected.", role1.equals(role2));
     }
 
     @Test
     public void equalsSameNamesTest() {
         role1.setName("name");
         role2.setName("name");
-        assertTrue("True expected.", role1.equals(role2));
+        Assert.assertTrue("True expected.", role1.equals(role2));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactoryTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCacheFactoryTest.java
@@ -20,20 +20,21 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class RolePermissionCacheFactoryTest extends Assert {
+public class RolePermissionCacheFactoryTest {
 
     @Test
     public void rolePermissionCacheFactoryTest() throws Exception {
         Constructor<RolePermissionCacheFactory> rolePermissionCacheFactory = RolePermissionCacheFactory.class.getDeclaredConstructor();
         rolePermissionCacheFactory.setAccessible(true);
         rolePermissionCacheFactory.newInstance();
-        assertTrue("True expected.", Modifier.isPrivate(rolePermissionCacheFactory.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(rolePermissionCacheFactory.getModifiers()));
     }
 
     @Test
     public void getInstanceTest() {
-        assertTrue("True expected.", RolePermissionCacheFactory.getInstance() instanceof RolePermissionCacheFactory);
-        assertEquals("Expected and actual values should be the same.", "RolePermissionId", RolePermissionCacheFactory.getInstance().getEntityIdCacheName());
+        Assert.assertTrue("True expected.", RolePermissionCacheFactory.getInstance() instanceof RolePermissionCacheFactory);
+        Assert.assertEquals("Expected and actual values should be the same.", "RolePermissionId", RolePermissionCacheFactory.getInstance().getEntityIdCacheName());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionCreatorImplTest.java
@@ -20,17 +20,18 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+
 @Category(JUnitTests.class)
-public class RolePermissionCreatorImplTest extends Assert {
+public class RolePermissionCreatorImplTest {
 
     @Test
     public void rolePermissionCreatorImplTest() {
         KapuaId[] scopeIds = {null, KapuaId.ANY};
         for (KapuaId scopeId : scopeIds) {
             RolePermissionCreatorImpl rolePermissionCreatorImpl = new RolePermissionCreatorImpl(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionCreatorImpl.getScopeId());
-            assertNull("Null expected.", rolePermissionCreatorImpl.getRoleId());
-            assertNull("Null expected.", rolePermissionCreatorImpl.getPermission());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionCreatorImpl.getScopeId());
+            Assert.assertNull("Null expected.", rolePermissionCreatorImpl.getRoleId());
+            Assert.assertNull("Null expected.", rolePermissionCreatorImpl.getPermission());
         }
     }
 
@@ -41,7 +42,7 @@ public class RolePermissionCreatorImplTest extends Assert {
 
         for (KapuaId roleId : roleIds) {
             rolePermissionCreatorImpl.setRoleId(roleId);
-            assertEquals("Expected and actual values should be the same.", roleId, rolePermissionCreatorImpl.getRoleId());
+            Assert.assertEquals("Expected and actual values should be the same.", roleId, rolePermissionCreatorImpl.getRoleId());
         }
     }
 
@@ -52,7 +53,7 @@ public class RolePermissionCreatorImplTest extends Assert {
 
         for (Permission permission : permissions) {
             rolePermissionCreatorImpl.setPermission(permission);
-            assertEquals("Expected and actual values should be the same.", permission, rolePermissionCreatorImpl.getPermission());
+            Assert.assertEquals("Expected and actual values should be the same.", permission, rolePermissionCreatorImpl.getPermission());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RolePermissionQueryImplTest.java
@@ -18,15 +18,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class RolePermissionQueryImplTest extends Assert {
+public class RolePermissionQueryImplTest {
 
     @Test
     public void rolePermissionQueryImplWithoutParametersTest() {
         RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl();
-        assertNull("Null expected.", rolePermissionQueryImpl.getScopeId());
-        assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
-        assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", rolePermissionQueryImpl.getScopeId());
+        Assert.assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
+        Assert.assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -35,9 +36,9 @@ public class RolePermissionQueryImplTest extends Assert {
 
         for (KapuaId scopeId : scopeIds) {
             RolePermissionQueryImpl rolePermissionQueryImpl = new RolePermissionQueryImpl(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionQueryImpl.getScopeId());
-            assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
-            assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, rolePermissionQueryImpl.getScopeId());
+            Assert.assertNull("rolePermissionQueryImpl.sortCriteria", rolePermissionQueryImpl.getSortCriteria());
+            Assert.assertNotNull("rolePermissionQueryImpl.defaultSortCriteria", rolePermissionQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/role/shiro/RoleQueryImplTest.java
@@ -18,15 +18,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class RoleQueryImplTest extends Assert {
+public class RoleQueryImplTest {
 
     @Test
     public void rolePermissionQueryImplWithoutParametersTest() {
         RoleQueryImpl roleQueryImpl = new RoleQueryImpl();
-        assertNull("Null expected.", roleQueryImpl.getScopeId());
-        assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
-        assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
+        Assert.assertNull("Null expected.", roleQueryImpl.getScopeId());
+        Assert.assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
+        Assert.assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
     }
 
     @Test
@@ -35,9 +36,9 @@ public class RoleQueryImplTest extends Assert {
 
         for (KapuaId scopeId : scopeIds) {
             RoleQueryImpl roleQueryImpl = new RoleQueryImpl(scopeId);
-            assertEquals("Expected and actual values should be the same.", scopeId, roleQueryImpl.getScopeId());
-            assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
-            assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
+            Assert.assertEquals("Expected and actual values should be the same.", scopeId, roleQueryImpl.getScopeId());
+            Assert.assertNull("roleQueryImpl.sortCriteria", roleQueryImpl.getSortCriteria());
+            Assert.assertNotNull("roleQueryImpl.defaultSortCriteria", roleQueryImpl.getDefaultSortCriteria());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealmTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/KapuaAuthorizingRealmTest.java
@@ -21,8 +21,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+
 @Category(JUnitTests.class)
-public class KapuaAuthorizingRealmTest extends Assert {
+public class KapuaAuthorizingRealmTest {
 
     KapuaAuthorizingRealm kapuaAuthorizingRealm;
     AuthenticationToken authenticationToken;
@@ -35,26 +36,26 @@ public class KapuaAuthorizingRealmTest extends Assert {
 
     @Test
     public void kapuaAuthorizingRealmTest() {
-        assertEquals("Expected and actual values should be the same.", "kapuaAuthorizingRealm", kapuaAuthorizingRealm.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", "kapuaAuthorizingRealm", kapuaAuthorizingRealm.getName());
     }
 
     @Test
     public void supportsTest() {
-        assertFalse("False expected.", kapuaAuthorizingRealm.supports(authenticationToken));
+        Assert.assertFalse("False expected.", kapuaAuthorizingRealm.supports(authenticationToken));
     }
 
     @Test
     public void supportsNullTest() {
-        assertFalse("False expected.", kapuaAuthorizingRealm.supports(null));
+        Assert.assertFalse("False expected.", kapuaAuthorizingRealm.supports(null));
     }
 
     @Test
     public void doGetAuthenticationInfoTest() {
-        assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
+        Assert.assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
     }
 
     @Test
     public void doGetAuthenticationInfoNullTest() {
-        assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
+        Assert.assertNull("Null expected.", kapuaAuthorizingRealm.doGetAuthenticationInfo(authenticationToken));
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/InternalUserOnlyExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/InternalUserOnlyExceptionTest.java
@@ -17,15 +17,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class InternalUserOnlyExceptionTest extends Assert {
+public class InternalUserOnlyExceptionTest {
 
     @Test
     public void internalUserOnlyExceptionTest() {
         InternalUserOnlyException internalUserOnlyException = new InternalUserOnlyException();
-        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.INTERNAL_USER_ONLY, internalUserOnlyException.getCode());
-        assertNull("Null expected.", internalUserOnlyException.getCause());
-        assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", internalUserOnlyException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.INTERNAL_USER_ONLY, internalUserOnlyException.getCode());
+        Assert.assertNull("Null expected.", internalUserOnlyException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "This action can be performed only by internal users.", internalUserOnlyException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", internalUserOnlyException.getKapuaErrorMessagesBundle());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaAuthorizationExceptionTest extends Assert {
+public class KapuaAuthorizationExceptionTest {
 
     KapuaAuthorizationErrorCodes[] kapuaAuthorizationErrorCodes;
     Object stringArgument, intArgument, booleanArgument;
@@ -44,24 +45,24 @@ public class KapuaAuthorizationExceptionTest extends Assert {
     public void kapuaAuthorizationExceptionCodeParameterTest() {
         for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i]);
-            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
-            assertNull("Null expected.", kapuaAuthorizationException.getCause());
-            assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
     @Test
     public void kapuaAuthorizationExceptionNullCodeParameterTest() {
         KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null);
-        assertNull("Null expected.", kapuaAuthorizationException.getCode());
-        assertNull("Null expected.", kapuaAuthorizationException.getCause());
-        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
+        Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         try {
             kapuaAuthorizationException.getMessage();
-            fail("NullPointerException expected");
+            Assert.fail("NullPointerException expected");
         } catch (Exception e) {
-            assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -69,10 +70,10 @@ public class KapuaAuthorizationExceptionTest extends Assert {
     public void kapuaAuthorizationExceptionCodeArgumentsParametersTest() {
         for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], stringArgument, intArgument, booleanArgument);
-            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
-            assertNull("Null expected.", kapuaAuthorizationException.getCause());
-            assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -80,14 +81,14 @@ public class KapuaAuthorizationExceptionTest extends Assert {
     public void kapuaAuthorizationExceptionNullCodeArgumentsParametersTest() {
         for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, stringArgument, intArgument, booleanArgument);
-            assertNull("Null expected.", kapuaAuthorizationException.getCode());
-            assertNull("Null expected.", kapuaAuthorizationException.getCause());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             try {
                 kapuaAuthorizationException.getMessage();
-                fail("NullPointerException expected");
+                Assert.fail("NullPointerException expected");
             } catch (Exception e) {
-                assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -96,10 +97,10 @@ public class KapuaAuthorizationExceptionTest extends Assert {
     public void kapuaAuthorizationExceptionCodeNullArgumentsParametersTest() {
         for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], null);
-            assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
-            assertNull("Null expected.", kapuaAuthorizationException.getCause());
-            assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -108,10 +109,10 @@ public class KapuaAuthorizationExceptionTest extends Assert {
         for (Throwable throwable : throwables) {
             for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
                 KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], throwable, stringArgument, intArgument, booleanArgument);
-                assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
-                assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
-                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -120,14 +121,14 @@ public class KapuaAuthorizationExceptionTest extends Assert {
     public void kapuaAuthorizationExceptionNullCodeCauseArgumentsParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, throwable, stringArgument, intArgument, booleanArgument);
-            assertNull("Null expected.", kapuaAuthorizationException.getCode());
-            assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             try {
                 kapuaAuthorizationException.getMessage();
-                fail("NullPointerException expected");
+                Assert.fail("NullPointerException expected");
             } catch (Exception e) {
-                assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -137,10 +138,10 @@ public class KapuaAuthorizationExceptionTest extends Assert {
         for (Throwable throwable : throwables) {
             for (int i = 0; i < kapuaAuthorizationErrorCodes.length; i++) {
                 KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(kapuaAuthorizationErrorCodes[i], throwable, null);
-                assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
-                assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
-                assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             }
         }
     }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SelfManagedOnlyExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SelfManagedOnlyExceptionTest.java
@@ -17,15 +17,16 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class SelfManagedOnlyExceptionTest extends Assert {
+public class SelfManagedOnlyExceptionTest {
 
     @Test
     public void selfManagedOnlyExceptionTest() {
         SelfManagedOnlyException selfManagedOnlyException = new SelfManagedOnlyException();
-        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SELF_MANAGED_ONLY, selfManagedOnlyException.getCode());
-        assertNull("Null expected.", selfManagedOnlyException.getCause());
-        assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyException.getMessage());
-        assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", selfManagedOnlyException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SELF_MANAGED_ONLY, selfManagedOnlyException.getCode());
+        Assert.assertNull("Null expected.", selfManagedOnlyException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "User cannot perform this action on behalf of another user. This action can be performed only in self-management.", selfManagedOnlyException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", "kapua-service-error-messages", selfManagedOnlyException.getKapuaErrorMessagesBundle());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/SubjectUnauthorizedExceptionTest.java
@@ -20,8 +20,9 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
 
+
 @Category(JUnitTests.class)
-public class SubjectUnauthorizedExceptionTest extends Assert {
+public class SubjectUnauthorizedExceptionTest {
 
     Permission permission, newPermission;
     SubjectUnauthorizedException subjectUnauthorizedException;
@@ -37,20 +38,20 @@ public class SubjectUnauthorizedExceptionTest extends Assert {
 
     @Test
     public void subjectUnauthorizedExceptionTest() {
-        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
-        assertNull("Null expected.", subjectUnauthorizedException.getCause());
-        assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Required permission: " + permission + ".", subjectUnauthorizedException.getMessage());
-        assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedException.getPermission());
-        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
+        Assert.assertNull("Null expected.", subjectUnauthorizedException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Required permission: " + permission + ".", subjectUnauthorizedException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", permission, subjectUnauthorizedException.getPermission());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
     }
 
     @Test
     public void subjectUnauthorizedExceptionNullTest() {
         subjectUnauthorizedException = new SubjectUnauthorizedException(null);
-        assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
-        assertNull("Null expected.", subjectUnauthorizedException.getCause());
-        assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Required permission: null.", subjectUnauthorizedException.getMessage());
-        assertNull("Null expected.", subjectUnauthorizedException.getPermission());
-        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Expected and actual values should be the same.", KapuaAuthorizationErrorCodes.SUBJECT_UNAUTHORIZED, subjectUnauthorizedException.getCode());
+        Assert.assertNull("Null expected.", subjectUnauthorizedException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", "User does not have permission to perform this action. Required permission: null.", subjectUnauthorizedException.getMessage());
+        Assert.assertNull("Null expected.", subjectUnauthorizedException.getPermission());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, subjectUnauthorizedException.getKapuaErrorMessagesBundle());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeysTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingKeysTest.java
@@ -17,12 +17,13 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class KapuaAuthorizationSettingKeysTest extends Assert {
+public class KapuaAuthorizationSettingKeysTest {
 
     @Test
     public void keyTest() {
-        assertEquals("Expected and actual values should be the same.", "authorization.key", KapuaAuthorizationSettingKeys.AUTHORIZATION_KEY.key());
-        assertEquals("Expected and actual values should be the same.", "authorization.eventAddress", KapuaAuthorizationSettingKeys.AUTHORIZATION_EVENT_ADDRESS.key());
+        Assert.assertEquals("Expected and actual values should be the same.", "authorization.key", KapuaAuthorizationSettingKeys.AUTHORIZATION_KEY.key());
+        Assert.assertEquals("Expected and actual values should be the same.", "authorization.eventAddress", KapuaAuthorizationSettingKeys.AUTHORIZATION_EVENT_ADDRESS.key());
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/setting/KapuaAuthorizationSettingTest.java
@@ -20,19 +20,20 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class KapuaAuthorizationSettingTest extends Assert {
+public class KapuaAuthorizationSettingTest {
 
     @Test
     public void kapuaAuthorizationSettingTest() throws Exception {
         Constructor<KapuaAuthorizationSetting> kapuaAuthorizationSetting = KapuaAuthorizationSetting.class.getDeclaredConstructor();
-        assertTrue("True expected.", Modifier.isPrivate(kapuaAuthorizationSetting.getModifiers()));
+        Assert.assertTrue("True expected.", Modifier.isPrivate(kapuaAuthorizationSetting.getModifiers()));
         kapuaAuthorizationSetting.setAccessible(true);
         kapuaAuthorizationSetting.newInstance();
     }
 
     @Test
     public void getInstanceTest() {
-        assertTrue("True expected.", KapuaAuthorizationSetting.getInstance() instanceof KapuaAuthorizationSetting);
+        Assert.assertTrue("True expected.", KapuaAuthorizationSetting.getInstance() instanceof KapuaAuthorizationSetting);
     }
 }

--- a/service/stream/api/src/test/java/org/eclipse/kapua/service/stream/StreamDomainTest.java
+++ b/service/stream/api/src/test/java/org/eclipse/kapua/service/stream/StreamDomainTest.java
@@ -23,8 +23,9 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
 
+
 @Category(JUnitTests.class)
-public class StreamDomainTest extends Assert {
+public class StreamDomainTest {
 
     StreamDomain streamDomain;
 
@@ -36,17 +37,17 @@ public class StreamDomainTest extends Assert {
     @Test
     public void getNameTest() {
         String expectedName = "stream";
-        assertEquals("Expected and actual values should be the same.", expectedName, streamDomain.getName());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedName, streamDomain.getName());
     }
 
     @Test
     public void getActionsTest() {
         Set expectedValue = new HashSet(Arrays.asList(Actions.write));
-        assertEquals("Expected and actual values should be the same.", expectedValue, streamDomain.getActions());
+        Assert.assertEquals("Expected and actual values should be the same.", expectedValue, streamDomain.getActions());
     }
 
     @Test
     public void getGroupableTest() {
-        assertFalse("False expected.", streamDomain.getGroupable());
+        Assert.assertFalse("False expected.", streamDomain.getGroupable());
     }
 }

--- a/service/stream/api/src/test/java/org/eclipse/kapua/service/stream/StreamDomainsTest.java
+++ b/service/stream/api/src/test/java/org/eclipse/kapua/service/stream/StreamDomainsTest.java
@@ -21,13 +21,14 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class StreamDomainsTest extends Assert {
+public class StreamDomainsTest {
 
     @Test
     public void streamDomainsTest() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, InstantiationException {
         Constructor<StreamDomains> streamDomains = StreamDomains.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(streamDomains.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(streamDomains.getModifiers()));
         streamDomains.setAccessible(true);
         streamDomains.newInstance();
     }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportClientGetExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportClientGetExceptionTest.java
@@ -17,16 +17,17 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class TransportClientGetExceptionTest extends Assert {
+public class TransportClientGetExceptionTest {
 
     @Test
     public void transportClientGetExceptionNullServerIpTest() {
         TransportClientGetException transportClientGetException = new TransportClientGetException(null);
-        assertNull("Null expected.", transportClientGetException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
-        assertNull("Null expected.", transportClientGetException.getCause());
+        Assert.assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        Assert.assertNull("Null expected.", transportClientGetException.getCause());
     }
 
     @Test
@@ -34,20 +35,20 @@ public class TransportClientGetExceptionTest extends Assert {
         String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
         for (String randomString : randomStrings) {
             TransportClientGetException transportClientGetException = new TransportClientGetException(randomString);
-            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
-            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
-            assertNull("Null expected.", transportClientGetException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            Assert.assertNull("Null expected.", transportClientGetException.getCause());
         }
     }
 
     @Test
     public void transportClientGetExceptionCauseServerIpNullTest() {
         TransportClientGetException transportClientGetException = new TransportClientGetException(null, null);
-        assertNull("Null expected.", transportClientGetException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
-        assertNull("Null expected.", transportClientGetException.getCause());
+        Assert.assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        Assert.assertNull("Null expected.", transportClientGetException.getCause());
     }
 
     @Test
@@ -56,10 +57,10 @@ public class TransportClientGetExceptionTest extends Assert {
         String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
         for (String randomString : randomStrings) {
             TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, randomString);
-            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
-            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
-            assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
         }
     }
 
@@ -68,10 +69,10 @@ public class TransportClientGetExceptionTest extends Assert {
         String[] randomStrings = {"a", "0.0.0.0", "asdfasfasfaf", "{@}]~ˇ^°˘˘˛˘`", "test", "127.0.0.0"};
         for (String randomString : randomStrings) {
             TransportClientGetException transportClientGetException = new TransportClientGetException(null, randomString);
-            assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
-            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-            assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
-            assertNull("Null expected.", transportClientGetException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", randomString, transportClientGetException.getRequestMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: " + randomString, transportClientGetException.getMessage());
+            Assert.assertNull("Null expected.", transportClientGetException.getCause());
         }
     }
 
@@ -79,10 +80,10 @@ public class TransportClientGetExceptionTest extends Assert {
     public void transportClientGetExceptionCauseNullServerIpTest() {
         Throwable throwable = new Throwable();
         TransportClientGetException transportClientGetException = new TransportClientGetException(throwable, null);
-        assertNull("Null expected.", transportClientGetException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
-        assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
-        assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
+        Assert.assertNull("Null expected.", transportClientGetException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.CLIENT_GET, transportClientGetException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "Cannot get an instance of the transport client to connect to host: null", transportClientGetException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", throwable, transportClientGetException.getCause());
     }
 
     @Test(expected = TransportClientGetException.class)

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportExceptionTest.java
@@ -20,8 +20,9 @@ import org.junit.experimental.categories.Category;
 
 import org.checkerframework.checker.nullness.qual.Nullable;
 
+
 @Category(JUnitTests.class)
-public class TransportExceptionTest extends Assert {
+public class TransportExceptionTest {
 
     TransportErrorCodes[] transportErrorCodes;
     String kapuaErrorMessage;
@@ -61,23 +62,23 @@ public class TransportExceptionTest extends Assert {
     public void transportExceptionCodeTest() {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i]);
-            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
-            assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-            assertNull("Null expected.", transportException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", transportException.getCause());
         }
     }
 
     @Test
     public void transportExceptionNullCodeTest() {
         TransportException transportException = new TransportExceptionImpl(null);
-        assertNull("Null expected.", transportException.getCode());
-        assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-        assertNull("Null expected.", transportException.getCause());
+        Assert.assertNull("Null expected.", transportException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+        Assert.assertNull("Null expected.", transportException.getCause());
         try {
             transportException.getMessage();
         } catch (Exception e) {
-            assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
         }
     }
 
@@ -85,10 +86,10 @@ public class TransportExceptionTest extends Assert {
     public void transportExceptionCodeArgumentsTest() {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], object, stringObject, intObject);
-            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
-            assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-            assertNull("Null expected.", transportException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", transportException.getCause());
         }
     }
 
@@ -96,10 +97,10 @@ public class TransportExceptionTest extends Assert {
     public void transportExceptionCodeNullArgumentsTest() {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], null);
-            assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
-            assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-            assertNull("Null expected.", transportException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", transportException.getCause());
         }
     }
 
@@ -107,13 +108,13 @@ public class TransportExceptionTest extends Assert {
     public void transportExceptionNullCodeArgumentsTest() {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             TransportException transportException = new TransportExceptionImpl(null, object, stringObject, intObject);
-            assertNull("Null expected.", transportException.getCode());
-            assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-            assertNull("Null expected.", transportException.getCause());
+            Assert.assertNull("Null expected.", transportException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+            Assert.assertNull("Null expected.", transportException.getCause());
             try {
                 transportException.getMessage();
             } catch (Exception e) {
-                assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
             }
         }
     }
@@ -123,10 +124,10 @@ public class TransportExceptionTest extends Assert {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             for (Throwable cause : throwable) {
                 TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], cause, object, stringObject, intObject);
-                assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
-                assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
-                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithObject[i], transportException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
             }
         }
     }
@@ -136,10 +137,10 @@ public class TransportExceptionTest extends Assert {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             for (Throwable cause : throwable) {
                 TransportException transportException = new TransportExceptionImpl(transportErrorCodes[i], cause, null);
-                assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
-                assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
-                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+                Assert.assertEquals("Expected and actual values should be the same.", transportErrorCodes[i], transportException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutObject[i], transportException.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
             }
         }
     }
@@ -149,13 +150,13 @@ public class TransportExceptionTest extends Assert {
         for (int i = 0; i < transportErrorCodes.length; i++) {
             for (Throwable cause : throwable) {
                 TransportException transportException = new TransportExceptionImpl(null, cause, object, stringObject, intObject);
-                assertNull("Null expected.", transportException.getCode());
-                assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
-                assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
+                Assert.assertNull("Null expected.", transportException.getCode());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, transportException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", cause, transportException.getCause());
                 try {
                     transportException.getMessage();
                 } catch (Exception e) {
-                    assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
+                    Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
                 }
             }
         }

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportSendExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportSendExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class TransportSendExceptionTest extends Assert {
+public class TransportSendExceptionTest {
 
     TransportMessage transportMessage;
     Throwable throwable;
@@ -39,55 +40,55 @@ public class TransportSendExceptionTest extends Assert {
     @Test
     public void transportSendExceptionWithMessageTest() {
         TransportSendException transportSendException = new TransportSendException(transportMessage);
-        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
-        assertNull("Null expected.", transportSendException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        Assert.assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
     public void transportSendExceptionWithNullMessageTest() {
         TransportSendException transportSendException = new TransportSendException(null);
-        assertNull("Null expected.", transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
-        assertNull("Null expected.", transportSendException.getCause());
+        Assert.assertNull("Null expected.", transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        Assert.assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
     public void transportSendExceptionWithCauseAndMessageTest() {
         TransportSendException transportSendException = new TransportSendException(throwable, transportMessage);
-        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
-        assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
     }
 
     @Test
     public void transportSendExceptionWithCauseAndMessageNullTest() {
         TransportSendException transportSendException = new TransportSendException(null, null);
-        assertNull("Null expected.", transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
-        assertNull("Null expected.", transportSendException.getCause());
+        Assert.assertNull("Null expected.", transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        Assert.assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
     public void transportSendExceptionWithNullCauseAndMessageTest() {
         TransportSendException transportSendException = new TransportSendException(null, transportMessage);
-        assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
-        assertNull("Null expected.", transportSendException.getCause());
+        Assert.assertEquals("Expected and actual values should be the same.", transportMessage, transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: " + transportMessage, transportSendException.getMessage());
+        Assert.assertNull("Null expected.", transportSendException.getCause());
     }
 
     @Test
     public void transportSendExceptionWithCauseAndNullMessageTest() {
         TransportSendException transportSendException = new TransportSendException(throwable, null);
-        assertNull("Null expected.", transportSendException.getRequestMessage());
-        assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
-        assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
-        assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
+        Assert.assertNull("Null expected.", transportSendException.getRequestMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.SEND_ERROR, transportSendException.getCode());
+        Assert.assertEquals("Expected and actual values should be the same.", "An error occurred when sending the message: null", transportSendException.getMessage());
+        Assert.assertEquals("Expected and actual values should be the same.", throwable, transportSendException.getCause());
     }
 
     @Test(expected = TransportSendException.class)

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportTimeoutExceptionTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/exception/TransportTimeoutExceptionTest.java
@@ -18,8 +18,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class TransportTimeoutExceptionTest extends Assert {
+public class TransportTimeoutExceptionTest {
 
     Long[] values;
     String[] expectedMessage;
@@ -37,10 +38,10 @@ public class TransportTimeoutExceptionTest extends Assert {
     public void transportTimeoutExceptionTest() {
         for (int i = 0; i < values.length; i++) {
             TransportTimeoutException transportTimeoutException = new TransportTimeoutException(values[i]);
-            assertEquals("Expected and actual values should be the same.", TransportErrorCodes.TIMEOUT, transportTimeoutException.getCode());
-            assertEquals("Expected and actual values should be the same.", values[i], transportTimeoutException.getTimeout());
-            assertEquals("Expected and actual values should be the same.", expectedMessage[i], transportTimeoutException.getMessage());
-            assertNull("Null expected.", transportTimeoutException.getCause());
+            Assert.assertEquals("Expected and actual values should be the same.", TransportErrorCodes.TIMEOUT, transportTimeoutException.getCode());
+            Assert.assertEquals("Expected and actual values should be the same.", values[i], transportTimeoutException.getTimeout());
+            Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], transportTimeoutException.getMessage());
+            Assert.assertNull("Null expected.", transportTimeoutException.getCause());
         }
     }
 

--- a/transport/api/src/test/java/org/eclipse/kapua/transport/utils/ClientIdGeneratorTest.java
+++ b/transport/api/src/test/java/org/eclipse/kapua/transport/utils/ClientIdGeneratorTest.java
@@ -21,8 +21,9 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Modifier;
 
+
 @Category(JUnitTests.class)
-public class ClientIdGeneratorTest extends Assert {
+public class ClientIdGeneratorTest {
 
     ClientIdGenerator clientIdGenerator;
 
@@ -34,7 +35,7 @@ public class ClientIdGeneratorTest extends Assert {
     @Test
     public void clientIdGeneratorTest() throws Exception {
         Constructor<ClientIdGenerator> clientIdGenerator = ClientIdGenerator.class.getDeclaredConstructor();
-        assertTrue(Modifier.isPrivate(clientIdGenerator.getModifiers()));
+        Assert.assertTrue(Modifier.isPrivate(clientIdGenerator.getModifiers()));
         clientIdGenerator.setAccessible(true);
         clientIdGenerator.newInstance();
     }
@@ -42,7 +43,7 @@ public class ClientIdGeneratorTest extends Assert {
     @Test
     public void nextWithoutParameterTest() {
         String newId = clientIdGenerator.next();
-        assertTrue("True expected.", newId.startsWith("Id"));
+        Assert.assertTrue("True expected.", newId.startsWith("Id"));
     }
 
     @Test
@@ -50,13 +51,13 @@ public class ClientIdGeneratorTest extends Assert {
         String[] parameters = {"1", "testtest", "1232153", "!!$%&/&(())", "a1"};
         for (String parameter : parameters) {
             String newId = clientIdGenerator.next(parameter);
-            assertTrue("True expected.", newId.startsWith(parameter));
+            Assert.assertTrue("True expected.", newId.startsWith(parameter));
         }
     }
 
     @Test
     public void nextWithNullParameterTest() {
         String newId = clientIdGenerator.next(null);
-        assertTrue("True expected.", newId.startsWith("null"));
+        Assert.assertTrue("True expected.", newId.startsWith("null"));
     }
 }

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttMessageTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttMessageTest.java
@@ -23,8 +23,9 @@ import org.junit.experimental.categories.Category;
 
 import java.util.Date;
 
+
 @Category(JUnitTests.class)
-public class MqttMessageTest extends Assert {
+public class MqttMessageTest {
 
     MqttTopic requestTopic, responseTopic;
     MqttPayload mqttPayload;
@@ -41,76 +42,76 @@ public class MqttMessageTest extends Assert {
     @Test
     public void mqttMessageConstructorTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, responseTopic, mqttPayload);
-        assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void mqttMessageConstructorRequestTopicNullTest() {
         MqttMessage mqttMessage = new MqttMessage(null, responseTopic, mqttPayload);
-        assertNull("Null expected!", mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertNull("Null expected!", mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void mqttMessageConstructorRequestPayloadNullTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, responseTopic, null);
-        assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
-        assertEquals("Expected and actual value should be the same!", "", mqttMessage.getPayload().toString());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", responseTopic, mqttMessage.getResponseTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", "", mqttMessage.getPayload().toString());
     }
 
     @Test
     public void mqttMessageConstructorResponseTopicNullTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, (MqttTopic) null, mqttPayload);
-        assertEquals("Expected and actual value should be the same!", requestTopic , mqttMessage.getRequestTopic());
-        assertNull("Null expected!", mqttMessage.getResponseTopic());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic , mqttMessage.getRequestTopic());
+        Assert.assertNull("Null expected!", mqttMessage.getResponseTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void mqttMessageConstructor2Test() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, date, mqttPayload);
-        assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void mqttMessageConstructor2MqttRequestNullTest() {
         MqttMessage mqttMessage = new MqttMessage(null, date, mqttPayload);
-        assertNull("Null expected!", mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertNull("Null expected!", mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void mqttMessageConstructor2RequestPayloadNullTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, date, null);
-        assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
-        assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
-        assertEquals("Expected and actual value should be the same!", "", mqttMessage.getPayload().toString());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic, mqttMessage.getRequestTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", date, mqttMessage.getTimestamp());
+        Assert.assertEquals("Expected and actual value should be the same!", "", mqttMessage.getPayload().toString());
     }
 
     @Test
     public void mqttMessageConstructor2DateNullTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, (Date) null, mqttPayload);
-        assertEquals("Expected and actual value should be the same!", requestTopic , mqttMessage.getRequestTopic());
-        assertNull("Null expected!", mqttMessage.getResponseTopic());
-        assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
+        Assert.assertEquals("Expected and actual value should be the same!", requestTopic , mqttMessage.getRequestTopic());
+        Assert.assertNull("Null expected!", mqttMessage.getResponseTopic());
+        Assert.assertEquals("Expected and actual value should be the same!", mqttPayload, mqttMessage.getPayload());
     }
 
     @Test
     public void expectResponseTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, responseTopic, mqttPayload);
-        assertTrue("The response should not be null!", mqttMessage.expectResponse());
+        Assert.assertTrue("The response should not be null!", mqttMessage.expectResponse());
     }
 
     @Test
     public void toStringTest() {
         MqttMessage mqttMessage = new MqttMessage(requestTopic, responseTopic, mqttPayload);
-        assertEquals("null, requestTopic, cGF5bG9hZC5jb2Rl", mqttMessage.toString());
+        Assert.assertEquals("null, requestTopic, cGF5bG9hZC5jb2Rl", mqttMessage.toString());
     }
 }

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttPayloadTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttPayloadTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 
+
 @Category(JUnitTests.class)
-public class MqttPayloadTest extends Assert {
+public class MqttPayloadTest {
 
     MqttPayload mqttPayload;
 
@@ -44,37 +45,37 @@ public class MqttPayloadTest extends Assert {
     @Test
     public void mqttPayloadSetAndGetTest() {
         mqttPayload.setBody(body);
-        assertEquals("Expected and actual values should be the same!", body, mqttPayload.getBody());
+        Assert.assertEquals("Expected and actual values should be the same!", body, mqttPayload.getBody());
     }
 
     @Test
     public void mqttPayloadSetAndGetNullTest() {
         mqttPayload.setBody(null);
-        assertNull("Null expected!", mqttPayload.getBody());
+        Assert.assertNull("Null expected!", mqttPayload.getBody());
     }
 
     @Test
     public void hasBodyTest() {
         mqttPayload.setBody(body);
-        assertTrue("Should contain body value!", mqttPayload.hasBody());
-        assertEquals("Expected and actual values should be the same!", body, mqttPayload.getBody());
+        Assert.assertTrue("Should contain body value!", mqttPayload.hasBody());
+        Assert.assertEquals("Expected and actual values should be the same!", body, mqttPayload.getBody());
     }
 
     @Test
     public void hasBodyNullTest() {
         mqttPayload.setBody(null);
-        assertFalse("Should not contain body value!", mqttPayload.hasBody());
-        assertNull("Null expected!", mqttPayload.getBody());
+        Assert.assertFalse("Should not contain body value!", mqttPayload.hasBody());
+        Assert.assertNull("Null expected!", mqttPayload.getBody());
     }
 
     @Test
     public void toStringTest() {
-        assertEquals("ISMkJSYnKCk9P+KBhEDigLnigLrigqzCsMK34oCaLC4tOzpfw4jLh8K/PD7Cq+KAmOKAneKAmcOJw5jiiI97fQ==", mqttPayload.toString());
+        Assert.assertEquals("ISMkJSYnKCk9P+KBhEDigLnigLrigqzCsMK34oCaLC4tOzpfw4jLh8K/PD7Cq+KAmOKAneKAmcOJw5jiiI97fQ==", mqttPayload.toString());
     }
 
     @Test
     public void toStringEmptyTest() {
         mqttPayload.setBody("".getBytes());
-        assertEquals("Empty string expected!", "", mqttPayload.toString());
+        Assert.assertEquals("Empty string expected!", "", mqttPayload.toString());
     }
 }

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttTopicTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/message/mqtt/MqttTopicTest.java
@@ -18,13 +18,14 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttTopicTest extends Assert {
+public class MqttTopicTest {
 
     @Test
     public void mqttTopicConstructorValidTest() {
         MqttTopic mqttTopic = new MqttTopic("mqttTopicConstructor");
-        assertEquals("Expected and actual values are not equal!", "mqttTopicConstructor", mqttTopic.getTopic());
+        Assert.assertEquals("Expected and actual values are not equal!", "mqttTopicConstructor", mqttTopic.getTopic());
     }
 
     @Test
@@ -32,7 +33,7 @@ public class MqttTopicTest extends Assert {
         String[] permittedValues = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844"};
         for (String value : permittedValues) {
             MqttTopic mqttTopic = new MqttTopic(value);
-            assertEquals("Expected and actual values are not equal!", value, mqttTopic.getTopic());
+            Assert.assertEquals("Expected and actual values are not equal!", value, mqttTopic.getTopic());
         }
     }
 
@@ -40,26 +41,26 @@ public class MqttTopicTest extends Assert {
     public void mqttTopicSecondConstructorValidTest() {
         String[] mqttFromParts = new String[]{"mqtt0123456789", "from", "parts!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ"};
         MqttTopic mqttTopic = new MqttTopic(mqttFromParts);
-        assertEquals("Expected and actual values are not equal!", "mqtt0123456789/from/parts!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", mqttTopic.getTopic());
+        Assert.assertEquals("Expected and actual values are not equal!", "mqtt0123456789/from/parts!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", mqttTopic.getTopic());
     }
 
     @Test
     public void getSplittedTopicValidTest() {
         String[] mqttValue = new String[]{"mqttFromParts"};
         MqttTopic mqttTopic = new MqttTopic(mqttValue);
-        assertArrayEquals("Expected and actual values are not equal!", mqttValue, mqttTopic.getSplittedTopic());
+        Assert.assertArrayEquals("Expected and actual values are not equal!", mqttValue, mqttTopic.getSplittedTopic());
     }
 
     @Test
     public void getSplittedEmptyTopicTest() {
         String[] mqttValue = new String[]{};
         MqttTopic mqttTopic = new MqttTopic(mqttValue);
-        assertArrayEquals("Expected and actual values are not equal!", mqttValue, mqttTopic.getSplittedTopic());
+        Assert.assertArrayEquals("Expected and actual values are not equal!", mqttValue, mqttTopic.getSplittedTopic());
     }
 
     @Test
     public void toStringTest() {
         MqttTopic mqttTopic = new MqttTopic("mqttFromParts");
-        assertEquals("Expected and actual values are not equal!", "mqttFromParts", mqttTopic.toString());
+        Assert.assertEquals("Expected and actual values are not equal!", "mqttFromParts", mqttTopic.toString());
     }
 }

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/MqttClientConnectionOptionsTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/MqttClientConnectionOptionsTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+
 @Category(JUnitTests.class)
-public class MqttClientConnectionOptionsTest extends Assert {
+public class MqttClientConnectionOptionsTest {
 
     MqttClientConnectionOptions connectOptions;
 
@@ -37,14 +38,14 @@ public class MqttClientConnectionOptionsTest extends Assert {
         String[] stringValues = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844ppooqqqqweqrttskjoijjnbvzbhdsjkpk++adasdascdadserfaolkaiw;leqawoejoaidmn,masdnjokjaduiyqhwidbhnaskjfhaskidhnkauidhkauisdjhdhadnjkahduiqhdeihjoljiaolidjpqdjp;qkd';adkpoakdpoqjwoejqwoejqldfkjlasjf"};
         for (String value : stringValues) {
             connectOptions.setClientId(value);
-            assertEquals("Expected and actual values are not equal!", value, connectOptions.getClientId());
+            Assert.assertEquals("Expected and actual values are not equal!", value, connectOptions.getClientId());
         }
     }
 
     @Test
     public void setAndGetClientIdNullTest() {
         connectOptions.setClientId(null);
-        assertNull("Null expected!", connectOptions.getClientId());
+        Assert.assertNull("Null expected!", connectOptions.getClientId());
     }
 
     @Test
@@ -52,14 +53,14 @@ public class MqttClientConnectionOptionsTest extends Assert {
         String[] stringValues = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844ppooqqqqweqrttskjoijjnbvzbhdsjkpk++adasdascdadserfaolkaiw;leqawoejoaidmn,masdnjokjaduiyqhwidbhnaskjfhaskidhnkauidhkauisdjhdhadnjkahduiqhdeihjoljiaolidjpqdjp;qkd';adkpoakdpoqjwoejqwoejqldfkjlasjf"};
         for (String value : stringValues) {
             connectOptions.setUsername(value);
-            assertEquals("Expected and actual values are not equal!", value, connectOptions.getUsername());
+            Assert.assertEquals("Expected and actual values are not equal!", value, connectOptions.getUsername());
         }
     }
 
     @Test
     public void setAndGetUsernameNullTest() {
         connectOptions.setUsername(null);
-        assertNull("Null expected!", connectOptions.getUsername());
+        Assert.assertNull("Null expected!", connectOptions.getUsername());
     }
 
     @Test
@@ -68,14 +69,14 @@ public class MqttClientConnectionOptionsTest extends Assert {
         for (String value : stringValues) {
             char[] charValue = value.toCharArray();
             connectOptions.setPassword(charValue);
-            assertEquals("Expected and actual values are not equal!", charValue, connectOptions.getPassword());
+            Assert.assertEquals("Expected and actual values are not equal!", charValue, connectOptions.getPassword());
         }
     }
 
     @Test
     public void setAndGetPasswordNullTest() {
         connectOptions.setPassword(null);
-        assertNull("Null expected!", connectOptions.getPassword());
+        Assert.assertNull("Null expected!", connectOptions.getPassword());
     }
 
     @Test
@@ -83,13 +84,13 @@ public class MqttClientConnectionOptionsTest extends Assert {
         URI[] uriPermittedFormats = { new URI("https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"), new URI("ldap://[2001:db8::7]/c=GB?objectClass?one"), new URI("mailto:Username.example@example.com"), new URI("news:comp.infosystems.www.servers.unix"), new URI("tel:+1-816-555-1212"), new URI("telnet://192.0.2.16:80/"), new URI("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")};
         for (URI value : uriPermittedFormats) {
             connectOptions.setEndpointURI(value);
-            assertEquals("Expected and actual values are not equal!", value, connectOptions.getEndpointURI());
+            Assert.assertEquals("Expected and actual values are not equal!", value, connectOptions.getEndpointURI());
         }
     }
 
     @Test
     public void setAndGetURINullTest() {
         connectOptions.setEndpointURI(null);
-        assertNull("Null expected!", connectOptions.getEndpointURI());
+        Assert.assertNull("Null expected!", connectOptions.getEndpointURI());
     }
 }

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientAlreadyConnectedExceptionTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientAlreadyConnectedExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttClientAlreadyConnectedExceptionTest extends Assert {
+public class MqttClientAlreadyConnectedExceptionTest {
 
     MqttClientAlreadyConnectedException exception;
 
@@ -33,9 +34,9 @@ public class MqttClientAlreadyConnectedExceptionTest extends Assert {
     public void constructorValidTest() {
         try {
             MqttClientAlreadyConnectedException exception = new MqttClientAlreadyConnectedException("clientID");
-            assertEquals("Expected and actual values should be the same!", "MqttClient " + exception.getClientId() + " is already connected.", exception.getMessage());
+            Assert.assertEquals("Expected and actual values should be the same!", "MqttClient " + exception.getClientId() + " is already connected.", exception.getMessage());
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 
@@ -45,10 +46,10 @@ public class MqttClientAlreadyConnectedExceptionTest extends Assert {
             String[] stringValues = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844ppooqqqqweqrttskjoijjnbvzbhdsjkpk++adasdascdadserfaolkaiw;leqawoejoaidmn,masdnjokjaduiyqhwidbhnaskjfhaskidhnkauidhkauisdjhdhadnjkahduiqhdeihjoljiaolidjpqdjp;qkd';adkpoakdpoqjwoejqwoejqldfkjlasjf"};
             for (String value : stringValues) {
                 MqttClientAlreadyConnectedException exception = new MqttClientAlreadyConnectedException(value);
-                assertEquals("Expected and actual values should be the same!", "MqttClient " + exception.getClientId() + " is already connected.", exception.getMessage());
+                Assert.assertEquals("Expected and actual values should be the same!", "MqttClient " + exception.getClientId() + " is already connected.", exception.getMessage());
             }
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientCallbackSetExceptionTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientCallbackSetExceptionTest.java
@@ -20,8 +20,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttClientCallbackSetExceptionTest extends Assert {
+public class MqttClientCallbackSetExceptionTest {
 
     MqttTopic mqttTopic;
     Throwable throwable;
@@ -37,41 +38,41 @@ public class MqttClientCallbackSetExceptionTest extends Assert {
     @Test
     public void constructorValidTest() {
         MqttClientCallbackSetException exception = new MqttClientCallbackSetException(throwable, "clientId", mqttTopic);
-        assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
-        assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
-        assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
     }
 
     @Test
     public void constructorCauseNullTest() {
         MqttClientCallbackSetException exception = new MqttClientCallbackSetException(null, "clientId", mqttTopic);
-        assertNull("Null expected!", exception.getCause());
-        assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
-        assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
+        Assert.assertNull("Null expected!", exception.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
     }
 
     @Test
     public void constructorClientIdNullTest() {
         MqttClientCallbackSetException exception = new MqttClientCallbackSetException(throwable, null, mqttTopic);
-        assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
-        assertNull("Null expected!", exception.getClientId());
-        assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
+        Assert.assertNull("Null expected!", exception.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same!", mqttTopic, exception.getTopic());
     }
 
     @Test (expected = NullPointerException.class)
     public void constructorMqttTopicNullTest() {
         MqttClientCallbackSetException exception = new MqttClientCallbackSetException(throwable, "clientId", null);
-        assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
-        assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
-        assertNull("Null expected!", exception.getTopic());
+        Assert.assertEquals("Expected and actual values should be the same!", throwable, exception.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
+        Assert.assertNull("Null expected!", exception.getTopic());
     }
 
     @Test (expected = NullPointerException.class)
     public void constructorAllNullTest() {
         MqttClientCallbackSetException exception = new MqttClientCallbackSetException(null, null, null);
-        assertNull("Null expected!", exception.getCause());
-        assertNull("Null expected!", exception.getClientId());
-        assertNull("Null expected!", exception.getTopic());
+        Assert.assertNull("Null expected!", exception.getCause());
+        Assert.assertNull("Null expected!", exception.getClientId());
+        Assert.assertNull("Null expected!", exception.getTopic());
     }
 
     @Test (expected = MqttClientCallbackSetException.class)

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientCleanExceptionTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientCleanExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttClientCleanExceptionTest extends Assert {
+public class MqttClientCleanExceptionTest {
 
     MqttClientCleanException exception;
     Throwable cause;
@@ -34,9 +35,9 @@ public class MqttClientCleanExceptionTest extends Assert {
     @Test
     public void constructorValidTest() {
         try {
-            assertEquals("MqttClient " + exception.getClientId() + " cannot be terminated properly. This can lead to resource leaks.", exception.getMessage());
+            Assert.assertEquals("MqttClient " + exception.getClientId() + " cannot be terminated properly. This can lead to resource leaks.", exception.getMessage());
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 
@@ -46,10 +47,10 @@ public class MqttClientCleanExceptionTest extends Assert {
             String[] stringValues = {"", "!#$%&'()=?⁄@‹›€°·‚,.-;:_Èˇ¿<>«‘”’ÉØ∏{}|ÆæÒuF8FFÔÓÌÏÎÅ«»Ç◊Ñˆ¯Èˇ", "regularNaming", "regular Naming", "49", "regularNaming49", "NAMING", "246465494135646120009090049684646496468456468496846464968496844ppooqqqqweqrttskjoijjnbvzbhdsjkpk++adasdascdadserfaolkaiw;leqawoejoaidmn,masdnjokjaduiyqhwidbhnaskjfhaskidhnkauidhkauisdjhdhadnjkahduiqhdeihjoljiaolidjpqdjp;qkd';adkpoakdpoqjwoejqwoejqldfkjlasjf"};
             for (String value : stringValues) {
                 MqttClientCleanException exception = new MqttClientCleanException(cause, value);
-                assertEquals("MqttClient " + exception.getClientId() + " cannot be terminated properly. This can lead to resource leaks.", exception.getMessage());
+                Assert.assertEquals("MqttClient " + exception.getClientId() + " cannot be terminated properly. This can lead to resource leaks.", exception.getMessage());
             }
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 
@@ -57,10 +58,10 @@ public class MqttClientCleanExceptionTest extends Assert {
     public void constructorCauseNullTest() {
         try {
             MqttClientCleanException exception = new MqttClientCleanException(null, "clientId");
-            assertNull("Null expected!", exception.getCause());
-            assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
+            Assert.assertNull("Null expected!", exception.getCause());
+            Assert.assertEquals("Expected and actual values should be the same!", "clientId", exception.getClientId());
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 
@@ -68,10 +69,10 @@ public class MqttClientCleanExceptionTest extends Assert {
     public void constructorClientIdNullTest() {
         try {
             MqttClientCleanException exception = new MqttClientCleanException(cause, null);
-            assertNull("Null expected!", exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+            Assert.assertNull("Null expected!", exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 
@@ -79,10 +80,10 @@ public class MqttClientCleanExceptionTest extends Assert {
     public void constructorAllNullTest() {
         try {
             MqttClientCleanException exception = new MqttClientCleanException(null, null);
-            assertNull("Null expected!", exception.getCause());
-            assertNull("Null expected!", exception.getClientId());
+            Assert.assertNull("Null expected!", exception.getCause());
+            Assert.assertNull("Null expected!", exception.getClientId());
         } catch (Exception ex) {
-            fail("Exception should not be thrown!");
+            Assert.fail("Exception should not be thrown!");
         }
     }
 

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientConnectExceptionTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientConnectExceptionTest.java
@@ -22,8 +22,9 @@ import org.junit.experimental.categories.Category;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+
 @Category(JUnitTests.class)
-public class MqttClientConnectExceptionTest extends Assert {
+public class MqttClientConnectExceptionTest {
 
     MqttClientConnectException exception1, exception2;
     Throwable cause;
@@ -44,9 +45,9 @@ public class MqttClientConnectExceptionTest extends Assert {
         URI[] uriPermittedFormats = { new URI("https://john.doe@www.example.com:123/forum/questions/?tag=networking&order=newest#top"), new URI("ldap://[2001:db8::7]/c=GB?objectClass?one"), new URI("mailto:Username.example@example.com"), new URI("news:comp.infosystems.www.servers.unix"), new URI("tel:+1-816-555-1212"), new URI("telnet://192.0.2.16:80/"), new URI("urn:oasis:names:specification:docbook:dtd:xml:4.1.2")};
         for (URI value : uriPermittedFormats) {
             MqttClientConnectException exception = new MqttClientConnectException(clientID, username, value);
-            assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-            assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+            Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+            Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
         }
     }
 
@@ -54,11 +55,11 @@ public class MqttClientConnectExceptionTest extends Assert {
     public void constructorURINullTest() {
         try {
             MqttClientConnectException exception = new MqttClientConnectException(clientID, username, null);
-            assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-            assertNull("Null expected!", exception.getUri());
+            Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+            Assert.assertNull("Null expected!", exception.getUri());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 
@@ -68,11 +69,11 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(clientID, null, value);
-                assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-                assertNull("Null expected!", exception.getUsername());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+                Assert.assertNull("Null expected!", exception.getUsername());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -83,11 +84,11 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(null, username, value);
-                assertNull("Null expected!", exception.getClientId());
-                assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertNull("Null expected!", exception.getClientId());
+                Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -96,11 +97,11 @@ public class MqttClientConnectExceptionTest extends Assert {
     public void constructorAllNullTest() {
         try {
             MqttClientConnectException exception = new MqttClientConnectException(null, null, null);
-            assertNull("Null expected!", exception.getClientId());
-            assertNull("Null expected!", exception.getUsername());
-            assertNull("Null expected!", exception.getUri());
+            Assert.assertNull("Null expected!", exception.getClientId());
+            Assert.assertNull("Null expected!", exception.getUsername());
+            Assert.assertNull("Null expected!", exception.getUri());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 
@@ -115,13 +116,13 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(cause, clientID, username, value);
-                assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-                assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-                assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
-                assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+                Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+                Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+                Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -132,13 +133,13 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(null, clientID, username, value);
-                assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-                assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-                assertNull("Null expected!", exception.getCause());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
-                assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+                Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+                Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+                Assert.assertNull("Null expected!", exception.getCause());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -149,13 +150,13 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(cause, null, username, value);
-                assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-                assertNull("Null expected!", exception.getClientId());
-                assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
-                assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+                Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+                Assert.assertNull("Null expected!", exception.getClientId());
+                Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -166,13 +167,13 @@ public class MqttClientConnectExceptionTest extends Assert {
         for (URI value : uriPermittedFormats) {
             try {
                 MqttClientConnectException exception = new MqttClientConnectException(cause, clientID, null, value);
-                assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-                assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-                assertNull("Null expected!", exception.getUsername());
-                assertEquals("Expected and actual values should be the same!", value, exception.getUri());
-                assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+                Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+                Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+                Assert.assertNull("Null expected!", exception.getUsername());
+                Assert.assertEquals("Expected and actual values should be the same!", value, exception.getUri());
+                Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
             } catch (Exception ex) {
-                fail("No exception expected!");
+                Assert.fail("No exception expected!");
             }
         }
     }
@@ -181,13 +182,13 @@ public class MqttClientConnectExceptionTest extends Assert {
     public void secondConstructorURINullTest() {
         try {
             MqttClientConnectException exception = new MqttClientConnectException(cause, clientID, username, null);
-            assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-            assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
-            assertNull("Null expected!", exception.getUri());
-            assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+            Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+            Assert.assertEquals("Expected and actual values should be the same!", clientID, exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", username, exception.getUsername());
+            Assert.assertNull("Null expected!", exception.getUri());
+            Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 
@@ -195,13 +196,13 @@ public class MqttClientConnectExceptionTest extends Assert {
     public void secondConstructorAllNullTest() {
         try {
             MqttClientConnectException exception = new MqttClientConnectException(null, null, null, null);
-            assertNull("Null expected!", exception.getCause());
-            assertNull("Null expected!", exception.getClientId());
-            assertNull("Null expected!", exception.getUsername());
-            assertNull("Null expected!", exception.getUri());
-            assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
+            Assert.assertNull("Null expected!", exception.getCause());
+            Assert.assertNull("Null expected!", exception.getClientId());
+            Assert.assertNull("Null expected!", exception.getUsername());
+            Assert.assertNull("Null expected!", exception.getUri());
+            Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", exception.getCode().toString());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientDisconnectExceptionTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientDisconnectExceptionTest.java
@@ -19,8 +19,9 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttClientDisconnectExceptionTest extends Assert {
+public class MqttClientDisconnectExceptionTest {
 
     MqttClientDisconnectException exception;
     String clientId = "clientName";
@@ -35,20 +36,20 @@ public class MqttClientDisconnectExceptionTest extends Assert {
     @Test
     public void constructorValidTest() {
         MqttClientDisconnectException exception = new MqttClientDisconnectException(cause, clientId);
-        assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-        assertEquals("Expected and actual values should be the same!", clientId, exception.getClientId());
-        assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
+        Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+        Assert.assertEquals("Expected and actual values should be the same!", clientId, exception.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
     }
 
     @Test
     public void constructorCauseNullTest() {
         try {
             MqttClientDisconnectException exception = new MqttClientDisconnectException(null, clientId);
-            assertNull("Null expected!", exception.getCause());
-            assertEquals("Expected and actual values should be the same!", clientId, exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
+            Assert.assertNull("Null expected!", exception.getCause());
+            Assert.assertEquals("Expected and actual values should be the same!", clientId, exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 
@@ -56,20 +57,20 @@ public class MqttClientDisconnectExceptionTest extends Assert {
     public void constructorClientIdNullTest() {
         try {
             MqttClientDisconnectException exception = new MqttClientDisconnectException(cause, null);
-            assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
-            assertNull("Null expected!", exception.getClientId());
-            assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
+            Assert.assertEquals("Expected and actual values should be the same!", cause, exception.getCause());
+            Assert.assertNull("Null expected!", exception.getClientId());
+            Assert.assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
         } catch (Exception ex) {
-            fail("No exception expected!");
+            Assert.fail("No exception expected!");
         }
     }
 
     @Test
     public void constructorAllNullTest() {
         MqttClientDisconnectException exception = new MqttClientDisconnectException(null, null);
-        assertNull("Null expected!", exception.getCause());
-        assertNull("Null expected!", exception.getClientId());
-        assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
+        Assert.assertNull("Null expected!", exception.getCause());
+        Assert.assertNull("Null expected!", exception.getClientId());
+        Assert.assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", exception.getCode().toString());
     }
 
     @Test (expected = MqttClientDisconnectException.class)

--- a/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientErrorCodesTest.java
+++ b/transport/mqtt/src/test/java/org/eclipse/kapua/transport/mqtt/test/mqtt/exception/MqttClientErrorCodesTest.java
@@ -18,56 +18,57 @@ import org.junit.Assert;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
+
 @Category(JUnitTests.class)
-public class MqttClientErrorCodesTest extends Assert {
+public class MqttClientErrorCodesTest {
 
     @Test
     public void alreadyConnectedTest() {
-        assertEquals("Expected and actual values should be the same!", "ALREADY_CONNECTED", MqttClientErrorCodes.ALREADY_CONNECTED.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "ALREADY_CONNECTED", MqttClientErrorCodes.ALREADY_CONNECTED.name());
     }
 
     @Test
     public void callbackSetErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "CALLBACK_SET_ERROR", MqttClientErrorCodes.CALLBACK_SET_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "CALLBACK_SET_ERROR", MqttClientErrorCodes.CALLBACK_SET_ERROR.name());
     }
 
     @Test
     public void cleanErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "CLEAN_ERROR", MqttClientErrorCodes.CLEAN_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "CLEAN_ERROR", MqttClientErrorCodes.CLEAN_ERROR.name());
     }
 
     @Test
     public void connectErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", MqttClientErrorCodes.CONNECT_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "CONNECT_ERROR", MqttClientErrorCodes.CONNECT_ERROR.name());
     }
 
     @Test
     public void disconnectErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", MqttClientErrorCodes.DISCONNECT_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "DISCONNECT_ERROR", MqttClientErrorCodes.DISCONNECT_ERROR.name());
     }
 
     @Test
     public void notConnectedTest() {
-        assertEquals("Expected and actual values should be the same!", "NOT_CONNECTED", MqttClientErrorCodes.NOT_CONNECTED.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "NOT_CONNECTED", MqttClientErrorCodes.NOT_CONNECTED.name());
     }
 
     @Test
     public void publishExceptionTest() {
-        assertEquals("Expected and actual values should be the same!", "PUBLISH_EXCEPTION", MqttClientErrorCodes.PUBLISH_EXCEPTION.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "PUBLISH_EXCEPTION", MqttClientErrorCodes.PUBLISH_EXCEPTION.name());
     }
 
     @Test
     public void subscribeErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "SUBSCRIBE_ERROR", MqttClientErrorCodes.SUBSCRIBE_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "SUBSCRIBE_ERROR", MqttClientErrorCodes.SUBSCRIBE_ERROR.name());
     }
 
     @Test
     public void terminateErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "TERMINATE_ERROR", MqttClientErrorCodes.TERMINATE_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "TERMINATE_ERROR", MqttClientErrorCodes.TERMINATE_ERROR.name());
     }
 
     @Test
     public void unsubscribeErrorTest() {
-        assertEquals("Expected and actual values should be the same!", "UNSUBSCRIBE_ERROR", MqttClientErrorCodes.UNSUBSCRIBE_ERROR.name());
+        Assert.assertEquals("Expected and actual values should be the same!", "UNSUBSCRIBE_ERROR", MqttClientErrorCodes.UNSUBSCRIBE_ERROR.name());
     }
 }


### PR DESCRIPTION
Refactoring to avoid test classes to extend Assert - part 7

Signed-off-by: dseurotech <davide.salvador@eurotech.com>