### PR TITLE
Fixed AccountService improper segregation

### DIFF
--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepDefinitionServiceImpl.java
@@ -50,7 +50,7 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
     public ListLoadResult<GwtJobStepDefinition> findAll() throws GwtKapuaException {
         List<GwtJobStepDefinition> gwtJobStepDefinitionList = new ArrayList<GwtJobStepDefinition>();
         try {
-            JobStepDefinitionListResult result = JOB_STEP_DEFINITION_SERVICE.query(JOB_STEP_DEFINITION_FACTORY.newQuery(null));
+            JobStepDefinitionListResult result = JOB_STEP_DEFINITION_SERVICE.query(JOB_STEP_DEFINITION_FACTORY.newQuery(KapuaId.ANY));
             for (JobStepDefinition jsd : result.getItems()) {
 
                 if (!Strings.isNullOrEmpty(JOB_STEP_DEFINITION_EXCLUDE_REGEX) && jsd.getName().matches(JOB_STEP_DEFINITION_EXCLUDE_REGEX)) {
@@ -76,7 +76,7 @@ public class GwtJobStepDefinitionServiceImpl extends KapuaRemoteServiceServlet i
 
         GwtJobStepDefinition gwtJobStepDefinition = null;
         try {
-            JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(null, jobStepDefinitionId);
+            JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(KapuaId.ANY, jobStepDefinitionId);
             if (jobStepDefinition != null) {
                 gwtJobStepDefinition = KapuaGwtJobModelConverter.convertJobStepDefinition(jobStepDefinition);
 

--- a/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
+++ b/console/module/job/src/main/java/org/eclipse/kapua/app/console/module/job/server/GwtJobStepServiceImpl.java
@@ -71,7 +71,7 @@ public class GwtJobStepServiceImpl extends KapuaRemoteServiceServlet implements 
             for (JobStep js : jobStepList.getItems()) {
                 GwtJobStep gwtJobStep = KapuaGwtJobModelConverter.convertJobStep(js);
 
-                JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getScopeId()), GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getJobStepDefinitionId()));
+                JobStepDefinition jobStepDefinition = JOB_STEP_DEFINITION_SERVICE.find(KapuaId.ANY, GwtKapuaCommonsModelConverter.convertKapuaId(gwtJobStep.getJobStepDefinitionId()));
                 gwtJobStep.setJobStepDefinitionName(jobStepDefinition.getName());
 
                 setEnumOnJobStepProperty(gwtJobStep.getStepProperties());

--- a/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
+++ b/job-engine/jbatch/src/main/java/org/eclipse/kapua/job/engine/jbatch/driver/JbatchDriver.java
@@ -146,7 +146,7 @@ public class JbatchDriver {
                 JobStep jobStep = jobStepIterator.next();
 
                 Step jslStep = new Step();
-                JobStepDefinition jobStepDefinition = STEP_DEFINITION_SERVICE.find(jobStep.getScopeId(), jobStep.getJobStepDefinitionId());
+                JobStepDefinition jobStepDefinition = STEP_DEFINITION_SERVICE.find(KapuaId.ANY, jobStep.getJobStepDefinitionId());
                 switch (jobStepDefinition.getStepType()) {
                     case GENERIC:
                         jslStep.setBatchlet(JobDefinitionBuildUtils.buildGenericStep(jobStepDefinition));

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessInfoDAOTest.java
@@ -33,10 +33,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -49,7 +49,7 @@ public class AccessInfoDAOTest {
 
     EntityManager entityManager;
     AccessInfoCreator accessInfoCreator;
-   KapuaId scopeId, accessInfoId;
+    KapuaId scopeId, accessInfoId;
     AccessInfoImpl entityToFindOrDelete;
     KapuaQuery kapuaQuery;
 
@@ -154,7 +154,7 @@ public class AccessInfoDAOTest {
         Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", AccessInfoDAO.find(entityManager, scopeId, accessInfoId) instanceof AccessInfo);
+        Assert.assertTrue("True expected.", AccessInfoDAO.find(entityManager, KapuaId.ANY, accessInfoId) instanceof AccessInfo);
     }
 
     @Test(expected = NullPointerException.class)
@@ -266,6 +266,7 @@ public class AccessInfoDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(AccessInfoImpl.class, accessInfoId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", AccessInfoDAO.delete(entityManager, scopeId, accessInfoId) instanceof AccessInfo);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessPermissionDAOTest.java
@@ -34,10 +34,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -153,7 +153,7 @@ public class AccessPermissionDAOTest {
         Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", AccessPermissionDAO.find(entityManager, scopeId, accessPermissionId) instanceof AccessPermission);
+        Assert.assertTrue("True expected.", AccessPermissionDAO.find(entityManager, KapuaId.ANY, accessPermissionId) instanceof AccessPermission);
     }
 
     @Test(expected = NullPointerException.class)
@@ -265,6 +265,7 @@ public class AccessPermissionDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(AccessPermissionImpl.class, accessPermissionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", AccessPermissionDAO.delete(entityManager, scopeId, accessPermissionId) instanceof AccessPermission);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessRoleDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessRoleDAOTest.java
@@ -19,9 +19,9 @@ import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
+import org.eclipse.kapua.service.authorization.access.AccessRole;
 import org.eclipse.kapua.service.authorization.access.AccessRoleCreator;
 import org.eclipse.kapua.service.authorization.access.AccessRoleListResult;
-import org.eclipse.kapua.service.authorization.access.AccessRole;
 import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleDAO;
 import org.eclipse.kapua.service.authorization.access.shiro.AccessRoleImpl;
 import org.junit.Assert;
@@ -33,10 +33,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -162,7 +162,7 @@ public class AccessRoleDAOTest {
         Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", AccessRoleDAO.find(entityManager, scopeId, accessRoleId) instanceof AccessRole);
+        Assert.assertTrue("True expected.", AccessRoleDAO.find(entityManager, KapuaId.ANY, accessRoleId) instanceof AccessRole);
     }
 
     @Test(expected = NullPointerException.class)
@@ -274,6 +274,7 @@ public class AccessRoleDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(AccessRoleImpl.class, accessRoleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", AccessRoleDAO.delete(entityManager, scopeId, accessRoleId) instanceof AccessRole);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/AccessTokenDAOTest.java
@@ -35,13 +35,12 @@ import javax.persistence.EntityExistsException;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Predicate;
-
-import javax.persistence.criteria.Root;
+import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -217,7 +216,7 @@ public class AccessTokenDAOTest {
         Mockito.when(entityManager.find(AccessTokenImpl.class, accessTokenId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", AccessTokenDAO.find(entityManager, scopeId, accessTokenId) instanceof AccessToken);
+        Assert.assertTrue("True expected.", AccessTokenDAO.find(entityManager, KapuaId.ANY, accessTokenId) instanceof AccessToken);
     }
 
     @Test(expected = NullPointerException.class)
@@ -439,6 +438,7 @@ public class AccessTokenDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(AccessTokenImpl.class, accessTokenId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", AccessTokenDAO.delete(entityManager, scopeId, accessTokenId) instanceof AccessToken);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/CredentialDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/CredentialDAOTest.java
@@ -21,10 +21,10 @@ import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
 import org.eclipse.kapua.service.authentication.credential.Credential;
+import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
+import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
 import org.eclipse.kapua.service.authentication.credential.CredentialStatus;
 import org.eclipse.kapua.service.authentication.credential.CredentialType;
-import org.eclipse.kapua.service.authentication.credential.CredentialListResult;
-import org.eclipse.kapua.service.authentication.credential.CredentialCreator;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialDAO;
 import org.eclipse.kapua.service.authentication.credential.shiro.CredentialImpl;
 import org.junit.Assert;
@@ -36,8 +36,8 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
@@ -250,7 +250,7 @@ public class CredentialDAOTest {
         Mockito.when(entityManager.find(CredentialImpl.class, credentialId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", CredentialDAO.find(entityManager, scopeId, credentialId) instanceof Credential);
+        Assert.assertTrue("True expected.", CredentialDAO.find(entityManager, KapuaId.ANY, credentialId) instanceof Credential);
     }
 
     @Test(expected = NullPointerException.class)
@@ -362,6 +362,7 @@ public class CredentialDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(CredentialImpl.class, credentialId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", CredentialDAO.delete(entityManager, scopeId, credentialId) instanceof Credential);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DomainDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/DomainDAOTest.java
@@ -36,14 +36,13 @@ import javax.persistence.EntityExistsException;
 import javax.persistence.NonUniqueResultException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-
-import javax.persistence.criteria.ParameterExpression;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
-import javax.persistence.criteria.Selection;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.ParameterExpression;
 import javax.persistence.criteria.Predicate;
+import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -185,7 +184,7 @@ public class DomainDAOTest {
         Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", DomainDAO.find(entityManager, scopeId, domainId) instanceof Domain);
+        Assert.assertTrue("True expected.", DomainDAO.find(entityManager, KapuaId.ANY, domainId) instanceof Domain);
     }
 
     @Test(expected = NullPointerException.class)
@@ -298,6 +297,7 @@ public class DomainDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(DomainImpl.class, domainId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", DomainDAO.delete(entityManager, scopeId, domainId) instanceof Domain);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/EventStoreDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/EventStoreDAOTest.java
@@ -25,7 +25,6 @@ import org.eclipse.kapua.model.KapuaEntity;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-
 import org.hamcrest.core.IsInstanceOf;
 import org.junit.Assert;
 import org.junit.Test;
@@ -35,12 +34,12 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Selection;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
-import javax.persistence.metamodel.EntityType;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
+import javax.persistence.criteria.Selection;
+import javax.persistence.metamodel.EntityType;
 import java.math.BigInteger;
 import java.sql.SQLException;
 import java.util.ArrayList;
@@ -177,22 +176,25 @@ public class EventStoreDAOTest {
         }
 
         //entityToFind not null
-        for (KapuaId event : eventIds) {
+        for (KapuaId eventId : eventIds) {
             eventStoreRecordImpl.setScopeId(null);
-            Mockito.when(entityManager.find(EventStoreRecordImpl.class, event)).thenReturn(eventStoreRecordImpl);
-            Assert.assertEquals("Expected and actual values should be the same.", eventStoreRecordImpl, EventStoreDAO.find(entityManager, null, event));
-            Assert.assertEquals("Expected and actual values should be the same.", eventStoreRecordImpl, EventStoreDAO.find(entityManager, scopeIdOne, event));
+            Mockito.when(entityManager.find(EventStoreRecordImpl.class, eventId)).thenReturn(eventStoreRecordImpl);
+            Assert.assertEquals("Expected and actual values should be the same.", eventStoreRecordImpl, EventStoreDAO.find(entityManager, null, eventId));
+            Assert.assertNull("Expected and actual values should be the same.", EventStoreDAO.find(entityManager, scopeIdOne, eventId));
+
             eventStoreRecordImpl.setScopeId(scopeIdOne);
-            Assert.assertEquals("Expected and actual values should be the same.", eventStoreRecordImpl, EventStoreDAO.find(entityManager, scopeIdOne, event));
+            Assert.assertEquals("Expected and actual values should be the same.", eventStoreRecordImpl, EventStoreDAO.find(entityManager, scopeIdOne, eventId));
+
             eventStoreRecordImpl.setScopeId(scopeIdTen);
-            Assert.assertNull("Null expected", EventStoreDAO.find(entityManager, scopeIdOne, event));
+            Assert.assertNull("Null expected", EventStoreDAO.find(entityManager, scopeIdOne, eventId));
+
             try {
-                EventStoreDAO.find(null, scopeIdOne, event);
+                EventStoreDAO.find(null, scopeIdOne, eventId);
             } catch (Exception e) {
                 Assert.assertEquals("NullPointerException expected.", nullPointerException.toString(), e.toString());
             }
             try {
-                EventStoreDAO.find(null, null, event);
+                EventStoreDAO.find(null, null, eventId);
             } catch (Exception e) {
                 Assert.assertEquals("NullPointerException expected.", nullPointerException.toString(), e.toString());
             }
@@ -246,7 +248,7 @@ public class EventStoreDAOTest {
         Mockito.when(entityManager.createQuery(criteriaQuery1)).thenReturn(query);
         for (long number : longNumberList) {
             Mockito.doReturn(number).when(query).getSingleResult();
-        Assert.assertThat("Long object expected.", EventStoreDAO.count(entityManager, kapuaQuery), IsInstanceOf.instanceOf(Long.class));
+            Assert.assertThat("Long object expected.", EventStoreDAO.count(entityManager, kapuaQuery), IsInstanceOf.instanceOf(Long.class));
         }
     }
 
@@ -271,19 +273,6 @@ public class EventStoreDAOTest {
                 EventStoreDAO.delete(null, scopeId, eventIds[1]);
             } catch (Exception e) {
                 Assert.assertEquals("NullPointerException expected", nullPointerException.toString(), e.toString());
-            }
-        }
-
-        //entityToDelete not null
-        for (KapuaId eventId : eventIds) {
-            for (KapuaId scopeId : scopeIds) {
-                Mockito.when(entityManager.find(EventStoreRecordImpl.class, eventId)).thenReturn(eventStoreRecordImpl);
-                Assert.assertEquals(eventStoreRecordImpl, EventStoreDAO.delete(entityManager, scopeId, eventId));
-                try {
-                    EventStoreDAO.delete(null, scopeId, eventId);
-                } catch (Exception e) {
-                    Assert.assertEquals("NullPointerException expected", nullPointerException.toString(), e.toString());
-                }
             }
         }
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/GroupDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/GroupDAOTest.java
@@ -19,7 +19,6 @@ import org.eclipse.kapua.commons.jpa.EntityManager;
 import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.KapuaQuery;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;
-
 import org.eclipse.kapua.service.authorization.group.Group;
 import org.eclipse.kapua.service.authorization.group.GroupCreator;
 import org.eclipse.kapua.service.authorization.group.GroupListResult;
@@ -34,10 +33,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -200,8 +199,8 @@ public class GroupDAOTest {
         Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", GroupDAO.find(entityManager, scopeId, groupId) instanceof Group);
-        Assert.assertNull("Null expected.", GroupDAO.find(entityManager, scopeId, groupId).getScopeId());
+        Assert.assertTrue("True expected.", GroupDAO.find(entityManager, KapuaId.ANY, groupId) instanceof Group);
+        Assert.assertNull("Null expected.", GroupDAO.find(entityManager, scopeId, groupId));
     }
 
     @Test(expected = NullPointerException.class)
@@ -311,6 +310,8 @@ public class GroupDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(GroupImpl.class, groupId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
+
         Assert.assertTrue("True expected.", GroupDAO.delete(entityManager, scopeId, groupId) instanceof Group);
     }
 

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MfaOptionDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/MfaOptionDAOTest.java
@@ -35,8 +35,8 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
@@ -192,7 +192,7 @@ public class MfaOptionDAOTest {
         Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, scopeId, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
+        Assert.assertThat("Instance of MfaOption object expected.", MfaOptionDAO.find(entityManager, KapuaId.ANY, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
     }
 
     @Test(expected = NullPointerException.class)
@@ -287,7 +287,7 @@ public class MfaOptionDAOTest {
         for (long number : longNumberList) {
             Mockito.doReturn(number).when(query).getSingleResult();
 
-        Assert.assertThat("Long object expected.", MfaOptionDAO.count(entityManager, kapuaQuery), IsInstanceOf.instanceOf(Long.class));
+            Assert.assertThat("Long object expected.", MfaOptionDAO.count(entityManager, kapuaQuery), IsInstanceOf.instanceOf(Long.class));
             Assert.assertEquals("Expected and actual values should be the same.", number, MfaOptionDAO.count(entityManager, kapuaQuery));
         }
     }
@@ -305,6 +305,7 @@ public class MfaOptionDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(MfaOptionImpl.class, mfaOptionId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertThat("Instance of MfaOption object expected.", MfaOptionDAO.delete(entityManager, scopeId, mfaOptionId), IsInstanceOf.instanceOf(MfaOption.class));
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RoleDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RoleDAOTest.java
@@ -33,10 +33,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -189,7 +189,7 @@ public class RoleDAOTest {
         Mockito.when(entityManager.find(RoleImpl.class, roleId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", RoleDAO.find(entityManager, scopeId, roleId) instanceof Role);
+        Assert.assertTrue("True expected.", RoleDAO.find(entityManager, KapuaId.ANY, roleId) instanceof Role);
     }
 
     @Test(expected = NullPointerException.class)
@@ -301,6 +301,7 @@ public class RoleDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(RoleImpl.class, roleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", RoleDAO.delete(entityManager, scopeId, roleId) instanceof Role);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/RolePermissionDAOTest.java
@@ -34,10 +34,10 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-import javax.persistence.criteria.Root;
-import javax.persistence.criteria.Expression;
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
+import javax.persistence.criteria.Expression;
+import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
 import javax.persistence.metamodel.EntityType;
 import java.sql.SQLException;
@@ -161,7 +161,7 @@ public class RolePermissionDAOTest {
         Mockito.when(entityManager.find(RolePermissionImpl.class, roleId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", RolePermissionDAO.find(entityManager, scopeId, roleId) instanceof RolePermission);
+        Assert.assertTrue("True expected.", RolePermissionDAO.find(entityManager, KapuaId.ANY, roleId) instanceof RolePermission);
     }
 
     @Test(expected = NullPointerException.class)
@@ -273,6 +273,7 @@ public class RolePermissionDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(RolePermissionImpl.class, roleId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", RolePermissionDAO.delete(entityManager, scopeId, roleId) instanceof RolePermission);
     }

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ScratchCodeDAOTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/ScratchCodeDAOTest.java
@@ -34,9 +34,8 @@ import org.mockito.Mockito;
 import javax.persistence.EntityExistsException;
 import javax.persistence.PersistenceException;
 import javax.persistence.TypedQuery;
-
-import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.CriteriaBuilder;
+import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Expression;
 import javax.persistence.criteria.Root;
 import javax.persistence.criteria.Selection;
@@ -194,7 +193,7 @@ public class ScratchCodeDAOTest {
         Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
         Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(null);
 
-        Assert.assertTrue("True expected.", ScratchCodeDAO.find(entityManager, scopeId, scratchCodeId) instanceof ScratchCode);
+        Assert.assertTrue("True expected.", ScratchCodeDAO.find(entityManager, KapuaId.ANY, scratchCodeId) instanceof ScratchCode);
     }
 
     @Test(expected = NullPointerException.class)
@@ -306,6 +305,7 @@ public class ScratchCodeDAOTest {
     @Test
     public void deleteTest() throws KapuaEntityNotFoundException {
         Mockito.when(entityManager.find(ScratchCodeImpl.class, scratchCodeId)).thenReturn(entityToFindOrDelete);
+        Mockito.when(entityToFindOrDelete.getScopeId()).thenReturn(KapuaId.ONE);
 
         Assert.assertTrue("True expected.", ScratchCodeDAO.delete(entityManager, scopeId, scratchCodeId) instanceof ScratchCode);
     }

--- a/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobStepDefinitions.java
+++ b/rest-api/resources/src/main/java/org/eclipse/kapua/app/api/resources/v1/resources/JobStepDefinitions.java
@@ -12,22 +12,14 @@
  *******************************************************************************/
 package org.eclipse.kapua.app.api.resources.v1.resources;
 
-import javax.ws.rs.Consumes;
-import javax.ws.rs.DefaultValue;
-import javax.ws.rs.GET;
-import javax.ws.rs.POST;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
-import javax.ws.rs.QueryParam;
-import javax.ws.rs.core.MediaType;
-
+import com.google.common.base.Strings;
 import org.eclipse.kapua.KapuaException;
 import org.eclipse.kapua.app.api.core.model.CountResult;
 import org.eclipse.kapua.app.api.core.model.EntityId;
 import org.eclipse.kapua.app.api.core.model.ScopeId;
 import org.eclipse.kapua.app.api.core.resources.AbstractKapuaResource;
 import org.eclipse.kapua.locator.KapuaLocator;
+import org.eclipse.kapua.model.id.KapuaId;
 import org.eclipse.kapua.model.query.SortOrder;
 import org.eclipse.kapua.service.KapuaService;
 import org.eclipse.kapua.service.job.Job;
@@ -40,7 +32,15 @@ import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionListResult
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionQuery;
 import org.eclipse.kapua.service.job.step.definition.JobStepDefinitionService;
 
-import com.google.common.base.Strings;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.DefaultValue;
+import javax.ws.rs.GET;
+import javax.ws.rs.POST;
+import javax.ws.rs.Path;
+import javax.ws.rs.PathParam;
+import javax.ws.rs.Produces;
+import javax.ws.rs.QueryParam;
+import javax.ws.rs.core.MediaType;
 
 @Path("{scopeId}/jobStepDefinitions")
 public class JobStepDefinitions extends AbstractKapuaResource {
@@ -52,11 +52,11 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     /**
      * Gets the {@link JobStep} list for a given {@link Job}.
      *
-     * @param scopeId       The {@link ScopeId} in which to search results.
-     * @param sortParam     The name of the parameter that will be used as a sorting key
-     * @param sortDir       The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
-     * @param offset        The result set offset.
-     * @param limit         The result set limit.
+     * @param scopeId   The {@link ScopeId} in which to search results.
+     * @param sortParam The name of the parameter that will be used as a sorting key
+     * @param sortDir   The sort direction. Can be ASCENDING (default), DESCENDING. Case-insensitive.
+     * @param offset    The result set offset.
+     * @param limit     The result set limit.
      * @return The {@link JobStepListResult} of all the jobs jobSteps associated to the current selected job.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
      * @since 1.5.0
@@ -70,7 +70,7 @@ public class JobStepDefinitions extends AbstractKapuaResource {
             @QueryParam("offset") @DefaultValue("0") int offset,
             @QueryParam("limit") @DefaultValue("50") int limit) throws KapuaException {
 
-        JobStepDefinitionQuery query = jobStepDefinitionFactory.newQuery(null);
+        JobStepDefinitionQuery query = jobStepDefinitionFactory.newQuery(KapuaId.ANY);
 
         if (!Strings.isNullOrEmpty(sortParam)) {
             query.setSortCriteria(query.fieldSortCriteria(sortParam, sortDir));
@@ -98,7 +98,8 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     public JobStepDefinitionListResult query(
             @PathParam("scopeId") ScopeId scopeId,
             JobStepDefinitionQuery query) throws KapuaException {
-        query.setScopeId(null);
+        query.setScopeId(KapuaId.ANY);
+
         return jobStepDefinitionService.query(query);
     }
 
@@ -118,7 +119,7 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     public CountResult count(
             @PathParam("scopeId") ScopeId scopeId,
             JobStepQuery query) throws KapuaException {
-        query.setScopeId(null);
+        query.setScopeId(KapuaId.ANY);
 
         return new CountResult(jobStepDefinitionService.count(query));
     }
@@ -126,7 +127,7 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     /**
      * Returns the Job specified by the "jobId" path parameter.
      *
-     * @param scopeId The {@link ScopeId} of the requested {@link Job}.
+     * @param scopeId          The {@link ScopeId} of the requested {@link Job}.
      * @param stepDefinitionId The id of the requested JobStep.
      * @return The requested Job object.
      * @throws KapuaException Whenever something bad happens. See specific {@link KapuaService} exceptions.
@@ -138,7 +139,7 @@ public class JobStepDefinitions extends AbstractKapuaResource {
     public JobStepDefinition find(
             @PathParam("scopeId") ScopeId scopeId,
             @PathParam("stepDefinitionId") EntityId stepDefinitionId) throws KapuaException {
-        return jobStepDefinitionService.find(null, stepDefinitionId);
+        return jobStepDefinitionService.find(KapuaId.ANY, stepDefinitionId);
     }
 
 }

--- a/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
+++ b/service/account/api/src/main/java/org/eclipse/kapua/service/account/AccountService.java
@@ -45,11 +45,11 @@ public interface AccountService extends KapuaEntityService<Account, AccountCreat
     AccountListResult query(@NotNull KapuaQuery query) throws KapuaException;
 
     /**
-     * Returns an {@link AccountListResult} of direct child {@link Account} of the given {@link Account#getId()}.
+     * Returns an {@link AccountListResult} of direct children {@link Account}s of the given {@link Account#getId()}.
      *
-     * @param accountId The {@link Account#getId()}.
-     * @return The {@link AccountListResult} of direct child {@link Account}.
+     * @param scopeId The {@link Account#getId()}.
+     * @return The {@link AccountListResult} of direct children {@link Account}s.
      * @throws KapuaException
      */
-    AccountListResult findChildrenRecursively(@NotNull KapuaId accountId) throws KapuaException;
+    AccountListResult findChildrenRecursively(@NotNull KapuaId scopeId) throws KapuaException;
 }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -255,8 +255,10 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         entityManagerSession.doTransactedAction(
                 EntityManagerContainer.<Account>create()
                         .onResultHandler(em -> {
-                            // Entity needs to be loaded in the context of the same EntityManger to be able to delete it afterwards
-                            Account account = AccountDAO.find(em, scopeId, accountId);
+                            Account account = scopeId.equals(accountId) ?
+                                    AccountDAO.find(em, KapuaId.ANY, accountId) :
+                                    AccountDAO.find(em, scopeId, accountId);
+
                             if (account == null) {
                                 throw new KapuaEntityNotFoundException(Account.TYPE, accountId);
                             }

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -103,7 +103,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Check if the parent account exists
-        if (findById(accountCreator.getScopeId()) == null) {
+        if (find(accountCreator.getScopeId()) == null) {
             throw new KapuaIllegalArgumentException(KapuaEntityAttributes.SCOPE_ID, "parent account does not exist: " + accountCreator.getScopeId() + "::");
         }
 
@@ -134,15 +134,19 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do create
-        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
-            Account account = AccountDAO.create(em, accountCreator);
-            em.persist(account);
+        return entityManagerSession.doTransactedAction(
+                EntityManagerContainer.<Account>create()
+                        .onResultHandler(em -> {
+                            Account account = AccountDAO.create(em, accountCreator);
+                            em.persist(account);
 
-            // Set the parent account path
-            String parentAccountPath = AccountDAO.find(em, null, accountCreator.getScopeId()).getParentAccountPath() + "/" + account.getId();
-            account.setParentAccountPath(parentAccountPath);
-            return AccountDAO.update(em, account);
-        }));
+                            // Set the parent account path
+                            String parentAccountPath = AccountDAO.find(em, KapuaId.ANY, accountCreator.getScopeId()).getParentAccountPath() + "/" + account.getId();
+                            account.setParentAccountPath(parentAccountPath);
+
+                            // Return updated account
+                            return AccountDAO.update(em, account);
+                        }));
     }
 
     @Override
@@ -178,6 +182,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         if (oldAccount.getScopeId() != null) {
             parentAccount = KapuaSecurityUtils.doPrivileged(() -> find(oldAccount.getScopeId()));
         }
+
         if (parentAccount != null && parentAccount.getExpirationDate() != null) {
             // if parent account never expires no check is needed
             if (account.getExpirationDate() == null || parentAccount.getExpirationDate().before(account.getExpirationDate())) {
@@ -216,11 +221,14 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do update
-        return entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> AccountDAO.update(em, account))
-                .onBeforeHandler(() -> {
-                    entityCache.remove(null, account);
-                    return null;
-                }));
+        return entityManagerSession.doTransactedAction(
+                EntityManagerContainer.<Account>create()
+                        .onBeforeHandler(() -> {
+                            entityCache.remove(null, account);
+                            return null;
+                        })
+                        .onResultHandler(em -> AccountDAO.update(em, account))
+        );
     }
 
     @Override
@@ -244,25 +252,28 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do delete
-        entityManagerSession.doTransactedAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
-            // Entity needs to be loaded in the context of the same EntityManger to be able to delete it afterwards
-            Account account = AccountDAO.find(em, scopeId, accountId);
-            if (account == null) {
-                throw new KapuaEntityNotFoundException(Account.TYPE, accountId);
-            }
+        entityManagerSession.doTransactedAction(
+                EntityManagerContainer.<Account>create()
+                        .onResultHandler(em -> {
+                            // Entity needs to be loaded in the context of the same EntityManger to be able to delete it afterwards
+                            Account account = AccountDAO.find(em, scopeId, accountId);
+                            if (account == null) {
+                                throw new KapuaEntityNotFoundException(Account.TYPE, accountId);
+                            }
 
-            // do not allow deletion of the kapua admin account
-            SystemSetting settings = SystemSetting.getInstance();
-            if (settings.getString(SystemSettingKey.SYS_PROVISION_ACCOUNT_NAME).equals(account.getName())) {
-                throw new KapuaIllegalAccessException(action.name());
-            }
+                            // do not allow deletion of the kapua admin account
+                            SystemSetting settings = SystemSetting.getInstance();
+                            if (settings.getString(SystemSettingKey.SYS_PROVISION_ACCOUNT_NAME).equals(account.getName())) {
+                                throw new KapuaIllegalAccessException(action.name());
+                            }
 
-            if (settings.getString(SystemSettingKey.SYS_ADMIN_USERNAME).equals(account.getName())) {
-                throw new KapuaIllegalAccessException(action.name());
-            }
+                            if (settings.getString(SystemSettingKey.SYS_ADMIN_USERNAME).equals(account.getName())) {
+                                throw new KapuaIllegalAccessException(action.name());
+                            }
 
-            return AccountDAO.delete(em, scopeId, accountId);
-        }).onAfterHandler((emptyParam) -> entityCache.remove(scopeId, accountId)));
+                            return AccountDAO.delete(em, scopeId, accountId);
+                        })
+                        .onAfterHandler((emptyParam) -> entityCache.remove(scopeId, accountId)));
     }
 
     @Override
@@ -272,13 +283,26 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
         ArgumentValidator.notNull(accountId, KapuaEntityAttributes.ENTITY_ID);
 
+        // If looking for a ScopeId equals to Account KapuaId, we are looking for our Account,
+        // so we need to use the un-scoped find (which checks for permissions).
+        // Otherwise, we will never find our account on our scope.
+        // In our scope we will find only our direct child Accounts
+        if (scopeId.equals(accountId)) {
+            return find(accountId);
+        }
+
         //
         // Check Access
         checkAccountPermission(scopeId, accountId, AccountDomains.ACCOUNT_DOMAIN, Actions.read);
 
         //
         // Do find
-        return findById(accountId);
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<Account>create()
+                        .onBeforeHandler(() -> (Account) entityCache.get(scopeId, accountId))
+                        .onResultHandler(em -> AccountDAO.find(em, scopeId, accountId))
+                        .onAfterHandler(entityCache::put)
+        );
     }
 
     @Override
@@ -287,7 +311,14 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         // Argument validation
         ArgumentValidator.notNull(accountId, KapuaEntityAttributes.ENTITY_ID);
 
-        Account account = findById(accountId);
+        //
+        // Do find
+        Account account = entityManagerSession.doAction(
+                EntityManagerContainer.<Account>create()
+                        .onBeforeHandler(() -> (Account) entityCache.get(null, accountId))
+                        .onResultHandler(em -> AccountDAO.find(em, KapuaId.ANY, accountId))
+                        .onAfterHandler(entityCache::put)
+        );
 
         //
         // Check Access
@@ -295,6 +326,8 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
         }
 
+        //
+        // Return result
         return account;
     }
 
@@ -306,20 +339,21 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
 
         //
         // Do find
-        return entityManagerSession.doAction(EntityManagerContainer.<Account>create().onResultHandler(em -> {
-                    Account account = AccountDAO.findByName(em, name);
-                    if (account != null) {
-                        checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
-                    }
-                    return account;
-                }
-        ).onBeforeHandler(() -> {
-            Account account = (Account) ((NamedEntityCache) entityCache).get(null, name);
-            if (account != null) {  // TODO: can this be put in the onAfterResultHandler ?
-                checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
-            }
-            return account;
-        }).onAfterHandler((entity) -> entityCache.put(entity)));
+        Account account = entityManagerSession.doAction(
+                EntityManagerContainer.<Account>create()
+                        .onBeforeHandler(() -> (Account) ((NamedEntityCache) entityCache).get(null, name))
+                        .onResultHandler(em -> AccountDAO.findByName(em, name))
+                        .onAfterHandler(entityCache::put));
+
+        //
+        // Check access
+        if (account != null) {
+            checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read);
+        }
+
+        //
+        // Return result
+        return account;
     }
 
     @Override
@@ -329,25 +363,31 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         ArgumentValidator.notNull(scopeId, KapuaEntityAttributes.SCOPE_ID);
 
         //
+        // Check Access
+        Account account = find(scopeId);
+
+        //
         // Make sure account exists
-        Account account = findById(scopeId);
         if (account == null) {
             throw new KapuaEntityNotFoundException(Account.TYPE, scopeId);
         }
 
         //
-        // Check Access
+        // Check access
         checkAccountPermission(account.getScopeId(), account.getId(), AccountDomains.ACCOUNT_DOMAIN, Actions.read, true);
-        return entityManagerSession.doAction(EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> {
-            AccountListResult result = null;
-            TypedQuery<Account> q;
-            q = em.createNamedQuery("Account.findChildAccountsRecursive", Account.class);
-            q.setParameter("parentAccountPath", "\\" + account.getParentAccountPath() + "/%");
 
-            result = new AccountListResultImpl();
-            result.addItems(q.getResultList());
-            return result;
-        }));
+        //
+        // Do find
+        return entityManagerSession.doAction(
+                EntityManagerContainer.<AccountListResult>create()
+                        .onResultHandler(em -> {
+                            TypedQuery<Account> q = em.createNamedQuery("Account.findChildAccountsRecursive", Account.class);
+                            q.setParameter("parentAccountPath", "\\" + account.getParentAccountPath() + "/%");
+
+                            AccountListResult result = new AccountListResultImpl();
+                            result.addItems(q.getResultList());
+                            return result;
+                        }));
     }
 
     @Override
@@ -363,7 +403,8 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         //
         // Do query
         return entityManagerSession.doAction(
-                EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> AccountDAO.query(em, query))
+                EntityManagerContainer.<AccountListResult>create()
+                        .onResultHandler(em -> AccountDAO.query(em, query))
         );
     }
 
@@ -380,29 +421,8 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         //
         // Do count
         return entityManagerSession.doAction(
-                EntityManagerContainer.<Long>create().onResultHandler(em -> AccountDAO.count(em, query))
-        );
-    }
-
-    /**
-     * Find an {@link Account} without authorization checks.
-     *
-     * @param accountId
-     * @return
-     * @throws KapuaException
-     * @since 1.0.0
-     */
-    private Account findById(KapuaId accountId) throws KapuaException {
-        //
-        // Argument Validation
-        ArgumentValidator.notNull(accountId, KapuaEntityAttributes.ENTITY_ID);
-
-        //
-        // Do find
-        return entityManagerSession.doAction(
-                EntityManagerContainer.<Account>create().onResultHandler(em -> AccountDAO.find(em, null, accountId))
-                        .onBeforeHandler(() -> (Account) entityCache.get(null, accountId))
-                        .onAfterHandler((entity) -> entityCache.put(entity))
+                EntityManagerContainer.<Long>create()
+                        .onResultHandler(em -> AccountDAO.count(em, query))
         );
     }
 
@@ -416,15 +436,10 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         //
         // Do find
         return entityManagerSession.doAction(
-                EntityManagerContainer.<AccountListResult>create().onResultHandler(em -> AccountDAO.query(em,
-                        new AccountQueryImpl(accountId)))
+                EntityManagerContainer.<AccountListResult>create()
+                        .onResultHandler(em -> AccountDAO.query(em, new AccountQueryImpl(accountId)))
         );
     }
-
-//    @Override
-//    protected Map<String, Object> getConfigValues(Account entity) throws KapuaException {
-//        return super.getConfigValues(entity.getId());
-//    }
 
     private void checkAccountPermission(KapuaId scopeId, KapuaId accountId, Domain domain, Actions action) throws KapuaException {
         checkAccountPermission(scopeId, accountId, domain, action, false);

--- a/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
+++ b/service/account/test-steps/src/main/java/org/eclipse/kapua/service/account/steps/AccountServiceSteps.java
@@ -401,15 +401,15 @@ public class AccountServiceSteps extends TestBase {
 
     @When("I try to delete the system account")
     public void deleteSystemAccount() throws Exception {
-        String adminUserName = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_USERNAME);
-        Account tmpAcc = accountService.findByName(adminUserName);
+        String adminAccountName = SystemSetting.getInstance().getString(SystemSettingKey.SYS_ADMIN_ACCOUNT);
+        Account adminAccount = accountService.findByName(adminAccountName);
 
-        Assert.assertNotNull(tmpAcc);
-        Assert.assertNotNull(tmpAcc.getId());
+        Assert.assertNotNull(adminAccount);
+        Assert.assertNotNull(adminAccount.getId());
 
         try {
             primeException();
-            accountService.delete(SYS_SCOPE_ID, tmpAcc.getId());
+            accountService.delete(KapuaId.ANY, adminAccount.getId());
         } catch (KapuaException ex) {
             verifyException(ex);
         }
@@ -841,7 +841,7 @@ public class AccountServiceSteps extends TestBase {
     @When("I look for my account by id and scope id")
     public void findMyAccountByIdAndScopeId() throws Exception {
         Account account = (Account) stepData.get(LAST_ACCOUNT);
-        Account selfAccount = accountService.find(account.getId(), account.getScopeId());
+        Account selfAccount = accountService.find(account.getId(), account.getId());
         stepData.put(LAST_ACCOUNT, selfAccount);
     }
 

--- a/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
+++ b/service/job/internal/src/main/java/org/eclipse/kapua/service/job/step/internal/JobStepServiceImpl.java
@@ -390,7 +390,7 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
     }
 
     private void validateJobStepProperties(JobStepCreator jobStepCreator) throws KapuaException {
-        JobStepDefinition jobStepDefinition = jobStepDefinitionService.find(jobStepCreator.getScopeId(), jobStepCreator.getJobStepDefinitionId());
+        JobStepDefinition jobStepDefinition = jobStepDefinitionService.find(KapuaId.ANY, jobStepCreator.getJobStepDefinitionId());
         ArgumentValidator.notNull(jobStepDefinition, "jobStepCreator.jobStepDefinitionId");
 
         try {
@@ -401,7 +401,7 @@ public class JobStepServiceImpl extends AbstractKapuaService implements JobStepS
     }
 
     private void validateJobStepProperties(JobStep jobStep) throws KapuaException {
-        JobStepDefinition jobStepDefinition = jobStepDefinitionService.find(jobStep.getScopeId(), jobStep.getJobStepDefinitionId());
+        JobStepDefinition jobStepDefinition = jobStepDefinitionService.find(KapuaId.ANY, jobStep.getJobStepDefinitionId());
         ArgumentValidator.notNull(jobStepDefinition, "jobStep.jobStepDefinitionId");
 
         try {

--- a/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobStepDefinitionServiceSteps.java
+++ b/service/job/test-steps/src/main/java/org/eclipse/kapua/service/job/steps/JobStepDefinitionServiceSteps.java
@@ -186,7 +186,7 @@ public class JobStepDefinitionServiceSteps extends JobServiceTestBase {
         primeException();
         try {
             stepData.remove(JOB_STEP_DEFINITION);
-            JobStepDefinition stepDefinition = jobStepDefinitionService.find(getCurrentScopeId(), currentStepDefId);
+            JobStepDefinition stepDefinition = jobStepDefinitionService.find(KapuaId.ANY, currentStepDefId);
             stepData.put(JOB_STEP_DEFINITION, stepDefinition);
         } catch (KapuaException ex) {
             verifyException(ex);
@@ -215,12 +215,12 @@ public class JobStepDefinitionServiceSteps extends JobServiceTestBase {
 
     @When("I count the step definition in the database")
     public void countStepDefinitionInDatabase() throws Exception {
-        updateCount(() -> (int) jobStepDefinitionService.count(jobStepDefinitionFactory.newQuery(getCurrentScopeId())));
+        updateCount(() -> (int) jobStepDefinitionService.count(jobStepDefinitionFactory.newQuery(KapuaId.ANY)));
     }
 
     @When("I query for step definitions in scope {int}")
     public void countStepDefinitijonsInScope(Integer id) throws Exception {
-        updateCount(() -> jobStepDefinitionService.query(jobStepDefinitionFactory.newQuery(getKapuaId(id))).getSize());
+        updateCount(() -> jobStepDefinitionService.query(jobStepDefinitionFactory.newQuery(KapuaId.ANY)).getSize());
     }
 
     @When("I delete the step definition")
@@ -228,7 +228,7 @@ public class JobStepDefinitionServiceSteps extends JobServiceTestBase {
         KapuaId currentStepDefId = (KapuaId) stepData.get(CURRENT_JOB_STEP_DEFINITION_ID);
         primeException();
         try {
-            jobStepDefinitionService.delete(getCurrentScopeId(), currentStepDefId);
+            jobStepDefinitionService.delete(KapuaId.ANY, currentStepDefId);
         } catch (KapuaException ex) {
             verifyException(ex);
         }

--- a/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
+++ b/service/job/test/src/test/resources/features/JobStepDefinitionService.feature
@@ -142,22 +142,6 @@ Feature: Job step definition service CRUD tests
     When I count the step definition in the database
     Then I count 10
 
-  Scenario: Count step definitions in wrong (empty) scope
-
-    Given I create 10 step definition items
-    Given Scope with ID 20
-    When I count the step definition in the database
-    Then I count 0
-
-  Scenario: Query for step definitions
-
-    Given Scope with ID 10
-    Then I create 10 step definition items
-    Given Scope with ID 20
-    Then I create 20 step definition items
-    When I query for step definitions in scope 10
-    Then I count 10
-
   Scenario: Step definition factory sanity checks
 
     Given I test the sanity of the step definition factory


### PR DESCRIPTION
This PR fixes an improper segregation of scopes in AccountService.

**Related Issue**
_None_

**Description of the solution adopted**
Fixed the invocations of `AcccountService.find(...) ` to always perform `checkAccess`

**Screenshots**
_None_

**Any side note on the changes made**
_None_