### PR TITLE
Fix - users that can modify expiration date of the account in which are defined

### DIFF
--- a/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
+++ b/qa/integration/src/test/resources/features/account/AccountExpirationI9n.feature
@@ -20,7 +20,7 @@ Feature: Account expiration features
 
 @setup
 Scenario: Initialize test environment
-    GivenInit Jaxb Context
+    Given Init Jaxb Context
     And Init Security Context
 
   Scenario: Account with future expiration date
@@ -513,6 +513,90 @@ Scenario: Initialize test environment
     Given I select account "account-b"
     Given I expect the exception "KapuaIllegalArgumentException" with the text "argument expirationDate"
     When I change the current account expiration date to "null"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: User cannot modify expiration date of the account in which it is defined
+  A user defined inside an account cannot update the expiration date if its account.
+  In this test the user tries to change the expiration date from a defined date to a "no expiration date".
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 20     |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | tomorrow       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain      | action |
+      | account     | read   |
+      | account     | write  |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Given I select account "account-a"
+    Given I expect the exception "KapuaAccountException" with the text "A user cannot modify expiration date of the account in which it's defined"
+    When I change the current account expiration date to "null"
+    Then An exception was thrown
+    And I logout
+
+  Scenario: User cannot modify expiration date of the account in which it is defined - 2
+  A user defined inside an account cannot update the expiration date if its account.
+  In this test the user tries to change the expiration date from a "no expiration date" to a defined date.
+
+    When I login as user with name "kapua-sys" and password "kapua-password"
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities | 50    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 20     |
+    Given Account
+      | name      | scopeId | expirationDate |
+      | account-a | 1       | null       |
+    And I configure account service
+      | type    | name                   | value |
+      | boolean | infiniteChildEntities  | true  |
+      | integer | maxNumberChildEntities |  10    |
+    And I configure user service
+      | type    | name                       | value |
+      | boolean | infiniteChildEntities      | true  |
+      | integer | maxNumberChildEntities     | 5     |
+    And User A
+      | name    | displayName  | email             | phoneNumber     | status  | userType |
+      | kapua-a | Kapua User A | kapua_a@kapua.com | +386 31 323 444 | ENABLED | INTERNAL |
+    And I add credentials
+      | name    | password          | enabled |
+      | kapua-a | ToManySecrets123# | true    |
+    And Add permissions to the last created user
+      | domain      | action |
+      | account     | read   |
+      | account     | write  |
+    And I logout
+    When I login as user with name "kapua-a" and password "ToManySecrets123#"
+    Given I select account "account-a"
+    Given I expect the exception "KapuaAccountException" with the text "A user cannot modify expiration date of the account in which it's defined"
+    When I change the current account expiration date to "20/11/1997"
     Then An exception was thrown
     And I logout
 

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -174,7 +174,7 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             //check if the updated account is an admin account
             if (setting.getString(SystemSettingKey.SYS_ADMIN_ACCOUNT).equals(account.getName())) {
                 //throw exception if trying to set an expiration date for an admin account
-                throw new KapuaIllegalArgumentException("notAllowedExpirationDate", account.getExpirationDate().toString());
+                throw new KapuaAccountException(KapuaAccountErrorCodes.OPERATION_NOT_ALLOWED, null, "Admin account cannot have an expiration date set");
             }
         }
 

--- a/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
+++ b/service/account/internal/src/main/java/org/eclipse/kapua/service/account/internal/AccountServiceImpl.java
@@ -169,11 +169,31 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
             authorizationService.checkPermission(permissionFactory.newPermission(AccountDomains.ACCOUNT_DOMAIN, Actions.write, account.getScopeId()));
         }
 
+        if (account.getExpirationDate() != null) {
+            SystemSetting setting = SystemSetting.getInstance();
+            //check if the updated account is an admin account
+            if (setting.getString(SystemSettingKey.SYS_ADMIN_ACCOUNT).equals(account.getName())) {
+                //throw exception if trying to set an expiration date for an admin account
+                throw new KapuaIllegalArgumentException("notAllowedExpirationDate", account.getExpirationDate().toString());
+            }
+        }
+
         //
         // Check existence
         Account oldAccount = find(account.getId());
         if (oldAccount == null) {
             throw new KapuaEntityNotFoundException(Account.TYPE, account.getId());
+        }
+
+        //
+        // Check if user tries to change expiration date of the account in which it is defined (the account is not the admin one considering previous checks)
+        if (KapuaSecurityUtils.getSession().getScopeId().equals(account.getId())) {
+            // Editing self - aka user that edits its account
+             if ( (oldAccount.getExpirationDate() == null && account.getExpirationDate() != null) || //old exp. date was "no expiration" and now the update restricts it
+                     (oldAccount.getExpirationDate() != null && ! oldAccount.getExpirationDate().equals(account.getExpirationDate())) ) { //old exp. date was some date and the update refers to another date
+                 // Editing the expiration date
+                 throw new KapuaAccountException(KapuaAccountErrorCodes.OPERATION_NOT_ALLOWED, null, "A user cannot modify expiration date of the account in which it's defined");
+             }
         }
 
         //
@@ -192,12 +212,6 @@ public class AccountServiceImpl extends AbstractKapuaConfigurableResourceLimited
         }
 
         if (account.getExpirationDate() != null) {
-            SystemSetting setting = SystemSetting.getInstance();
-            //check if the updated account is an admin account
-            if (setting.getString(SystemSettingKey.SYS_ADMIN_ACCOUNT).equals(account.getName())) {
-                //throw exception if trying to set an expiration date for an admin account
-                throw new KapuaIllegalArgumentException("notAllowedExpirationDate", account.getExpirationDate().toString());
-            }
             // check that expiration date is after all the children account
             // if expiration date is null it means the account never expires, so it will be obviously later its children
             AccountListResult childrenAccounts = findChildrenRecursively(account.getId());


### PR DESCRIPTION
Brief description of the PR.
This PR adds a new check in the update function of the Account Service class to control that a user defined in an account cannot modify its expiration date.  Of course a user of the parent account, provided he has the permissions, it's still able to update the expiration date of such account. 

**Description of the solution adopted**
I've moved the checked for the modification of the exp. date in the admin account above in the update function, this allows me to assume that in the new check I've inserted (the one that verifies in fact if the user defined in the account tries to update the exp. date of it) we are not in the admin account. 

