### PR TITLE
Upgraded JUnit dependency from 4.12 to 4.13.2 - CVE-2020-15250

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <joda.version>2.9.4</joda.version>
         <jolokia-jvm.version>1.3.4</jolokia-jvm.version>
         <jose4j.version>0.7.10</jose4j.version>
-        <junit.version>4.12</junit.version>
+        <junit.version>4.13.2</junit.version>
         <liquibase.version>3.6.3</liquibase.version>
         <log4j-api.version>2.17.1</log4j-api.version>
         <log4j2-mock.version>0.0.2</log4j2-mock.version>


### PR DESCRIPTION
Upgraded JUnit dependency from 4.12 to 4.13.2 solving following CVEs:

- CVE-2020-15250

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_