### PR TITLE
Upgraded Spring Security from 5.7.4 to 5.7.5 - CVE-2022-31692

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
         <spotify.version>8.15.1</spotify.version>
         <spring.version>5.3.23</spring.version>
         <spring-boot.version>2.5.14</spring-boot.version> <!-- 2.3.x is not fully supported by camel (will be on camel 3.4) -->
-        <spring-security.version>5.7.4</spring-security.version>
+        <spring-security.version>5.7.5</spring-security.version>
         <swagger-ui.version>3.23.0</swagger-ui.version>
         <zxing.version>3.4.1</zxing.version>
 


### PR DESCRIPTION
This PR upgrades Spring Security dependencies from 5.7.4 to 5.7.5 to solve follwoing CVEs

- CVE-2022-31692

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependencies

**Screenshots**
_None_

**Any side note on the changes made**
_None_