### PR TITLE
Bump Netty version from 4.1.84.Final to 4.1.87.final - CVE-2022-41881 CVE-2022-41915

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -107,7 +107,7 @@
         <log4j2-mock.version>0.0.2</log4j2-mock.version>
         <logback.version>1.2.11</logback.version> <!-- Logback 1.3.x requires slf4j 2.x. Logback 1.4.x requires Java 11. See https://logback.qos.ch/dependencies.html-->
         <mockito.version>1.10.19</mockito.version>
-        <netty.version>4.1.84.Final</netty.version>
+        <netty.version>4.1.87.Final</netty.version>
         <netty3.version>3.10.6.Final</netty3.version>
         <owasp-encoder.version>1.2.3</owasp-encoder.version>
         <opencsv.version>3.7</opencsv.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1905,6 +1905,11 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
+                <artifactId>netty-handler-ssl-ocsp</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
                 <artifactId>netty-resolver</artifactId>
                 <version>${netty.version}</version>
             </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1920,16 +1920,6 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-transport</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
-                <artifactId>netty-transport-classes-epoll</artifactId>
-                <version>${netty.version}</version>
-            </dependency>
-            <dependency>
-                <groupId>io.netty</groupId>
                 <artifactId>netty-resolver-dns-classes-macos</artifactId>
                 <version>${netty.version}</version>
             </dependency>
@@ -1952,13 +1942,17 @@
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
-                <artifactId>netty-transport-classes-kqueue</artifactId>
+                <artifactId>netty-transport</artifactId>
+                <version>${netty.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>io.netty</groupId>
+                <artifactId>netty-transport-classes-epoll</artifactId>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>
                 <groupId>io.netty</groupId>
                 <artifactId>netty-transport-classes-kqueue</artifactId>
-                <classifier>osx-aarch_64</classifier>
                 <version>${netty.version}</version>
             </dependency>
             <dependency>


### PR DESCRIPTION
This PR bumps Netty dependencies version from 4.1.84.Final to 4.1.87.Final solving following CVEs:

- CVE-2022-41881 
- CVE-2022-41915

**Related Issue**
_None_

**Description of the solution adopted**
Bumped dependencies versions

**Screenshots**
_None_

**Any side note on the changes made**
Sorted Netty dependencies in `dependencyManagement` section in root pom.xml and added/fixed some references