### PR TITLE
Feature - Liquibase unlocker tool

### DIFF
--- a/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
+++ b/commons/src/main/java/org/eclipse/kapua/commons/liquibase/KapuaLiquibaseClient.java
@@ -168,6 +168,18 @@ public class KapuaLiquibaseClient {
         }
     }
 
+    public void forceReleaseChangelogLock() {
+        LOG.info("Trying to release changelog lock...");
+        try (Connection connection = DriverManager.getConnection(jdbcUrl, username, password)) {
+            Database database = DatabaseFactory.getInstance().findCorrectDatabaseImplementation(new JdbcConnection(connection));
+            Liquibase liquibase = new Liquibase((String) null, new FileSystemResourceAccessor(), database);
+            liquibase.forceReleaseLocks();
+        } catch (LiquibaseException | SQLException e) {
+            LOG.error("Running release changelog lock... ERROR! Error: {}", e.getMessage(), e);
+            throw new RuntimeException(e); // TODO: throw an appropriate exception!
+        }
+    }
+
     protected static synchronized File loadChangelogs() throws IOException {
         String tmpDirectory = SystemUtils.getJavaIoTmpDir().getAbsolutePath();
 

--- a/extras/liquibaseUnlocker/README.md
+++ b/extras/liquibaseUnlocker/README.md
@@ -1,0 +1,22 @@
+Liquibase "changeLogLock" table unlocker tool
+==========
+
+## Introduction
+
+This module contains a Java Application that unlocks a stucked deployment caused by a wrong execution of liquibase updates 
+
+## Background
+
+The liquibase updates, run on changelog files, are performed concurrently by some Kapua containers. To ensure that a single container is running an update on the DB, aka to ensure the right concurrent access to this shared resource, liquibase uses a table called DATABASECHANGELOGLOCK to track which entity is performing the update. A row in this table testifies the presence of an entity making an update, therefore consulting it before performing an update allows you to understand if it is possible to acquire the lock on the resource.
+After the update, the container that locked the recourse releases the lock by deleting the row in this table.
+
+It may happen that, while inside the critical section, the container running the update is stopped for some reason, for example for a crash. After this event, the DATABASECHANGELOGLOCK is left with a row therefore the lock will never be released. If subsequent containers tries to perform other liquibase updates (for example, the mentioned container that has been restarted) they will be blocked endlessly trying to enter the critical section.  
+
+Tu unlock this situation, a manual operation on such table (for example, the deletion of the row or the deletion of the entire table) sometime works. The fact is that the liquibase api provides an explicit command to troubleshoot this situation, in a more safe way, so it is encouraged to use it. Furthermore, the mentioned manual operation requires access to the DB retrieving credentials and so on. The proposed script doesn't require this and get the job done with a single invocation.
+
+#### Usage
+
+```bash
+java -jar kapua-liquibaseUnlocker-2.0.0-SNAPSHOT-app.jar
+```
+To be used when the deployment is stucked for the afore mentioned reasons, the lock will be released and the deployment will continue.

--- a/extras/liquibaseUnlocker/pom.xml
+++ b/extras/liquibaseUnlocker/pom.xml
@@ -21,7 +21,7 @@
         <version>2.0.0-SNAPSHOT</version>
     </parent>
 
-    <artifactId>liquibaseUnlocker</artifactId>
+    <artifactId>kapua-liquibaseUnlocker</artifactId>
 
     <dependencies>
         <!-- -->
@@ -67,6 +67,14 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
                     <filters>
@@ -108,10 +116,5 @@
             </plugin>
         </plugins>
     </build>
-    <!--    <properties>-->
-<!--        <maven.compiler.source>8</maven.compiler.source>-->
-<!--        <maven.compiler.target>8</maven.compiler.target>-->
-<!--        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>-->
-<!--    </properties>-->
 
 </project>

--- a/extras/liquibaseUnlocker/pom.xml
+++ b/extras/liquibaseUnlocker/pom.xml
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+ -->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.eclipse.kapua</groupId>
+        <artifactId>kapua-extras</artifactId>
+        <version>2.0.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>liquibaseUnlocker</artifactId>
+
+    <dependencies>
+        <!-- -->
+        <!-- Kapua -->
+        <dependency>
+            <groupId>org.eclipse.kapua</groupId>
+            <artifactId>kapua-commons</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- External-->
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-logging</groupId>
+            <artifactId>commons-logging</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>commons-configuration</groupId>
+            <artifactId>commons-configuration</artifactId>
+        </dependency>
+
+        <!-- -->
+        <!-- Logging -->
+        <dependency>
+            <groupId>org.slf4j</groupId>
+            <artifactId>slf4j-api</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-classic</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>ch.qos.logback</groupId>
+            <artifactId>logback-core</artifactId>
+        </dependency>
+
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-shade-plugin</artifactId>
+                <configuration>
+                    <filters>
+                        <filter>
+                            <artifact>*:*</artifact>
+                            <excludes>
+                                <exclude>META-INF/*.SF</exclude>
+                                <exclude>META-INF/*.DSA</exclude>
+                                <exclude>META-INF/*.RSA</exclude>
+                                <exclude>META-INF/maven/**</exclude>
+                                <exclude>META-INF/DEPENDENCIES</exclude>
+                                <exclude>bundle.properties</exclude>
+                                <exclude>about.*</exclude>
+                                <exclude>OSGI-OPT/**</exclude>
+                                <exclude>LICENSE</exclude>
+                            </excludes>
+                        </filter>
+                    </filters>
+                    <transformers>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                            <mainClass>org.eclipse.kapua.extras.liquibaseUnlocker.Application</mainClass>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheNoticeResourceTransformer">
+                            <addHeader>false</addHeader>
+                        </transformer>
+                        <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                    </transformers>
+                    <shadedArtifactAttached>true</shadedArtifactAttached>
+                    <shadedClassifierName>app</shadedClassifierName>
+                </configuration>
+                <executions>
+                    <execution>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>shade</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <!--    <properties>-->
+<!--        <maven.compiler.source>8</maven.compiler.source>-->
+<!--        <maven.compiler.target>8</maven.compiler.target>-->
+<!--        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>-->
+<!--    </properties>-->
+
+</project>

--- a/extras/liquibaseUnlocker/pom.xml
+++ b/extras/liquibaseUnlocker/pom.xml
@@ -67,16 +67,9 @@
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-compiler-plugin</artifactId>
-                <configuration>
-                    <source>1.8</source>
-                    <target>1.8</target>
-                </configuration>
-            </plugin>
-            <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <configuration>
+                    <dependencyReducedPomLocation>${project.build.directory}/dependency-reduced-pom.xml</dependencyReducedPomLocation>
                     <filters>
                         <filter>
                             <artifact>*:*</artifact>

--- a/extras/liquibaseUnlocker/src/main/java/org/eclipse/kapua/extras/liquibaseUnlocker/Application.java
+++ b/extras/liquibaseUnlocker/src/main/java/org/eclipse/kapua/extras/liquibaseUnlocker/Application.java
@@ -1,0 +1,52 @@
+/*******************************************************************************
+ * Copyright (c) 2022 Eurotech and/or its affiliates and others
+ *
+ * This program and the accompanying materials are made
+ * available under the terms of the Eclipse Public License 2.0
+ * which is available at https://www.eclipse.org/legal/epl-2.0/
+ *
+ * SPDX-License-Identifier: EPL-2.0
+ *
+ * Contributors:
+ *     Eurotech - initial API and implementation
+ *******************************************************************************/
+package org.eclipse.kapua.extras.liquibaseUnlocker;
+
+import com.google.common.base.MoreObjects;
+import org.eclipse.kapua.commons.jpa.JdbcConnectionUrlResolvers;
+import org.eclipse.kapua.commons.liquibase.KapuaLiquibaseClient;
+import org.eclipse.kapua.commons.setting.system.SystemSetting;
+import org.eclipse.kapua.commons.setting.system.SystemSettingKey;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class Application {
+
+    private static final Logger LOG = LoggerFactory.getLogger(Application.class.getName());
+
+    private static final SystemSetting SYSTEM_SETTING = SystemSetting.getInstance();
+
+    private Application() {
+    }
+
+    public static void main(String[] args) {
+        LOG.info("Liquibase change log table unlocker tool... STARTING");
+        try {
+            {
+                String dbUsername = SYSTEM_SETTING.getString(SystemSettingKey.DB_USERNAME);
+                String dbPassword = SYSTEM_SETTING.getString(SystemSettingKey.DB_PASSWORD);
+                String schema = MoreObjects.firstNonNull(
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA_ENV),
+                        SYSTEM_SETTING.getString(SystemSettingKey.DB_SCHEMA)
+                );
+
+                new KapuaLiquibaseClient(JdbcConnectionUrlResolvers.resolveJdbcUrl(), dbUsername, dbPassword, schema).forceReleaseChangelogLock();
+            }
+        } catch (Exception e) {
+            LOG.info("Liquibase change log table unlocker tool... ERROR!", e);
+            return;
+        }
+
+        LOG.info("Liquibase change log table unlocker tool... DONE!");
+    }
+}

--- a/extras/liquibaseUnlocker/src/main/resources/logback.xml
+++ b/extras/liquibaseUnlocker/src/main/resources/logback.xml
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+    Copyright (c) 2022 Eurotech and/or its affiliates and others
+
+    This program and the accompanying materials are made
+    available under the terms of the Eclipse Public License 2.0
+    which is available at https://www.eclipse.org/legal/epl-2.0/
+
+    SPDX-License-Identifier: EPL-2.0
+
+    Contributors:
+        Eurotech - initial API and implementation
+-->
+<!DOCTYPE xml>
+<configuration>
+
+    <appender name="console" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <logger name="liquibase" level="INFO"/>
+
+    <root level="${LOGBACK_LOG_LEVEL:-info}">
+        <appender-ref ref="console"/>
+    </root>
+</configuration>

--- a/extras/pom.xml
+++ b/extras/pom.xml
@@ -28,6 +28,7 @@
         <module>foreignkeys</module>
         <module>es-migrator</module>
         <module>encryption-migrator</module>
+        <module>liquibaseUnlocker</module>
     </modules>
 
 </project>


### PR DESCRIPTION
This PR introduces another tool inside the extra module which unlocks stucked beployments caused by a wrong execution of liquibase updates. In particular, when the containers leave the lock on the liquibase update process but  are actually out of the critical section (for example, in the case of a crash)

