### PR TITLE
Replacing `centos:7` with `rocky:8` as Docker base image

### DIFF
--- a/assembly/java-base/docker/Dockerfile
+++ b/assembly/java-base/docker/Dockerfile
@@ -26,6 +26,7 @@ RUN yum install -y java-1.8.0-openjdk && \
 RUN mkdir -p /etc/opt/kapua && \
     openssl req -x509 -newkey rsa:4096 -keyout /etc/opt/kapua/key.pem -out /etc/opt/kapua/cert.pem -days 365 -nodes -subj '/O=Eclipse Kapua/C=XX' && \
     openssl pkcs8 -topk8 -in /etc/opt/kapua/key.pem -out /etc/opt/kapua/key.pk8 -nocrypt && \
+    chmod +r /etc/opt/kapua/key.pk8 && \
     rm /etc/opt/kapua/key.pem
 
 EXPOSE 8778

--- a/assembly/java-base/pom.xml
+++ b/assembly/java-base/pom.xml
@@ -26,7 +26,7 @@
     <artifactId>kapua-assembly-java-base</artifactId>
 
     <properties>
-        <docker.base.image>centos:7</docker.base.image>
+        <docker.base.image>rockylinux:8</docker.base.image>
         <jolokia.agent.url>https://repo1.maven.org/maven2/org/jolokia/jolokia-jvm/1.3.4/jolokia-jvm-1.3.4-agent.jar</jolokia.agent.url>
     </properties>
 


### PR DESCRIPTION
this pr changes the java base image from centos 7 to rocky 8