### PR TITLE
Exclude `jakarta.security.auth.message-api` dependency from Artemis dependencies

### DIFF
--- a/assembly/events-broker/pom.xml
+++ b/assembly/events-broker/pom.xml
@@ -25,7 +25,7 @@
     <packaging>pom</packaging>
     <artifactId>kapua-assembly-events-broker</artifactId>
 
-        <dependencies>
+    <dependencies>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-assembly-java-base</artifactId>
@@ -34,17 +34,8 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>apache-artemis</artifactId>
-            <version>${artemis.version}</version>
             <classifier>bin</classifier>
             <type>tar.gz</type>
-            <!--
-            <exclusions>
-                <exclusion>
-                    <groupId>log4j</groupId>
-                    <artifactId>log4j</artifactId>
-                </exclusion>
-            </exclusions>
-             -->
         </dependency>
     </dependencies>
 

--- a/broker/client/pom.xml
+++ b/broker/client/pom.xml
@@ -182,12 +182,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- test -->

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -124,14 +124,7 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
 
         <!-- misc -->

--- a/consumer/commons/pom.xml
+++ b/consumer/commons/pom.xml
@@ -109,12 +109,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-client</artifactId>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <!-- camel -->
         <dependency>

--- a/consumer/telemetry/pom.xml
+++ b/consumer/telemetry/pom.xml
@@ -101,7 +101,7 @@
             <artifactId>kapua-device-registry-api</artifactId>
             <scope>provided</scope>
         </dependency>
-                <dependency>
+        <dependency>
             <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-device-registry-internal</artifactId>
             <scope>provided</scope>
@@ -149,15 +149,9 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <version>${activemq.version}</version>
             <scope>provided</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
+
         <!-- camel -->
         <dependency>
             <groupId>org.apache.camel</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -2136,6 +2136,11 @@
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
                     </exclusion>
+                    <exclusion>
+                        <!-- FIXME: This exclusion can be rmeoved after https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/4106 gets approved -->
+                        <groupId>jakarta.security.auth.message</groupId>
+                        <artifactId>jakarta.security.auth.message-api</artifactId>
+                    </exclusion>
                 </exclusions>
             </dependency>
             <dependency>
@@ -2148,6 +2153,11 @@
                     <exclusion>
                         <groupId>log4j</groupId>
                         <artifactId>log4j</artifactId>
+                    </exclusion>
+                    <exclusion>
+                        <!-- FIXME: This exclusion can be rmeoved after https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/4106 gets approved -->
+                        <groupId>jakarta.security.auth.message</groupId>
+                        <artifactId>jakarta.security.auth.message-api</artifactId>
                     </exclusion>
                 </exclusions>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2126,7 +2126,36 @@
             </dependency>
 
             <!-- -->
-            <!-- Active MQ Artemis-->
+            <!-- Apache Active MQ Artemis-->
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>apache-artemis</artifactId>
+                <version>${artemis.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>apache-artemis</artifactId>
+                <version>${artemis.version}</version>
+                <classifier>bin</classifier>
+                <type>tar.gz</type>
+                <exclusions>
+                    <exclusion>
+                        <groupId>log4j</groupId>
+                        <artifactId>log4j</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-amqp-protocol</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>artemis-junit</artifactId>
@@ -2138,21 +2167,54 @@
                     </exclusion>
                 </exclusions>
             </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-amqp-protocol</artifactId>
-                <version>${artemis.version}</version>
-            </dependency>
 
-            <!-- Activemq -->
+            <!-- -->
+            <!-- Apache ActiveMQ -->
             <dependency>
                 <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-client</artifactId>
+                <artifactId>activemq-broker</artifactId>
                 <version>${activemq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jms_1.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.apache.activemq</groupId>
                 <artifactId>activemq-camel</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-client</artifactId>
+                <version>${activemq.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.apache.geronimo.specs</groupId>
+                        <artifactId>geronimo-jms_1.1_spec</artifactId>
+                    </exclusion>
+                </exclusions>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>artemis-jms-server</artifactId>
+                <version>${artemis.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-kahadb-store</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-mqtt</artifactId>
+                <version>${activemq.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.activemq</groupId>
+                <artifactId>activemq-spring</artifactId>
                 <version>${activemq.version}</version>
             </dependency>
 

--- a/qa/common/pom.xml
+++ b/qa/common/pom.xml
@@ -156,12 +156,6 @@
         <dependency>
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -327,12 +327,6 @@
             <groupId>org.apache.activemq</groupId>
             <artifactId>activemq-broker</artifactId>
             <scope>test</scope>
-            <exclusions>
-                <exclusion>
-                    <groupId>org.apache.geronimo.specs</groupId>
-                    <artifactId>geronimo-jms_1.1_spec</artifactId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.apache.activemq</groupId>

--- a/qa/pom.xml
+++ b/qa/pom.xml
@@ -15,14 +15,15 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
+
     <parent>
         <groupId>org.eclipse.kapua</groupId>
         <artifactId>kapua</artifactId>
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <packaging>pom</packaging>
     <artifactId>kapua-qa</artifactId>
+    <packaging>pom</packaging>
 
     <modules>
         <module>common</module>
@@ -31,44 +32,8 @@
         <module>markers</module>
     </modules>
 
-    <dependencyManagement>
-        <dependencies>
-            <!-- Activemq -->
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-broker</artifactId>
-                <version>${activemq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-camel</artifactId>
-                <version>${activemq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-kahadb-store</artifactId>
-                <version>${activemq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-mqtt</artifactId>
-                <version>${activemq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>activemq-spring</artifactId>
-                <version>${activemq.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>org.apache.activemq</groupId>
-                <artifactId>artemis-jms-server</artifactId>
-                <version>${artemis.version}</version>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <profiles>
-        <!-- Profile for running integration tests with Kapua infrastructure started
-             inside dockerized environment. -->
+        <!-- Profile for running integration tests with Kapua infrastructure started inside dockerized environment. -->
         <profile>
             <id>I9nTests</id>
             <build>


### PR DESCRIPTION
This PR excludes `jakarta.security.auth.message-api` dependency from Artemis dependencies.
This exclusion can be removed after https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/4106 gets approved.

**Related Issue**
Eclipse IP review: https://gitlab.eclipse.org/eclipsefdn/emo-team/iplab/-/issues/4106

**Description of the solution adopted**
Added the dependency to the exclusion list in dependency management

**Screenshots**
_None_

**Any side note on the changes made**
Cleaned up dependency managemnt definition moving everything to root `pom.xml`