### PR TITLE
Upgraded Apache Commons Compress from 1.18 to 1.22 - CVE-2021-35515 CVE-2021-35516 CVE-2021-35517 CVE-2021-36090

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -38,8 +38,9 @@
         <commons-beanutils.version>1.9.4</commons-beanutils.version>
         <commons-cli.version>1.4</commons-cli.version>
         <commons-codec.version>1.15</commons-codec.version>
-        <commons-configuration.version>1.9</commons-configuration.version>
         <commons-collections.version>3.2.2</commons-collections.version>
+        <commons-configuration.version>1.9</commons-configuration.version>
+        <commons-compress.version>1.22</commons-compress.version>
         <commons-fileupload.versison>1.4</commons-fileupload.versison>
         <commons-imaging.version>1.0-alpha3</commons-imaging.version>
         <commons-io.version>2.11.0</commons-io.version>
@@ -1202,6 +1203,16 @@
                 <version>${commons-codec.version}</version>
             </dependency>
             <dependency>
+                <groupId>commons-collections</groupId>
+                <artifactId>commons-collections</artifactId>
+                <version>${commons-collections.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.apache.commons</groupId>
+                <artifactId>commons-compress</artifactId>
+                <version>${commons-compress.version}</version>
+            </dependency>
+            <dependency>
                 <groupId>commons-configuration</groupId>
                 <artifactId>commons-configuration</artifactId>
                 <version>${commons-configuration.version}</version>
@@ -1211,11 +1222,6 @@
                         <artifactId>commons-logging</artifactId>
                     </exclusion>
                 </exclusions>
-            </dependency>
-            <dependency>
-                <groupId>commons-collections</groupId>
-                <artifactId>commons-collections</artifactId>
-                <version>${commons-collections.version}</version>
             </dependency>
             <dependency>
                 <groupId>org.apache.commons</groupId>


### PR DESCRIPTION
This PR upgrades the version of Apache Commons Compress from 1.18 to 1.22 solving following CVEs:

- CVE-2021-35515
- CVE-2021-35516
- CVE-2021-35517
- CVE-2021-36090

**Related Issue**
_None_

**Description of the solution adopted**
Upgraded dependency version

**Screenshots**
_None_

**Any side note on the changes made**
_None_