### PR TITLE
Upgraded Logback dependencies from 1.2.3 to 1.2.11 - CVE-2021-42550

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -85,7 +85,7 @@
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
-        <logback.version>1.2.3</logback.version>
+        <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
         <netty.version>4.1.84.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>

--- a/simulator-kura/pom.xml
+++ b/simulator-kura/pom.xml
@@ -23,7 +23,6 @@
     </parent>
 
     <artifactId>kapua-simulator-kura</artifactId>
-
     <description>This is a framework for simulating Eclipse Kura IoT gateway instances</description>
 
     <properties>
@@ -34,37 +33,46 @@
 
     <dependencies>
         <dependency>
-            <groupId>org.eclipse.paho</groupId>
-            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+            <optional>true</optional>
         </dependency>
+
         <dependency>
-            <groupId>org.eclipse.neoscada.utils</groupId>
-            <artifactId>org.eclipse.scada.utils</artifactId>
+            <groupId>commons-cli</groupId>
+            <artifactId>commons-cli</artifactId>
         </dependency>
 
         <dependency>
             <groupId>com.google.protobuf</groupId>
             <artifactId>protobuf-java</artifactId>
         </dependency>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>com.google.code.gson</groupId>
+            <artifactId>gson</artifactId>
+        </dependency>
+
 
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
         </dependency>
 
         <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
+            <groupId>org.eclipse.neoscada.utils</groupId>
+            <artifactId>org.eclipse.scada.utils</artifactId>
         </dependency>
-
         <dependency>
-            <groupId>com.google.code.gson</groupId>
-            <artifactId>gson</artifactId>
+            <groupId>org.eclipse.paho</groupId>
+            <artifactId>org.eclipse.paho.client.mqttv3</artifactId>
         </dependency>
 
         <dependency>
@@ -77,30 +85,19 @@
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
         </dependency>
-
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>jul-to-slf4j</artifactId>
             <optional>true</optional>
         </dependency>
 
-        <dependency>
-            <groupId>commons-cli</groupId>
-            <artifactId>commons-cli</artifactId>
-        </dependency>
-
-        <dependency>
-            <groupId>ch.qos.logback</groupId>
-            <artifactId>logback-classic</artifactId>
-            <optional>true</optional>
-        </dependency>
-
+        <!-- -->
+        <!-- Test dependencies -->
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>


### PR DESCRIPTION
Upgraded Logback dependencies from 1.2.3 to 1.3.4 solving following CVEs

- CVE-2021-42550 

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_