### PR TITLE
Upgraded Springboot dependencies from 2.5.2 to 2.5.14 in Kapua 2.x - CVE-2022-22965 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring.version>5.3.23</spring.version>
+        <spring-boot.version>2.5.14</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
         <spring-security.version>5.7.4</spring-security.version>
-        <spring-boot.version>2.5.2</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring.version>5.3.23</spring.version>
-        <spring-security.version>5.5.1</spring-security.version>
+        <spring-security.version>5.7.4</spring-security.version>
         <spring-boot.version>2.5.2</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>


### PR DESCRIPTION
This PR upgrades the Springboot dependencies versions from 2.5.2 to 2.5.14 solving following CVEs

CVE-2022-22965 

The following transient dependencies are also upgraded:

- io.micrometer:micrometer-core 1.7.1 > 1.7.12 
- org.apache.activemq:activemq-openwire-legacy 5.16.2 > 5.16.5
- org.apache.tomcat.embed:tomcat-embed-el 9.0.48 > 9.0.63

**Related Issue**
This PR depends on https://github.com/eclipse/kapua/pull/3636

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
The commit that sets fixed version for Netty needs to be backported to 1.x versions