### PR TITLE
Upgraded Snakeyaml dependency from 1.28 to 1.33 - CVE-2022-38752 CVE-2022-38751 CVE-2022-38750 CVE-2022-38749

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -102,7 +102,7 @@
         <scada-utils.version>0.4.0</scada-utils.version>
         <shiro.version>1.10.0</shiro.version>
         <slf4j.version>1.7.33</slf4j.version>
-        <snakeyaml.version>1.28</snakeyaml.version>
+        <snakeyaml.version>1.33</snakeyaml.version>
         <spotify.version>8.15.1</spotify.version>
         <spring.version>5.3.23</spring.version>
         <spring-security.version>5.5.1</spring-security.version>


### PR DESCRIPTION
Upgraded Snakeyaml dependency from 1.28 to 1.33 solving following CVEs

CVE-2022-38749
CVE-2022-38750
CVE-2022-38751
CVE-2022-38752

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_