### PR TITLE
Upgraded Spring dependencies from 5.3.8 to 5.3.23 in Kapua 2.x - CVE-2021-22096 CVE-2022-22950 CVE-2022-22965 CVE-2022-22968 CVE-2022-22970 CVE-2022-22971

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,14 +30,10 @@
 
         <!-- Dependencies versions -->
         <activemq.version>5.14.5</activemq.version>
-        <camel.version>3.11.0</camel.version> <!-- latest 3.11.0 -->
-        <spring.version>5.3.8</spring.version> <!-- latest 5.3.8 -->
-        <spring-security.version>5.5.1</spring-security.version> <!-- latest 5.5.1 -->
-        <spring-boot.version>2.5.2</spring-boot.version> <!-- latest 2.5.2 --> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
-
         <aopalliance.version>1.0</aopalliance.version>
         <artemis.version>2.19.0</artemis.version>
         <assertj.version>3.2.0</assertj.version>
+        <camel.version>3.11.0</camel.version> <!-- latest 3.11.0 -->
         <checker-framework.version>3.15.0</checker-framework.version>
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
@@ -108,6 +104,9 @@
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.28</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
+        <spring.version>5.3.23</spring.version>
+        <spring-security.version>5.5.1</spring-security.version>
+        <spring-boot.version>2.5.2</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
 
@@ -2183,29 +2182,8 @@
                 <version>${camel.version}</version>
             </dependency>
 
-            <!-- Springboot -->
-            <!-- http://localhost:8080/actuator/health -->
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-spring-boot</artifactId>
-                <version>${camel.version}</version> <!-- use the same version as your Camel core version -->
-            </dependency>
-            <dependency>
-                <groupId>org.apache.camel.springboot</groupId>
-                <artifactId>camel-spring-boot-starter</artifactId>
-                <version>${camel.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-web</artifactId>
-                <version>${spring-boot.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.springframework.boot</groupId>
-                <artifactId>spring-boot-starter-actuator</artifactId>
-                <version>${spring-boot.version}</version>
-            </dependency>
-            <!-- spring -->
+            <!-- -->
+            <!-- Spring -->
             <dependency>
                 <groupId>org.springframework</groupId>
                 <artifactId>spring-aop</artifactId>
@@ -2238,9 +2216,44 @@
             </dependency>
             <dependency>
                 <groupId>org.springframework</groupId>
+                <artifactId>spring-web</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-webmvc</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
                 <artifactId>spring-tx</artifactId>
                 <version>${spring.version}</version>
             </dependency>
+
+            <!-- Spring boot -->
+            <!-- http://localhost:8080/actuator/health -->
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot</artifactId>
+                <version>${camel.version}</version> <!-- use the same version as your Camel core version -->
+            </dependency>
+            <dependency>
+                <groupId>org.apache.camel.springboot</groupId>
+                <artifactId>camel-spring-boot-starter</artifactId>
+                <version>${camel.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-web</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework.boot</groupId>
+                <artifactId>spring-boot-starter-actuator</artifactId>
+                <version>${spring-boot.version}</version>
+            </dependency>
+
+            <!-- Spring Security -->
             <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-core</artifactId>


### PR DESCRIPTION
This PR upgrades the version of Spring dependencies from 5.3.8 to 5.2.23 solving following CVEs:

- CVE-2021-22096
- CVE-2022-22950
- CVE-2022-22965
- CVE-2022-22968
- CVE-2022-22970
- CVE-2022-22971

This PR don't affect Springboot nor Spring Security dependencies

**Related Issue**
_None_

**Description of the solution adopted**
Updated versions

**Screenshots**
_None_

**Any side note on the changes made**
_None_