### PR TITLE
Upgraded Jackson dependencies from 2.13.1 to 2.13.4/2.13.4.2 - CVE-2020-36518 CVE-2022-42003 CVE-2022-42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -60,7 +60,7 @@
         <hikaricp.version>4.0.3</hikaricp.version>
         <hk2-api.version>2.5.0-b05</hk2-api.version>
         <httpcomponents.version>4.5.13</httpcomponents.version>
-        <jackson.version>2.13.1</jackson.version>
+        <jackson.version>2.13.4</jackson.version>
         <javassist.version>3.26.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
         <javax-batch-api.version>1.0.1</javax-batch-api.version>
@@ -1896,7 +1896,9 @@
             <dependency>
                 <groupId>com.fasterxml.jackson.core</groupId>
                 <artifactId>jackson-databind</artifactId>
-                <version>${jackson.version}</version>
+                <!-- This '.2' is due to the fact that they released some patches for 2.13.4 only for this artifact.
+                In future releases it is likely to be aligned with all others artifact versions -->
+                <version>${jackson.version}.2</version>
             </dependency>
             <dependency>
                 <groupId>com.fasterxml.jackson.dataformat</groupId>
@@ -1914,6 +1916,21 @@
                 <version>${jackson.version}</version>
             </dependency>
             <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-guava</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jdk8</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>com.fasterxml.jackson.datatype</groupId>
+                <artifactId>jackson-datatype-jsr310</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>com.fasterxml.jackson.jaxrs</groupId>
                 <artifactId>jackson-jaxrs-base</artifactId>
                 <version>${jackson.version}</version>
@@ -1928,7 +1945,11 @@
                 <artifactId>jackson-module-jaxb-annotations</artifactId>
                 <version>${jackson.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>com.fasterxml.jackson.module</groupId>
+                <artifactId>jackson-module-parameter-names</artifactId>
+                <version>${jackson.version}</version>
+            </dependency>
 
             <!-- -->
             <!-- Logging -->


### PR DESCRIPTION
This PR upgrades Jackson dependencies from 2.13.1 to 2.13.4 (2.13.4.2 for `jackson-databind` artifact) solving following CVEs

- CVE-2020-36518
- CVE-2022-42003
- CVE-2022-42004

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies and added more explicit declaration of jackson dependencies.

**Screenshots**
_None_

**Any side note on the changes made**
_None_