### PR TITLE
Upgraded Spring Security from 5.5.1 to 5.7.4 in Kapua 2.x - CVE-2022-22976 CVE-2022-22978

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,7 +105,7 @@
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring.version>5.3.23</spring.version>
-        <spring-security.version>5.5.1</spring-security.version>
+        <spring-security.version>5.7.4</spring-security.version>
         <spring-boot.version>2.5.2</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>


### PR DESCRIPTION
This PR upgrades the version of Spring Security dependencies from 5.5.1 to 5.7.4 solving following CVEs:

- CVE-2022-22976 
- CVE-2022-22978

**Related Issue**
_None_

**Description of the solution adopted**
Updated dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_