### PR TITLE
Replaced org.apache.sanselan:sanselan with org.apache.commons:commons-imaging - CVE-2018-17201 CVE-2018-17202

### DIFF
--- a/console/module/account/pom.xml
+++ b/console/module/account/pom.xml
@@ -70,8 +70,8 @@
 
         <!-- External Dependencies -->
         <dependency>
-            <groupId>org.apache.sanselan</groupId>
-            <artifactId>sanselan</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-imaging</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
+++ b/console/module/account/src/main/java/org/eclipse/kapua/app/console/module/account/server/GwtAccountServiceImpl.java
@@ -19,8 +19,9 @@ import com.extjs.gxt.ui.client.data.PagingLoadConfig;
 import com.extjs.gxt.ui.client.data.PagingLoadResult;
 import com.google.common.collect.Sets;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.sanselan.ImageFormat;
-import org.apache.sanselan.Sanselan;
+import org.apache.commons.imaging.ImageFormat;
+import org.apache.commons.imaging.ImageFormats;
+import org.apache.commons.imaging.Imaging;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccount;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountCreator;
 import org.eclipse.kapua.app.console.module.account.shared.model.GwtAccountQuery;
@@ -633,14 +634,14 @@ public class GwtAccountServiceImpl extends KapuaRemoteServiceServlet implements 
                     LOG.info("Downloaded file: {}", tmpFile);
 
                     // Image metadata content checks
-                    ImageFormat imgFormat = Sanselan.guessFormat(tmpFile);
+                    ImageFormat imgFormat = Imaging.guessFormat(tmpFile);
 
-                    if (imgFormat.equals(ImageFormat.IMAGE_FORMAT_BMP) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_GIF) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_JPEG) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_PNG)) {
-                        LOG.info("Detected image format: {}", imgFormat.name);
-                    } else if (imgFormat.equals(ImageFormat.IMAGE_FORMAT_UNKNOWN)) {
+                    if (imgFormat.equals(ImageFormats.BMP) ||
+                            imgFormat.equals(ImageFormats.GIF) ||
+                            imgFormat.equals(ImageFormats.JPEG) ||
+                            imgFormat.equals(ImageFormats.PNG)) {
+                        LOG.info("Detected image format: {}", imgFormat.getName());
+                    } else if (imgFormat.equals(ImageFormats.UNKNOWN)) {
                         LOG.error("Unknown file format for URL: {}", iconResource);
                         throw new IOException("Unknown file format for URL: " + iconResource);
                     } else {

--- a/console/module/device/pom.xml
+++ b/console/module/device/pom.xml
@@ -68,8 +68,8 @@
             <artifactId>opencsv</artifactId>
         </dependency>
         <dependency>
-            <groupId>org.apache.sanselan</groupId>
-            <artifactId>sanselan</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-imaging</artifactId>
         </dependency>
         <dependency>
             <groupId>commons-codec</groupId>

--- a/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
+++ b/console/module/device/src/main/java/org/eclipse/kapua/app/console/module/device/server/GwtDeviceManagementServiceImpl.java
@@ -15,8 +15,9 @@ package org.eclipse.kapua.app.console.module.device.server;
 import com.extjs.gxt.ui.client.data.BaseListLoadResult;
 import com.extjs.gxt.ui.client.data.ListLoadResult;
 import org.apache.commons.codec.binary.Base64;
-import org.apache.sanselan.ImageFormat;
-import org.apache.sanselan.Sanselan;
+import org.apache.commons.imaging.ImageFormat;
+import org.apache.commons.imaging.ImageFormats;
+import org.apache.commons.imaging.Imaging;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaErrorCode;
 import org.eclipse.kapua.app.console.module.api.client.GwtKapuaException;
 import org.eclipse.kapua.app.console.module.api.server.KapuaRemoteServiceServlet;
@@ -874,14 +875,14 @@ public class GwtDeviceManagementServiceImpl extends KapuaRemoteServiceServlet im
                     LOG.info("Downloaded file: {}", tmpFile);
 
                     // Image metadata content checks
-                    ImageFormat imgFormat = Sanselan.guessFormat(tmpFile);
+                    ImageFormat imgFormat = Imaging.guessFormat(tmpFile);
 
-                    if (imgFormat.equals(ImageFormat.IMAGE_FORMAT_BMP) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_GIF) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_JPEG) ||
-                            imgFormat.equals(ImageFormat.IMAGE_FORMAT_PNG)) {
-                        LOG.info("Detected image format: {}", imgFormat.name);
-                    } else if (imgFormat.equals(ImageFormat.IMAGE_FORMAT_UNKNOWN)) {
+                    if (imgFormat.equals(ImageFormats.BMP) ||
+                            imgFormat.equals(ImageFormats.GIF) ||
+                            imgFormat.equals(ImageFormats.JPEG) ||
+                            imgFormat.equals(ImageFormats.PNG)) {
+                        LOG.info("Detected image format: {}", imgFormat.getName());
+                    } else if (imgFormat.equals(ImageFormats.UNKNOWN)) {
                         LOG.error("Unknown file format for URL: {}", iconResource);
                         throw new IOException("Unknown file format for URL: " + iconResource);
                     } else {

--- a/console/pom.xml
+++ b/console/pom.xml
@@ -35,7 +35,6 @@
         <com.google.gwt.version>2.4.0</com.google.gwt.version>
         <com.extjs.gxt.version>2.2.5</com.extjs.gxt.version>
         <com.allen-sauer.gwt.log.version>3.1.8</com.allen-sauer.gwt.log.version>
-        <sanselan.version>0.97-incubator</sanselan.version>
     </properties>
 
     <repositories>
@@ -247,14 +246,6 @@
                 <artifactId>commons-fileupload</artifactId>
                 <version>${commons-fileupload.versison}</version>
             </dependency>
-            <dependency>
-                <!-- Imaging utils used to handle device component configuration  icons -->
-                <!-- Former commons-imaging changed because the 1.0-FINAL was not contined/supported in maven -->
-                <groupId>org.apache.sanselan</groupId>
-                <artifactId>sanselan</artifactId>
-                <version>${sanselan.version}</version>
-            </dependency>
-
         </dependencies>
     </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -41,6 +41,7 @@
         <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
         <commons-fileupload.versison>1.4</commons-fileupload.versison>
+        <commons-imaging.version>1.0-alpha3</commons-imaging.version>
         <commons-io.version>2.11.0</commons-io.version>
         <commons-lang.version>3.4</commons-lang.version>
         <commons-logging.version>1.2</commons-logging.version>
@@ -1217,6 +1218,11 @@
                 <version>${commons-collections.version}</version>
             </dependency>
             <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-imaging</artifactId>
+                <version>${commons-imaging.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-io</groupId>
                 <artifactId>commons-io</artifactId>
                 <version>${commons-io.version}</version>
@@ -1237,6 +1243,7 @@
                 <version>${commons-pool.version}</version>
             </dependency>
 
+            <!-- Apache Httpcomponents -->
             <dependency>
                 <groupId>org.apache.httpcomponents</groupId>
                 <artifactId>httpclient</artifactId>


### PR DESCRIPTION
This PR replaces  `org.apache.sanselan:sanselan-0.97-incubator` dependency with `org.apache.commons:commons-imaging:1.0-alpha3` solving following CVEs:

- CVE-2018-17201 
- CVE-2018-17202

Apache Commons Imaging is the successor of Apache Sanselan.

**Related Issue**
_None_

**Description of the solution adopted**
Replaced dependency and adapted code.

**Screenshots**
_None_

**Any side note on the changes made**
_None_