### PR TITLE
Upgraded Spring Security from 4.1.3.RELEASE to 4.2.20.RELEASE in Kapua 1.x - CVE-2018-1199 CVE-2020-5408

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,7 +101,7 @@
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
-        <spring-security.version>4.1.3.RELEASE</spring-security.version>
+        <spring-security.version>4.2.20.RELEASE</spring-security.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
 

--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         <slf4j.version>1.7.33</slf4j.version>
         <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
+        <spring.version>4.3.30.RELEASE</spring.version>
         <spring-security.version>4.2.20.RELEASE</spring-security.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
@@ -2106,10 +2107,39 @@
 
             <!-- Spring -->
             <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-aop</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-beans</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-context</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-core</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.springframework</groupId>
+                <artifactId>spring-expression</artifactId>
+                <version>${spring.version}</version>
+            </dependency>
+
+            <!-- Spring Security-->
+            <dependency>
                 <groupId>org.springframework.security</groupId>
                 <artifactId>spring-security-core</artifactId>
                 <version>${spring-security.version}</version>
             </dependency>
+
+
             <dependency>
                 <groupId>org.webjars</groupId>
                 <artifactId>swagger-ui</artifactId>


### PR DESCRIPTION
This PR upgrades Spring Security dependencies from 4.1.3.RELEASE to 4.2.20.RELEASE solving following CVEs

- CVE-2018-1199 
- CVE-2020-5408

Following transitive dependencies gets upgraded from 4.3.2.RELEASE to 4.3.30.RELEASE

- org.springframework:spring-aop
- org.springframework:spring-beans
- org.springframework:spring-context
- org.springframework:spring-core
- org.springframework:spring-expression

solving following CVEs

- CVE-2018-11039
- CVE-2018-11040
- CVE-2018-1199
- CVE-2018-1270
- CVE-2018-1271
- CVE-2018-1272
- CVE-2018-15756

**Related Issue**
This PR is the counterpart of PR #3642 made on `develop`
Kapua 1.x didn't migrated to Spring 5, so we need to made different PRs

**Description of the solution adopted**
Upgraded the dependencies

**Screenshots**
_None_

**Any side note on the changes made**
Set fixed definition of Spring dependencies