### PR TITLE
Upgraded Netty dependencies from 4.1.60.Final to 4.1.84.Final - CVE-2021-21409 CVE-2021-37136 CVE-2021-37137 CVE-2021-43797 CVE-2022-24823

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -172,8 +172,22 @@
                 <include>commons-io:commons-io</include>
 
                 <include>io.dropwizard.metrics:metrics-core</include>
-                <include>io.netty:netty-all</include>
                 <include>io.netty:netty</include>
+                <include>io.netty:netty-all</include>
+                <include>io.netty:netty-buffer</include>
+                <include>io.netty:netty-transport</include>
+                <include>io.netty:netty-handler</include>
+                <include>io.netty:netty-handler-proxy</include>
+                <include>io.netty:netty-codec</include>
+                <include>io.netty:netty-codec-http</include>
+                <include>io.netty:netty-codec-mqtt</include>
+                <include>io.netty:netty-codec-socks</include>
+                <include>io.netty:netty-common</include>
+                <include>io.netty:netty-resolver</include>
+                <include>io.netty:netty-transport-classes-epoll</include>
+                <include>io.netty:netty-transport-native-epoll</include>
+                <include>io.netty:netty-transport-classes-kqueue</include>
+                <include>io.netty:netty-transport-native-kqueue</include>
 
                 <include>javax.annotation:javax.annotation-api</include>
                 <include>javax.inject:javax.inject</include>

--- a/pom.xml
+++ b/pom.xml
@@ -91,7 +91,7 @@
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.3</logback.version>
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.60.Final</netty.version>
+        <netty.version>4.1.84.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>
         <opencsv.version>3.7</opencsv.version>


### PR DESCRIPTION
This PR updates Netty dependencies from 4.1.60.Final to 4.1.84 to solve following CVEs:

- CVE-2021-21409 
- CVE-2021-37136 
- CVE-2021-37137 
- CVE-2021-43797 
- CVE-2022-24823

**Related Issue**
_None_

**Description of the solution adopted**
Updated dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_