### PR TITLE
Fix `KAPUA_SWAGGER_ENABLE variable is not set` warning

### DIFF
--- a/deployment/docker/compose/docker-compose.yml
+++ b/deployment/docker/compose/docker-compose.yml
@@ -129,7 +129,7 @@ services:
       - KAPUA_KEYSTORE
       - KAPUA_KEYSTORE_PASSWORD
       - LOGBACK_LOG_LEVEL
-      - SWAGGER=${KAPUA_SWAGGER_ENABLE}
+      - SWAGGER=${KAPUA_SWAGGER_ENABLE:-true}
   job-engine:
     container_name: job-engine
     image: kapua/kapua-job-engine:${IMAGE_VERSION}


### PR DESCRIPTION
Brief description of the PR.
This PR fixes #3666.

**Description of the solution adopted**
Add the default value `true` to the variable.