### PR TITLE
Fixed MFA secret key handling

### DIFF
--- a/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticator.java
+++ b/service/security/authentication/api/src/main/java/org/eclipse/kapua/service/authentication/mfa/MfaAuthenticator.java
@@ -34,13 +34,13 @@ public interface MfaAuthenticator {
     /**
      * Validates a code generated with the authenticator app.
      *
-     * @param encryptedSecret  The encoded secret key
+     * @param mfaSecretKey     The MFA secret key.
      * @param verificationCode The verification code
-     * @return {@code true} if the verficationCode is valid, {@code false} otherwise
+     * @return {@code true} if the verficationCode is valid, {@code false} otherwise.
      * @throws KapuaException
      * @since 1.3.0
      */
-    boolean authorize(String encryptedSecret, int verificationCode) throws KapuaException;
+    boolean authorize(String mfaSecretKey, int verificationCode) throws KapuaException;
 
     /**
      * Validates a scratch code.

--- a/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorImpl.java
+++ b/service/security/shiro/src/main/java/org/eclipse/kapua/service/authentication/shiro/mfa/MfaAuthenticatorImpl.java
@@ -21,7 +21,6 @@ import org.eclipse.kapua.commons.util.log.ConfigurationPrinter;
 import org.eclipse.kapua.service.authentication.mfa.MfaAuthenticator;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSetting;
 import org.eclipse.kapua.service.authentication.shiro.setting.KapuaAuthenticationSettingKeys;
-import org.eclipse.kapua.service.authentication.shiro.utils.AuthenticationUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.security.crypto.bcrypt.BCrypt;
@@ -89,19 +88,17 @@ public class MfaAuthenticatorImpl implements MfaAuthenticator {
     }
 
     @Override
-    public boolean authorize(String encryptedSecret, int verificationCode) throws KapuaException {
+    public boolean authorize(String mfaSecretKey, int verificationCode) throws KapuaException {
         //
         // Argument validation
-        ArgumentValidator.notNull(encryptedSecret, "encryptedSecret");
+        ArgumentValidator.notNull(mfaSecretKey, "mfaSecretKey");
         ArgumentValidator.notNegative(verificationCode, "verificationCode");
 
         //
         // Do check
-        String secret = AuthenticationUtils.decryptAes(encryptedSecret);
-
         GoogleAuthenticator ga = new GoogleAuthenticator(GOOGLE_AUTHENTICATOR_CONFIG);
 
-        return ga.authorize(secret, verificationCode);
+        return ga.authorize(mfaSecretKey, verificationCode);
     }
 
     @Override


### PR DESCRIPTION
This PR fixes a but which was introduced in #3655 which is now preventing the MFA authentication to work.

**Related Issue**
This PR fixes issue introduced in #3655 

**Description of the solution adopted**
Removed decryption of `mfaSecretKey` since the value is already decrypted from the database.

**Screenshots**
_None_

**Any side note on the changes made**
This likely has been added back with #3655 after it was removed in #3549.
My bad! 🙇 