### PR TITLE
Break unwanted module dependencies - Servlet filters

### DIFF
--- a/assembly/broker/descriptors/kapua-broker.xml
+++ b/assembly/broker/descriptors/kapua-broker.xml
@@ -306,6 +306,7 @@
                 <include>${pom.groupId}:kapua-job-engine-client</include>
                 <include>${pom.groupId}:kapua-commons-rest-model</include>
                 <include>${pom.groupId}:kapua-commons-rest-errors</include>
+                <include>${pom.groupId}:kapua-commons-rest-filters</include>
                 <include>${pom.groupId}:kapua-scheduler-api</include>
                 <include>${pom.groupId}:kapua-scheduler-quartz</include>
                 <include>org.quartz-scheduler:quartz</include>

--- a/broker/core/pom.xml
+++ b/broker/core/pom.xml
@@ -115,10 +115,6 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-rest-api-core</artifactId>
-        </dependency>
-        <dependency>
-            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-job-engine-client</artifactId>
         </dependency>
         <dependency>

--- a/commons-rest/filters/about.html
+++ b/commons-rest/filters/about.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Strict//EN"
+        "http://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd">
+<html xmlns="http://www.w3.org/1999/xhtml">
+<head>
+    <meta http-equiv="Content-Type" content="text/html; charset=ISO-8859-1" />
+    <title>About</title>
+</head>
+<body lang="EN-US">
+<h2>About This Content</h2>
+
+<p>November 30, 2017</p>
+<h3>License</h3>
+
+<p>
+    The Eclipse Foundation makes available all content in this plug-in
+    (&quot;Content&quot;). Unless otherwise indicated below, the Content
+    is provided to you under the terms and conditions of the Eclipse
+    Public License Version 2.0 (&quot;EPL&quot;). A copy of the EPL is
+    available at <a href="http://www.eclipse.org/legal/epl-2.0">http://www.eclipse.org/legal/epl-2.0</a>.
+    For purposes of the EPL, &quot;Program&quot; will mean the Content.
+</p>
+
+<p>
+    If you did not receive this Content directly from the Eclipse
+    Foundation, the Content is being redistributed by another party
+    (&quot;Redistributor&quot;) and different terms and conditions may
+    apply to your use of any object code in the Content. Check the
+    Redistributor's license that was provided with the Content. If no such
+    license exists, contact the Redistributor. Unless otherwise indicated
+    below, the terms and conditions of the EPL still apply to any source
+    code in the Content and such source code may be obtained at <a
+        href="http://www.eclipse.org/">http://www.eclipse.org</a>.
+</p>
+
+</body>
+</html>

--- a/commons-rest/filters/pom.xml
+++ b/commons-rest/filters/pom.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2017, 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <artifactId>kapua-commons-rest</artifactId>
+        <groupId>org.eclipse.kapua</groupId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kapua-commons-rest-filters</artifactId>
+    <dependencies>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-endpoint-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-rest-api-core</artifactId>
+        </dependency>
+        <!-- re-declare as provided as our web container will provide this -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <!-- Apache Shiro security framework -->
+        <dependency>
+            <groupId>org.apache.shiro</groupId>
+            <artifactId>shiro-web</artifactId>
+        </dependency>
+
+        <dependency>
+            <groupId>javax.servlet</groupId>
+            <artifactId>javax.servlet-api</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/CORSResponseFilter.java
+++ b/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/CORSResponseFilter.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.core.filter;
+package org.eclipse.kapua.commons.rest.filters;
 
 import com.google.common.collect.HashMultimap;
 import com.google.common.collect.Multimap;
@@ -18,8 +18,8 @@ import com.google.common.net.HttpHeaders;
 import liquibase.util.StringUtils;
 import org.apache.shiro.web.util.WebUtils;
 import org.eclipse.kapua.KapuaException;
-import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSetting;
-import org.eclipse.kapua.app.api.core.settings.KapuaApiCoreSettingKeys;
+import org.eclipse.kapua.commons.rest.filters.settings.KapuaRestFiltersSetting;
+import org.eclipse.kapua.commons.rest.filters.settings.KapuaRestFiltersSettingKeys;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.locator.KapuaLocator;
 import org.eclipse.kapua.model.id.KapuaId;
@@ -74,12 +74,12 @@ public class CORSResponseFilter implements Filter {
     private ScheduledFuture<?> refreshTask;
 
     private Multimap<String, KapuaId> allowedOrigins = HashMultimap.create();
-    private final List<String> allowedSystemOrigins = KapuaApiCoreSetting.getInstance().getList(String.class, KapuaApiCoreSettingKeys.API_CORS_ORIGINS_ALLOWED);
+    private final List<String> allowedSystemOrigins = KapuaRestFiltersSetting.getInstance().getList(String.class, KapuaRestFiltersSettingKeys.API_CORS_ORIGINS_ALLOWED);
 
     @Override
     public void init(FilterConfig filterConfig) {
         logger.info("Initializing with FilterConfig: {}...", filterConfig);
-        int intervalSecs = KapuaApiCoreSetting.getInstance().getInt(KapuaApiCoreSettingKeys.API_CORS_REFRESH_INTERVAL, 60);
+        int intervalSecs = KapuaRestFiltersSetting.getInstance().getInt(KapuaRestFiltersSettingKeys.API_CORS_REFRESH_INTERVAL, 60);
         initRefreshThread(intervalSecs);
         logger.info("Initializing with FilterConfig: {}... DONE!", filterConfig);
     }

--- a/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/KapuaSessionCleanupFilter.java
+++ b/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/KapuaSessionCleanupFilter.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.core.filter;
+package org.eclipse.kapua.commons.rest.filters;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.subject.Subject;

--- a/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/SwaggerUIFilter.java
+++ b/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/SwaggerUIFilter.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.core.filter;
+package org.eclipse.kapua.commons.rest.filters;
 
 import org.apache.shiro.web.util.WebUtils;
 import org.slf4j.Logger;
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 public class SwaggerUIFilter implements Filter {
     private final Logger logger =
-        LoggerFactory.getLogger(SwaggerUIFilter.class);
+            LoggerFactory.getLogger(SwaggerUIFilter.class);
     private boolean swaggerEnable;
 
 
@@ -41,11 +41,11 @@ public class SwaggerUIFilter implements Filter {
     @Override
     public void doFilter(ServletRequest request, ServletResponse response,
                          FilterChain chain)
-    throws IOException, ServletException {
+            throws IOException, ServletException {
         if (!swaggerEnable) {
             HttpServletResponse httpResponse = WebUtils.toHttp(response);
             httpResponse.sendError(
-                HttpServletResponse.SC_NOT_FOUND, "Swagger UI disabled");
+                    HttpServletResponse.SC_NOT_FOUND, "Swagger UI disabled");
             return;
         }
         chain.doFilter(request, response);

--- a/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/settings/KapuaRestFiltersSetting.java
+++ b/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/settings/KapuaRestFiltersSetting.java
@@ -1,0 +1,43 @@
+/*******************************************************************************
+ * Copyright (c) 2016, 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.commons.rest.filters.settings;
+
+import org.eclipse.kapua.commons.setting.AbstractKapuaSetting;
+
+/**
+ * API setting implementation.
+ *
+ * @since 1.0
+ */
+public class KapuaRestFiltersSetting extends AbstractKapuaSetting<KapuaRestFiltersSettingKeys> {
+
+    private static final String API_SETTING_RESOURCE = "kapua-api-core-settings.properties";
+
+    private static final KapuaRestFiltersSetting INSTANCE = new KapuaRestFiltersSetting();
+
+    /**
+     * Construct a new api setting reading settings from {@link KapuaRestFiltersSetting#API_SETTING_RESOURCE}
+     */
+    private KapuaRestFiltersSetting() {
+        super(API_SETTING_RESOURCE);
+    }
+
+    /**
+     * Return the api setting instance (singleton)
+     *
+     * @return A singleton instance of {@link KapuaRestFiltersSetting}
+     */
+    public static KapuaRestFiltersSetting getInstance() {
+        return INSTANCE;
+    }
+}

--- a/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/settings/KapuaRestFiltersSettingKeys.java
+++ b/commons-rest/filters/src/main/java/org/eclipse/kapua/commons/rest/filters/settings/KapuaRestFiltersSettingKeys.java
@@ -10,7 +10,7 @@
  * Contributors:
  *     Eurotech - initial API and implementation
  *******************************************************************************/
-package org.eclipse.kapua.app.api.core.settings;
+package org.eclipse.kapua.commons.rest.filters.settings;
 
 import org.eclipse.kapua.commons.setting.SettingKey;
 
@@ -19,25 +19,16 @@ import org.eclipse.kapua.commons.setting.SettingKey;
  *
  * @since 1.0.0
  */
-public enum KapuaApiCoreSettingKeys implements SettingKey {
+public enum KapuaRestFiltersSettingKeys implements SettingKey {
 
     /**
-     * @since 1.0.0
+     * @since 1.5.0
      */
-    API_PATH_PARAM_SCOPEID_WILDCARD("api.path.param.scopeId.wildcard"),
-
+    API_CORS_REFRESH_INTERVAL("api.cors.refresh.interval"),
     /**
-     * @since 1.0.0
+     * @since 1.5.0
      */
-    API_EXCEPTION_STACKTRACE_SHOW("api.exception.stacktrace.show"),
-
-    /**
-     * Whether DeviceManagementPakages.download and DeviceManagementPakages.uninstall should return 200 with DeviceManagementOperation entity ({@code false}) or
-     * 204 without a content ({@code false})
-     *
-     * @since 2.0.0
-     */
-    API_DEVICE_MANAGEMENT_PACKAGE_RESPONSE_LEGACY_MODE("api.device.management.package.response.legacy.mode");
+    API_CORS_ORIGINS_ALLOWED("api.cors.origins.allowed");
 
     private final String key;
 
@@ -47,7 +38,7 @@ public enum KapuaApiCoreSettingKeys implements SettingKey {
      * @param key The value for the setting.
      * @since 1.0.0
      */
-    KapuaApiCoreSettingKeys(String key) {
+    KapuaRestFiltersSettingKeys(String key) {
         this.key = key;
     }
 

--- a/commons-rest/pom.xml
+++ b/commons-rest/pom.xml
@@ -26,5 +26,6 @@
     <modules>
         <module>model</module>
         <module>errors</module>
+        <module>filters</module>
     </modules>
 </project>

--- a/job-engine/app/web/pom.xml
+++ b/job-engine/app/web/pom.xml
@@ -113,7 +113,7 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
-            <artifactId>kapua-rest-api-core</artifactId>
+            <artifactId>kapua-commons-rest-filters</artifactId>
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>

--- a/job-engine/app/web/src/main/webapp/WEB-INF/web.xml
+++ b/job-engine/app/web/src/main/webapp/WEB-INF/web.xml
@@ -36,7 +36,7 @@
 
     <filter>
         <filter-name>CORSResponseFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.filter.CORSResponseFilter</filter-class>
+        <filter-class>org.eclipse.kapua.commons.rest.filters.CORSResponseFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>CORSResponseFilter</filter-name>
@@ -54,7 +54,7 @@
 
     <filter>
         <filter-name>KapuaSessionCleanUpFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter</filter-class>
+        <filter-class>org.eclipse.kapua.commons.rest.filters.KapuaSessionCleanupFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>KapuaSessionCleanUpFilter</filter-name>

--- a/pom.xml
+++ b/pom.xml
@@ -979,6 +979,11 @@
             </dependency>
             <dependency>
                 <groupId>org.eclipse.kapua</groupId>
+                <artifactId>kapua-commons-rest-filters</artifactId>
+                <version>2.0.0-SNAPSHOT</version>
+            </dependency>
+            <dependency>
+                <groupId>org.eclipse.kapua</groupId>
                 <artifactId>kapua-scheduler-api</artifactId>
                 <version>${project.version}</version>
             </dependency>

--- a/qa/integration/pom.xml
+++ b/qa/integration/pom.xml
@@ -176,6 +176,11 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons-rest-filters</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-scheduler-api</artifactId>
         </dependency>
         <dependency>

--- a/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
+++ b/qa/integration/src/test/java/org/eclipse/kapua/integration/misc/KapuaSessionCleanupFilterTest.java
@@ -14,7 +14,7 @@ package org.eclipse.kapua.integration.misc;
 
 import org.apache.shiro.SecurityUtils;
 import org.apache.shiro.mgt.SecurityManager;
-import org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter;
+import org.eclipse.kapua.commons.rest.filters.KapuaSessionCleanupFilter;
 import org.eclipse.kapua.commons.security.KapuaSecurityUtils;
 import org.eclipse.kapua.commons.security.KapuaSession;
 import org.eclipse.kapua.qa.markers.junit.JUnitTests;

--- a/rest-api/web/pom.xml
+++ b/rest-api/web/pom.xml
@@ -106,6 +106,10 @@
         </dependency>
         <dependency>
             <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons-rest-filters</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
             <artifactId>kapua-scheduler-api</artifactId>
         </dependency>
         <dependency>

--- a/rest-api/web/src/main/webapp/WEB-INF/web.xml
+++ b/rest-api/web/src/main/webapp/WEB-INF/web.xml
@@ -45,7 +45,7 @@
 
     <filter>
         <filter-name>SwaggerUIFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.filter.SwaggerUIFilter</filter-class>
+        <filter-class>org.eclipse.kapua.commons.rest.filters.SwaggerUIFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>SwaggerUIFilter</filter-name>
@@ -54,7 +54,7 @@
 
     <filter>
         <filter-name>CORSResponseFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.filter.CORSResponseFilter</filter-class>
+        <filter-class>org.eclipse.kapua.commons.rest.filters.CORSResponseFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>CORSResponseFilter</filter-name>
@@ -63,7 +63,7 @@
 
     <filter>
         <filter-name>KapuaSessionCleanUpFilter</filter-name>
-        <filter-class>org.eclipse.kapua.app.api.core.filter.KapuaSessionCleanupFilter</filter-class>
+        <filter-class>org.eclipse.kapua.commons.rest.filters.KapuaSessionCleanupFilter</filter-class>
     </filter>
     <filter-mapping>
         <filter-name>KapuaSessionCleanUpFilter</filter-name>


### PR DESCRIPTION
This completes the work started in https://github.com/eclipse/kapua/pull/3683, moving the Servlet filters out of rest-api-core, thus completely breaking unwanted dependancies to that module.
