### PR TITLE
Upgraded Gson dependencies from 2.7 to 2.10 - CVE-2022-25647

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <elasticsearch.version>7.8.1</elasticsearch.version>
         <googleauth.version>1.5.0</googleauth.version>
-        <gson.version>2.7</gson.version>
+        <gson.version>2.10</gson.version>
         <guava.version>30.1-jre</guava.version>
         <guava-failureaccess.version>1.0.1</guava-failureaccess.version>
         <guava-listenablefuture.version>9999.0-empty-to-avoid-conflict-with-guava</guava-listenablefuture.version>


### PR DESCRIPTION
Upgraded Gson dependencies from 2.7 to 2.10 solving following CVEs:

- CVE-2022-25647

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_