### PR TITLE
Upgraded Httpcomponents to latest 4.x

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -59,8 +59,9 @@
         <h2.version>1.4.199</h2.version>
         <hikaricp.version>4.0.3</hikaricp.version>
         <hk2-api.version>2.5.0-b05</hk2-api.version>
-        <httpcomponents-client.version>4.5.13</httpcomponents-client.version>
         <httpcomponents-asyncclient.version>4.1.5</httpcomponents-asyncclient.version>
+        <httpcomponents-client.version>4.5.13</httpcomponents-client.version>
+        <httpcomponents-core.version>4.4.15</httpcomponents-core.version>
         <jackson.version>2.13.4</jackson.version>
         <javassist.version>3.26.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
@@ -1246,7 +1247,21 @@
                 <artifactId>httpasyncclient</artifactId>
                 <version>${httpcomponents-asyncclient.version}</version>
             </dependency>
-
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore</artifactId>
+                <version>${httpcomponents-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore-nio</artifactId>
+                <version>${httpcomponents-core.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpcore-osgi</artifactId>
+                <version>${httpcomponents-core.version}</version>
+            </dependency>
 
             <!-- -->
             <!-- Misc -->

--- a/pom.xml
+++ b/pom.xml
@@ -59,7 +59,7 @@
         <h2.version>1.4.199</h2.version>
         <hikaricp.version>4.0.3</hikaricp.version>
         <hk2-api.version>2.5.0-b05</hk2-api.version>
-        <httpcomponents.version>4.5.13</httpcomponents.version>
+        <httpcomponents-client.version>4.5.13</httpcomponents-client.version>
         <jackson.version>2.13.4</jackson.version>
         <javassist.version>3.26.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
@@ -1237,7 +1237,7 @@
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
-                <version>${httpcomponents.version}</version>
+                <version>${httpcomponents-client.version}</version>
             </dependency>
 
             <!-- -->

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,7 @@
         <hikaricp.version>4.0.3</hikaricp.version>
         <hk2-api.version>2.5.0-b05</hk2-api.version>
         <httpcomponents-client.version>4.5.13</httpcomponents-client.version>
+        <httpcomponents-asyncclient.version>4.1.5</httpcomponents-asyncclient.version>
         <jackson.version>2.13.4</jackson.version>
         <javassist.version>3.26.0-GA</javassist.version>
         <javax-annotation-api.version>1.2</javax-annotation-api.version>
@@ -1234,11 +1235,18 @@
                 <artifactId>commons-pool2</artifactId>
                 <version>${commons-pool.version}</version>
             </dependency>
+
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>
                 <version>${httpcomponents-client.version}</version>
             </dependency>
+            <dependency>
+                <groupId>org.apache.httpcomponents</groupId>
+                <artifactId>httpasyncclient</artifactId>
+                <version>${httpcomponents-asyncclient.version}</version>
+            </dependency>
+
 
             <!-- -->
             <!-- Misc -->


### PR DESCRIPTION
This PR upgrades version and sets fixed version on root pom.xml for the following components:

- httpcomponents:httpclient to 4.5.13
- httpcomponents:httpasyncclient to 4.1.4
- httpcomponents:httpcore to 4.4.15
- httpcomponents:httpcore-nio to 4.4.15
- httpcomponents:httpcore-osgi to 4.4.15

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_