### PR TITLE
KapuaException throws NPE on null error code, but only if there is a message bundle

### DIFF
--- a/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
+++ b/rest-api/core/src/test/java/org/eclipse/kapua/app/api/core/exception/RestApiRuntimeExceptionTest.java
@@ -44,13 +44,13 @@ public class RestApiRuntimeExceptionTest {
         Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void restApiRuntimeExceptionNullCodeTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null);
 
         Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
         Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
-        restApiRuntimeException.getMessage();
+        Assert.assertEquals("Error: ", restApiRuntimeException.getMessage());
     }
 
     @Test
@@ -62,13 +62,13 @@ public class RestApiRuntimeExceptionTest {
         Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void restApiRuntimeExceptionNullCodeArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, stringObject, intObject, charObject);
 
         Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
         Assert.assertNull("Null expected.", restApiRuntimeException.getCause());
-        restApiRuntimeException.getMessage();
+        Assert.assertEquals("Error: String Object, 10, c", restApiRuntimeException.getMessage());
     }
 
     @Test
@@ -89,14 +89,13 @@ public class RestApiRuntimeExceptionTest {
         Assert.assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void restApiRuntimeExceptionNullCodeCauseArgumentsTest() {
         RestApiRuntimeException restApiRuntimeException = new RestApiRuntimeException(null, cause, stringObject, intObject, charObject);
 
         Assert.assertNull("Null expected.", restApiRuntimeException.getCode());
         Assert.assertEquals("Expected and actual values should be the same.", cause, restApiRuntimeException.getCause());
-
-        restApiRuntimeException.getMessage();
+        Assert.assertEquals("Error: String Object, 10, c", restApiRuntimeException.getMessage());
     }
 
     @Test

--- a/service/api/src/main/java/org/eclipse/kapua/ExceptionMessageUtils.java
+++ b/service/api/src/main/java/org/eclipse/kapua/ExceptionMessageUtils.java
@@ -106,6 +106,10 @@ public class ExceptionMessageUtils {
             LOG.warn("Could not load exception messages for resource: {} in locale: {}. A generic error message will be printed.", resourceBundleName, locale);
             return null;
         }
+        if (code == null) {
+            LOG.warn("Could not load exception messages for null code. A generic error message will be printed.");
+            return null;
+        }
         try {
             messagePattern = resourceBundle.getString(code.name());
         } catch (MissingResourceException mre) {

--- a/service/api/src/test/java/org/eclipse/kapua/ExceptionMessageUtilsTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/ExceptionMessageUtilsTest.java
@@ -90,9 +90,10 @@ public class ExceptionMessageUtilsTest {
         ExceptionMessageUtils.getLocalizedMessage("kapua-service-error-messages", locale, mockedKapuaErrorCode, objectList);
     }
 
-    @Test(expected = NullPointerException.class)
-    public void getLocalizedMessageNullKapuaErrorCodeTest() {
-        ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[0], locale, null, objectList);
+    @Test
+    public void nullErrorCodeLeadsToDefaultErrorMessage() {
+        final String got = ExceptionMessageUtils.getLocalizedMessage(resourceBundleName[0], locale, null, objectList);
+        Assert.assertEquals("Error: 0, 10, 100000, String, c, -10, -1000000000, -100000000000, 10, 10.0, null, 10.1, true, false", got);
     }
 
     @Test

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaExceptionTest.java
@@ -55,18 +55,8 @@ public class KapuaExceptionTest {
         Assert.assertNull("Null expected.", kapuaException.getCode());
         Assert.assertNull("Null expected.", kapuaException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaException.getMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
-        try {
-            kapuaException.getLocalizedMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Error: ", kapuaException.getMessage());
+        Assert.assertEquals("Error: ", kapuaException.getLocalizedMessage());
     }
 
     @Test
@@ -85,18 +75,8 @@ public class KapuaExceptionTest {
         Assert.assertNull("Null expected.", kapuaException.getCode());
         Assert.assertNull("Null expected.", kapuaException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaException.getMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
-        try {
-            kapuaException.getLocalizedMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Error: user, 2, c", kapuaException.getMessage());
+        Assert.assertEquals("Error: user, 2, c", kapuaException.getLocalizedMessage());
     }
 
     @Test
@@ -115,18 +95,8 @@ public class KapuaExceptionTest {
         Assert.assertNull("Null expected.", kapuaException.getCode());
         Assert.assertNull("Null expected.", kapuaException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaException.getMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
-        try {
-            kapuaException.getLocalizedMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Error: ", kapuaException.getMessage());
+        Assert.assertEquals("Error: ", kapuaException.getLocalizedMessage());
     }
 
     @Test
@@ -148,18 +118,8 @@ public class KapuaExceptionTest {
             Assert.assertNull("Null expected.", kapuaException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
-            try {
-                kapuaException.getMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
-            try {
-                kapuaException.getLocalizedMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
+            Assert.assertEquals("Error: user, 2, c", kapuaException.getMessage());
+            Assert.assertEquals("Error: user, 2, c", kapuaException.getLocalizedMessage());
         }
     }
 
@@ -182,18 +142,8 @@ public class KapuaExceptionTest {
             Assert.assertNull("Null expected.", kapuaException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaException.getKapuaErrorMessagesBundle());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaException.getCause());
-            try {
-                kapuaException.getMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
-            try {
-                kapuaException.getLocalizedMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
+            Assert.assertEquals("Error: ", kapuaException.getMessage());
+            Assert.assertEquals("Error: ", kapuaException.getLocalizedMessage());
         }
     }
 

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalArgumentExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaIllegalArgumentExceptionTest.java
@@ -113,7 +113,7 @@ public class KapuaIllegalArgumentExceptionTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaIllegalArgumentExceptionNullKapuaErrorCodesStringParametersTest() {
         for (String name : argumentName) {
             for (String value : argumentValue) {
@@ -122,26 +122,42 @@ public class KapuaIllegalArgumentExceptionTest {
                 Assert.assertEquals("Expected and actual values should be the same.", name, kapuaIllegalArgumentException.getArgumentName());
                 Assert.assertEquals("Expected and actual values should be the same.", value, kapuaIllegalArgumentException.getArgumentValue());
                 Assert.assertNull("Null expected.", kapuaIllegalArgumentException.getCause());
-                kapuaIllegalArgumentException.getMessage();
+                Assert.assertEquals(String.format("Error: %s, %s", name, value), kapuaIllegalArgumentException.getMessage());
             }
         }
     }
 
-    @Test(expected = KapuaIllegalArgumentException.class)
+    @Test
     public void throwingExceptionStringParametersTest() throws KapuaIllegalArgumentException {
         for (String name : argumentName) {
             for (String value : argumentValue) {
-                throw new KapuaIllegalArgumentException(name, value);
+                try {
+                    throw new KapuaIllegalArgumentException(name, value);
+                } catch (KapuaIllegalArgumentException ex) {
+                    Assert.assertEquals(
+                            String.format("An illegal value was provided for the argument %s: %s.", name, value),
+                            ex.getMessage());
+                } catch (Throwable t) {
+                    Assert.fail();
+                }
             }
         }
     }
 
-    @Test(expected = KapuaIllegalArgumentException.class)
+    @Test
     public void throwingExceptionKapuaErrorCodesStringParametersTest() throws KapuaIllegalArgumentException {
         for (String name : argumentName) {
             for (String value : argumentValue) {
                 for (KapuaErrorCodes code : kapuaErrorCodes) {
-                    throw new KapuaIllegalArgumentException(code, name, value);
+                    try {
+                        throw new KapuaIllegalArgumentException(code, name, value);
+                    } catch (KapuaIllegalArgumentException ex) {
+                        //We just want to check that this type of exception is thrown two lines above... very low value test
+                        //correct error messages are tested separately above
+                        Assert.assertTrue(true);
+                    } catch (Throwable t) {
+                        Assert.fail();
+                    }
                 }
             }
         }

--- a/service/api/src/test/java/org/eclipse/kapua/KapuaRuntimeExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/KapuaRuntimeExceptionTest.java
@@ -56,18 +56,8 @@ public class KapuaRuntimeExceptionTest {
         Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
         Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaRuntimeException.getMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
-        try {
-            kapuaRuntimeException.getLocalizedMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Error: ", kapuaRuntimeException.getMessage());
+        Assert.assertEquals("Error: ", kapuaRuntimeException.getLocalizedMessage());
     }
 
     @Test
@@ -99,18 +89,8 @@ public class KapuaRuntimeExceptionTest {
         Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
         Assert.assertNull("Null expected.", kapuaRuntimeException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaRuntimeException.getMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
-        try {
-            kapuaRuntimeException.getLocalizedMessage();
-            Assert.fail("NullPointerException expected.");
-        } catch (Exception e) {
-            Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Error: user, 1, c", kapuaRuntimeException.getMessage());
+        Assert.assertEquals("Error: user, 1, c", kapuaRuntimeException.getLocalizedMessage());
     }
 
     @Test
@@ -132,18 +112,8 @@ public class KapuaRuntimeExceptionTest {
             Assert.assertNull("Null expected.", kapuaRuntimeException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaRuntimeException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaRuntimeException.getKapuaErrorMessagesBundle());
-            try {
-                kapuaRuntimeException.getMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
-            try {
-                kapuaRuntimeException.getLocalizedMessage();
-                Assert.fail("NullPointerException expected.");
-            } catch (Exception e) {
-                Assert.assertEquals("NullPointerException expected.", new NullPointerException().toString(), e.toString());
-            }
+            Assert.assertEquals("Error: user, 1, c", kapuaRuntimeException.getMessage());
+            Assert.assertEquals("Error: user, 1, c", kapuaRuntimeException.getLocalizedMessage());
         }
     }
 
@@ -165,7 +135,7 @@ public class KapuaRuntimeExceptionTest {
 
         for (Throwable throwable : throwables) {
             for (String msg : messages) {
-        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+                Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwable, msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
                 Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwable, msg).toString(), KapuaRuntimeException.internalError(throwable, msg).toString());
                 Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(throwable, msg).getMessage());
                 Assert.assertEquals("Expected and actual values should be the same.", throwable, KapuaRuntimeException.internalError(throwable, msg).getCause());
@@ -184,7 +154,7 @@ public class KapuaRuntimeExceptionTest {
         String[] arguments = {"Message", "java.lang.Throwable"};
 
         for (int i = 0; i < throwables.length; i++) {
-        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+            Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(throwables[i]), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
             Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, throwables[i], arguments[i]).toString(), KapuaRuntimeException.internalError(throwables[i]).toString());
             Assert.assertEquals("Expected and actual values should be the same.", expectedMessage[i], KapuaRuntimeException.internalError(throwables[i]).getMessage());
             Assert.assertEquals("Expected and actual values should be the same.", throwables[i], KapuaRuntimeException.internalError(throwables[i]).getCause());
@@ -204,7 +174,7 @@ public class KapuaRuntimeExceptionTest {
         String[] messages = {"Message", null};
 
         for (String msg : messages) {
-        Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
+            Assert.assertThat("Instance of KapuaRuntimeException expected.", KapuaRuntimeException.internalError(msg), IsInstanceOf.instanceOf(KapuaRuntimeException.class));
             Assert.assertEquals("Expected and actual values should be the same.", new KapuaRuntimeException(KapuaErrorCodes.INTERNAL_ERROR, null, msg).toString(), KapuaRuntimeException.internalError(msg).toString());
             Assert.assertEquals("Expected and actual values should be the same.", "An internal error occurred: " + msg + ".", KapuaRuntimeException.internalError(msg).getMessage());
             Assert.assertNull("Null expected.", KapuaRuntimeException.internalError(msg).getCause());

--- a/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
+++ b/service/api/src/test/java/org/eclipse/kapua/locator/KapuaLocatorExceptionTest.java
@@ -36,8 +36,8 @@ public class KapuaLocatorExceptionTest {
                 KapuaLocatorErrorCodes.FACTORY_UNAVAILABLE, KapuaLocatorErrorCodes.FACTORY_PROVIDER_INVALID, KapuaLocatorErrorCodes.COMPONENT_UNAVAILABLE,
                 KapuaLocatorErrorCodes.COMPONENT_PROVIDER_INVALID, KapuaLocatorErrorCodes.INVALID_CONFIGURATION};
         argument1 = "argument1";
-        argument2 = "argument2";
-        argument3 = "argument3";
+        argument2 = 42;
+        argument3 = 'c';
         throwables = new Throwable[]{new Throwable(), null};
         expectedMessageNullArguments = new String[]{"Service unavailable {0}", "{0} is not a valid service provider for {1}", "Factory unavailable {0}",
                 "{0} is not a valid factory provider for {1}", "Error: ", "Error: ", "Error: "};
@@ -57,13 +57,13 @@ public class KapuaLocatorExceptionTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesParameterTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null);
         Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
         Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
-        kapuaLocatorException.getMessage();
+        Assert.assertEquals("Error: ", kapuaLocatorException.getMessage());
     }
 
     @Test
@@ -88,22 +88,22 @@ public class KapuaLocatorExceptionTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaLocatorExceptionNullKapuaLocatorErrorCodesObjectParametersTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, argument1, argument2, argument3);
         Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
         Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
-        kapuaLocatorException.getMessage();
+        Assert.assertEquals("Error: argument1, 42, c", kapuaLocatorException.getMessage());
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaLocatorExceptionNullKapuaLocatorErrorCodesNullObjectParametersTest() {
         KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, null);
         Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
         Assert.assertNull("Null expected.", kapuaLocatorException.getCause());
         Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
-        kapuaLocatorException.getMessage();
+        Assert.assertEquals("Error: ", kapuaLocatorException.getMessage());
     }
 
     @Test
@@ -132,26 +132,25 @@ public class KapuaLocatorExceptionTest {
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesThrowableObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, throwable, argument1, argument2, argument3);
             Assert.assertNull("Null expected.", kapuaLocatorException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
-            kapuaLocatorException.getMessage();
+            Assert.assertEquals("Error: argument1, 42, c", kapuaLocatorException.getMessage());
         }
     }
 
-    @Test(expected = NullPointerException.class)
+    @Test
     public void kapuaLocatorExceptionKapuaLocatorNullErrorCodesThrowableNullObjectParametersTest() {
         for (Throwable throwable : throwables) {
             KapuaLocatorException kapuaLocatorException = new KapuaLocatorException(null, throwable, null);
             Assert.assertNull("Null expected", kapuaLocatorException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaLocatorException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", expectedErrorMessage, kapuaLocatorException.getKapuaErrorMessagesBundle());
-            kapuaLocatorException.getMessage();
-
+            Assert.assertEquals("Error: ", kapuaLocatorException.getMessage());
         }
     }
 }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authentication/shiro/KapuaAuthenticationExceptionTest.java
@@ -24,7 +24,7 @@ import org.junit.experimental.categories.Category;
 public class KapuaAuthenticationExceptionTest {
 
     KapuaAuthenticationErrorCodes[] kapuaAuthenticationErrorCodes;
-    String kapuaErrorMessage, expectedMessageWithoutArguments, expectedMessageWithArguments;
+    String kapuaErrorMessageBundle, expectedMessageWithoutArguments, expectedMessageWithArguments;
     Object stringObject, intObject, charObject;
     Throwable[] throwables;
 
@@ -35,7 +35,7 @@ public class KapuaAuthenticationExceptionTest {
                 KapuaAuthenticationErrorCodes.LOCKED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_LOGIN_CREDENTIAL, KapuaAuthenticationErrorCodes.UNKNOWN_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.INVALID_SESSION_CREDENTIALS,
                 KapuaAuthenticationErrorCodes.EXPIRED_SESSION_CREDENTIALS, KapuaAuthenticationErrorCodes.LOCKED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.DISABLED_SESSION_CREDENTIAL, KapuaAuthenticationErrorCodes.JWK_FILE_ERROR,
                 KapuaAuthenticationErrorCodes.REFRESH_ERROR, KapuaAuthenticationErrorCodes.JWK_GENERATION_ERROR, KapuaAuthenticationErrorCodes.JWT_CERTIFICATE_NOT_FOUND, KapuaAuthenticationErrorCodes.PASSWORD_CANNOT_BE_CHANGED};
-        kapuaErrorMessage = "kapua-authentication-service-error-messages";
+        kapuaErrorMessageBundle = "kapua-authentication-service-error-messages";
         expectedMessageWithoutArguments = "Error: ";
         stringObject = "String Object";
         intObject = 10;
@@ -51,7 +51,7 @@ public class KapuaAuthenticationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, kapuaAuthenticationException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutArguments, kapuaAuthenticationException.getMessage());
             Assert.assertNull("Null expected.", kapuaAuthenticationException.getCause());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -62,7 +62,7 @@ public class KapuaAuthenticationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, kapuaAuthenticationException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithArguments, kapuaAuthenticationException.getMessage());
             Assert.assertNull("Null expected.", kapuaAuthenticationException.getCause());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -73,7 +73,7 @@ public class KapuaAuthenticationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, kapuaAuthenticationException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutArguments, kapuaAuthenticationException.getMessage());
             Assert.assertNull("Null expected.", kapuaAuthenticationException.getCause());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -85,7 +85,7 @@ public class KapuaAuthenticationExceptionTest {
                 Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, kapuaAuthenticationException.getCode());
                 Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithArguments, kapuaAuthenticationException.getMessage());
                 Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthenticationException.getCause());
-                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -98,7 +98,7 @@ public class KapuaAuthenticationExceptionTest {
                 Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthenticationErrorCode, kapuaAuthenticationException.getCode());
                 Assert.assertEquals("Expected and actual values should be the same.", expectedMessageWithoutArguments, kapuaAuthenticationException.getMessage());
                 Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthenticationException.getCause());
-                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthenticationException.getKapuaErrorMessagesBundle());
             }
         }
     }

--- a/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
+++ b/service/security/shiro/src/test/java/org/eclipse/kapua/service/authorization/shiro/exception/KapuaAuthorizationExceptionTest.java
@@ -25,7 +25,7 @@ public class KapuaAuthorizationExceptionTest {
     KapuaAuthorizationErrorCodes[] kapuaAuthorizationErrorCodes;
     Object stringArgument, intArgument, booleanArgument;
     Throwable[] throwables;
-    String kapuaErrorMessage;
+    String kapuaErrorMessageBundle;
     String[] errorMessagesWithoutArguments, errorMessagesWithArguments;
 
     @Before
@@ -36,7 +36,7 @@ public class KapuaAuthorizationExceptionTest {
         intArgument = 10;
         booleanArgument = true;
         throwables = new Throwable[]{null, new Throwable(), new Throwable(new Exception()), new Throwable("message")};
-        kapuaErrorMessage = "kapua-service-error-messages";
+        kapuaErrorMessageBundle = "kapua-service-error-messages";
         errorMessagesWithoutArguments = new String[]{"Error: ", "User does not have permission to perform this action. Required permission: {0}.", "Error: "};
         errorMessagesWithArguments = new String[]{"Error: " + stringArgument + ", " + intArgument + ", " + booleanArgument, "User does not have permission to perform this action. Required permission: " + stringArgument + ".", "Error: " + stringArgument + ", " + intArgument + ", " + booleanArgument};
     }
@@ -48,7 +48,7 @@ public class KapuaAuthorizationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -57,13 +57,8 @@ public class KapuaAuthorizationExceptionTest {
         KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null);
         Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
         Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
-        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
-        try {
-            kapuaAuthorizationException.getMessage();
-            Assert.fail("NullPointerException expected");
-        } catch (Exception e) {
-            Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
-        }
+        Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+        Assert.assertEquals("Error: ", kapuaAuthorizationException.getMessage());
     }
 
     @Test
@@ -73,7 +68,7 @@ public class KapuaAuthorizationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -83,13 +78,8 @@ public class KapuaAuthorizationExceptionTest {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, stringArgument, intArgument, booleanArgument);
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
-            try {
-                kapuaAuthorizationException.getMessage();
-                Assert.fail("NullPointerException expected");
-            } catch (Exception e) {
-                Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
-            }
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Error: string argument, 10, true", kapuaAuthorizationException.getMessage());
         }
     }
 
@@ -100,7 +90,7 @@ public class KapuaAuthorizationExceptionTest {
             Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCause());
             Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
         }
     }
 
@@ -112,7 +102,7 @@ public class KapuaAuthorizationExceptionTest {
                 Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
                 Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
                 Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithArguments[i], kapuaAuthorizationException.getMessage());
-                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             }
         }
     }
@@ -123,13 +113,8 @@ public class KapuaAuthorizationExceptionTest {
             KapuaAuthorizationException kapuaAuthorizationException = new KapuaAuthorizationException(null, throwable, stringArgument, intArgument, booleanArgument);
             Assert.assertNull("Null expected.", kapuaAuthorizationException.getCode());
             Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
-            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
-            try {
-                kapuaAuthorizationException.getMessage();
-                Assert.fail("NullPointerException expected");
-            } catch (Exception e) {
-                Assert.assertEquals("Expected and actual values should be the same.", new NullPointerException().toString(), e.toString());
-            }
+            Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+            Assert.assertEquals("Error: string argument, 10, true", kapuaAuthorizationException.getMessage());
         }
     }
 
@@ -141,7 +126,7 @@ public class KapuaAuthorizationExceptionTest {
                 Assert.assertEquals("Expected and actual values should be the same.", kapuaAuthorizationErrorCodes[i], kapuaAuthorizationException.getCode());
                 Assert.assertEquals("Expected and actual values should be the same.", throwable, kapuaAuthorizationException.getCause());
                 Assert.assertEquals("Expected and actual values should be the same.", errorMessagesWithoutArguments[i], kapuaAuthorizationException.getMessage());
-                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessage, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
+                Assert.assertEquals("Expected and actual values should be the same.", kapuaErrorMessageBundle, kapuaAuthorizationException.getKapuaErrorMessagesBundle());
             }
         }
     }


### PR DESCRIPTION
A corner case exists where getting the details of a KapuaException (or derivates) throws an NPE, but only if the message bundle connected IS present. If the message bundle is missing, the code falls back to a standard error message.

As it is BAD practice to have exceptions throwing other exceptions, the code needs to be corrected to always fall back to the default error message.

Also: many tests were using incorrect patterns which left out many test cases (e.g.: using @Test(expected = NullPointerException.class) within loops), or generally just testing that the NPE above was thrown (validating an incorrect behaviour)
